### PR TITLE
feat: support ZIP bundles in DescriptorResolver (#26)

### DIFF
--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorResolver.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorResolver.kt
@@ -20,6 +20,7 @@ package io.plugwerk.descriptor
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import java.util.zip.ZipInputStream
 
 class DescriptorResolver(
     private val plugwerkParser: PlugwerkDescriptorParser = PlugwerkDescriptorParser(),
@@ -31,9 +32,39 @@ class DescriptorResolver(
 
         return tryParse { plugwerkParser.parseFromJar(ByteArrayInputStream(bytes)) }
             ?: tryParse { manifestParser.parseFromJar(ByteArrayInputStream(bytes)) }
+            ?: tryParse { resolveFromZipBundle(bytes) }
             ?: throw DescriptorNotFoundException(
-                "No descriptor found in JAR (tried plugwerk.yml, MANIFEST.MF, plugin.properties)",
+                "No descriptor found in artifact (tried plugwerk.yml, MANIFEST.MF, plugin.properties, ZIP bundle)",
             )
+    }
+
+    private fun resolveFromZipBundle(bytes: ByteArray): PlugwerkDescriptor {
+        val rootJars = mutableListOf<ByteArray>()
+        val libJars = mutableListOf<ByteArray>()
+
+        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory && entry.name.endsWith(".jar")) {
+                    validateEntryName(entry.name)
+                    val jarBytes = zip.readBytes()
+                    if ('/' !in entry.name) {
+                        rootJars += jarBytes
+                    } else {
+                        libJars += jarBytes
+                    }
+                }
+                entry = zip.nextEntry
+            }
+        }
+
+        for (jarBytes in rootJars + libJars) {
+            val descriptor = tryParse { plugwerkParser.parseFromJar(ByteArrayInputStream(jarBytes)) }
+                ?: tryParse { manifestParser.parseFromJar(ByteArrayInputStream(jarBytes)) }
+            if (descriptor != null) return descriptor
+        }
+
+        throw DescriptorNotFoundException("No descriptor found in any JAR inside ZIP bundle")
     }
 
     private fun tryParse(block: () -> PlugwerkDescriptor): PlugwerkDescriptor? = try {

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
@@ -26,6 +26,8 @@ import java.util.jar.Attributes
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class DescriptorResolverTest {
 
@@ -87,6 +89,104 @@ class DescriptorResolverTest {
         }
     }
 
+    // --- ZIP bundle tests ---
+
+    @Test
+    fun `resolve finds plugwerk yml inside root-level JAR in ZIP bundle`() {
+        val yaml = """
+            plugwerk:
+              id: "zip-bundle-plugin"
+              version: "1.2.3"
+              name: "ZIP Bundle Plugin"
+        """.trimIndent()
+        val innerJar = createJarWithEntry("plugwerk.yml", yaml)
+        val zip = createZipWithEntry("my-plugin.jar", innerJar.readBytes())
+
+        val descriptor = resolver.resolve(zip)
+
+        assertEquals("zip-bundle-plugin", descriptor.id)
+        assertEquals("1.2.3", descriptor.version)
+    }
+
+    @Test
+    fun `resolve prefers root-level JAR over lib subdirectory JAR in ZIP bundle`() {
+        val rootYaml = """
+            plugwerk:
+              id: "root-plugin"
+              version: "1.0.0"
+              name: "Root Plugin"
+        """.trimIndent()
+        val libYaml = """
+            plugwerk:
+              id: "lib-plugin"
+              version: "2.0.0"
+              name: "Lib Plugin"
+        """.trimIndent()
+        val rootJarBytes = createJarWithEntry("plugwerk.yml", rootYaml).readBytes()
+        val libJarBytes = createJarWithEntry("plugwerk.yml", libYaml).readBytes()
+        val zip = createZipWithEntries(
+            "my-plugin.jar" to rootJarBytes,
+            "lib/dependency.jar" to libJarBytes,
+        )
+
+        val descriptor = resolver.resolve(zip)
+
+        assertEquals("root-plugin", descriptor.id)
+    }
+
+    @Test
+    fun `resolve finds descriptor in lib subdirectory JAR when no root-level JAR has descriptor`() {
+        val libYaml = """
+            plugwerk:
+              id: "lib-only-plugin"
+              version: "3.0.0"
+              name: "Lib Only Plugin"
+        """.trimIndent()
+        val libJarBytes = createJarWithEntry("plugwerk.yml", libYaml).readBytes()
+        val zip = createZipWithEntries(
+            "lib/my-plugin.jar" to libJarBytes,
+        )
+
+        val descriptor = resolver.resolve(zip)
+
+        assertEquals("lib-only-plugin", descriptor.id)
+    }
+
+    @Test
+    fun `resolve falls back to manifest in nested JAR inside ZIP bundle`() {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", "manifest-in-zip")
+            mainAttributes.putValue("Plugin-Version", "5.0.0")
+        }
+        val innerJarBytes = createJarWithManifest(manifest).readBytes()
+        val zip = createZipWithEntry("plugin.jar", innerJarBytes)
+
+        val descriptor = resolver.resolve(zip)
+
+        assertEquals("manifest-in-zip", descriptor.id)
+        assertEquals("5.0.0", descriptor.version)
+    }
+
+    @Test
+    fun `resolve throws when ZIP bundle contains no JAR with descriptor`() {
+        val innerJarBytes = createJarWithEntry("some-file.txt", "content").readBytes()
+        val zip = createZipWithEntry("plugin.jar", innerJarBytes)
+
+        assertThrows<DescriptorNotFoundException> {
+            resolver.resolve(zip)
+        }
+    }
+
+    @Test
+    fun `resolve throws when ZIP bundle contains no JAR entries at all`() {
+        val zip = createZipWithEntry("readme.txt", "no jars here".toByteArray())
+
+        assertThrows<DescriptorNotFoundException> {
+            resolver.resolve(zip)
+        }
+    }
+
     @Test
     fun `resolve propagates parse error for malformed plugwerk yml`() {
         val badYaml = """
@@ -131,6 +231,28 @@ class DescriptorResolverTest {
             jar.putNextEntry(JarEntry(entryName))
             jar.write(content.toByteArray())
             jar.closeEntry()
+        }
+        return ByteArrayInputStream(baos.toByteArray())
+    }
+
+    private fun createZipWithEntry(entryName: String, content: ByteArray): ByteArrayInputStream {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zip ->
+            zip.putNextEntry(ZipEntry(entryName))
+            zip.write(content)
+            zip.closeEntry()
+        }
+        return ByteArrayInputStream(baos.toByteArray())
+    }
+
+    private fun createZipWithEntries(vararg entries: Pair<String, ByteArray>): ByteArrayInputStream {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zip ->
+            entries.forEach { (name, content) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content)
+                zip.closeEntry()
+            }
         }
         return ByteArrayInputStream(baos.toByteArray())
     }


### PR DESCRIPTION
## Summary

- `DescriptorResolver` failed silently for ZIP bundles (multi-JAR archives) because `JarInputStream` only sees the outer ZIP level, while descriptors live inside the nested plugin JAR
- Adds a third fallback `resolveFromZipBundle()` that iterates the outer ZIP with `ZipInputStream`, extracts each `.jar` entry, and applies the existing descriptor resolution chain on it
- Root-level JARs (no `/` in path) are tried before `lib/` subdirectory JARs

Closes #26
Part of #7

## Changes

- `DescriptorResolver.kt` — `resolveFromZipBundle()` + third fallback in `resolve()`
- `DescriptorResolverTest.kt` — 6 new ZIP-bundle test cases (TDD: red → green)

## Test plan

- [x] ZIP with root-level JAR containing `plugwerk.yml` → resolved
- [x] ZIP with root-level JAR + `lib/*.jar` → root JAR wins
- [x] ZIP with only `lib/*.jar` → lib JAR used as fallback
- [x] ZIP with JAR but no descriptor → `DescriptorNotFoundException`
- [x] ZIP with no JAR entries → `DescriptorNotFoundException`
- [x] ZIP bundle with `MANIFEST.MF` in nested JAR → resolved via fallback
- [x] All existing plain-JAR tests still green
- [x] Spotless / ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)