### PR TITLE
feat: descriptor validation with format and semantic checks

### DIFF
--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorExceptions.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorExceptions.kt
@@ -20,3 +20,6 @@ package io.plugwerk.descriptor
 class DescriptorParseException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class DescriptorNotFoundException(message: String) : RuntimeException(message)
+
+class DescriptorValidationException(val violations: List<String>) :
+    RuntimeException("Descriptor validation failed: ${violations.joinToString("; ")}")

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
@@ -1,0 +1,97 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.descriptor
+
+
+private val PLUGIN_ID_REGEX = Regex("^[a-zA-Z0-9._-]{1,128}$")
+
+// Each range part: optional operator + version, optionally followed by a hyphen range end
+private val SEMVER_RANGE_PART = Regex("(>=?|<=?|~|\\^|=)?v?\\d+\\.\\d+(\\.\\d+)?([-+][\\w.]+)?")
+private val SEMVER_RANGE_REGEX = Regex(
+    "^\\s*${SEMVER_RANGE_PART.pattern}" +
+        "(\\s+-\\s+${SEMVER_RANGE_PART.pattern})?" +
+        "(\\s+${SEMVER_RANGE_PART.pattern}(\\s+-\\s+${SEMVER_RANGE_PART.pattern})?)*\\s*$",
+)
+private const val NAME_MAX_LENGTH = 255
+private const val TAG_MAX_LENGTH = 64
+private val URL_SCHEMES = setOf("http", "https")
+
+internal object DescriptorValidator {
+
+    /**
+     * Validates the given [descriptor] and throws [DescriptorValidationException] if any
+     * constraint is violated. The exception lists all violations at once.
+     */
+    fun validate(descriptor: PlugwerkDescriptor) {
+        val violations = mutableListOf<String>()
+
+        if (!PLUGIN_ID_REGEX.matches(descriptor.id)) {
+            violations += "id '${descriptor.id}' must match pattern ${PLUGIN_ID_REGEX.pattern}"
+        }
+
+        if (descriptor.name.length > NAME_MAX_LENGTH) {
+            violations += "name must not exceed $NAME_MAX_LENGTH characters (got ${descriptor.name.length})"
+        }
+
+        descriptor.homepage?.let { url ->
+            if (!isValidHttpUrl(url)) violations += "homepage must be a valid http/https URL: '$url'"
+        }
+        descriptor.repository?.let { url ->
+            if (!isValidHttpUrl(url)) violations += "repository must be a valid http/https URL: '$url'"
+        }
+        descriptor.icon?.let { url ->
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+                if (!isValidHttpUrl(url)) violations += "icon must be a valid http/https URL or a relative path: '$url'"
+            }
+        }
+
+        descriptor.categories.forEachIndexed { i, cat ->
+            if (cat.length > TAG_MAX_LENGTH) {
+                violations += "categories[$i] must not exceed $TAG_MAX_LENGTH characters: '$cat'"
+            }
+        }
+        descriptor.tags.forEachIndexed { i, tag ->
+            if (tag.length > TAG_MAX_LENGTH) {
+                violations += "tags[$i] must not exceed $TAG_MAX_LENGTH characters: '$tag'"
+            }
+        }
+
+        descriptor.requiresSystemVersion?.let { range ->
+            if (!isValidSemVerRange(range)) {
+                violations += "requiresSystemVersion '$range' is not a valid SemVer range"
+            }
+        }
+
+        if (violations.isNotEmpty()) throw DescriptorValidationException(violations)
+    }
+
+    private fun isValidHttpUrl(url: String): Boolean {
+        return try {
+            val parsed = java.net.URI(url)
+            parsed.scheme in URL_SCHEMES && parsed.host != null && parsed.host.isNotEmpty()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun isValidSemVerRange(range: String): Boolean {
+        // Normalize plugwerk conjunction syntax (">=1.0.0 & <2.0.0") to space-separated form
+        val normalized = range.replace(Regex("\\s*&\\s*"), " ")
+        return SEMVER_RANGE_REGEX.matches(normalized)
+    }
+}

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
@@ -79,13 +79,11 @@ internal object DescriptorValidator {
         if (violations.isNotEmpty()) throw DescriptorValidationException(violations)
     }
 
-    private fun isValidHttpUrl(url: String): Boolean {
-        return try {
-            val parsed = java.net.URI(url)
-            parsed.scheme in URL_SCHEMES && parsed.host != null && parsed.host.isNotEmpty()
-        } catch (_: Exception) {
-            false
-        }
+    private fun isValidHttpUrl(url: String): Boolean = try {
+        val parsed = java.net.URI(url)
+        parsed.scheme in URL_SCHEMES && parsed.host != null && parsed.host.isNotEmpty()
+    } catch (_: Exception) {
+        false
     }
 
     private fun isValidSemVerRange(range: String): Boolean {

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
@@ -17,7 +17,6 @@
  */
 package io.plugwerk.descriptor
 
-
 private val PLUGIN_ID_REGEX = Regex("^[a-zA-Z0-9._-]{1,128}$")
 
 // Each range part: optional operator + version, optionally followed by a hyphen range end

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParser.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParser.kt
@@ -86,7 +86,7 @@ class PlugwerkDescriptorParser {
             )
         } ?: emptyList()
 
-        return PlugwerkDescriptor(
+        val descriptor = PlugwerkDescriptor(
             id = id,
             version = version,
             name = name,
@@ -103,6 +103,8 @@ class PlugwerkDescriptorParser {
             homepage = yaml.homepage,
             repository = yaml.repository,
         )
+        DescriptorValidator.validate(descriptor)
+        return descriptor
     }
 }
 

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.descriptor
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class DescriptorValidatorTest {
+
+    private fun minimalDescriptor(
+        id: String = "my-plugin",
+        name: String = "My Plugin",
+        version: String = "1.0.0",
+        homepage: String? = null,
+        repository: String? = null,
+        icon: String? = null,
+        categories: List<String> = emptyList(),
+        tags: List<String> = emptyList(),
+        requiresSystemVersion: String? = null,
+    ) = PlugwerkDescriptor(
+        id = id,
+        version = version,
+        name = name,
+        homepage = homepage,
+        repository = repository,
+        icon = icon,
+        categories = categories,
+        tags = tags,
+        requiresSystemVersion = requiresSystemVersion,
+    )
+
+    @Test
+    fun `valid descriptor passes without exception`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor())
+        }
+    }
+
+    // ---- id ----
+
+    @ParameterizedTest
+    @ValueSource(strings = ["my-plugin", "acme.pdf_export", "A1B2", "a-b-c.d_e"])
+    fun `valid plugin ids pass`(id: String) {
+        assertDoesNotThrow { DescriptorValidator.validate(minimalDescriptor(id = id)) }
+    }
+
+    @Test
+    fun `plugin id at max length of 128 passes`() {
+        assertDoesNotThrow { DescriptorValidator.validate(minimalDescriptor(id = "a".repeat(128))) }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["has space", "../traversal", "plugin/slash"])
+    fun `invalid plugin ids throw DescriptorValidationException`(id: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(id = id))
+        }
+        assertTrue(ex.violations.any { it.contains("id") })
+    }
+
+    @Test
+    fun `plugin id exceeding 128 chars throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(id = "a".repeat(129)))
+        }
+        assertTrue(ex.violations.any { it.contains("id") })
+    }
+
+    // ---- name ----
+
+    @Test
+    fun `name at max length of 255 passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(name = "a".repeat(255)))
+        }
+    }
+
+    @Test
+    fun `name exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(name = "a".repeat(256)))
+        }
+        assertTrue(ex.violations.any { it.contains("name") })
+    }
+
+    // ---- URL fields ----
+
+    @ParameterizedTest
+    @ValueSource(strings = ["https://example.com", "http://example.com/path?q=1"])
+    fun `valid URLs pass`(url: String) {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(homepage = url, repository = url))
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ftp://example.com", "not-a-url", "javascript:alert(1)"])
+    fun `invalid homepage URL throws`(url: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(homepage = url))
+        }
+        assertTrue(ex.violations.any { it.contains("homepage") })
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ftp://example.com", "not-a-url"])
+    fun `invalid repository URL throws`(url: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(repository = url))
+        }
+        assertTrue(ex.violations.any { it.contains("repository") })
+    }
+
+    @Test
+    fun `icon as relative path passes without URL validation`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(icon = "icons/plugin.png"))
+        }
+    }
+
+    @Test
+    fun `icon as valid https URL passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(icon = "https://example.com/icon.png"))
+        }
+    }
+
+    @Test
+    fun `icon as invalid https URL throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(icon = "https://"))
+        }
+        assertTrue(ex.violations.any { it.contains("icon") })
+    }
+
+    // ---- categories / tags ----
+
+    @Test
+    fun `tag at max length of 64 passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(tags = listOf("a".repeat(64))))
+        }
+    }
+
+    @Test
+    fun `tag exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(tags = listOf("a".repeat(65))))
+        }
+        assertTrue(ex.violations.any { it.contains("tags") })
+    }
+
+    @Test
+    fun `category exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(categories = listOf("a".repeat(65))))
+        }
+        assertTrue(ex.violations.any { it.contains("categories") })
+    }
+
+    // ---- requiresSystemVersion ----
+
+    @ParameterizedTest
+    @ValueSource(strings = [">=1.0.0", ">=2.0.0 <4.0.0", ">=2.0.0 & <4.0.0", "1.0.0 - 2.0.0"])
+    fun `valid SemVer ranges pass`(range: String) {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(requiresSystemVersion = range))
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["not-a-range", ">> 1.0.0", "latest"])
+    fun `invalid SemVer ranges throw`(range: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(requiresSystemVersion = range))
+        }
+        assertTrue(ex.violations.any { it.contains("requiresSystemVersion") })
+    }
+
+    // ---- multiple violations reported at once ----
+
+    @Test
+    fun `multiple violations are reported together`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(
+                    id = "../bad",
+                    name = "a".repeat(256),
+                    homepage = "ftp://bad",
+                ),
+            )
+        }
+        assertTrue(ex.violations.size >= 3)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.controller
 import io.plugwerk.api.model.ErrorResponse
 import io.plugwerk.descriptor.DescriptorNotFoundException
 import io.plugwerk.descriptor.DescriptorParseException
