### PR TITLE
feat(ui): visually indicate DRAFT release status (#53)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -521,6 +521,8 @@ components:
             type: string
         latestVersion:
           type: string
+        latestDraftVersion:
+          type: string
         downloadCount:
           type: integer
           format: int64

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -102,7 +102,9 @@ class CatalogController(
             allReleases.filter { it.status == ReleaseStatus.DRAFT }
                 .maxByOrNull { it.createdAt }
                 ?.version
-        } else null
+        } else {
+            null
+        }
         return ResponseEntity.ok(pluginMapper.toDto(plugin, ns, latestVersion, latestDraftVersion))
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -72,9 +72,18 @@ class CatalogController(
             releaseRepository.findLatestPublishedVersionsForPlugins(pluginIds)
                 .associate { row -> (row[0] as java.util.UUID) to (row[1] as String) }
         }
+        val draftOnlyIds = pluginIds.filter { it !in latestVersions }
+        val latestDraftVersions: Map<java.util.UUID, String> = if (draftOnlyIds.isEmpty()) {
+            emptyMap()
+        } else {
+            releaseRepository.findLatestDraftVersionsForPlugins(draftOnlyIds)
+                .associate { row -> (row[0] as java.util.UUID) to (row[1] as String) }
+        }
 
         val response = PluginPagedResponse(
-            content = resultPage.content.map { pluginMapper.toDto(it, ns, latestVersions[it.id]) },
+            content = resultPage.content.map {
+                pluginMapper.toDto(it, ns, latestVersions[it.id], latestDraftVersions[it.id])
+            },
             totalElements = resultPage.totalElements,
             page = resultPage.number,
             propertySize = resultPage.size,
@@ -85,11 +94,16 @@ class CatalogController(
 
     override fun getPlugin(ns: String, pluginId: String): ResponseEntity<PluginDto> {
         val plugin = pluginService.findByNamespaceAndPluginId(ns, pluginId)
-        val latestVersion = releaseService.findAllByPlugin(ns, pluginId)
-            .filter { it.status == ReleaseStatus.PUBLISHED }
+        val allReleases = releaseService.findAllByPlugin(ns, pluginId)
+        val latestVersion = allReleases.filter { it.status == ReleaseStatus.PUBLISHED }
             .maxByOrNull { it.createdAt }
             ?.version
-        return ResponseEntity.ok(pluginMapper.toDto(plugin, ns, latestVersion))
+        val latestDraftVersion = if (latestVersion == null) {
+            allReleases.filter { it.status == ReleaseStatus.DRAFT }
+                .maxByOrNull { it.createdAt }
+                ?.version
+        } else null
+        return ResponseEntity.ok(pluginMapper.toDto(plugin, ns, latestVersion, latestDraftVersion))
     }
 
     override fun listReleases(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
@@ -33,7 +33,12 @@ import java.net.URI
 @Component
 class PluginMapper {
 
-    fun toDto(entity: PluginEntity, namespaceSlug: String, latestVersion: String? = null): PluginDto = PluginDto(
+    fun toDto(
+        entity: PluginEntity,
+        namespaceSlug: String,
+        latestVersion: String? = null,
+        latestDraftVersion: String? = null,
+    ): PluginDto = PluginDto(
         id = entity.id!!,
         pluginId = entity.pluginId,
         name = entity.name,
@@ -45,6 +50,7 @@ class PluginMapper {
         categories = entity.categories.toList().takeIf { it.isNotEmpty() },
         tags = entity.tags.toList().takeIf { it.isNotEmpty() },
         latestVersion = latestVersion,
+        latestDraftVersion = if (latestVersion == null) latestDraftVersion else null,
         icon = entity.icon?.let { URI(it) },
         homepage = entity.homepage?.let { URI(it) },
         repository = entity.repository?.let { URI(it) },

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -78,4 +78,26 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         """,
     )
     fun findLatestPublishedVersionsForPlugins(@Param("pluginIds") pluginIds: Collection<UUID>): List<Array<Any>>
+
+    /**
+     * Returns the latest draft version string per plugin for a given set of plugin IDs.
+     * Used as fallback for plugins that have no published release yet.
+     * Result is a list of [pluginId, version] pairs where version is the most recently
+     * created DRAFT release.
+     */
+    @Query(
+        """
+        SELECT r.plugin.id, r.version
+        FROM PluginReleaseEntity r
+        WHERE r.plugin.id IN :pluginIds
+          AND r.status = io.plugwerk.spi.model.ReleaseStatus.DRAFT
+          AND r.createdAt = (
+            SELECT MAX(r2.createdAt)
+            FROM PluginReleaseEntity r2
+            WHERE r2.plugin.id = r.plugin.id
+              AND r2.status = io.plugwerk.spi.model.ReleaseStatus.DRAFT
+          )
+        """,
+    )
+    fun findLatestDraftVersionsForPlugins(@Param("pluginIds") pluginIds: Collection<UUID>): List<Array<Any>>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -98,7 +98,7 @@ class CatalogControllerTest {
             ),
         )
             .thenReturn(PageImpl(listOf(plugin)))
-        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins")
             .andExpect {
@@ -134,7 +134,7 @@ class CatalogControllerTest {
     fun `GET plugin by id returns 200`() {
         whenever(pluginService.findByNamespaceAndPluginId("acme", "my-plugin")).thenReturn(plugin)
         whenever(releaseService.findAllByPlugin("acme", "my-plugin")).thenReturn(emptyList())
-        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins/my-plugin")
             .andExpect {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -91,7 +91,7 @@ class ManagementControllerTest {
                 any(), any(),
             ),
         ).thenReturn(plugin)
-        whenever(pluginMapper.toDto(any(), any(), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
 
         mockMvc.post("/api/v1/namespaces/acme/plugins") {
             contentType = MediaType.APPLICATION_JSON
@@ -132,7 +132,7 @@ class ManagementControllerTest {
                 anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
             ),
         ).thenReturn(plugin)
-        whenever(pluginMapper.toDto(any(), any(), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
 
         mockMvc.patch("/api/v1/namespaces/acme/plugins/my-plugin") {
             contentType = MediaType.APPLICATION_JSON

--- a/plugwerk-server/plugwerk-server-frontend/src/api/generated/.openapi-generator/FILES
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/generated/.openapi-generator/FILES
@@ -1,6 +1,5 @@
 .gitignore
 .npmignore
-.openapi-generator-ignore
 README.md
 api.ts
 api/catalog-api.ts

--- a/plugwerk-server/plugwerk-server-frontend/src/api/generated/api/management-api.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/generated/api/management-api.ts
@@ -185,30 +185,19 @@ export const ManagementApiAxiosParamCreator = function (configuration?: Configur
         },
         /**
          * 
-         * @summary Upload a new release
+         * @summary Upload a new release (descriptor is read from the JAR)
          * @param {string} ns Namespace slug
-         * @param {string} pluginId PF4J Plugin-Id
          * @param {File} artifact 
-         * @param {string} version 
-         * @param {string} [changelog] 
-         * @param {string} [requiresSystemVersion] 
-         * @param {number} [requiresApiLevel] 
-         * @param {string} [pluginDependencies] JSON array of plugin dependencies
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadRelease: async (ns: string, pluginId: string, artifact: File, version: string, changelog?: string, requiresSystemVersion?: string, requiresApiLevel?: number, pluginDependencies?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadRelease: async (ns: string, artifact: File, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'ns' is not null or undefined
             assertParamExists('uploadRelease', 'ns', ns)
-            // verify required parameter 'pluginId' is not null or undefined
-            assertParamExists('uploadRelease', 'pluginId', pluginId)
             // verify required parameter 'artifact' is not null or undefined
             assertParamExists('uploadRelease', 'artifact', artifact)
-            // verify required parameter 'version' is not null or undefined
-            assertParamExists('uploadRelease', 'version', version)
-            const localVarPath = `/namespaces/{ns}/plugins/{pluginId}/releases`
-                .replace(`{${"ns"}}`, encodeURIComponent(String(ns)))
-                .replace(`{${"pluginId"}}`, encodeURIComponent(String(pluginId)));
+            const localVarPath = `/namespaces/{ns}/releases`
+                .replace(`{${"ns"}}`, encodeURIComponent(String(ns)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -227,26 +216,6 @@ export const ManagementApiAxiosParamCreator = function (configuration?: Configur
 
             if (artifact !== undefined) { 
                 localVarFormParams.append('artifact', artifact as any);
-            }
-    
-            if (version !== undefined) { 
-                localVarFormParams.append('version', version as any);
-            }
-    
-            if (changelog !== undefined) { 
-                localVarFormParams.append('changelog', changelog as any);
-            }
-    
-            if (requiresSystemVersion !== undefined) { 
-                localVarFormParams.append('requiresSystemVersion', requiresSystemVersion as any);
-            }
-    
-            if (requiresApiLevel !== undefined) { 
-                localVarFormParams.append('requiresApiLevel', requiresApiLevel as any);
-            }
-    
-            if (pluginDependencies !== undefined) { 
-                localVarFormParams.append('pluginDependencies', pluginDependencies as any);
             }
     
     
@@ -319,20 +288,14 @@ export const ManagementApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Upload a new release
+         * @summary Upload a new release (descriptor is read from the JAR)
          * @param {string} ns Namespace slug
-         * @param {string} pluginId PF4J Plugin-Id
          * @param {File} artifact 
-         * @param {string} version 
-         * @param {string} [changelog] 
-         * @param {string} [requiresSystemVersion] 
-         * @param {number} [requiresApiLevel] 
-         * @param {string} [pluginDependencies] JSON array of plugin dependencies
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadRelease(ns: string, pluginId: string, artifact: File, version: string, changelog?: string, requiresSystemVersion?: string, requiresApiLevel?: number, pluginDependencies?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PluginReleaseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadRelease(ns, pluginId, artifact, version, changelog, requiresSystemVersion, requiresApiLevel, pluginDependencies, options);
+        async uploadRelease(ns: string, artifact: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PluginReleaseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadRelease(ns, artifact, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ManagementApi.uploadRelease']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -379,13 +342,13 @@ export const ManagementApiFactory = function (configuration?: Configuration, bas
         },
         /**
          * 
-         * @summary Upload a new release
+         * @summary Upload a new release (descriptor is read from the JAR)
          * @param {ManagementApiUploadReleaseRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         uploadRelease(requestParameters: ManagementApiUploadReleaseRequest, options?: RawAxiosRequestConfig): AxiosPromise<PluginReleaseDto> {
-            return localVarFp.uploadRelease(requestParameters.ns, requestParameters.pluginId, requestParameters.artifact, requestParameters.version, requestParameters.changelog, requestParameters.requiresSystemVersion, requestParameters.requiresApiLevel, requestParameters.pluginDependencies, options).then((request) => request(axios, basePath));
+            return localVarFp.uploadRelease(requestParameters.ns, requestParameters.artifact, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -488,53 +451,11 @@ export interface ManagementApiUploadReleaseRequest {
     readonly ns: string
 
     /**
-     * PF4J Plugin-Id
-     * @type {string}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly pluginId: string
-
-    /**
      * 
      * @type {File}
      * @memberof ManagementApiUploadRelease
      */
     readonly artifact: File
-
-    /**
-     * 
-     * @type {string}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly version: string
-
-    /**
-     * 
-     * @type {string}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly changelog?: string
-
-    /**
-     * 
-     * @type {string}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly requiresSystemVersion?: string
-
-    /**
-     * 
-     * @type {number}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly requiresApiLevel?: number
-
-    /**
-     * JSON array of plugin dependencies
-     * @type {string}
-     * @memberof ManagementApiUploadRelease
-     */
-    readonly pluginDependencies?: string
 }
 
 /**
@@ -582,14 +503,14 @@ export class ManagementApi extends BaseAPI {
 
     /**
      * 
-     * @summary Upload a new release
+     * @summary Upload a new release (descriptor is read from the JAR)
      * @param {ManagementApiUploadReleaseRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ManagementApi
      */
     public uploadRelease(requestParameters: ManagementApiUploadReleaseRequest, options?: RawAxiosRequestConfig) {
-        return ManagementApiFp(this.configuration).uploadRelease(requestParameters.ns, requestParameters.pluginId, requestParameters.artifact, requestParameters.version, requestParameters.changelog, requestParameters.requiresSystemVersion, requestParameters.requiresApiLevel, requestParameters.pluginDependencies, options).then((request) => request(this.axios, this.basePath));
+        return ManagementApiFp(this.configuration).uploadRelease(requestParameters.ns, requestParameters.artifact, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/api/generated/model/plugin-dto.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/generated/model/plugin-dto.ts
@@ -88,6 +88,12 @@ export interface PluginDto {
     'latestVersion'?: string;
     /**
      * 
+     * @type {string}
+     * @memberof PluginDto
+     */
+    'latestDraftVersion'?: string;
+    /**
+     * 
      * @type {number}
      * @memberof PluginDto
      */

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -44,6 +44,7 @@ function formatRelativeTime(dateStr: string | undefined): string {
 
 export function PluginCard({ plugin, namespace }: PluginCardProps) {
   const isDeprecated = plugin.status === 'archived'
+  const isDraft = !plugin.latestVersion
 
   return (
     <Card
@@ -57,9 +58,13 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
         height: '100%',
         textDecoration: 'none',
         transition: 'border-color 0.15s, box-shadow 0.15s',
+        ...(isDraft && {
+          borderColor: tokens.badge.draft.text,
+          opacity: 0.8,
+        }),
         '&:hover': {
-          borderColor: tokens.color.primary,
-          boxShadow: `0 0 0 1px ${tokens.color.primary}`,
+          borderColor: isDraft ? tokens.badge.draft.text : tokens.color.primary,
+          boxShadow: `0 0 0 1px ${isDraft ? tokens.badge.draft.text : tokens.color.primary}`,
         },
       }}
     >
@@ -110,6 +115,7 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
               <Typography variant="caption" color="text.disabled">
                 {plugin.author ?? namespace}
               </Typography>
+              {isDraft && <Badge variant="draft">Draft</Badge>}
               {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
             </Box>
           </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -44,7 +44,7 @@ function formatRelativeTime(dateStr: string | undefined): string {
 
 export function PluginCard({ plugin, namespace }: PluginCardProps) {
   const isDeprecated = plugin.status === 'archived'
-  const isDraft = !plugin.latestVersion
+  const isDraft = !plugin.latestVersion && !!plugin.latestDraftVersion
 
   return (
     <Card
@@ -107,8 +107,8 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
               >
                 {plugin.name}
               </Typography>
-              {plugin.latestVersion && (
-                <Badge variant="version">v{plugin.latestVersion}</Badge>
+              {(plugin.latestVersion ?? plugin.latestDraftVersion) && (
+                <Badge variant="version">v{plugin.latestVersion ?? plugin.latestDraftVersion}</Badge>
               )}
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -44,6 +44,7 @@ function formatRelativeTime(dateStr: string | undefined): string {
 
 export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
   const isDeprecated = plugin.status === 'archived'
+  const isDraft = !plugin.latestVersion
   return (
     <Box
       component={Link}
@@ -59,10 +60,12 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         borderColor: 'divider',
         textDecoration: 'none',
         color: 'inherit',
-        bgcolor: 'background.paper',
+        bgcolor: isDraft ? tokens.badge.draft.bg + '44' : 'background.paper',
+        borderLeft: isDraft ? `3px solid ${tokens.badge.draft.text}` : undefined,
+        opacity: isDraft ? 0.8 : 1,
         transition: 'background-color 0.15s',
         '&:last-child': { borderBottom: 'none' },
-        '&:hover': { bgcolor: 'background.default' },
+        '&:hover': { bgcolor: isDraft ? tokens.badge.draft.bg + '88' : 'background.default' },
       }}
     >
       <Box
@@ -92,6 +95,7 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
       {plugin.latestVersion && (
         <Badge variant="version">v{plugin.latestVersion}</Badge>
       )}
+      {isDraft && <Badge variant="draft">Draft</Badge>}
       {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
 
       <Box sx={{ display: 'flex', gap: 2, color: 'text.disabled', flexShrink: 0 }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -92,11 +92,11 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         <Typography variant="caption" color="text.disabled">{plugin.author ?? namespace}</Typography>
       </Box>
 
+      {isDraft && <Badge variant="draft">Draft</Badge>}
+      {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
       {(plugin.latestVersion ?? plugin.latestDraftVersion) && (
         <Badge variant="version">v{plugin.latestVersion ?? plugin.latestDraftVersion}</Badge>
       )}
-      {isDraft && <Badge variant="draft">Draft</Badge>}
-      {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
 
       <Box sx={{ display: 'flex', gap: 2, color: 'text.disabled', flexShrink: 0 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -44,7 +44,7 @@ function formatRelativeTime(dateStr: string | undefined): string {
 
 export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
   const isDeprecated = plugin.status === 'archived'
-  const isDraft = !plugin.latestVersion
+  const isDraft = !plugin.latestVersion && !!plugin.latestDraftVersion
   return (
     <Box
       component={Link}
@@ -92,8 +92,8 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         <Typography variant="caption" color="text.disabled">{plugin.author ?? namespace}</Typography>
       </Box>
 
-      {plugin.latestVersion && (
-        <Badge variant="version">v{plugin.latestVersion}</Badge>
+      {(plugin.latestVersion ?? plugin.latestDraftVersion) && (
+        <Badge variant="version">v{plugin.latestVersion ?? plugin.latestDraftVersion}</Badge>
       )}
       {isDraft && <Badge variant="draft">Draft</Badge>}
       {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -9,18 +9,24 @@ import {
   Button,
   Box,
   Typography,
+  Tooltip,
+  Snackbar,
+  Alert,
 } from '@mui/material'
-import { Download } from 'lucide-react'
+import { Download, CheckCircle } from 'lucide-react'
+import { useState } from 'react'
 import { Badge } from '../common/Badge'
 import type { PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import type { BadgeVariant } from '../common/Badge'
+import { reviewsApi } from '../../api/config'
 
 interface VersionsTabProps {
   releases: PluginReleaseDto[]
   namespace: string
   pluginId: string
   currentVersion?: string
+  canApprove?: boolean
 }
 
 const statusToBadge: Record<string, BadgeVariant> = {
@@ -30,7 +36,25 @@ const statusToBadge: Record<string, BadgeVariant> = {
   yanked:     'yanked',
 }
 
-export function VersionsTab({ releases, namespace, pluginId, currentVersion }: VersionsTabProps) {
+export function VersionsTab({ releases, namespace, pluginId, currentVersion, canApprove }: VersionsTabProps) {
+  const [approvingId, setApprovingId] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+  async function handleApprove(rel: PluginReleaseDto) {
+    if (!rel.id) return
+    setApprovingId(rel.id)
+    try {
+      await reviewsApi.approveRelease({ ns: namespace, releaseId: rel.id })
+      setToast({ message: `v${rel.version} approved and published.`, severity: 'success' })
+      // Update status locally to avoid full reload
+      rel.status = 'published'
+    } catch {
+      setToast({ message: `Failed to approve v${rel.version}.`, severity: 'error' })
+    } finally {
+      setApprovingId(null)
+    }
+  }
+
   return (
     <Box sx={{ overflowX: 'auto' }}>
       <Table aria-label="Release versions" size="small">
@@ -40,21 +64,30 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion }: V
             <TableCell>Released</TableCell>
             <TableCell>Status</TableCell>
             <TableCell>Changelog</TableCell>
-            <TableCell>Download</TableCell>
+            <TableCell>Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {releases.map((rel) => {
             const isCurrent = rel.version === currentVersion
+            const isDraft = rel.status === 'draft'
+            const isYanked = rel.status === 'yanked'
             return (
               <TableRow
                 key={rel.id}
-                sx={isCurrent ? { background: tokens.color.primaryLight + '33' } : {}}
+                sx={{
+                  opacity: isDraft ? 0.7 : 1,
+                  ...(isDraft && {
+                    borderLeft: `3px solid ${tokens.badge.draft.text}`,
+                    background: tokens.badge.draft.bg + '55',
+                  }),
+                  ...(isCurrent && !isDraft && { background: tokens.color.primaryLight + '33' }),
+                }}
               >
                 <TableCell>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <Badge variant="version">v{rel.version}</Badge>
-                    {isCurrent && (
+                    {isCurrent && !isDraft && (
                       <Typography variant="caption" sx={{ color: tokens.color.primary, fontWeight: 600 }}>
                         current
                       </Typography>
@@ -77,7 +110,24 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion }: V
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  {rel.status !== 'yanked' ? (
+                  {isDraft && canApprove ? (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="success"
+                      startIcon={<CheckCircle size={14} />}
+                      loading={approvingId === rel.id}
+                      onClick={() => handleApprove(rel)}
+                    >
+                      Approve
+                    </Button>
+                  ) : isDraft ? (
+                    <Tooltip title="Awaiting review — download not available yet">
+                      <Typography variant="caption" color="text.disabled">Pending review</Typography>
+                    </Tooltip>
+                  ) : isYanked ? (
+                    <Typography variant="caption" color="text.disabled">Unavailable</Typography>
+                  ) : (
                     <Button
                       variant="text"
                       size="small"
@@ -87,8 +137,6 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion }: V
                     >
                       .jar
                     </Button>
-                  ) : (
-                    <Typography variant="caption" color="text.disabled">Unavailable</Typography>
                   )}
                 </TableCell>
               </TableRow>
@@ -96,6 +144,17 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion }: V
           })}
         </TableBody>
       </Table>
+
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Box,
   Container,
@@ -13,8 +13,19 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
+  Snackbar,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
 } from '@mui/material'
+import { CheckCircle } from 'lucide-react'
 import { AdminSidebar } from '../components/admin/AdminSidebar'
+import { reviewsApi } from '../api/config'
+import { useAuthStore } from '../stores/authStore'
+import type { ReviewItemDto } from '../api/generated/model'
 
 function GeneralSection() {
   return (
@@ -68,15 +79,106 @@ function UsersSection() {
 }
 
 function ReviewsSection() {
+  const namespace = useAuthStore((s) => s.namespace)
+  const [items, setItems] = useState<ReviewItemDto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [approvingId, setApprovingId] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const res = await reviewsApi.listPendingReviews({ ns: namespace })
+        setItems(res.data)
+      } catch {
+        setItems([])
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [namespace])
+
+  async function handleApprove(item: ReviewItemDto) {
+    setApprovingId(item.releaseId)
+    try {
+      await reviewsApi.approveRelease({ ns: namespace, releaseId: item.releaseId })
+      setItems((prev) => prev.filter((i) => i.releaseId !== item.releaseId))
+      setToast({ message: `${item.pluginName} v${item.version} approved and published.`, severity: 'success' })
+    } catch {
+      setToast({ message: `Failed to approve ${item.pluginName} v${item.version}.`, severity: 'error' })
+    } finally {
+      setApprovingId(null)
+    }
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box>
         <Typography variant="h2" gutterBottom>Pending Reviews</Typography>
         <Divider sx={{ mb: 3 }} />
       </Box>
-      <Typography variant="body2" color="text.secondary">
-        Releases awaiting review will appear here.
-      </Typography>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No releases awaiting review.
+        </Typography>
+      ) : (
+        <Table size="small" aria-label="Pending reviews">
+          <TableHead>
+            <TableRow>
+              <TableCell>Plugin</TableCell>
+              <TableCell>Version</TableCell>
+              <TableCell>Submitted</TableCell>
+              <TableCell>Action</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow key={item.releaseId}>
+                <TableCell>
+                  <Typography variant="body2" fontWeight={500}>{item.pluginName}</Typography>
+                  <Typography variant="caption" color="text.secondary">{item.pluginId}</Typography>
+                </TableCell>
+                <TableCell>v{item.version}</TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.disabled">
+                    {new Date(item.submittedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    color="success"
+                    startIcon={<CheckCircle size={14} />}
+                    loading={approvingId === item.releaseId}
+                    onClick={() => handleApprove(item)}
+                  >
+                    Approve
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -21,11 +21,13 @@ import { ChangelogTab } from '../components/plugin-detail/ChangelogTab'
 import { DependenciesTab } from '../components/plugin-detail/DependenciesTab'
 import { catalogApi } from '../api/config'
 import type { PluginDto, PluginReleaseDto } from '../api/generated/model'
+import { useAuthStore } from '../stores/authStore'
 
 const TAB_IDS = ['overview', 'versions', 'changelog', 'dependencies']
 
 export function PluginDetailPage() {
   const { namespace = 'default', pluginId = '' } = useParams<{ namespace: string; pluginId: string }>()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const [plugin, setPlugin] = useState<PluginDto | null>(null)
   const [releases, setReleases] = useState<PluginReleaseDto[]>([])
   const [loading, setLoading] = useState(true)
@@ -132,6 +134,7 @@ export function PluginDetailPage() {
                       namespace={namespace}
                       pluginId={pluginId}
                       currentVersion={latestRelease?.version}
+                      canApprove={isAuthenticated}
                     />
                   )}
                   {tab === 2 && i === 2 && <ChangelogTab releases={releases} />}

--- a/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
@@ -24,7 +24,7 @@ export const tokens = {
 
   badge: {
     published: { bg: '#DEFBE6', text: '#198038' },
-    draft:     { bg: '#E0E0E0', text: '#393939' },
+    draft:     { bg: '#FFE8CC', text: '#A84400' },
     deprecated:{ bg: '#FFF1C7', text: '#8A6A00' },
     yanked:    { bg: '#FFD7D9', text: '#DA1E28' },
     tag:       { bg: '#D0E2FF', text: '#0043CE' },


### PR DESCRIPTION
## Summary

- **Draft badge token**: changed from neutral gray to amber (`#FFE8CC` / `#A84400`) to clearly signal "not yet published"
- **VersionsTab**: DRAFT rows are dimmed (opacity 0.7) with an amber left border and amber background tint; download button replaced by a "Pending review" tooltip for anonymous users, or an **Approve** button for authenticated users (with loading state and toast feedback)
- **AdminSettingsPage → Pending Reviews**: section is now fully functional — fetches pending releases via `reviewsApi.listPendingReviews`, shows a table with plugin name/version/date and an Approve button per row; approved items are removed from the list with success/error toast
- **PluginDetailPage**: passes `canApprove={isAuthenticated}` down to `VersionsTab`

## Test plan

- [ ] Upload a plugin release (stays DRAFT) — verify amber badge, dimmed/bordered row, no download link
- [ ] As unauthenticated user: hover "Pending review" — verify tooltip appears
- [ ] Log in → Versions tab → DRAFT row shows **Approve** button
- [ ] Click Approve → success toast appears, status changes to PUBLISHED, download button appears
- [ ] Admin Settings → Pending Reviews: verify list loads, Approve removes item from list
- [ ] Verify no regression on PUBLISHED / DEPRECATED / YANKED rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)