### PR TITLE
refactor(db): use namespace UUID instead of slug in artifact_key (#54)

### DIFF
--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -131,7 +131,7 @@ ON CONFLICT (namespace_id, plugin_id) DO NOTHING;
 -- Releases — one PUBLISHED release per plugin
 -- ============================================================
 INSERT INTO plugin_release (id, plugin_id, version, artifact_sha256, artifact_key, requires_system_version, status, created_at, updated_at)
-SELECT gen_random_uuid(), p.id, rel.version, rel.sha, rel.key, rel.req, 'PUBLISHED'::varchar, now()-rel.ago::interval, now()-rel.ago::interval
+SELECT gen_random_uuid(), p.id, rel.version, rel.sha, (rel.ns_id || ':' || rel.plugin_id_str || ':' || rel.version || ':jar'), rel.req, 'PUBLISHED'::varchar, now()-rel.ago::interval, now()-rel.ago::interval
 FROM plugin p
 JOIN (VALUES
   -- default namespace

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -101,7 +101,7 @@ class PluginReleaseService(
 
         val extension = originalFilename?.substringAfterLast('.')?.lowercase()
             ?.takeIf { it == "zip" || it == "jar" } ?: "jar"
-        val artifactKey = "$namespaceSlug/${descriptor.id}/${descriptor.version}.$extension"
+        val artifactKey = "${plugin.namespace.id}:${descriptor.id}:${descriptor.version}:$extension"
         storageService.store(artifactKey, ByteArrayInputStream(bytes), bytes.size.toLong())
 
         return releaseRepository.save(

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
@@ -87,9 +87,11 @@ class PluginReleaseServiceIntegrationTest {
     @Autowired
     lateinit var descriptorResolver: DescriptorResolver
 
+    lateinit var testNamespace: io.plugwerk.server.domain.NamespaceEntity
+
     @BeforeEach
     fun setUp() {
-        namespaceService.create("rel-int-ns", "Integration Org")
+        testNamespace = namespaceService.create("rel-int-ns", "Integration Org")
     }
 
     @Test
@@ -100,7 +102,7 @@ class PluginReleaseServiceIntegrationTest {
         val result = releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
 
         assertThat(result.version).isEqualTo("1.0.0")
-        assertThat(result.artifactKey).isEqualTo("rel-int-ns/auto-plugin/1.0.0")
+        assertThat(result.artifactKey).isEqualTo("${testNamespace.id}:auto-plugin:1.0.0:jar")
         assertThat(result.status).isEqualTo(ReleaseStatus.DRAFT)
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -40,6 +40,7 @@ import org.mockito.kotlin.whenever
 import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayInputStream
 import java.util.Optional
+import java.util.UUID
 import kotlin.test.assertFailsWith
 
 @ExtendWith(MockitoExtension::class)
@@ -57,7 +58,8 @@ class PluginReleaseServiceTest {
 
     lateinit var releaseService: PluginReleaseService
 
-    private val namespace = NamespaceEntity(slug = "acme", ownerOrg = "ACME Corp")
+    private val namespaceId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    private val namespace = NamespaceEntity(id = namespaceId, slug = "acme", ownerOrg = "ACME Corp")
     private val plugin = PluginEntity(namespace = namespace, pluginId = "my-plugin", name = "My Plugin")
 
     @BeforeEach
@@ -83,19 +85,21 @@ class PluginReleaseServiceTest {
         whenever(releaseRepository.existsByPluginAndVersion(plugin, "1.0.0")).thenReturn(false)
         whenever(
             storageService.store(any<String>(), any<java.io.InputStream>(), any<Long>()),
-        ).thenReturn("acme/my-plugin/1.0.0")
+        ).thenReturn("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar")
         val savedRelease = PluginReleaseEntity(
             plugin = plugin,
             version = "1.0.0",
             artifactSha256 = "sha",
-            artifactKey = "acme/my-plugin/1.0.0",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar",
         )
         whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(savedRelease)
 
         val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
 
         assertThat(result.version).isEqualTo("1.0.0")
-        verify(storageService).store(eq("acme/my-plugin/1.0.0.jar"), any<java.io.InputStream>(), any<Long>())
+        verify(
+            storageService,
+        ).store(eq("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar"), any<java.io.InputStream>(), any<Long>())
         verify(releaseRepository).save(any<PluginReleaseEntity>())
     }
 
@@ -127,12 +131,12 @@ class PluginReleaseServiceTest {
         whenever(releaseRepository.existsByPluginAndVersion(newPlugin, "1.0.0")).thenReturn(false)
         whenever(
             storageService.store(any<String>(), any<java.io.InputStream>(), any<Long>()),
-        ).thenReturn("acme/new-plugin/1.0.0")
+        ).thenReturn("00000000-0000-0000-0000-000000000001:new-plugin:1.0.0:jar")
         val savedRelease = PluginReleaseEntity(
             plugin = newPlugin,
             version = "1.0.0",
             artifactSha256 = "sha",
-            artifactKey = "acme/new-plugin/1.0.0",
+            artifactKey = "00000000-0000-0000-0000-000000000001:new-plugin:1.0.0:jar",
         )
         whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(savedRelease)
 
@@ -159,7 +163,7 @@ class PluginReleaseServiceTest {
             plugin = plugin,
             version = "1.0.0",
             artifactSha256 = "sha",
-            artifactKey = "acme/my-plugin/1.0.0",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar",
         )
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
         whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
@@ -177,7 +181,7 @@ class PluginReleaseServiceTest {
             plugin = plugin,
             version = "1.0.0",
             artifactSha256 = "sha",
-            artifactKey = "acme/my-plugin/1.0.0",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar",
         )
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
         whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
@@ -185,7 +189,7 @@ class PluginReleaseServiceTest {
 
         releaseService.delete("acme", "my-plugin", "1.0.0")
 
-        verify(storageService).delete("acme/my-plugin/1.0.0")
+        verify(storageService).delete("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar")
         verify(releaseRepository).delete(release)
     }
 }


### PR DESCRIPTION
## Summary

- Replace `artifact_key` format from `{slug}/{plugin-id}/{version}.{ext}` to `{namespace-uuid}:{plugin-id}:{version}:{ext}`
- `PluginReleaseService.upload()` now derives the key from `plugin.namespace.id` (immutable UUID) instead of the mutable namespace slug
- `seed-testdata.sql` generates `artifact_key` dynamically in the SELECT from `rel.ns_id`, so no data rows needed updating

## Motivation

Closes #54. A slug-based key becomes stale if the namespace is ever renamed, silently breaking all download links. Using the UUID decouples the storage path from the slug entirely.

## Test plan

- [x] `PluginReleaseServiceTest` — unit tests updated with fixed namespace UUID; all 6 tests pass
- [x] `PluginReleaseServiceIntegrationTest` — assertion updated to `${testNamespace.id}:auto-plugin:1.0.0:jar`; pre-existing Spring Boot 4.x `@DataJpaTest` context failure is unrelated to this change (verified by running the same test on `main` before changes)
- [x] `spotlessApply` passes
- [ ] Manual: re-run `seed-testdata.sql` on a local dev DB and verify `artifact_key` values contain UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)