+import io.plugwerk.descriptor.DescriptorValidationException
 import io.plugwerk.server.service.ArtifactNotFoundException
 import io.plugwerk.server.service.ArtifactStorageException
 import io.plugwerk.server.service.NamespaceAlreadyExistsException
@@ -73,7 +74,11 @@ class GlobalExceptionHandler {
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Invalid request")
 
-    @ExceptionHandler(DescriptorNotFoundException::class, DescriptorParseException::class)
+    @ExceptionHandler(
+        DescriptorNotFoundException::class,
+        DescriptorParseException::class,
+        DescriptorValidationException::class,
+    )
     fun handleDescriptorError(ex: RuntimeException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, ex.message ?: "Plugin descriptor is invalid or missing")
 


### PR DESCRIPTION
## Summary

Closes #57.

- Adds `DescriptorValidator` in `plugwerk-descriptor` that validates a `PlugwerkDescriptor` after parsing and collects **all** violations before throwing `DescriptorValidationException`
- Extends `GlobalExceptionHandler` to map `DescriptorValidationException` → HTTP 422

## Validation rules

| Field | Rule |
|-------|------|
| `id` | Regex `^[a-zA-Z0-9._-]{1,128}$` — prevents path traversal and injection |
| `name` | Max 255 characters |
| `homepage`, `repository` | Must be valid `http`/`https` URL when present |
| `icon` | URL-validated only when the value starts with `http://`/`https://`; relative paths are left as-is |
| `categories[]`, `tags[]` | Each entry max 64 characters |
| `requiresSystemVersion` | Must match a valid SemVer range expression |

## Test plan

- [ ] `DescriptorValidatorTest` — 33 unit tests covering all rules (valid and invalid inputs, parameterized)
- [ ] All existing `plugwerk-descriptor` tests still pass
- [ ] Full backend build passes (`./gradlew :plugwerk-server:plugwerk-server-backend:build`)
- [ ] Upload a JAR with a descriptor that violates a rule → API returns HTTP 422 with a descriptive message

🤖 Generated with [Claude Code](https://claude.com/claude-code)