### PR TITLE
feat(ui): auto-refresh catalog after plugin upload (#52)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -58,13 +58,9 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
         height: '100%',
         textDecoration: 'none',
         transition: 'border-color 0.15s, box-shadow 0.15s',
-        ...(isDraft && {
-          borderColor: tokens.badge.draft.text,
-          opacity: 0.8,
-        }),
         '&:hover': {
-          borderColor: isDraft ? tokens.badge.draft.text : tokens.color.primary,
-          boxShadow: `0 0 0 1px ${isDraft ? tokens.badge.draft.text : tokens.color.primary}`,
+          borderColor: tokens.color.primary,
+          boxShadow: `0 0 0 1px ${tokens.color.primary}`,
         },
       }}
     >

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -60,12 +60,10 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         borderColor: 'divider',
         textDecoration: 'none',
         color: 'inherit',
-        bgcolor: isDraft ? tokens.badge.draft.bg + '44' : 'background.paper',
-        borderLeft: isDraft ? `3px solid ${tokens.badge.draft.text}` : undefined,
-        opacity: isDraft ? 0.8 : 1,
+        bgcolor: 'background.paper',
         transition: 'background-color 0.15s',
         '&:last-child': { borderBottom: 'none' },
-        '&:hover': { bgcolor: isDraft ? tokens.badge.draft.bg + '88' : 'background.default' },
+        '&:hover': { bgcolor: 'background.default' },
       }}
     >
       <Box

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
@@ -7,11 +7,13 @@ import { renderWithRouter } from '../../test/renderWithTheme'
 import { UploadModal } from './UploadModal'
 import { useUiStore } from '../../stores/uiStore'
 import { useAuthStore } from '../../stores/authStore'
+import { usePluginStore } from '../../stores/pluginStore'
 import axios from 'axios'
 import * as apiConfig from '../../api/config'
 
 vi.mock('../../api/config', () => ({
   axiosInstance: { post: vi.fn(), get: vi.fn() },
+  catalogApi: { listPlugins: vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0, totalPages: 0, page: 0, size: 24 } }) },
 }))
 
 describe('UploadModal', () => {
@@ -94,5 +96,48 @@ describe('UploadModal', () => {
       expect(useUiStore.getState().uploadModalOpen).toBe(false)
     }, { timeout: 15000 })
     expect(useUiStore.getState().toasts.length).toBeGreaterThan(0)
+  }, 20000)
+
+  it('re-fetches catalog after successful upload', async () => {
+    useUiStore.setState({ uploadModalOpen: true })
+    vi.mocked(apiConfig.axiosInstance.post).mockResolvedValue({ data: {} })
+
+    const user = userEvent.setup()
+    renderWithRouter(<UploadModal />)
+
+    const file = new File(['fake-jar'], 'plugin.jar', { type: 'application/java-archive' })
+    await user.upload(screen.getByLabelText(/select plugin jar or zip file/i), file)
+    await user.click(screen.getByRole('button', { name: /upload release/i }))
+
+    await waitFor(() => {
+      expect(vi.mocked(apiConfig.catalogApi.listPlugins)).toHaveBeenCalledWith(
+        expect.objectContaining({ ns: 'acme' }),
+      )
+    }, { timeout: 15000 })
+  }, 20000)
+
+  it('does not re-fetch catalog when upload fails', async () => {
+    useUiStore.setState({ uploadModalOpen: true })
+    const axiosError = new axios.AxiosError('Request failed', '422', undefined, undefined, {
+      status: 422,
+      data: { message: 'Invalid descriptor' },
+      statusText: 'Unprocessable Entity',
+      headers: {},
+      config: {} as never,
+    })
+    vi.mocked(apiConfig.axiosInstance.post).mockRejectedValue(axiosError)
+    vi.mocked(apiConfig.catalogApi.listPlugins).mockClear()
+
+    const user = userEvent.setup()
+    renderWithRouter(<UploadModal />)
+
+    const file = new File(['fake-jar'], 'plugin.jar', { type: 'application/java-archive' })
+    await user.upload(screen.getByLabelText(/select plugin jar or zip file/i), file)
+    await user.click(screen.getByRole('button', { name: /upload release/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    }, { timeout: 15000 })
+    expect(vi.mocked(apiConfig.catalogApi.listPlugins)).not.toHaveBeenCalled()
   }, 20000)
 })

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
@@ -7,7 +7,6 @@ import { renderWithRouter } from '../../test/renderWithTheme'
 import { UploadModal } from './UploadModal'
 import { useUiStore } from '../../stores/uiStore'
 import { useAuthStore } from '../../stores/authStore'
-import { usePluginStore } from '../../stores/pluginStore'
 import axios from 'axios'
 import * as apiConfig from '../../api/config'
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -19,6 +19,7 @@ import axios from 'axios'
 import { axiosInstance } from '../../api/config'
 import { useUiStore } from '../../stores/uiStore'
 import { useAuthStore } from '../../stores/authStore'
+import { usePluginStore } from '../../stores/pluginStore'
 import { tokens } from '../../theme/tokens'
 
 export function UploadModal() {
@@ -69,6 +70,7 @@ export function UploadModal() {
         },
       })
       addToast({ type: 'success', title: 'Release uploaded', message: 'Your release is pending review.' })
+      usePluginStore.getState().fetchPlugins(namespace)
       handleClose()
     } catch (err: unknown) {
       const message = axios.isAxiosError(err)


### PR DESCRIPTION
## Summary

- After a successful upload in `UploadModal`, `pluginStore.fetchPlugins(namespace)` is called to re-fetch the catalog list — the new plugin appears immediately without manual reload
- Error cases (422, 409 etc.) do not trigger a refresh
- Draft plugins in `PluginCard` and `PluginListRow` are now indicated only by the amber badge — no border override, background tint, or opacity change

## Test plan

- [ ] Upload a plugin JAR → new plugin appears in catalog without page reload
- [ ] Upload with invalid JAR (no descriptor) → error shown, catalog not refreshed
- [x] `re-fetches catalog after successful upload` test passes
- [x] `does not re-fetch catalog when upload fails` test passes
- [x] All 9 UploadModal tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)