### PR TITLE
feat: project scaffolding with templates, docs, and governance files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: '[BUG] '
+labels: ['bug', 'triage']
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Step one
+2. Step two
+
+## Expected Behavior
+
+What should happen.
+
+## Actual Behavior
+
+What actually happens.
+
+## Environment
+
+- OS:
+- Version:
+
+## Additional Context
+
+Any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[FEAT] '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Summary
+
+Brief description of the feature.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+
+How should this work?
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Any other context, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+Brief description of changes.
+
+## Related Issues
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactoring
+- [ ] CI/Build
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets or credentials committed
+- [ ] Commit messages follow Conventional Commits
+- [ ] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)
+
+## AI Agent Disclosure
+
+- [ ] This PR was authored by a human
+- [ ] This PR was authored by an AI agent (specify: _______)
+- [ ] This PR was co-authored by human + AI agent

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+Read AGENTS.md and CLAUDE.md in the repository root for project instructions and conventions.
+Follow Conventional Commits for all commit messages.
+Follow the branch naming convention: feature/<issue-id>_<short-description>.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,47 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/criew/opaa/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: criew,*[bot]
+          create-file-commit-message: "chore: initialize CLA signatures file"
+          signed-commit-message: "chore: add $contributorName to CLA signatories"
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! :tada:
+
+            Before we can merge this PR, you need to sign the **Contributor License Agreement (CLA)**.
+            This is required to allow OPAA to offer commercial licensing alongside its open-source license.
+
+            Please read [CLA.md](https://github.com/criew/opaa/blob/main/CLA.md) — it is short and written in plain language.
+
+            Then post the following comment **in this PR**:
+
+            > I have read the CLA Document and I hereby sign the CLA
+
+            If you are contributing on behalf of a company, an authorized representative of your employer must also post this comment.
+
+            If you use an AI coding agent, you (the human operator) sign on behalf of the submission.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          lock-pullrequest-aftermerge: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Java
+*.class
+*.jar
+*.war
+*.ear
+
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+.vscode/
+.settings/
+.project
+.classpath
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+
+# Node (Web UI)
+node_modules/
+dist/
+
+# Docker
+docker-compose.override.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+Universal AI agent instructions for PlugWerk. All AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) should read this file first.
+
+## What PlugWerk Is
+
+PlugWerk is a **plugin marketplace for the Java/PF4J ecosystem** – the missing link between the PF4J plugin framework and a product's plugin ecosystem. Think Maven Central, but for runtime plugins instead of build dependencies.
+
+Two artifacts:
+- **PlugWerk Server** – Spring Boot 3.x web application: REST API, catalog, upload, versioning, download
+- **PlugWerk Client SDK** – Pure Java 11+ library embedded in host applications: discovery, download, install, update lifecycle
+
+Project concept: `docs/concepts/concept-pf4j-marketplace-en.md`
+
+## Project Status
+
+Currently in the **concept/planning phase**. No code exists yet. Next step: Gradle multi-module project for Phase 1 (MVP).
+
+## Language
+
+All project communication is in **English**: code, documentation, issues, PR descriptions, reviews, ADRs.
+
+## Git Workflow
+
+- **Never commit directly to `main`** – always use a feature branch
+- Branch naming: `feature/<issue-id>_<short-description>` (e.g. `feature/42_user-auth`) – every branch ties back to a GitHub Issue
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
+- AI-generated commits include a `Co-Authored-By` trailer
+- PRs use the template at `.github/PULL_REQUEST_TEMPLATE.md` (includes AI agent disclosure section)
+- One logical change per PR; reference fixed issues with `Closes #N` in the PR body
+- Issues use the templates in `.github/ISSUE_TEMPLATE/`:
+  - Bugs: `bug_report.md`
+  - Features: `feature_request.md`
+
+## Documentation
+
+- Architecture Decision Records: `docs/adrs/` — use `docs/adrs/TEMPLATE.md` for new ADRs
+- Feature specifications: `docs/features/` — GitHub Issues link to their corresponding spec file
+- Project concept: `docs/concepts/`
+
+## Architecture
+
+### Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Server Backend | Spring Boot 3.x / Java 21+ |
+| Server API | Spring Web (REST) + OpenAPI |
+| Database | PostgreSQL |
+| Storage | Filesystem / S3-compatible (MinIO) |
+| Cache | Redis |
+| Web UI | React / TypeScript (or Vaadin) |
+| Auth | Spring Security + OIDC/OAuth2 |
+| Client SDK | Pure Java 11+ (no Spring dependency) |
+| Build | Gradle multi-module |
+
+### Planned Module Structure
+
+```
+plugwerk/
+├── plugwerk-server/        # Spring Boot application
+├── plugwerk-client-sdk/    # Pure Java 11+ library
+├── plugwerk-common/        # Shared DTOs, constants
+└── plugwerk-descriptor/    # plugwerk.yml parser/validator
+```
+
+### Key Design Constraints
+
+- **Client SDK has zero Spring dependency** – must work in any Java 11+ application
+- **pf4j-update backward compatibility** – `PlugWerkUpdateRepository` is a drop-in for `DefaultUpdateRepository`; `GET /plugins.json` maintains pf4j-update format
+- **Transactional installation** – no partial state on failure; rollback requires retaining previous version
+- **Namespace isolation** – all resources are scoped to a namespace; one server serves multiple products/organizations

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,77 @@
+# Contributor License Agreement
+
+**PlugWerk – Plugin Marketplace for the Java Ecosystem**
+
+This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the PlugWerk project. By signing this Agreement, you accept and agree to the following terms for your present and future contributions to PlugWerk.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual or legal entity submitting a Contribution.
+
+**"Contribution"** means any original work of authorship, including modifications or additions, that you intentionally submit to the project.
+
+**"Licensor"** means the copyright owner of PlugWerk who accepts your Contribution.
+
+---
+
+## 2. Grant of Copyright License
+
+You grant the Licensor a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** copyright license to:
+
+- reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and any derivative works thereof;
+- **sublicense the above rights under any license terms**, including proprietary commercial licenses.
+
+This sublicensing right is essential to PlugWerk's dual-licensing model, which allows the project to be offered both under an open-source license and under commercial licenses.
+
+---
+
+## 3. Grant of Patent License
+
+You grant the Licensor a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contributions, where such license applies to patent claims licensable by you that are necessarily infringed by your Contributions.
+
+---
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each Contribution is your original creation, or you have sufficient rights to submit it under this Agreement.
+3. Your Contribution does not include third-party material that would restrict the Licensor's ability to sublicense it.
+4. If your employer has rights to intellectual property that you create (including your Contributions), your employer has either waived those rights or signed a Corporate CLA with the Licensor.
+
+You agree to notify the Licensor promptly if any of these representations become inaccurate.
+
+---
+
+## 5. Corporate Contributors
+
+If you are contributing on behalf of a company or organization, **both you and your employer** must agree to this CLA. The authorized representative of your employer must sign by posting the acknowledgment comment below. Individual engineers then do not need to sign separately.
+
+---
+
+## 6. No Obligation to Use
+
+This Agreement does not obligate the Licensor to include your Contribution in the project or in any product.
+
+---
+
+## 7. How to Sign
+
+**Sign electronically** by posting the following comment on your first Pull Request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username and the date of signing are recorded automatically in `signatures/cla.json`.
+
+---
+
+## 8. AI Agent Contributions
+
+If you use an AI coding agent (Claude Code, GitHub Copilot, Cursor, Codex, etc.) to generate or assist with a Contribution, **you** (the human operator) are the contributor and must sign this CLA. The AI agent itself does not sign. By signing, you represent that you have reviewed the AI-generated Contribution and take responsibility for it.
+
+---
+
+*This Agreement is governed by applicable law. Questions: open an issue or contact the maintainers.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**Read `AGENTS.md` first** – it contains the authoritative project conventions (language, git workflow, architecture, documentation structure). This file only adds Claude-specific context.
+
+## Additional Architecture Details
+
+### Core Data Model
+
+```
+Namespace (slug, owner_org, settings JSON)
+  └── Plugin (plugin_id unique per ns, categories[], tags[], status)
+        └── PluginRelease (SemVer version, artifact_sha256, requires_system_version,
+                          plugin_dependencies JSON, status: draft/published/deprecated/yanked)
+
+User → Organization → Namespace → Role (RBAC)
+```
+
+### API Structure
+
+All endpoints: `/api/v1/namespaces/{ns}/...`
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/plugins` | Catalog with filters |
+| `GET` | `/plugins/{id}/releases/{version}/download` | Artifact download |
+| `GET` | `/plugins.json` | pf4j-update compatible drop-in |
+| `POST` | `/plugins/{id}/releases` | Upload new release |
+| `POST` | `/updates/check` | Body: installed plugins+versions → available updates |
+| `GET` | `/reviews/pending` | Admin review queue |
+| `POST` | `/reviews/{releaseId}/approve` | Approve release |
+
+### Client SDK Core Classes
+
+```java
+PlugWerkConfig           // Builder pattern or properties file
+PlugWerkClient           // Configurable HTTP client
+PlugWerkCatalog          // Catalog queries
+PlugWerkInstaller        // Download + SHA-256 verification + transactional install
+PlugWerkUpdateChecker    // Update polling
+PlugWerkUpdateRepository // Implements pf4j-update UpdateRepository (drop-in replacement)
+PlugWerkPluginManager    // Optional: wraps DefaultPluginManager + PlugWerk features
+```
+
+### Plugin Descriptor (`plugwerk.yml`)
+
+Embedded in plugin artifacts. Extends the PF4J manifest (`MANIFEST.MF` / `plugin.properties`) with:
+- `requires.system-version` – SemVer range (e.g. `>=2.0.0 & <4.0.0`)
+- `requires.api-level` – integer (alternative to concrete version)
+- `requires.plugins[]` – plugin-to-plugin dependencies with version ranges
+- `namespace`, `categories[]`, `tags[]`, `license`, `icon`, `screenshots`
+
+If `plugwerk.yml` is absent, the server falls back to the PF4J manifest.
+
+## Implementation Phases
+
+- **Phase 1 (MVP):** REST API + PostgreSQL + filesystem storage + API key auth + minimal Web UI + `plugins.json` endpoint + Client SDK as pf4j-update drop-in
+- **Phase 2 (Enterprise):** Multi-namespace, RBAC/OIDC, review/approval workflow, code signing, S3/MinIO, dependency resolution in client
+- **Phase 3 (Ecosystem):** Embeddable UI component, webhooks, vulnerability scanning, Gradle/Maven CI/CD plugin, SaaS multi-tenancy
+
+## Deployment (Self-Hosted Minimal)
+
+```
+Docker Compose:
+├── plugwerk-server  (Spring Boot)
+├── postgres
+├── minio            (optional S3 storage)
+└── nginx            (reverse proxy, TLS)
+```
+
+Health: `/actuator/health` | Metrics: Prometheus | Logging: structured JSON

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to OPAA
+
+Thank you for your interest in contributing to OPAA! This project welcomes contributions from both humans and AI coding agents.
+
+## Contributor License Agreement (CLA)
+
+**Before your first Pull Request can be merged, you must sign the CLA.**
+
+OPAA uses a dual-licensing model: the core is open source, and commercial licenses are offered for organizations that cannot comply with the open-source license. The CLA grants the project the right to sublicense your contributions under both open-source and commercial terms — this is what makes dual licensing legally possible.
+
+**How to sign:** Read [CLA.md](./CLA.md) (it's short), then post this comment on your first PR:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded automatically. You only need to sign once.
+
+**AI agent operators:** If you use an AI coding agent, you (the human) sign the CLA. See [CLA.md § 8](./CLA.md#8-ai-agent-contributions) for details.
+
+**Corporate contributors:** If you contribute on behalf of an employer, also read [CLA.md § 5](./CLA.md#5-corporate-contributors).
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork
+3. Create a feature branch: `git checkout -b feature/42_my-feature`
+4. Make your changes
+5. Push and open a Pull Request
+
+## Branch Naming
+
+Use the format `feature/<issue-id>_<short-description>`:
+
+```
+feature/42_user-authentication
+feature/15_fix-null-pointer
+feature/7_add-contributing-guide
+```
+
+Every branch ties back to a GitHub Issue via its ID.
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+feat: add user authentication
+fix(api): handle null response from service
+docs: update architecture decision records
+```
+
+## Pull Requests
+
+- All changes go through PRs — no direct pushes to `main`
+- Fill out the PR template completely
+- Link related GitHub Issues with `Closes #N`
+- Ensure tests pass before requesting review
+
+## Issues
+
+- **Issues must be written in English**
+- Use the provided issue templates for bug reports and feature requests
+- For larger features, create a feature spec in `docs/features/` and link it from the issue
+
+## AI Agent Contributors
+
+This project explicitly welcomes contributions from AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex, etc.).
+
+### Expectations for AI-generated code
+
+- All AI contributions go through the same PR review process as human code
+- Use Conventional Commits format
+- Include a `Co-Authored-By` trailer in commits (e.g., `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`)
+- Mark AI involvement in the PR template's AI Agent Disclosure section
+- Read `AGENTS.md` (or `CLAUDE.md` for Claude) before starting work
+
+### For humans reviewing AI-generated code
+
+- Review AI code with the same rigor as human code
+- Watch for hallucinated imports, non-existent APIs, and subtle logic errors
+- Verify that AI agents followed the project conventions documented here
+
+## Code of Conduct
+
+Be respectful and constructive. We're building something together.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# plugwerk
-PlugWerk – Plugin Marketplace for the Java Ecosystem
+# PlugWerk
+
+**Plugin Marketplace for the Java/PF4J Ecosystem**
+
+PlugWerk is the missing link between [PF4J](https://github.com/pf4j/pf4j) and a product's plugin ecosystem. It provides centralized infrastructure for distributing, managing, and updating plugins at runtime – comparable to Maven Central for build dependencies, but designed for runtime plugins.
+
+## Overview
+
+PlugWerk consists of two artifacts:
+
+- **PlugWerk Server** – A Spring Boot web application serving as a central plugin marketplace: catalog, upload, versioning, download, and REST API.
+- **PlugWerk Client SDK** – A pure Java 11+ library that can be embedded into any Java application: plugin discovery, download, installation, update checking, and PF4J lifecycle integration.
+
+## Status
+
+> This project is currently in the **concept and planning phase**. See [`docs/concepts/`](docs/concepts/) for the full product concept.
+
+## Key Features
+
+- Searchable plugin catalog with full-text search and compatibility filtering
+- Plugin upload via Web UI or REST API (CI/CD-ready)
+- SemVer-based versioning with compatibility matrix (`requires: >=2.0.0 & <4.0.0`)
+- SHA-256 checksum verification and optional code signing
+- Drop-in replacement for [`pf4j-update`](https://github.com/pf4j/pf4j-update) – backward compatible `plugins.json` endpoint
+- Multi-namespace support: one server serves multiple products/organizations
+- Self-hosted (Docker Compose / Kubernetes) or SaaS
+
+## Architecture
+
+```
+PlugWerk Server  ←──REST/HTTPS──  PlugWerk Client SDK
+  ├── REST API                       ├── PlugWerkUpdateRepository  (pf4j-update drop-in)
+  ├── Web UI                         ├── PlugWerkInstaller
+  ├── Service Layer                  └── PlugWerkUpdateChecker
+  ├── PostgreSQL
+  ├── S3/Filesystem (artifacts)
+  └── Redis (cache)
+```
+
+**Tech stack:** Spring Boot 3.x / Java 21+ · PostgreSQL · React/TypeScript · Spring Security + OIDC · Gradle multi-module
+
+## Documentation
+
+- [Product Concept (EN)](docs/concepts/concept-pf4j-marketplace-en.md)
+- [Produktkonzept (DE)](docs/concepts/concept-pf4j-marketplace-de.md)
+- [Architecture Decision Records](docs/adrs/)
+
+## Contributing
+
+- Language: **English** for all code, docs, issues, and reviews
+- Branches: `feature/<issue-id>_<short-description>` – never commit directly to `main`
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) format
+- Use the issue and PR templates in `.github/`

--- a/docs/adrs/0001-collaboration-workflow.md
+++ b/docs/adrs/0001-collaboration-workflow.md
@@ -1,0 +1,41 @@
+# ADR-0001: Collaboration Workflow for Humans and AI Agents
+
+## Status
+
+Accepted
+
+## Context
+
+PlugWerk is a new open-source project where multiple humans and AI coding agents (Claude Code, GitHub Copilot, Cursor,
+etc.) collaborate. We need to establish conventions for documentation, branching, commits, and code review from the
+start.
+
+## Decision
+
+We adopt the following workflow:
+
+1. **Dual instruction files**: `AGENTS.md` as the universal AI agent instruction file (supported by 60+ tools), and
+   `CLAUDE.md` for Claude-specific behavior that imports AGENTS.md.
+
+2. **Documentation split**: GitHub Issues for task tracking and collaboration. `docs/adrs/` for Architecture Decision
+   Records (ADRs). `docs/features/` for feature specifications. Issues link to their corresponding feature spec files.
+
+3. **Branch naming**: `feature/<issue-id>_<short-description>` format (e.g., `feature/42_user-auth`,
+   `feature/15_fix-null-pointer`). Every branch ties back to a GitHub Issue. AI-generated worktree branch names are
+   acceptable.
+
+4. **Conventional Commits**: All commit messages follow the Conventional Commits specification. AI agents include
+   `Co-Authored-By` trailers.
+
+5. **PR-based workflow**: No direct pushes to `main`. All changes go through Pull Requests with review. PR template
+   includes AI agent disclosure.
+
+6. **Transparency**: AI contributions are clearly labeled through commit trailers and PR template disclosure. This is
+   provenance tracking, not gatekeeping.
+
+## Consequences
+
+- **Easier**: Onboarding new contributors (human or AI) — clear conventions from day one. AI agents can read AGENTS.md
+  and immediately understand project norms. Architecture decisions are documented and discoverable.
+- **Harder**: Slightly more overhead per contribution (branch naming, PR template, commit format). But this overhead is
+  minimal and prevents confusion as the team grows.

--- a/docs/adrs/TEMPLATE.md
+++ b/docs/adrs/TEMPLATE.md
@@ -1,0 +1,17 @@
+# ADR-NNNN: Title
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by ADR-NNNN
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/docs/concepts/concept-pf4j-marketplace-de.md
+++ b/docs/concepts/concept-pf4j-marketplace-de.md
@@ -1,0 +1,561 @@
+# PlugWerk – Plugin Marketplace für das Java-Ökosystem
+
+**Konzept-Paper | Produktvision, Features, Umsetzungsskizze & Betriebsmodell**
+
+Stand: 19. März 2026 | Version 0.1 – Entwurf
+
+---
+
+## 1. Executive Summary
+
+Java-Anwendungen, die auf PF4J (Plugin Framework for Java) setzen, fehlt eine zentrale Infrastruktur für die Distribution, Verwaltung und Aktualisierung von Plugins. Jedes Team, das PF4J integriert, baut sich eigene Deployment-Pipelines, eigene Update-Mechanismen und eigene Plugin-Verzeichnisse. Dieses Muster wiederholt sich projekt- und unternehmensübergreifend.
+
+**PlugWerk** schließt diese Lücke als eigenständiges Produkt. Es besteht aus zwei Artefakten:
+
+1. **PlugWerk Server** – eine Webanwendung, die als zentraler Plugin-Marketplace fungiert: Katalog, Upload, Versionierung, Download und REST-API.
+2. **PlugWerk Client SDK** – eine Java-Bibliothek, die in beliebige Java-Anwendungen eingebunden wird und die Verbindung zum Marketplace herstellt: Plugin-Discovery, Download, Installation, Update-Prüfung und Lifecycle-Integration mit PF4J.
+
+Das Produkt ist bewusst **produktunabhängig** konzipiert. Jedes Java-Softwareprodukt, das PF4J nutzt oder nutzen möchte, kann PlugWerk als seine Plugin-Infrastruktur einsetzen – vergleichbar mit dem Verhältnis von Maven Central zu Maven, aber spezialisiert auf Runtime-Plugins statt Build-Dependencies.
+
+---
+
+## 2. Problemanalyse
+
+### 2.1 Status Quo im PF4J-Ökosystem
+
+PF4J ist ein bewährtes, leichtgewichtiges Plugin-Framework (~100 KB, Apache License), das unter anderem von Netflix Spinnaker und Appsmith eingesetzt wird. Das Ökosystem umfasst:
+
+| Modul         | Funktion                                    | Status             |
+|---------------|---------------------------------------------|--------------------|
+| pf4j          | Core: Plugin-Loading, Classloader-Isolation  | Aktiv, v3.12+      |
+| pf4j-spring   | Spring-Framework-Integration                 | Aktiv              |
+| pf4j-update   | Update-Mechanismus (JSON-basiert)            | Stagniert (2020)   |
+| pf4j-plus     | ServiceRegistry, EventBus, Config            | Neu (Jan 2026)     |
+| pf4j-jpms     | Java Module System PoC                       | Experimentell      |
+
+**Die Lücke:** Keines dieser Module bietet eine vollständige Marketplace-Lösung. `pf4j-update` kommt am nächsten – es definiert ein `plugins.json`-Format und einen `UpdateManager` – aber es ist:
+
+- ein reiner Client ohne Server-Komponente
+- auf statisches JSON-Hosting beschränkt (kein Upload, kein Katalog, keine Suche)
+- seit 2020 kaum weiterentwickelt
+- ohne Sicherheitsfeatures (kein Signing, kein Review-Prozess)
+
+### 2.2 Wiederkehrende Probleme bei Teams
+
+- **Kein Standard für Plugin-Distribution:** Jedes Produkt baut eigene FTP/S3/Nexus-basierte Lösungen.
+- **Keine Discovery:** Nutzer wissen nicht, welche Plugins es gibt, ohne Dokumentation zu lesen.
+- **Kein Lifecycle-Management:** Updates, Rollbacks und Kompatibilitätsprüfungen werden manuell gelöst.
+- **Kein Vertrauensmodell:** Es gibt keinen Mechanismus, um die Integrität heruntergeladener Plugins zu verifizieren.
+
+---
+
+## 3. Produktvision
+
+> **PlugWerk macht Plugin-Management für Java-Anwendungen so einfach wie Dependency-Management mit Maven – aber zur Laufzeit.**
+
+### 3.1 Zielbild
+
+Ein Java-Softwareprodukt integriert das PlugWerk Client SDK (eine Maven-Dependency). Ab diesem Moment können seine Endnutzer oder Administratoren:
+
+- einen Plugin-Katalog durchsuchen (entweder über ein eingebettetes UI oder programmatisch)
+- Plugins mit einem Klick installieren, updaten oder deinstallieren
+- sicher sein, dass nur kompatible und verifizierte Plugins angeboten werden
+
+Plugin-Entwickler (intern oder extern) können:
+
+- ihre Plugins über eine Web-Oberfläche oder CI/CD-Pipeline hochladen
+- Metadaten pflegen (Beschreibung, Screenshots, Changelog, Kompatibilitätsmatrix)
+- Releases verwalten und ältere Versionen zurückziehen
+
+Produktbetreiber können:
+
+- ihren eigenen PlugWerk-Server betreiben (Self-Hosted) oder einen gehosteten Service nutzen (SaaS)
+- Namespaces/Kanäle für ihre Produkte anlegen
+- Freigabeworkflows und Berechtigungen steuern
+
+### 3.2 Abgrenzung
+
+PlugWerk ist **kein**:
+
+- Build-Tool oder Dependency-Manager (kein Maven-/Gradle-Ersatz)
+- Plugin-Framework (kein PF4J-Ersatz, sondern eine Erweiterung davon)
+- Application Server oder Runtime-Container (kein OSGi-Ersatz)
+
+PlugWerk ist **das fehlende Bindeglied** zwischen dem Plugin-Framework (PF4J) und dem Plugin-Ökosystem eines Produkts.
+
+---
+
+## 4. Feature-Katalog
+
+### 4.1 PlugWerk Server
+
+#### 4.1.1 Plugin-Katalog & Discovery
+
+- Durchsuchbares Verzeichnis aller Plugins mit Volltextsuche
+- Filterung nach: Produkt/Namespace, Kategorie/Tags, Kompatibilitätsversion, Bewertung, Aktualität
+- Detailseite pro Plugin: Beschreibung, Screenshots, Changelog, Lizenz, Autor, Download-Zahlen, Kompatibilitätsmatrix
+- Katalog verfügbar als Web-UI und als REST-API
+
+#### 4.1.2 Plugin-Upload & Release-Management
+
+- Upload über Web-UI oder REST-API (CI/CD-tauglich)
+- Automatische Extraktion von Plugin-Metadaten aus dem PF4J-Manifest (Plugin-Id, Plugin-Version, Plugin-Provider, Plugin-Dependencies)
+- Erweitertes Manifest-Format (PlugWerk Descriptor): zusätzliche Felder wie Kompatibilitätsbereich, Beschreibung, Kategorie, Lizenz, Icon
+- Multi-Version-Support: mehrere Releases pro Plugin, mit Status (Draft, Published, Deprecated, Yanked)
+- Changelog-Pflege pro Release
+
+#### 4.1.3 Versionierung & Kompatibilität
+
+- SemVer-basierte Versionierung (konsistent mit pf4j-update)
+- Kompatibilitätsmatrix: Plugin deklariert, mit welchen Versionen des Host-Produkts es kompatibel ist (`requires: >=2.0.0 & <3.0.0`)
+- Dependency-Resolution: Plugin-zu-Plugin-Abhängigkeiten werden beim Download/Install aufgelöst
+- API-Level-Konzept (optional): Host-Produkte können ein API-Level deklarieren, Plugins referenzieren dieses statt konkreter Produktversionen
+
+#### 4.1.4 Sicherheit & Trust
+
+- **Code-Signing:** Plugins können mit einem privaten Schlüssel signiert werden; der Client verifiziert die Signatur vor Installation
+- **Checksum-Verifikation:** SHA-256-Hashes für alle Artefakte, automatische Prüfung im Client
+- **Review-Workflow:** Optional aktivierbarer Freigabeprozess – Plugins müssen von einem Admin/Reviewer genehmigt werden, bevor sie im Katalog sichtbar sind
+- **Vulnerability-Scanning:** Integration mit Tools wie OWASP Dependency-Check oder Trivy für die Analyse der Plugin-Dependencies
+- **RBAC (Role-Based Access Control):** Rollen wie Admin, Reviewer, Publisher, Consumer mit granularen Berechtigungen
+
+#### 4.1.5 Multi-Tenancy & Namespaces
+
+- **Namespace-Konzept:** Jedes Host-Produkt erhält einen eigenen Namespace (z.B. `acme-crm`, `logistics-suite`)
+- Plugins sind einem oder mehreren Namespaces zugeordnet
+- Namespace-spezifische Einstellungen: Kompatibilitätsvorgaben, Freigabeworkflow, Branding
+- Mandantenfähigkeit: ein PlugWerk-Server kann mehrere Produkte/Organisationen bedienen
+- API-Keys pro Namespace für authentifizierten Zugriff
+
+#### 4.1.6 REST-API
+
+- RESTful API als primäre Schnittstelle (Web-UI nutzt dieselbe API)
+- Endpunkte für: Katalog-Abfrage, Plugin-Details, Download, Upload, Release-Management, Namespace-Verwaltung, User/Rollen-Management
+- Authentifizierung: API-Key und/oder OAuth2/OIDC
+- Rate-Limiting und Quota-Management
+- OpenAPI/Swagger-Dokumentation
+
+#### 4.1.7 Web-UI
+
+- Modernes, responsives Web-Frontend
+- Plugin-Katalog mit Karten- und Listenansicht
+- Plugin-Detailseite mit Installationshinweisen
+- Admin-Bereich: Upload, Release-Management, Review-Queue, Namespace-Verwaltung, User-Management
+- Dashboard: Download-Statistiken, aktive Plugins, Versionsverteilung
+
+### 4.2 PlugWerk Client SDK
+
+#### 4.2.1 Marketplace-Connectivity
+
+- REST-Client zur Kommunikation mit dem PlugWerk Server
+- Konfigurierbare Server-URL(s) – auch mehrere Repositories gleichzeitig (analog Maven Central + private Repos)
+- Authentifizierung per API-Key oder Token
+- Offline-fähig: gecachter Katalog, funktioniert auch bei temporärer Server-Unerreichbarkeit
+
+#### 4.2.2 Plugin-Discovery
+
+- Programmatische Suche im Katalog (nach Name, Tags, Kompatibilität)
+- Abfrage verfügbarer Updates für installierte Plugins
+- Abfrage neuer, noch nicht installierter Plugins
+- Kompatibilitätsfilterung: nur Plugins anzeigen, die zur aktuellen Host-Version passen
+
+#### 4.2.3 Download & Installation
+
+- Download von Plugin-Artefakten (ZIP/JAR) mit Checksum-Verifikation
+- Signatur-Verifikation (wenn aktiviert)
+- Automatische Dependency-Resolution: benötigte Plugins werden mitgeladen
+- Installation in das konfigurierte PF4J-Plugins-Verzeichnis
+- Transaktionale Installation: bei Fehler kein halbfertiger Zustand
+
+#### 4.2.4 Update & Rollback
+
+- Automatische oder manuelle Update-Prüfung
+- Update mit Versionswechsel: altes Plugin deaktivieren → neues installieren → starten
+- Rollback: vorherige Version beibehalten und bei Bedarf wiederherstellen
+- Update-Policy konfigurierbar: automatisch, nur benachrichtigen, manuell
+
+#### 4.2.5 Lifecycle-Integration
+
+- Nahtlose Integration mit dem PF4J `PluginManager`
+- Erweiterung des `pf4j-update` `UpdateManager` (Rückwärtskompatibilität)
+- Events/Callbacks: `onInstall`, `onUpdate`, `onUninstall`, `onRollback`
+- Health-Check: Plugin nach Installation auf Lauffähigkeit prüfen
+
+#### 4.2.6 Einbettbares UI (Optional)
+
+- Swing/JavaFX-Komponente oder Webkomponente (für Web-Anwendungen) zur Einbettung eines Plugin-Managers in das Host-Produkt
+- Zeigt verfügbare, installierte und update-fähige Plugins
+- Ermöglicht Installation/Update/Deinstallation durch den Endnutzer
+- Vollständig konfigurierbar und thembar
+
+---
+
+## 5. Plugin Descriptor Format
+
+Über das Standard-PF4J-Manifest hinaus definiert PlugWerk ein erweitertes Descriptor-Format:
+
+```yaml
+# plugwerk.yml – liegt im Plugin-Artefakt
+plugwerk:
+  # Pflichtfelder (erweitern PF4J-Manifest)
+  id: "acme-pdf-export"
+  version: "1.2.0"
+  name: "PDF Export Plugin"
+  description: "Exportiert Berichte als PDF mit konfigurierbaren Templates."
+  author: "ACME GmbH"
+  license: "Apache-2.0"
+
+  # Kompatibilität
+  requires:
+    system-version: ">=2.0.0 & <4.0.0"    # Host-Produkt-Version
+    api-level: 3                            # Optional: API-Level statt konkreter Version
+    plugins:                                # Plugin-zu-Plugin-Dependencies
+      - id: "acme-template-engine"
+        version: ">=1.0.0"
+
+  # Katalog-Metadaten
+  namespace: "acme-crm"
+  categories:
+    - "export"
+    - "reporting"
+  tags:
+    - "pdf"
+    - "report"
+    - "template"
+  icon: "icon.png"                          # Relativ im Artefakt
+  screenshots:
+    - "screenshot-config.png"
+    - "screenshot-output.png"
+  homepage: "https://plugins.acme.com/pdf-export"
+  repository: "https://github.com/acme/pdf-export-plugin"
+
+  # Sicherheit
+  min-java-version: "17"
+  signed: true
+```
+
+Der Descriptor ist abwärtskompatibel: Fehlt die `plugwerk.yml`, extrahiert der Server die Basisinformationen aus dem PF4J-Manifest (`MANIFEST.MF` oder `plugin.properties`). Die erweiterten Felder sind dann leer und können über die Web-UI nachgepflegt werden.
+
+---
+
+## 6. Architektur – Grobe Umsetzungsskizze
+
+### 6.1 Technologie-Stack
+
+| Komponente            | Technologie                                     | Begründung                                                |
+|-----------------------|-------------------------------------------------|-----------------------------------------------------------|
+| **Server Backend**    | Spring Boot 3.x / Java 21+                      | PF4J-Ökosystem ist Java; Spring Boot ist Standard          |
+| **Server API**        | Spring Web (REST) + OpenAPI                      | Branchenstandard, gute Tooling-Unterstützung               |
+| **Server Datenbank**  | PostgreSQL                                       | Robust, JSON-Support, Volltextsuche                        |
+| **Server Storage**    | Filesystem / S3-kompatibel (MinIO)               | Plugin-Artefakte als Binaries; S3 für Skalierung           |
+| **Server Web-UI**     | React / TypeScript oder Vaadin                   | React für SaaS-Variante; Vaadin als Java-only-Alternative  |
+| **Server Auth**       | Spring Security + OIDC/OAuth2                    | Enterprise-tauglich, Keycloak-kompatibel                   |
+| **Client SDK**        | Reines Java (Java 11+ Kompatibilität)            | Minimale Dependencies, maximale Einsetzbarkeit             |
+| **Client HTTP**       | java.net.http.HttpClient oder OkHttp             | Kein Spring-Zwang im Client                                |
+| **Build**             | Gradle (Multi-Module-Projekt)                    | Modernes Build-Tool, gut für Multi-Modul                   |
+
+### 6.2 Systemarchitektur
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      PlugWerk Server                         │
+│                                                             │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │ REST-API │  │  Web-UI  │  │  Auth    │  │  Admin-API  │  │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └─────┬──────┘  │
+│       │              │             │               │         │
+│  ┌────┴──────────────┴─────────────┴───────────────┴──────┐  │
+│  │                   Service Layer                        │  │
+│  │  ┌────────────┐ ┌──────────┐ ┌───────────┐ ┌────────┐ │  │
+│  │  │  Catalog   │ │ Release  │ │ Namespace │ │Security│ │  │
+│  │  │  Service   │ │ Service  │ │  Service  │ │Service │ │  │
+│  │  └──────┬─────┘ └────┬─────┘ └─────┬─────┘ └───┬────┘ │  │
+│  └─────────┼────────────┼─────────────┼────────────┼──────┘  │
+│       ┌────┴────┐  ┌────┴────┐   ┌────┴────┐               │
+│       │Postgres │  │ Storage │   │  Cache  │               │
+│       │  (Meta) │  │(S3/FS)  │   │(Redis)  │               │
+│       └─────────┘  └─────────┘   └─────────┘               │
+└─────────────────────────────────────────────────────────────┘
+          ▲                    ▲
+          │  REST/HTTPS        │  REST/HTTPS
+          │                    │
+┌─────────┴──────┐    ┌───────┴────────────────────┐
+│  Plugin-       │    │  Host-Anwendung            │
+│  Entwickler    │    │  ┌──────────────────────┐   │
+│  (Upload via   │    │  │ PlugWerk Client SDK   │   │
+│   API / CI/CD) │    │  │  ┌────────────────┐  │   │
+│                │    │  │  │ pf4j            │  │   │
+│                │    │  │  │ PluginManager   │  │   │
+│                │    │  │  └────────────────┘  │   │
+│                │    │  └──────────────────────┘   │
+└────────────────┘    └────────────────────────────┘
+```
+
+### 6.3 Datenmodell (Kern-Entitäten)
+
+```
+Namespace
+├── id (UUID)
+├── slug (unique, z.B. "acme-crm")
+├── display_name
+├── description
+├── owner_organization_id
+├── settings (JSON: review_required, auto_approve, etc.)
+└── api_keys[]
+
+Plugin
+├── id (UUID)
+├── plugin_id (PF4J Plugin-Id, unique pro Namespace)
+├── namespace_id (FK)
+├── name
+├── description (Markdown)
+├── author
+├── license
+├── icon_url
+├── homepage_url
+├── repository_url
+├── categories[]
+├── tags[]
+├── created_at
+├── updated_at
+├── download_count (aggregiert)
+└── status (active, suspended, archived)
+
+PluginRelease
+├── id (UUID)
+├── plugin_id (FK)
+├── version (SemVer)
+├── changelog (Markdown)
+├── artifact_path (S3/FS-Referenz)
+├── artifact_size_bytes
+├── artifact_sha256
+├── signature (optional, Base64)
+├── requires_system_version (SemVer-Range)
+├── requires_api_level (int, optional)
+├── requires_java_version
+├── plugin_dependencies (JSON Array)
+├── status (draft, published, deprecated, yanked)
+├── published_at
+├── download_count
+└── reviewed_by (FK, optional)
+
+User / Organization / Role
+├── Standard RBAC-Modell
+└── Zuordnung: User → Organization → Namespace → Role
+```
+
+### 6.4 API-Design (Auszug Kern-Endpunkte)
+
+```
+# Katalog (öffentlich oder API-Key-geschützt)
+GET    /api/v1/namespaces/{ns}/plugins              # Liste mit Filtern
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}    # Details
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases  # Alle Releases
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}/download
+
+# pf4j-update-kompatibel (Drop-in für bestehende Clients)
+GET    /api/v1/namespaces/{ns}/plugins.json          # pf4j-update-Format
+
+# Upload & Management (authentifiziert)
+POST   /api/v1/namespaces/{ns}/plugins               # Neues Plugin anlegen
+POST   /api/v1/namespaces/{ns}/plugins/{pluginId}/releases  # Neuen Release hochladen
+PATCH  /api/v1/namespaces/{ns}/plugins/{pluginId}    # Metadaten aktualisieren
+PATCH  /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}  # Release-Status ändern
+
+# Update-Check (für Client SDK)
+POST   /api/v1/namespaces/{ns}/updates/check         # Body: installierte Plugins + Versionen
+                                                      # Response: verfügbare Updates + neue Plugins
+
+# Admin
+GET    /api/v1/namespaces/{ns}/reviews/pending        # Review-Queue
+POST   /api/v1/namespaces/{ns}/reviews/{releaseId}/approve
+POST   /api/v1/namespaces/{ns}/reviews/{releaseId}/reject
+```
+
+### 6.5 Client SDK – Architektur
+
+```java
+// Kernklassen
+PlugWerkClient                  // HTTP-Client, konfigurierbar
+PlugWerkCatalog                 // Katalog-Abfragen
+PlugWerkInstaller               // Download + Installation + Verifikation
+PlugWerkUpdateChecker           // Update-Prüfung
+
+// PF4J-Integration
+PlugWerkUpdateRepository        // Implementiert pf4j-update UpdateRepository
+                               // → Drop-in-Ersatz für DefaultUpdateRepository
+PlugWerkPluginManager           // Optionaler erweiterter PluginManager
+                               // → Wraps DefaultPluginManager + PlugWerk-Features
+
+// Konfiguration
+PlugWerkConfig                  // Server-URL, API-Key, Namespace, Cache-Dir, etc.
+```
+
+**Designprinzipien des Client SDK:**
+- Keine Spring-Abhängigkeit (reines Java 11+)
+- Minimale externe Dependencies (nur HTTP-Client, JSON-Parser, SLF4J)
+- Rückwärtskompatibel mit `pf4j-update` – bestehende Integrationen können schrittweise migrieren
+- Thread-safe für parallele Downloads
+- Konfiguration via Builder-Pattern oder Properties-File
+
+---
+
+## 7. Umsetzungsplan (Phasen)
+
+### Phase 1 – MVP (geschätzt: 8–12 Wochen)
+
+**Ziel:** Ein funktionsfähiger Marketplace, der den pf4j-update-Workflow ersetzt und erweitert.
+
+**Server:**
+- REST-API für Plugin-Upload, Katalog-Abfrage, Download
+- PostgreSQL-Datenbank mit Kern-Entitäten
+- Filesystem-basierter Artefakt-Storage
+- API-Key-Authentifizierung (einfach)
+- Minimales Web-UI: Plugin-Liste, Plugin-Detail, Upload-Formular
+- `plugins.json`-Endpunkt (pf4j-update-kompatibel)
+- Docker-basiertes Deployment
+
+**Client SDK:**
+- `PlugWerkUpdateRepository` als Drop-in für `pf4j-update`
+- Katalog-Abfrage, Download mit SHA-256-Verifikation
+- Update-Check
+- Properties-basierte Konfiguration
+
+**Descriptor:**
+- `plugwerk.yml` mit Pflichtfeldern
+- Fallback auf PF4J-Manifest
+
+### Phase 2 – Enterprise Features (geschätzt: 6–10 Wochen)
+
+- Multi-Namespace-Support
+- RBAC mit OIDC/OAuth2 (Keycloak-Integration)
+- Review-/Approval-Workflow
+- Code-Signing und Signatur-Verifikation
+- Erweitertes Web-UI: Dashboard, Statistiken, Admin-Bereich
+- S3-kompatibler Storage (MinIO)
+- Dependency-Resolution im Client
+
+### Phase 3 – Ökosystem & Skalierung (fortlaufend)
+
+- Einbettbare UI-Komponente (Web Component / Vaadin)
+- Plugin-Bewertungen und Kommentare
+- Webhook-Integration (Benachrichtigungen bei neuen Releases)
+- Vulnerability-Scanning der Artefakte
+- Gradle/Maven-Plugin für CI/CD-Upload
+- SaaS-Hosting-Option (Multi-Tenant mit Billing)
+- CLI-Tool für Plugin-Entwickler
+- Plugin-Sandbox/Testumgebung
+
+---
+
+## 8. Betriebsmodell
+
+### 8.1 Deployment-Varianten
+
+#### Variante A: Self-Hosted (Open Core)
+
+Der Kunde betreibt den PlugWerk-Server in seiner eigenen Infrastruktur.
+
+- **Deployment:** Docker Compose (Einzelserver) oder Kubernetes (Helm Chart)
+- **Minimale Infrastruktur:** 1 Server mit Docker, PostgreSQL, ~50 GB Storage
+- **Skalierung:** Horizontal über Kubernetes (stateless App-Server, shared DB + S3)
+- **Zielgruppe:** Unternehmen mit eigenen Rechenzentren, Datenschutzanforderungen, On-Premise-Pflicht
+
+```
+Docker Compose (Minimal):
+├── plugwerk-server  (Spring Boot App)
+├── postgres        (Datenbank)
+├── minio           (optional, S3-Storage)
+└── nginx           (Reverse Proxy, TLS)
+```
+
+#### Variante B: SaaS / Managed Service
+
+devtank42 betreibt den PlugWerk-Server als Managed Service.
+
+- **Deployment:** Multi-Tenant auf Kubernetes
+- **Isolation:** Namespace-basiert (logische Trennung) oder dedizierte Instanzen (Enterprise-Tier)
+- **Zielgruppe:** Startups, SaaS-Produkte, Teams ohne eigene Infrastruktur
+
+### 8.2 Lizenzmodell
+
+| Tier | Umfang | Preis |
+|------|--------|-------|
+| **Community** | Open Source (Apache 2.0), Self-Hosted, 1 Namespace, unbegrenzte Plugins, Community-Support | Kostenlos |
+| **Professional** | Self-Hosted, Multi-Namespace, RBAC, Review-Workflow, Code-Signing, E-Mail-Support | Subscription (pro Server) |
+| **Enterprise** | Self-Hosted oder Managed, Vulnerability-Scanning, SSO/OIDC, SLA, Dedicated Support | Subscription (nach Vereinbarung) |
+| **SaaS** | Managed Service, Pay-per-Namespace oder Flatrate, alles inklusive | Monatlich (pro Namespace + Download-Volumen) |
+
+**Open-Core-Strategie:** Der Kern (API, Katalog, Client SDK, Basis-UI) ist Open Source. Enterprise-Features (RBAC, Signing, Scanning, Multi-Tenancy) sind proprietäre Add-ons.
+
+### 8.3 Support & Maintenance
+
+- **Community:** GitHub Issues, Discussions, Community-Forum
+- **Professional:** E-Mail-Support, garantierte Reaktionszeit (48h)
+- **Enterprise:** Dedicated Support, SLA (4h Response), Onboarding, Custom Development
+- **Updates:** Regelmäßige Releases (monatlich Patch, quartalsweise Minor), LTS-Versionen (jährlich)
+
+### 8.4 Monitoring & Betrieb
+
+- Health-Endpoints (`/actuator/health`) für Kubernetes Probes
+- Prometheus-Metriken: API-Latenz, Download-Throughput, Storage-Auslastung, Active Namespaces
+- Structured Logging (JSON) für ELK/Grafana Loki
+- Backup-Strategie: PostgreSQL-Dumps + S3-Bucket-Replikation
+- Disaster Recovery: RTO < 4h, RPO < 1h (Enterprise-Tier)
+
+---
+
+## 9. Wettbewerbsanalyse
+
+| Lösung | Vergleich zu PlugWerk | Stärke | Schwäche für unseren Use Case |
+|--------|---------------------|--------|------------------------------|
+| **pf4j-update** | Direkter Vorläufer; PlugWerk erweitert diesen Ansatz | Leichtgewichtig, pf4j-nativ | Kein Server, kein Katalog, stagniert |
+| **Eclipse p2** | Ähnliches Konzept (Update-Sites + Client) | Bewährt, mächtig | An OSGi/Eclipse gebunden, extrem komplex |
+| **JetBrains Marketplace** | Referenzmodell für UX | Exzellente UX, Kompatibilitätsmatrix | Proprietär, nur für JetBrains-IDEs |
+| **Atlassian Marketplace** | Referenz für kommerzielles Modell | Monetarisierung, Reviews, Vendor-Mgmt | Proprietär, nur für Atlassian-Produkte |
+| **Gradle Plugin Portal** | Ähnlich für Build-Plugins | Discovery, Versionierung | Nur Gradle-Plugins, nicht Runtime |
+| **Maven Central / Nexus** | Artefakt-Hosting | Universell, bewährt | Kein Plugin-Lifecycle, keine Kompatibilitätsmatrix |
+| **OSGi (Felix, Karaf)** | Technisch verwandt | Hot-Deploy, Isolation, Dependency-Mgmt | Komplexer Stack, kein Marketplace-Aspekt |
+
+**Positionierung:** PlugWerk ist der **einzige generische, produktunabhängige Plugin-Marketplace für das PF4J-Ökosystem**. Es kombiniert die Einfachheit von pf4j-update mit der Funktionalität eines vollwertigen Marketplaces.
+
+---
+
+## 10. Risiken & Mitigationsstrategien
+
+| Risiko | Eintrittswahrscheinlichkeit | Auswirkung | Mitigation |
+|--------|-----------------------------|------------|------------|
+| PF4J-Entwicklung stagniert oder wird eingestellt | Mittel | Hoch | PlugWerk abstrahiert die PF4J-Abhängigkeit im Client SDK; bei Bedarf kann ein eigener PluginManager implementiert werden. Zudem: PF4J ist Apache-lizenziert und kann geforkt werden. |
+| Geringe Adoption mangels Bekanntheit | Hoch | Hoch | Open-Source-Core für Reichweite, Integration in pf4j-Ökosystem anstreben (offizielles pf4j-Projekt?), Talks/Blog-Posts in der Java-Community |
+| Sicherheitslücken in gehosteten Plugins | Mittel | Hoch | Vulnerability-Scanning, Review-Prozess, Code-Signing; Haftungsausschluss im Nutzungsvertrag |
+| Komplexität des Kompatibilitätsmodells | Mittel | Mittel | MVP startet mit einfacher SemVer-Range; API-Level-Konzept erst in Phase 2 |
+| Konkurrenz durch PF4J-eigene Lösung | Niedrig | Hoch | Frühzeitig Kontakt zum PF4J-Maintainer (Decebal Suiu) suchen; idealerweise PlugWerk als offizielles Ökosystem-Projekt positionieren |
+
+---
+
+## 11. Projektname & Branding
+
+**Name: PlugWerk**
+
+Der Name verbindet „Plug" (Plugin) mit dem deutschen Wort „Werk" (Fabrik/Opus) und spiegelt sowohl den deutschen Ursprung des Produkts als auch das Konzept eines Fertigungszentrums für Plugins wider. Er ist international aussprechbar und transportiert Assoziationen von Handwerkskunst und Zuverlässigkeit.
+
+Aufgaben vor dem Launch:
+- Domainverfügbarkeit prüfen und registrieren
+- Markenrechtliche Prüfung
+- Logo- und Visual-Identity-Design
+- Landingpage
+
+---
+
+## 12. Nächste Schritte
+
+1. **Feedback zu diesem Konzept** – Abstimmung zu Scope, Priorisierung, Namensgebung
+2. **Technischer PoC** – MVP-Server mit REST-API + Client SDK als Drop-in für pf4j-update (2–3 Wochen)
+3. **Repository-Setup** – Gradle Multi-Module-Projekt, CI/CD-Pipeline, Contribution-Guidelines
+4. **Community-Validierung** – Konzept im PF4J GitHub Discussions vorstellen, Feedback der Community einholen
+5. **Domain & Branding** – Name finalisieren, Domain sichern, minimale Landingpage
+
+---
+
+*Dieses Dokument ist ein lebendiger Entwurf. Änderungen und Ergänzungen werden versioniert nachgeführt.*

--- a/docs/concepts/concept-pf4j-marketplace-en.md
+++ b/docs/concepts/concept-pf4j-marketplace-en.md
@@ -1,0 +1,561 @@
+# PlugWerk – Plugin Marketplace for the Java Ecosystem
+
+**Concept Paper | Product Vision, Features, Implementation Outline & Operating Model**
+
+Date: March 19, 2026 | Version 0.1 – Draft
+
+---
+
+## 1. Executive Summary
+
+Java applications built on PF4J (Plugin Framework for Java) lack a centralized infrastructure for distributing, managing, and updating plugins. Every team that integrates PF4J ends up building its own deployment pipelines, update mechanisms, and plugin registries. This pattern repeats across projects and organizations.
+
+**PlugWerk** closes this gap as a standalone product. It consists of two artifacts:
+
+1. **PlugWerk Server** – a web application that serves as a central plugin marketplace: catalog, upload, versioning, download, and REST API.
+2. **PlugWerk Client SDK** – a Java library that can be embedded into any Java application to connect to the marketplace: plugin discovery, download, installation, update checking, and lifecycle integration with PF4J.
+
+The product is intentionally **product-agnostic**. Any Java software product that uses or wants to use PF4J can adopt PlugWerk as its plugin infrastructure – comparable to the relationship between Maven Central and Maven, but specialized for runtime plugins rather than build dependencies.
+
+---
+
+## 2. Problem Analysis
+
+### 2.1 Status Quo in the PF4J Ecosystem
+
+PF4J is a proven, lightweight plugin framework (~100 KB, Apache License), used by Netflix Spinnaker and Appsmith among others. The ecosystem includes:
+
+| Module        | Function                                     | Status             |
+|---------------|----------------------------------------------|--------------------|
+| pf4j          | Core: plugin loading, classloader isolation   | Active, v3.12+     |
+| pf4j-spring   | Spring Framework integration                  | Active             |
+| pf4j-update   | Update mechanism (JSON-based)                 | Stagnant (2020)    |
+| pf4j-plus     | ServiceRegistry, EventBus, Config             | New (Jan 2026)     |
+| pf4j-jpms     | Java Module System PoC                        | Experimental       |
+
+**The gap:** None of these modules provides a complete marketplace solution. `pf4j-update` comes closest – it defines a `plugins.json` format and an `UpdateManager` – but it is:
+
+- a pure client with no server component
+- limited to static JSON hosting (no upload, no catalog, no search)
+- barely maintained since 2020
+- lacking security features (no signing, no review process)
+
+### 2.2 Recurring Problems Across Teams
+
+- **No standard for plugin distribution:** Every product builds its own FTP/S3/Nexus-based solutions.
+- **No discovery:** Users don't know what plugins exist without reading documentation.
+- **No lifecycle management:** Updates, rollbacks, and compatibility checks are handled manually.
+- **No trust model:** There is no mechanism to verify the integrity of downloaded plugins.
+
+---
+
+## 3. Product Vision
+
+> **PlugWerk makes plugin management for Java applications as easy as dependency management with Maven – but at runtime.**
+
+### 3.1 Target State
+
+A Java software product integrates the PlugWerk Client SDK (a Maven dependency). From that moment, its end users or administrators can:
+
+- browse a plugin catalog (either through an embedded UI or programmatically)
+- install, update, or uninstall plugins with a single click
+- be assured that only compatible and verified plugins are offered
+
+Plugin developers (internal or external) can:
+
+- upload their plugins through a web interface or CI/CD pipeline
+- maintain metadata (description, screenshots, changelog, compatibility matrix)
+- manage releases and withdraw older versions
+
+Product operators can:
+
+- run their own PlugWerk server (self-hosted) or use a hosted service (SaaS)
+- create namespaces/channels for their products
+- control approval workflows and permissions
+
+### 3.2 Scope Boundaries
+
+PlugWerk is **not**:
+
+- a build tool or dependency manager (not a Maven/Gradle replacement)
+- a plugin framework (not a PF4J replacement, but an extension of it)
+- an application server or runtime container (not an OSGi replacement)
+
+PlugWerk is **the missing link** between the plugin framework (PF4J) and a product's plugin ecosystem.
+
+---
+
+## 4. Feature Catalog
+
+### 4.1 PlugWerk Server
+
+#### 4.1.1 Plugin Catalog & Discovery
+
+- Searchable directory of all plugins with full-text search
+- Filtering by: product/namespace, category/tags, compatibility version, rating, recency
+- Detail page per plugin: description, screenshots, changelog, license, author, download count, compatibility matrix
+- Catalog available as Web UI and REST API
+
+#### 4.1.2 Plugin Upload & Release Management
+
+- Upload via Web UI or REST API (CI/CD-ready)
+- Automatic extraction of plugin metadata from the PF4J manifest (Plugin-Id, Plugin-Version, Plugin-Provider, Plugin-Dependencies)
+- Extended manifest format (PlugWerk Descriptor): additional fields such as compatibility range, description, category, license, icon
+- Multi-version support: multiple releases per plugin, with status (Draft, Published, Deprecated, Yanked)
+- Per-release changelog management
+
+#### 4.1.3 Versioning & Compatibility
+
+- SemVer-based versioning (consistent with pf4j-update)
+- Compatibility matrix: plugins declare which host product versions they support (`requires: >=2.0.0 & <3.0.0`)
+- Dependency resolution: plugin-to-plugin dependencies are resolved during download/install
+- API level concept (optional): host products can declare an API level; plugins reference this instead of concrete product versions
+
+#### 4.1.4 Security & Trust
+
+- **Code signing:** Plugins can be signed with a private key; the client verifies the signature before installation
+- **Checksum verification:** SHA-256 hashes for all artifacts, automatic verification in the client
+- **Review workflow:** Optionally enabled approval process – plugins must be approved by an admin/reviewer before appearing in the catalog
+- **Vulnerability scanning:** Integration with tools like OWASP Dependency-Check or Trivy for analyzing plugin dependencies
+- **RBAC (Role-Based Access Control):** Roles such as Admin, Reviewer, Publisher, Consumer with granular permissions
+
+#### 4.1.5 Multi-Tenancy & Namespaces
+
+- **Namespace concept:** Each host product receives its own namespace (e.g., `acme-crm`, `logistics-suite`)
+- Plugins are assigned to one or more namespaces
+- Namespace-specific settings: compatibility requirements, approval workflow, branding
+- Multi-tenancy: a single PlugWerk server can serve multiple products/organizations
+- API keys per namespace for authenticated access
+
+#### 4.1.6 REST API
+
+- RESTful API as the primary interface (Web UI uses the same API)
+- Endpoints for: catalog queries, plugin details, download, upload, release management, namespace management, user/role management
+- Authentication: API key and/or OAuth2/OIDC
+- Rate limiting and quota management
+- OpenAPI/Swagger documentation
+
+#### 4.1.7 Web UI
+
+- Modern, responsive web frontend
+- Plugin catalog with card and list views
+- Plugin detail page with installation instructions
+- Admin area: upload, release management, review queue, namespace management, user management
+- Dashboard: download statistics, active plugins, version distribution
+
+### 4.2 PlugWerk Client SDK
+
+#### 4.2.1 Marketplace Connectivity
+
+- REST client for communication with the PlugWerk Server
+- Configurable server URL(s) – including multiple repositories simultaneously (analogous to Maven Central + private repos)
+- Authentication via API key or token
+- Offline-capable: cached catalog, works even when server is temporarily unreachable
+
+#### 4.2.2 Plugin Discovery
+
+- Programmatic catalog search (by name, tags, compatibility)
+- Query available updates for installed plugins
+- Query new, not yet installed plugins
+- Compatibility filtering: only display plugins matching the current host version
+
+#### 4.2.3 Download & Installation
+
+- Download of plugin artifacts (ZIP/JAR) with checksum verification
+- Signature verification (if enabled)
+- Automatic dependency resolution: required plugins are downloaded together
+- Installation into the configured PF4J plugins directory
+- Transactional installation: no half-finished state on failure
+
+#### 4.2.4 Update & Rollback
+
+- Automatic or manual update checking
+- Update with version switch: deactivate old plugin → install new → start
+- Rollback: retain previous version and restore on demand
+- Configurable update policy: automatic, notify-only, manual
+
+#### 4.2.5 Lifecycle Integration
+
+- Seamless integration with the PF4J `PluginManager`
+- Extension of the `pf4j-update` `UpdateManager` (backward compatible)
+- Events/callbacks: `onInstall`, `onUpdate`, `onUninstall`, `onRollback`
+- Health check: verify plugin functionality after installation
+
+#### 4.2.6 Embeddable UI (Optional)
+
+- Swing/JavaFX component or web component (for web applications) for embedding a plugin manager in the host product
+- Shows available, installed, and updatable plugins
+- Enables installation/update/uninstallation by end users
+- Fully configurable and themeable
+
+---
+
+## 5. Plugin Descriptor Format
+
+Beyond the standard PF4J manifest, PlugWerk defines an extended descriptor format:
+
+```yaml
+# plugwerk.yml – included in the plugin artifact
+plugwerk:
+  # Required fields (extending PF4J manifest)
+  id: "acme-pdf-export"
+  version: "1.2.0"
+  name: "PDF Export Plugin"
+  description: "Exports reports as PDF with configurable templates."
+  author: "ACME GmbH"
+  license: "Apache-2.0"
+
+  # Compatibility
+  requires:
+    system-version: ">=2.0.0 & <4.0.0"    # Host product version
+    api-level: 3                            # Optional: API level instead of concrete version
+    plugins:                                # Plugin-to-plugin dependencies
+      - id: "acme-template-engine"
+        version: ">=1.0.0"
+
+  # Catalog metadata
+  namespace: "acme-crm"
+  categories:
+    - "export"
+    - "reporting"
+  tags:
+    - "pdf"
+    - "report"
+    - "template"
+  icon: "icon.png"                          # Relative path within artifact
+  screenshots:
+    - "screenshot-config.png"
+    - "screenshot-output.png"
+  homepage: "https://plugins.acme.com/pdf-export"
+  repository: "https://github.com/acme/pdf-export-plugin"
+
+  # Security
+  min-java-version: "17"
+  signed: true
+```
+
+The descriptor is backward compatible: if `plugwerk.yml` is missing, the server extracts base information from the PF4J manifest (`MANIFEST.MF` or `plugin.properties`). Extended fields remain empty and can be maintained via the Web UI.
+
+---
+
+## 6. Architecture – Implementation Outline
+
+### 6.1 Technology Stack
+
+| Component             | Technology                                      | Rationale                                                  |
+|-----------------------|-------------------------------------------------|------------------------------------------------------------|
+| **Server Backend**    | Spring Boot 3.x / Java 21+                      | PF4J ecosystem is Java; Spring Boot is the industry standard|
+| **Server API**        | Spring Web (REST) + OpenAPI                      | Industry standard, excellent tooling support                |
+| **Server Database**   | PostgreSQL                                       | Robust, JSON support, full-text search                     |
+| **Server Storage**    | Filesystem / S3-compatible (MinIO)               | Plugin artifacts as binaries; S3 for scalability           |
+| **Server Web UI**     | React / TypeScript or Vaadin                     | React for SaaS variant; Vaadin as Java-only alternative    |
+| **Server Auth**       | Spring Security + OIDC/OAuth2                    | Enterprise-ready, Keycloak-compatible                      |
+| **Client SDK**        | Pure Java (Java 11+ compatibility)               | Minimal dependencies, maximum portability                  |
+| **Client HTTP**       | java.net.http.HttpClient or OkHttp               | No Spring dependency required in the client                |
+| **Build**             | Gradle (multi-module project)                    | Modern build tool, well-suited for multi-module            |
+
+### 6.2 System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      PlugWerk Server                        │
+│                                                             │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │ REST API │  │  Web UI  │  │   Auth   │  │ Admin API  │  │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └─────┬──────┘  │
+│       │              │             │               │         │
+│  ┌────┴──────────────┴─────────────┴───────────────┴──────┐  │
+│  │                   Service Layer                        │  │
+│  │  ┌────────────┐ ┌──────────┐ ┌───────────┐ ┌────────┐ │  │
+│  │  │  Catalog   │ │ Release  │ │ Namespace │ │Security│ │  │
+│  │  │  Service   │ │ Service  │ │  Service  │ │Service │ │  │
+│  │  └──────┬─────┘ └────┬─────┘ └─────┬─────┘ └───┬────┘ │  │
+│  └─────────┼────────────┼─────────────┼────────────┼──────┘  │
+│       ┌────┴────┐  ┌────┴────┐   ┌────┴────┐               │
+│       │Postgres │  │ Storage │   │  Cache  │               │
+│       │ (Meta)  │  │(S3/FS)  │   │(Redis)  │               │
+│       └─────────┘  └─────────┘   └─────────┘               │
+└─────────────────────────────────────────────────────────────┘
+          ▲                    ▲
+          │  REST/HTTPS        │  REST/HTTPS
+          │                    │
+┌─────────┴──────┐    ┌───────┴────────────────────┐
+│  Plugin        │    │  Host Application          │
+│  Developer     │    │  ┌──────────────────────┐   │
+│  (Upload via   │    │  │ PlugWerk Client SDK  │   │
+│   API / CI/CD) │    │  │  ┌────────────────┐  │   │
+│                │    │  │  │ pf4j            │  │   │
+│                │    │  │  │ PluginManager   │  │   │
+│                │    │  │  └────────────────┘  │   │
+│                │    │  └──────────────────────┘   │
+└────────────────┘    └────────────────────────────┘
+```
+
+### 6.3 Data Model (Core Entities)
+
+```
+Namespace
+├── id (UUID)
+├── slug (unique, e.g. "acme-crm")
+├── display_name
+├── description
+├── owner_organization_id
+├── settings (JSON: review_required, auto_approve, etc.)
+└── api_keys[]
+
+Plugin
+├── id (UUID)
+├── plugin_id (PF4J Plugin-Id, unique per namespace)
+├── namespace_id (FK)
+├── name
+├── description (Markdown)
+├── author
+├── license
+├── icon_url
+├── homepage_url
+├── repository_url
+├── categories[]
+├── tags[]
+├── created_at
+├── updated_at
+├── download_count (aggregated)
+└── status (active, suspended, archived)
+
+PluginRelease
+├── id (UUID)
+├── plugin_id (FK)
+├── version (SemVer)
+├── changelog (Markdown)
+├── artifact_path (S3/FS reference)
+├── artifact_size_bytes
+├── artifact_sha256
+├── signature (optional, Base64)
+├── requires_system_version (SemVer range)
+├── requires_api_level (int, optional)
+├── requires_java_version
+├── plugin_dependencies (JSON array)
+├── status (draft, published, deprecated, yanked)
+├── published_at
+├── download_count
+└── reviewed_by (FK, optional)
+
+User / Organization / Role
+├── Standard RBAC model
+└── Mapping: User → Organization → Namespace → Role
+```
+
+### 6.4 API Design (Core Endpoints Excerpt)
+
+```
+# Catalog (public or API-key-protected)
+GET    /api/v1/namespaces/{ns}/plugins              # List with filters
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}    # Details
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases  # All releases
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}
+GET    /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}/download
+
+# pf4j-update compatible (drop-in for existing clients)
+GET    /api/v1/namespaces/{ns}/plugins.json          # pf4j-update format
+
+# Upload & Management (authenticated)
+POST   /api/v1/namespaces/{ns}/plugins               # Create new plugin
+POST   /api/v1/namespaces/{ns}/plugins/{pluginId}/releases  # Upload new release
+PATCH  /api/v1/namespaces/{ns}/plugins/{pluginId}    # Update metadata
+PATCH  /api/v1/namespaces/{ns}/plugins/{pluginId}/releases/{version}  # Change release status
+
+# Update check (for Client SDK)
+POST   /api/v1/namespaces/{ns}/updates/check         # Body: installed plugins + versions
+                                                      # Response: available updates + new plugins
+
+# Admin
+GET    /api/v1/namespaces/{ns}/reviews/pending        # Review queue
+POST   /api/v1/namespaces/{ns}/reviews/{releaseId}/approve
+POST   /api/v1/namespaces/{ns}/reviews/{releaseId}/reject
+```
+
+### 6.5 Client SDK – Architecture
+
+```java
+// Core classes
+PlugWerkClient                  // HTTP client, configurable
+PlugWerkCatalog                 // Catalog queries
+PlugWerkInstaller               // Download + installation + verification
+PlugWerkUpdateChecker           // Update checking
+
+// PF4J integration
+PlugWerkUpdateRepository        // Implements pf4j-update UpdateRepository
+                                // → Drop-in replacement for DefaultUpdateRepository
+PlugWerkPluginManager           // Optional extended PluginManager
+                                // → Wraps DefaultPluginManager + PlugWerk features
+
+// Configuration
+PlugWerkConfig                  // Server URL, API key, namespace, cache dir, etc.
+```
+
+**Client SDK design principles:**
+- No Spring dependency (pure Java 11+)
+- Minimal external dependencies (only HTTP client, JSON parser, SLF4J)
+- Backward compatible with `pf4j-update` – existing integrations can migrate incrementally
+- Thread-safe for parallel downloads
+- Configuration via builder pattern or properties file
+
+---
+
+## 7. Implementation Plan (Phases)
+
+### Phase 1 – MVP (estimated: 8–12 weeks)
+
+**Goal:** A functional marketplace that replaces and extends the pf4j-update workflow.
+
+**Server:**
+- REST API for plugin upload, catalog queries, download
+- PostgreSQL database with core entities
+- Filesystem-based artifact storage
+- API key authentication (simple)
+- Minimal Web UI: plugin list, plugin detail, upload form
+- `plugins.json` endpoint (pf4j-update compatible)
+- Docker-based deployment
+
+**Client SDK:**
+- `PlugWerkUpdateRepository` as drop-in for `pf4j-update`
+- Catalog queries, download with SHA-256 verification
+- Update checking
+- Properties-based configuration
+
+**Descriptor:**
+- `plugwerk.yml` with required fields
+- Fallback to PF4J manifest
+
+### Phase 2 – Enterprise Features (estimated: 6–10 weeks)
+
+- Multi-namespace support
+- RBAC with OIDC/OAuth2 (Keycloak integration)
+- Review/approval workflow
+- Code signing and signature verification
+- Extended Web UI: dashboard, statistics, admin area
+- S3-compatible storage (MinIO)
+- Dependency resolution in the client
+
+### Phase 3 – Ecosystem & Scaling (ongoing)
+
+- Embeddable UI component (Web Component / Vaadin)
+- Plugin ratings and comments
+- Webhook integration (notifications on new releases)
+- Vulnerability scanning of artifacts
+- Gradle/Maven plugin for CI/CD uploads
+- SaaS hosting option (multi-tenant with billing)
+- CLI tool for plugin developers
+- Plugin sandbox/test environment
+
+---
+
+## 8. Operating Model
+
+### 8.1 Deployment Variants
+
+#### Variant A: Self-Hosted (Open Core)
+
+The customer operates the PlugWerk server in their own infrastructure.
+
+- **Deployment:** Docker Compose (single server) or Kubernetes (Helm chart)
+- **Minimum infrastructure:** 1 server with Docker, PostgreSQL, ~50 GB storage
+- **Scaling:** Horizontal via Kubernetes (stateless app servers, shared DB + S3)
+- **Target audience:** Companies with their own data centers, data privacy requirements, on-premise mandates
+
+```
+Docker Compose (Minimal):
+├── plugwerk-server  (Spring Boot app)
+├── postgres         (database)
+├── minio            (optional, S3 storage)
+└── nginx            (reverse proxy, TLS)
+```
+
+#### Variant B: SaaS / Managed Service
+
+devtank42 operates the PlugWerk server as a managed service.
+
+- **Deployment:** Multi-tenant on Kubernetes
+- **Isolation:** Namespace-based (logical separation) or dedicated instances (enterprise tier)
+- **Target audience:** Startups, SaaS products, teams without their own infrastructure
+
+### 8.2 Licensing Model
+
+| Tier | Scope | Price |
+|------|-------|-------|
+| **Community** | Open Source (Apache 2.0), self-hosted, 1 namespace, unlimited plugins, community support | Free |
+| **Professional** | Self-hosted, multi-namespace, RBAC, review workflow, code signing, email support | Subscription (per server) |
+| **Enterprise** | Self-hosted or managed, vulnerability scanning, SSO/OIDC, SLA, dedicated support | Subscription (by arrangement) |
+| **SaaS** | Managed service, pay-per-namespace or flat rate, all features included | Monthly (per namespace + download volume) |
+
+**Open core strategy:** The core (API, catalog, Client SDK, base UI) is open source. Enterprise features (RBAC, signing, scanning, multi-tenancy) are proprietary add-ons.
+
+### 8.3 Support & Maintenance
+
+- **Community:** GitHub Issues, Discussions, community forum
+- **Professional:** Email support, guaranteed response time (48h)
+- **Enterprise:** Dedicated support, SLA (4h response), onboarding, custom development
+- **Updates:** Regular releases (monthly patch, quarterly minor), LTS versions (annually)
+
+### 8.4 Monitoring & Operations
+
+- Health endpoints (`/actuator/health`) for Kubernetes probes
+- Prometheus metrics: API latency, download throughput, storage utilization, active namespaces
+- Structured logging (JSON) for ELK/Grafana Loki
+- Backup strategy: PostgreSQL dumps + S3 bucket replication
+- Disaster recovery: RTO < 4h, RPO < 1h (enterprise tier)
+
+---
+
+## 9. Competitive Analysis
+
+| Solution | Comparison to PlugWerk | Strength | Weakness for Our Use Case |
+|----------|----------------------|----------|--------------------------|
+| **pf4j-update** | Direct predecessor; PlugWerk extends this approach | Lightweight, pf4j-native | No server, no catalog, stagnant |
+| **Eclipse p2** | Similar concept (update sites + client) | Proven, powerful | Tied to OSGi/Eclipse, extremely complex |
+| **JetBrains Marketplace** | Reference model for UX | Excellent UX, compatibility matrix | Proprietary, JetBrains IDEs only |
+| **Atlassian Marketplace** | Reference for commercial model | Monetization, reviews, vendor mgmt | Proprietary, Atlassian products only |
+| **Gradle Plugin Portal** | Similar for build plugins | Discovery, versioning | Gradle plugins only, not runtime |
+| **Maven Central / Nexus** | Artifact hosting | Universal, proven | No plugin lifecycle, no compatibility matrix |
+| **OSGi (Felix, Karaf)** | Technically related | Hot-deploy, isolation, dependency mgmt | Complex stack, no marketplace aspect |
+
+**Positioning:** PlugWerk is the **only generic, product-agnostic plugin marketplace for the PF4J ecosystem**. It combines the simplicity of pf4j-update with the functionality of a full-featured marketplace.
+
+---
+
+## 10. Risks & Mitigation Strategies
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| PF4J development stagnates or is discontinued | Medium | High | PlugWerk abstracts the PF4J dependency in the Client SDK; a custom PluginManager can be implemented if needed. Additionally, PF4J is Apache-licensed and can be forked. |
+| Low adoption due to lack of visibility | High | High | Open source core for reach, seek integration into the pf4j ecosystem (official pf4j project?), talks/blog posts in the Java community |
+| Security vulnerabilities in hosted plugins | Medium | High | Vulnerability scanning, review process, code signing; liability disclaimer in terms of service |
+| Complexity of the compatibility model | Medium | Medium | MVP starts with simple SemVer range; API level concept deferred to Phase 2 |
+| Competition from a PF4J-native solution | Low | High | Establish early contact with PF4J maintainer (Decebal Suiu); ideally position PlugWerk as an official ecosystem project |
+
+---
+
+## 11. Project Name & Branding
+
+**Name: PlugWerk**
+
+The name combines "Plug" (plugin) with the German word "Werk" (works/factory/opus), reflecting both the product's German origin and the concept of a manufacturing hub for plugins. It is internationally pronounceable and carries connotations of craftsmanship and reliability.
+
+Tasks before launch:
+- Domain availability check and registration
+- Trademark clearance
+- Logo and visual identity design
+- Landing page
+
+---
+
+## 12. Next Steps
+
+1. **Feedback on this concept** – alignment on scope, prioritization, naming
+2. **Technical PoC** – MVP server with REST API + Client SDK as drop-in for pf4j-update (2–3 weeks)
+3. **Repository setup** – Gradle multi-module project, CI/CD pipeline, contribution guidelines
+4. **Community validation** – present concept in PF4J GitHub Discussions, gather community feedback
+5. **Domain & branding** – finalize domain, secure it, create minimal landing page
+
+---
+
+*This document is a living draft. Changes and additions will be tracked by version.*


### PR DESCRIPTION
## Summary

- Add governance files: Apache 2.0 LICENSE, CLA, CONTRIBUTING.md
- Add GitHub templates: issue templates (bug report, feature request), PR template with AI disclosure
- Add CLA bot workflow for contributor license agreement enforcement
- Add AI agent instruction files: `AGENTS.md` (universal), `CLAUDE.md` (Claude-specific), `.github/copilot-instructions.md`
- Add product concept documents (EN + DE) under `docs/concepts/`
- Add ADR template and ADR-0001 (collaboration workflow) under `docs/adrs/`
- Add `.gitignore` for Java/Gradle/Node/Docker stack
- Update `README.md` with project overview, architecture summary, documentation links, and contributing guidelines

## Related Issues

Closes #1

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring
- [x] CI/Build

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent (specify: _______)
- [x] This PR was co-authored by human + AI agent (Claude Code / Opus 4.6)