### PR TITLE
fix: replace old project name OPAA with PlugWerk

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,18 +23,18 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: signatures/cla.json
-          path-to-document: https://github.com/criew/opaa/blob/main/CLA.md
+          path-to-document: https://github.com/devtank42gmbh/plugwerk/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: criew,*[bot]
+          allowlist: devtank42gmbh,*[bot]
           create-file-commit-message: "chore: initialize CLA signatures file"
           signed-commit-message: "chore: add $contributorName to CLA signatories"
           custom-notsigned-prcomment: |
             Thank you for your contribution! :tada:
 
             Before we can merge this PR, you need to sign the **Contributor License Agreement (CLA)**.
-            This is required to allow OPAA to offer commercial licensing alongside its open-source license.
+            This is required to allow PlugWerk to offer commercial licensing alongside its open-source license.
 
-            Please read [CLA.md](https://github.com/criew/opaa/blob/main/CLA.md) — it is short and written in plain language.
+            Please read [CLA.md](https://github.com/devtank42gmbh/plugwerk/blob/main/CLA.md) — it is short and written in plain language.
 
             Then post the following comment **in this PR**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to OPAA
+# Contributing to PlugWerk
 
-Thank you for your interest in contributing to OPAA! This project welcomes contributions from both humans and AI coding agents.
+Thank you for your interest in contributing to PlugWerk! This project welcomes contributions from both humans and AI coding agents.
 
 ## Contributor License Agreement (CLA)
 
 **Before your first Pull Request can be merged, you must sign the CLA.**
 
-OPAA uses a dual-licensing model: the core is open source, and commercial licenses are offered for organizations that cannot comply with the open-source license. The CLA grants the project the right to sublicense your contributions under both open-source and commercial terms — this is what makes dual licensing legally possible.
+PlugWerk uses a dual-licensing model: the core is open source, and commercial licenses are offered for organizations that cannot comply with the open-source license. The CLA grants the project the right to sublicense your contributions under both open-source and commercial terms — this is what makes dual licensing legally possible.
 
 **How to sign:** Read [CLA.md](./CLA.md) (it's short), then post this comment on your first PR:
 


### PR DESCRIPTION
## Summary

- Replace all occurrences of old project name "OPAA" with "PlugWerk" in `CONTRIBUTING.md`
- Update CLA workflow URLs from `criew/opaa` to `devtank42gmbh/plugwerk`
- Update CLA allowlist from `criew` to `devtank42gmbh`

## Related Issues

Closes #5

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [x] CI/Build

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent (specify: _______)
- [x] This PR was co-authored by human + AI agent (Claude Code / Opus 4.6)