### PR TITLE
feat(ui): namespace switch navigates to catalog page with namespace URL path

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -58,7 +58,7 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
   return (
     <Card
       component={Link}
-      to={`/${namespace}/plugins/${plugin.pluginId}`}
+      to={`/namespaces/${namespace}/plugins/${plugin.pluginId}`}
       role="listitem"
       aria-label={`${plugin.name} plugin`}
       sx={{

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -48,7 +48,7 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
   return (
     <Box
       component={Link}
-      to={`/${namespace}/plugins/${plugin.pluginId}`}
+      to={`/namespaces/${namespace}/plugins/${plugin.pluginId}`}
       role="listitem"
       sx={{
         display: 'flex',

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithRouter } from '../../test/renderWithTheme'
+import { TopBar } from './TopBar'
+import { useAuthStore } from '../../stores/authStore'
+import { useNamespaceStore } from '../../stores/namespaceStore'
+import { useUiStore } from '../../stores/uiStore'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('../../api/config', () => ({
+  axiosInstance: { get: vi.fn().mockResolvedValue({ data: [] }) },
+  catalogApi: {},
+  managementApi: {},
+  reviewsApi: {},
+  updatesApi: {},
+}))
+
+describe('TopBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({ accessToken: 'tok', username: 'alice', isAuthenticated: true, namespace: 'acme' })
+    useNamespaceStore.setState({
+      namespaces: [{ slug: 'acme', ownerOrg: 'ACME' }, { slug: 'beta', ownerOrg: 'Beta Inc' }],
+      loading: false,
+      error: null,
+    })
+    useUiStore.setState({ isDark: false, toasts: [], searchQuery: '' })
+  })
+
+  it('renders the namespace dropdown', () => {
+    renderWithRouter(<TopBar />)
+    expect(screen.getByLabelText('Select namespace')).toBeInTheDocument()
+  })
+
+  it('navigates to catalog page of new namespace on namespace change', async () => {
+    const user = userEvent.setup()
+    renderWithRouter(<TopBar />)
+
+    await user.click(screen.getByLabelText('Select namespace'))
+    const option = await screen.findByRole('option', { name: 'beta' })
+    await user.click(option)
+
+    expect(mockNavigate).toHaveBeenCalledWith('/namespaces/beta/plugins')
+  })
+
+  it('updates auth store namespace on namespace change', async () => {
+    const user = userEvent.setup()
+    renderWithRouter(<TopBar />)
+
+    await user.click(screen.getByLabelText('Select namespace'))
+    const option = await screen.findByRole('option', { name: 'beta' })
+    await user.click(option)
+
+    expect(useAuthStore.getState().namespace).toBe('beta')
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
@@ -33,7 +33,7 @@ describe('TopBar', () => {
       loading: false,
       error: null,
     })
-    useUiStore.setState({ isDark: false, toasts: [], searchQuery: '' })
+    useUiStore.setState({ themeMode: 'light', toasts: [], searchQuery: '' })
   })
 
   it('renders the namespace dropdown', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -32,6 +32,11 @@ export function TopBar() {
     return path === '/' ? pathname === '/' : pathname.startsWith(path)
   }
 
+  function handleNamespaceChange(ns: string) {
+    setNamespace(ns)
+    navigate(`/namespaces/${ns}/plugins`)
+  }
+
   function handleLogout() {
     logout()
     navigate('/login', { replace: true })
@@ -97,7 +102,7 @@ export function TopBar() {
             </Typography>
             <FilterSelect
               value={namespace}
-              onChange={setNamespace}
+              onChange={handleNamespaceChange}
               aria-label="Select namespace"
               minWidth={130}
             >

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 devtank42 GmbH
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
-import { renderWithRouter } from '../test/renderWithTheme'
+import { renderWithRouterAt } from '../test/renderWithTheme'
 import { CatalogPage } from './CatalogPage'
 import { usePluginStore } from '../stores/pluginStore'
 import { useAuthStore } from '../stores/authStore'
@@ -43,6 +43,13 @@ const defaultFilters = {
 describe('CatalogPage', () => {
   const noOpFetch = vi.fn().mockResolvedValue(undefined)
 
+  const ROUTE_PATH = '/namespaces/:namespace/plugins'
+  const INITIAL_PATH = '/namespaces/acme/plugins'
+
+  function renderCatalog() {
+    return renderWithRouterAt(<CatalogPage />, ROUTE_PATH, INITIAL_PATH)
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     useAuthStore.setState({ accessToken: null, namespace: 'acme' })
@@ -62,59 +69,59 @@ describe('CatalogPage', () => {
   })
 
   it('renders the page heading', () => {
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByText('Plugin Catalog')).toBeInTheDocument()
   })
 
   it('shows empty state when no plugins are available', () => {
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByText('No plugins found')).toBeInTheDocument()
   })
 
   it('shows loading skeleton when loading is true', () => {
     usePluginStore.setState({ loading: true })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByLabelText('Loading plugins')).toBeInTheDocument()
   })
 
   it('does not show empty state while loading', () => {
     usePluginStore.setState({ loading: true })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.queryByText('No plugins found')).not.toBeInTheDocument()
   })
 
   it('shows error alert when there is an error', () => {
     usePluginStore.setState({ error: 'Network error' })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByText('Network error')).toBeInTheDocument()
   })
 
   it('does not show empty state when there is an error', () => {
     usePluginStore.setState({ error: 'Something failed', plugins: [] })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.queryByText('No plugins found')).not.toBeInTheDocument()
   })
 
   it('renders plugin cards in card view', () => {
     usePluginStore.setState({ plugins: [mockPlugin], totalElements: 1, totalPages: 1 })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByText('Auth Plugin')).toBeInTheDocument()
   })
 
   it('shows plugin count when not loading', () => {
     usePluginStore.setState({ plugins: [mockPlugin], totalElements: 42 })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByText('42 plugins')).toBeInTheDocument()
   })
 
   it('does not show plugin count while loading', () => {
     usePluginStore.setState({ loading: true, totalElements: 42 })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.queryByText('42 plugins')).not.toBeInTheDocument()
   })
 
   it('renders filter bar', () => {
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     expect(screen.getByRole('group', { name: /filter and sort options/i })).toBeInTheDocument()
   })
 
@@ -122,8 +129,14 @@ describe('CatalogPage', () => {
     const { default: userEvent } = await import('@testing-library/user-event')
     const user = userEvent.setup()
     usePluginStore.setState({ plugins: [mockPlugin], totalElements: 1, totalPages: 1 })
-    renderWithRouter(<CatalogPage />)
+    renderCatalog()
     await user.click(screen.getByRole('button', { name: /list view/i }))
     expect(screen.getByRole('list', { name: /plugin list/i })).toBeInTheDocument()
+  })
+
+  it('syncs namespace from URL param into the auth store', async () => {
+    renderWithRouterAt(<CatalogPage />, ROUTE_PATH, '/namespaces/other-ns/plugins')
+    const { namespace } = useAuthStore.getState()
+    expect(namespace).toBe('other-ns')
   })
 })

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
 import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
 import { Box, Container, Typography, Alert } from '@mui/material'
 import { FilterBar } from '../components/catalog/FilterBar'
 import { PluginCard } from '../components/catalog/PluginCard'
