### PR TITLE
feat(backend): track plugin download counts (#61)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
@@ -48,6 +48,7 @@ class PluginReleaseMapper(private val objectMapper: ObjectMapper) {
         artifactSha256 = entity.artifactSha256,
         requiresSystemVersion = entity.requiresSystemVersion,
         pluginDependencies = parseDependencies(entity.pluginDependencies),
+        downloadCount = entity.downloadCount,
         createdAt = entity.createdAt,
     )
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
@@ -114,6 +114,9 @@ class PluginReleaseEntity(
     @Column(name = "plugin_dependencies")
     var pluginDependencies: String? = null,
 
+    @Column(name = "download_count", nullable = false)
+    var downloadCount: Long = 0,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 50)
     var status: ReleaseStatus = ReleaseStatus.DRAFT,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -24,6 +24,7 @@ import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.Optional
@@ -40,6 +41,10 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
     fun findAllByPluginAndStatus(plugin: PluginEntity, status: ReleaseStatus): List<PluginReleaseEntity>
 
     fun existsByPluginAndVersion(plugin: PluginEntity, version: String): Boolean
+
+    @Modifying
+    @Query("UPDATE PluginReleaseEntity r SET r.downloadCount = r.downloadCount + 1 WHERE r.id = :id")
+    fun incrementDownloadCount(@Param("id") id: UUID)
 
     @Query(
         """

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -78,9 +78,12 @@ class PluginReleaseService(
         return releaseRepository.save(release)
     }
 
+    @Transactional
     fun downloadArtifact(namespaceSlug: String, pluginId: String, version: String): InputStream {
         val release = findByVersion(namespaceSlug, pluginId, version)
-        return storageService.retrieve(release.artifactKey)
+        val stream = storageService.retrieve(release.artifactKey)
+        releaseRepository.incrementDownloadCount(release.id!!)
+        return stream
     }
 
     @Transactional

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -171,6 +171,12 @@ databaseChangeLog:
                   name: plugin_dependencies
                   type: jsonb
               - column:
+                  name: download_count
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
                   name: status
                   type: varchar(50)
                   defaultValue: DRAFT

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapperTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapperTest.kt
@@ -60,6 +60,23 @@ class PluginReleaseMapperTest {
         assertThat(dto.artifactSha256).isEqualTo("deadbeef")
         assertThat(dto.requiresSystemVersion).isEqualTo(">=2.0.0")
         assertThat(dto.status).isEqualTo(PluginReleaseDto.Status.PUBLISHED)
+        assertThat(dto.downloadCount).isEqualTo(0L)
+    }
+
+    @Test
+    fun `toDto maps non-zero downloadCount`() {
+        val release = PluginReleaseEntity(
+            id = UUID.randomUUID(),
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "abc",
+            artifactKey = "key",
+            downloadCount = 42L,
+        )
+
+        val dto = mapper.toDto(release, "my-plugin")
+
+        assertThat(dto.downloadCount).isEqualTo(42L)
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -192,4 +192,24 @@ class PluginReleaseServiceTest {
         verify(storageService).delete("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar")
         verify(releaseRepository).delete(release)
     }
+
+    @Test
+    fun `downloadArtifact increments download counter`() {
+        val releaseId = UUID.randomUUID()
+        val release = PluginReleaseEntity(
+            id = releaseId,
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar",
+        )
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findByPluginAndVersion(plugin, "1.0.0")).thenReturn(Optional.of(release))
+        whenever(storageService.retrieve(release.artifactKey)).thenReturn(ByteArrayInputStream(ByteArray(0)))
+
+        releaseService.downloadArtifact("acme", "my-plugin", "1.0.0")
+
+        verify(releaseRepository).incrementDownloadCount(releaseId)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `download_count BIGINT DEFAULT 0 NOT NULL` to `plugin_release` (updated `0001_initial_schema.yaml` directly — app not in production)
- `PluginReleaseRepository.incrementDownloadCount()` uses an atomic JPQL `UPDATE` — thread-safe, no lost updates under concurrent requests
- `PluginReleaseService.downloadArtifact()` increments the counter after successful artifact retrieval (within `@Transactional`)
- `PluginReleaseMapper` exposes `downloadCount` in `PluginReleaseDto` (field already present in OpenAPI spec)

## Test plan

- [x] `PluginReleaseMapperTest`: `downloadCount` defaults to 0, non-zero value mapped correctly
- [x] `PluginReleaseServiceTest`: `incrementDownloadCount()` is called on every download
- [x] All unit tests green, `spotlessApply` clean
- [ ] Manual: download an artifact via `GET /api/v1/namespaces/{ns}/plugins/{id}/releases/{version}/download` and verify `downloadCount` increments in the catalog response

## Related

- Closes #61
- Extended scope (download_event audit table): #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)