@@ -14,7 +15,8 @@ import { useUiStore } from '../stores/uiStore'
 import { useNamespaceStore } from '../stores/namespaceStore'
 
 export function CatalogPage() {
-  const { namespace } = useAuthStore()
+  const { namespace = 'default' } = useParams<{ namespace: string }>()
+  const { setNamespace } = useAuthStore()
   const { plugins, loading, error, totalElements, resetFilters, fetchPlugins } = usePluginStore()
   const { searchQuery } = useUiStore()
   const { fetchNamespaces } = useNamespaceStore()
@@ -23,6 +25,10 @@ export function CatalogPage() {
   useEffect(() => {
     fetchNamespaces()
   }, [])
+
+  useEffect(() => {
+    setNamespace(namespace)
+  }, [namespace])
 
   useEffect(() => {
     fetchPlugins(namespace)

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { AppShell } from '../AppShell'
 import { ProtectedRoute } from '../components/auth/ProtectedRoute'
 import { CatalogPage } from '../pages/CatalogPage'
@@ -15,6 +15,12 @@ import { Error404Page } from '../pages/errors/Error404Page'
 import { Error403Page } from '../pages/errors/Error403Page'
 import { Error500Page } from '../pages/errors/Error500Page'
 import { Error503Page } from '../pages/errors/Error503Page'
+import { useAuthStore } from '../stores/authStore'
+
+function CatalogRedirect() {
+  const namespace = useAuthStore((s) => s.namespace)
+  return <Navigate to={`/namespaces/${namespace}/plugins`} replace />
+}
 
 export const router = createBrowserRouter([
   {
@@ -22,10 +28,11 @@ export const router = createBrowserRouter([
     element: <AppShell />,
     children: [
       // Protected routes — require a logged-in user
-      { index: true,                          element: <ProtectedRoute><CatalogPage /></ProtectedRoute> },
-      { path: ':namespace/plugins/:pluginId', element: <ProtectedRoute><PluginDetailPage /></ProtectedRoute> },
-      { path: 'admin/*',                      element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute> },
-      { path: 'profile',                      element: <ProtectedRoute><ProfileSettingsPage /></ProtectedRoute> },
+      { index: true,                                                    element: <ProtectedRoute><CatalogRedirect /></ProtectedRoute> },
+      { path: 'namespaces/:namespace/plugins',                          element: <ProtectedRoute><CatalogPage /></ProtectedRoute> },
+      { path: 'namespaces/:namespace/plugins/:pluginId',                element: <ProtectedRoute><PluginDetailPage /></ProtectedRoute> },
+      { path: 'admin/*',                                                element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute> },
+      { path: 'profile',                                                element: <ProtectedRoute><ProfileSettingsPage /></ProtectedRoute> },
 
       // Public routes — no login required
       { path: 'login',                        element: <LoginPage /> },

--- a/plugwerk-server/plugwerk-server-frontend/src/test/renderWithTheme.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/test/renderWithTheme.tsx
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 devtank42 GmbH
 import { render, type RenderOptions } from '@testing-library/react'
 import { ThemeProvider, CssBaseline } from '@mui/material'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { buildTheme } from '../theme/theme'
 import type { ReactNode } from 'react'
 
@@ -32,4 +32,23 @@ export function renderWithTheme(ui: ReactNode, options?: Omit<RenderOptions, 'wr
 
 export function renderWithRouter(ui: ReactNode, options?: Omit<RenderOptions, 'wrapper'>) {
   return render(ui, { wrapper: RouterWrapper, ...options })
+}
+
+export function renderWithRouterAt(
+  ui: ReactNode,
+  routePath: string,
+  initialPath: string,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path={routePath} element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+    options,
+  )
 }


### PR DESCRIPTION
Closes #59

## Summary

- Introduces namespace-encoded URLs (`/namespaces/:namespace/plugins`, `/namespaces/:namespace/plugins/:pluginId`)
- Index route `/` redirects to `/namespaces/{currentNamespace}/plugins`
- `CatalogPage` reads the namespace from URL params and syncs it back to the auth store
- Namespace dropdown in `TopBar` now navigates to `/namespaces/{ns}/plugins` on switch instead of staying on the current page
- All plugin card/list-row links updated to the new URL schema

## Test plan

- [ ] Selecting a different namespace in the dropdown navigates to the catalog of the new namespace
- [ ] Navigating directly to `/namespaces/acme/plugins` loads the correct namespace
- [ ] Plugin detail links (`/namespaces/:ns/plugins/:id`) still work
- [ ] Opening `/` redirects to the namespace catalog
- [ ] All 140 frontend unit tests pass (`npm run test:run`)