### PR TITLE
feat: E2E smoke tests, Scalar API docs, README and ADRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,37 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: plugwerk-server/plugwerk-server-frontend/package-lock.json
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run E2E smoke test
+        run: ./scripts/smoke-test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Universal AI agent instructions for Plugwerk. All AI coding agents (Claude Code,
 
 ## What Plugwerk Is
 
-Plugwerk is a **plugin marketplace for the Java/PF4J ecosystem** – the missing link between the PF4J plugin framework and a product's plugin ecosystem. Think Maven Central, but for runtime plugins instead of build dependencies.
+Plugwerk is **plugin management and marketplace software for the Java/PF4J ecosystem** – the missing link between the PF4J plugin framework and a product's plugin ecosystem. Think Maven Central, but for runtime plugins instead of build dependencies.
 
 Two artifacts:
 - **Plugwerk Server** – Spring Boot 4.x + Kotlin web application: REST API, catalog, upload, versioning, download

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement
 
-**PlugWerk – Plugin Marketplace for the Java Ecosystem**
+**PlugWerk – Plugin Management and Marketplace Software for the Java Ecosystem**
 
 This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the PlugWerk project. By signing this Agreement, you accept and agree to the following terms for your present and future contributions to PlugWerk.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ docker compose up -d postgres
 ### Running the Server
 
 ```bash
-./gradlew :plugwerk-server:plugwerk-server-backend:bootRun --args='--spring.profiles.active=dev'
+./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
 ```
 
 The server starts at `http://localhost:8080`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties* ./
 COPY plugwerk-api/ plugwerk-api/
-COPY plugwerk-common/ plugwerk-common/
+COPY plugwerk-spi/ plugwerk-spi/
 COPY plugwerk-descriptor/ plugwerk-descriptor/
 COPY plugwerk-server/ plugwerk-server/
 COPY plugwerk-client-plugin/ plugwerk-client-plugin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY plugwerk-api/ plugwerk-api/
 COPY plugwerk-common/ plugwerk-common/
 COPY plugwerk-descriptor/ plugwerk-descriptor/
 COPY plugwerk-server/ plugwerk-server/
-COPY plugwerk-client-sdk/ plugwerk-client-sdk/
+COPY plugwerk-client-plugin/ plugwerk-client-plugin/
 
 RUN apk add --no-cache nodejs npm && \
     cd plugwerk-server/plugwerk-server-frontend && npm ci && cd ../.. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY plugwerk-server/ plugwerk-server/
 COPY plugwerk-client-plugin/ plugwerk-client-plugin/
 
 RUN apk add --no-cache nodejs npm && \
-    cd plugwerk-server/plugwerk-server-frontend && npm ci && cd ../.. && \
     chmod +x gradlew && \
     ./gradlew :plugwerk-server:plugwerk-server-backend:bootJar --no-daemon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY plugwerk-descriptor/ plugwerk-descriptor/
 COPY plugwerk-server/ plugwerk-server/
 COPY plugwerk-client-plugin/ plugwerk-client-plugin/
 
-RUN apk add --no-cache nodejs npm && \
+RUN apk add --no-cache bash nodejs npm && \
     chmod +x gradlew && \
     ./gradlew :plugwerk-server:plugwerk-server-backend:bootJar --no-daemon
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,95 @@ The server starts at `http://localhost:8080`.
 docker compose up
 ```
 
-Starts Plugwerk Server + PostgreSQL 18.
+Starts Plugwerk Server + PostgreSQL 18. Open `http://localhost:8080` in your browser.
+
+## Quick Start (Self-Hosted)
+
+```bash
+# Clone and start
+git clone https://github.com/devtank42gmbh/plugwerk.git
+cd plugwerk
+docker compose up -d
+
+# Wait for health
+curl http://localhost:8080/actuator/health
+```
+
+### First login
+
+Default dev credentials (change in production via `PLUGWERK_JWT_SECRET` and `plugwerk.auth.dev-users`):
+
+| Username | Password |
+|---|---|
+| `test` | `test` |
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test","password":"test"}' | jq -r '.accessToken')
+```
+
+### Create a namespace and upload a plugin
+
+```bash
+# Create namespace
+curl -X POST http://localhost:8080/api/v1/namespaces \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"slug":"myproduct","ownerOrg":"My Company"}'
+
+# Upload a plugin JAR (must contain plugwerk.yml)
+curl -X POST http://localhost:8080/api/v1/namespaces/myproduct/releases \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "artifact=@my-plugin-1.0.0.jar"
+
+# List plugins
+curl http://localhost:8080/api/v1/namespaces/myproduct/plugins \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### API Documentation
+
+Interactive API reference powered by [Scalar](https://scalar.com/):
+
+```
+http://localhost:8080/api-docs
+```
+
+The raw OpenAPI 3.1 spec is available at:
+
+```
+http://localhost:8080/api-docs/openapi.yaml
+```
+
+### Client SDK (Gradle)
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("io.plugwerk:plugwerk-client-plugin:<version>")
+}
+```
+
+```kotlin
+val config = PlugwerkConfig.builder()
+    .serverUrl("https://plugins.mycompany.com")
+    .namespace("myproduct")
+    .apiKey(System.getenv("PLUGWERK_API_KEY"))
+    .build()
+
+val marketplace = PlugwerkMarketplace(config)
+// Use as pf4j-update UpdateRepository drop-in:
+val updateManager = UpdateManager(pluginManager, listOf(marketplace.asUpdateRepository()))
+```
+
+### E2E Smoke Test
+
+```bash
+./scripts/smoke-test.sh
+```
+
+Runs the full upload → catalog → download flow against a Docker Compose stack.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,210 @@
 # Plugwerk
 
-**Plugin Marketplace for the Java/PF4J Ecosystem**
+**Self-Hosted Plugin Management and Marketplace Software for the Java/PF4J Ecosystem**
 
-Plugwerk is the missing link between [PF4J](https://github.com/pf4j/pf4j) and a product's plugin ecosystem. It provides centralized infrastructure for distributing, managing, and updating plugins at runtime – comparable to Maven Central for build dependencies, but designed for runtime plugins.
+Plugwerk is the missing link between [PF4J](https://github.com/pf4j/pf4j) and a product's plugin ecosystem. It gives you a central, self-hosted hub for publishing, versioning, distributing, and updating plugins at runtime — comparable to Maven Central for build dependencies, but designed for runtime plugins.
 
-## Overview
+## Who is Plugwerk for?
 
-Plugwerk consists of two artifacts:
+| Role | How Plugwerk helps |
+|------|--------------------|
+| **Application developers** | Integrate the `plugwerk-client-plugin` into your PF4J-based application to let users discover, install, and update plugins at runtime — without shipping a new application release |
+| **Plugin developers** | Upload plugin artifacts via the Web UI or REST API, manage versions and metadata, and publish releases with a single API call from your CI/CD pipeline |
+| **Operations teams** | Deploy a self-hosted, Docker-based plugin management platform for your organization; one server can serve multiple products via namespaces |
 
-- **Plugwerk Server** – A Spring Boot web application serving as a central plugin marketplace: catalog, upload, versioning, download, and REST API.
-- **Plugwerk Client SDK** – A Kotlin library (Java 11+ compatible) deployed as a PF4J plugin with isolated classloader: plugin discovery, download, installation, update checking, and PF4J lifecycle integration.
+## How it works
 
-## Status
+```
+Your Application                     Plugwerk Server
+┌────────────────────────────────┐    ┌─────────────────────────────┐
+│ PF4J PluginManager             │    │ REST API  /api/v1/...       │
+│  ↕ plugwerk-client-plugin      │◄──►│ Web UI    http://...        │
+│    PlugwerkMarketplace         │    │ PostgreSQL + Artifact Store │
+└────────────────────────────────┘    └─────────────────────────────┘
+         ↑ runtime install/update               ↑ upload via CI/CD
+         |                                      |
+  end users / admins                    plugin developers
+```
 
-> **Phase 1 (MVP) is in active development.** The Gradle multi-module project is scaffolded and building. See [Issue #7](https://github.com/devtank42gmbh/plugwerk/issues/7) for the full task breakdown.
+A **namespace** scopes all plugins for one product (e.g. `acme-crm`). Plugin artifacts (JAR/ZIP) embed a `plugwerk.yml` descriptor; the server reads it automatically on upload.
+
+## Quick Start (Self-Hosted)
+
+### Prerequisites
+
+- Docker + Docker Compose
+
+### Start with Docker Compose
+
+```bash
+git clone https://github.com/devtank42gmbh/plugwerk.git
+cd plugwerk
+docker compose up -d
+```
+
+Wait for the server to be ready:
+
+```bash
+curl http://localhost:8080/actuator/health
+# {"status":"UP"}
+```
+
+Open the Web UI at **http://localhost:8080**.
+
+### Default credentials
+
+| Username | Password |
+|----------|----------|
+| `test`   | `test`   |
+
+> **Production:** Set `PLUGWERK_JWT_SECRET` to a strong secret (at least 32 characters) and configure proper user credentials. Never use the defaults on a publicly accessible server.
+
+### Obtain a token and create a namespace
+
+```bash
+# Login
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test","password":"test"}' | jq -r '.accessToken')
+
+# Create a namespace for your product
+curl -s -X POST http://localhost:8080/api/v1/namespaces \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"slug":"myproduct","ownerOrg":"My Company"}'
+```
+
+### Upload and publish a plugin
+
+```bash
+# Upload a plugin JAR/ZIP — descriptor is read automatically from plugwerk.yml inside the artifact
+curl -s -X POST http://localhost:8080/api/v1/namespaces/myproduct/releases \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "artifact=@my-plugin-1.0.0.jar"
+# Returns: {"id":"...","version":"1.0.0","status":"draft",...}
+
+# Publish the release (draft → published)
+RELEASE_ID="<id from above>"
+curl -s -X POST http://localhost:8080/api/v1/namespaces/myproduct/reviews/$RELEASE_ID/approve \
+  -H "Authorization: Bearer $TOKEN"
+
+# Browse the catalog
+curl -s http://localhost:8080/api/v1/namespaces/myproduct/plugins | jq .
+```
+
+## Integrating the Client SDK into your Application
+
+The `plugwerk-client-plugin` is a PF4J plugin with an isolated classloader — it has no dependency conflicts with your application. Add it to your PF4J plugins directory and use it to connect to a Plugwerk server at runtime.
+
+### Add to your Gradle project
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    // plugwerk-spi provides the ExtensionPoint interfaces
+    implementation("io.plugwerk:plugwerk-spi:<version>")
+}
+```
+
+The `plugwerk-client-plugin` ZIP is deployed as a PF4J plugin alongside your application's plugins, not as a compile-time dependency.
+
+### Configure and use the client
+
+```kotlin
+import io.plugwerk.spi.PlugwerkConfig
+import io.plugwerk.spi.PlugwerkMarketplace
+
+// Build the configuration
+val config = PlugwerkConfig.builder()
+    .serverUrl("https://plugins.mycompany.com")
+    .namespace("myproduct")
+    .apiKey(System.getenv("PLUGWERK_API_KEY"))
+    .build()
+
+// Use as a pf4j-update UpdateRepository drop-in
+val marketplace = PlugwerkMarketplace(config)
+val updateManager = UpdateManager(pluginManager, listOf(marketplace.asUpdateRepository()))
+
+// Or use the granular extension points directly
+val catalog = pluginManager.getExtension(PlugwerkCatalog::class.java)
+val installer = pluginManager.getExtension(PlugwerkInstaller::class.java)
+val updateChecker = pluginManager.getExtension(PlugwerkUpdateChecker::class.java)
+```
+
+### pf4j-update drop-in replacement
+
+Already using `pf4j-update`? Point it at Plugwerk's `plugins.json` endpoint — no code changes required:
+
+```
+https://your-plugwerk-server/api/v1/namespaces/{namespace}/plugins.json
+```
+
+### The `plugwerk.yml` descriptor
+
+Embed this file inside your plugin JAR/ZIP so the server can read metadata automatically:
+
+```yaml
+# src/main/resources/plugwerk.yml
+plugwerk:
+  id: com.example.my-plugin         # must match Plugin-Id in MANIFEST.MF
+  version: 1.2.0
+  name: My Plugin
+  description: Exports reports as PDF with configurable templates
+  author: ACME GmbH
+  license: Apache-2.0
+  requires:
+    system-version: ">=2.0.0 & <4.0.0"   # compatible host application versions
+    plugins:
+      - id: com.example.template-engine
+        version: ">=1.0.0"
+  categories:
+    - export
+    - reporting
+  tags:
+    - pdf
+    - report
+```
+
+If `plugwerk.yml` is absent, the server falls back to the PF4J manifest (`MANIFEST.MF` / `plugin.properties`).
+
+## API Documentation
+
+Interactive API reference powered by [Scalar](https://scalar.com/) — open in the browser after starting the server:
+
+```
+http://localhost:8080/api-docs
+```
+
+Raw OpenAPI 3.1 spec:
+
+```
+http://localhost:8080/api-docs/openapi.yaml
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_DB_URL` | `jdbc:postgresql://localhost:5432/plugwerk` | PostgreSQL JDBC URL |
+| `PLUGWERK_DB_USERNAME` | `plugwerk` | Database username |
+| `PLUGWERK_DB_PASSWORD` | `plugwerk` | Database password |
+| `PLUGWERK_JWT_SECRET` | _(dev default)_ | HMAC-SHA256 signing secret, minimum 32 characters. **Must be changed in production.** |
+| `PLUGWERK_BASE_URL` | `http://localhost:8080` | Public base URL of the server (used for artifact download links) |
+| `PLUGWERK_STORAGE_ROOT` | `/var/plugwerk/artifacts` | Filesystem path for storing artifact binaries |
+| `PLUGWERK_STORAGE_TYPE` | `fs` | Storage backend: `fs` (filesystem) |
 
 ## Key Features
 
-- Searchable plugin catalog with full-text search and compatibility filtering
+- Searchable plugin catalog with full-text search, category and tag filters
 - Plugin upload via Web UI or REST API (CI/CD-ready)
-- SemVer-based versioning with compatibility matrix (`requires: >=2.0.0 & <4.0.0`)
-- SHA-256 checksum verification and optional code signing
-- Drop-in replacement for [`pf4j-update`](https://github.com/pf4j/pf4j-update) – backward compatible `plugins.json` endpoint
+- SemVer-based versioning with compatibility ranges (`requires: >=2.0.0 & <4.0.0`)
+- SHA-256 checksum verification for artifact integrity
+- Drop-in replacement for [`pf4j-update`](https://github.com/pf4j/pf4j-update) — backward-compatible `plugins.json` endpoint
+- Review/approval workflow before releases are published
 - Multi-namespace support: one server serves multiple products/organizations
-- Self-hosted (Docker Compose / Kubernetes) or SaaS
+- Self-hosted via Docker Compose (open source, AGPL-3.0)
 
-## Module Structure
-
-```
-plugwerk/
-├── plugwerk-api/                  # OpenAPI 3.1 spec (API-First) + generated DTOs/interfaces
-├── plugwerk-spi/                  # Shared ExtensionPoint interfaces, DTOs, constants
-├── plugwerk-descriptor/           # plugwerk.yml parser/validator + PF4J manifest fallback
-├── plugwerk-server/
-│   ├── plugwerk-server-backend/   # Spring Boot 4.x + Kotlin REST API
-│   └── plugwerk-server-frontend/  # React + TypeScript + Material UI + Zustand
-└── plugwerk-client-plugin/        # PF4J plugin with isolated classloader (OkHttp + Jackson)
-```
-
-## Technology Stack
-
-| Component | Technology |
-|-----------|-----------|
-| Language | Kotlin |
-| Server Backend | Spring Boot 4.x / JVM 21+ |
-| Server API | Spring Web (REST) + OpenAPI 3.1 (API-First) |
-| Database | PostgreSQL 18 + Liquibase |
-| Storage | Filesystem (MVP) / S3-compatible (Phase 2) |
-| Web UI | React / TypeScript / Material UI / Zustand |
-| Auth | API key (MVP) / Spring Security + OIDC (Phase 2) |
-| Client SDK | PF4J plugin / OkHttp / Jackson / JVM 11+ |
-| Build | Gradle 9.x multi-module (Kotlin DSL) |
-| Tests | JUnit 6 + Mockito + Testcontainers |
-
-## Quick Start (Development)
+## Development Setup
 
 ### Prerequisites
 
@@ -61,7 +212,7 @@ plugwerk/
 - Node.js 20+
 - Docker (for PostgreSQL)
 
-### Run
+### Run locally
 
 ```bash
 # Start PostgreSQL
@@ -70,98 +221,16 @@ docker compose up -d postgres
 # Build all modules
 ./gradlew build
 
-# Run the server (dev profile)
-./gradlew :plugwerk-server:plugwerk-server-backend:bootRun --args='--spring.profiles.active=dev'
+# Start the server
+./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
 ```
 
-The server starts at `http://localhost:8080`.
-
-### Docker Compose (full stack)
+The server starts at `http://localhost:8080`. The Vite dev server (frontend with hot reload) starts separately:
 
 ```bash
-docker compose up
-```
-
-Starts Plugwerk Server + PostgreSQL 18. Open `http://localhost:8080` in your browser.
-
-## Quick Start (Self-Hosted)
-
-```bash
-# Clone and start
-git clone https://github.com/devtank42gmbh/plugwerk.git
-cd plugwerk
-docker compose up -d
-
-# Wait for health
-curl http://localhost:8080/actuator/health
-```
-
-### First login
-
-Default dev credentials (change in production via `PLUGWERK_JWT_SECRET` and `plugwerk.auth.dev-users`):
-
-| Username | Password |
-|---|---|
-| `test` | `test` |
-
-```bash
-TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"username":"test","password":"test"}' | jq -r '.accessToken')
-```
-
-### Create a namespace and upload a plugin
-
-```bash
-# Create namespace
-curl -X POST http://localhost:8080/api/v1/namespaces \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"slug":"myproduct","ownerOrg":"My Company"}'
-
-# Upload a plugin JAR (must contain plugwerk.yml)
-curl -X POST http://localhost:8080/api/v1/namespaces/myproduct/releases \
-  -H "Authorization: Bearer $TOKEN" \
-  -F "artifact=@my-plugin-1.0.0.jar"
-
-# List plugins
-curl http://localhost:8080/api/v1/namespaces/myproduct/plugins \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-### API Documentation
-
-Interactive API reference powered by [Scalar](https://scalar.com/):
-
-```
-http://localhost:8080/api-docs
-```
-
-The raw OpenAPI 3.1 spec is available at:
-
-```
-http://localhost:8080/api-docs/openapi.yaml
-```
-
-### Client SDK (Gradle)
-
-```kotlin
-// build.gradle.kts
-dependencies {
-    implementation("io.plugwerk:plugwerk-client-plugin:<version>")
-}
-```
-
-```kotlin
-val config = PlugwerkConfig.builder()
-    .serverUrl("https://plugins.mycompany.com")
-    .namespace("myproduct")
-    .apiKey(System.getenv("PLUGWERK_API_KEY"))
-    .build()
-
-val marketplace = PlugwerkMarketplace(config)
-// Use as pf4j-update UpdateRepository drop-in:
-val updateManager = UpdateManager(pluginManager, listOf(marketplace.asUpdateRepository()))
+cd plugwerk-server/plugwerk-server-frontend
+npm run dev
+# Frontend available at http://localhost:5173 (proxies /api → localhost:8080)
 ```
 
 ### E2E Smoke Test
@@ -172,8 +241,38 @@ val updateManager = UpdateManager(pluginManager, listOf(marketplace.asUpdateRepo
 
 Runs the full upload → catalog → download flow against a Docker Compose stack.
 
+### Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `./gradlew build` | Build all modules + run all tests |
+| `./gradlew build -x test` | Build without tests |
+| `./gradlew :plugwerk-api:openApiGenerate` | Regenerate backend DTOs/interfaces from OpenAPI spec |
+| `./gradlew :plugwerk-server:plugwerk-server-backend:bootRun` | Start the backend server (port 8080) |
+| `npm run dev` | Start the Vite frontend dev server (port 5173) |
+| `npm run generate:api` | Regenerate TypeScript client from OpenAPI spec |
+| `npm run test:run` | Run frontend tests (Vitest) |
+| `npm run test:coverage` | Frontend tests with V8 coverage report |
+
+## Module Structure
+
+```
+plugwerk/
+├── plugwerk-api/                  # OpenAPI 3.1 spec (API-First) + generated DTOs/interfaces
+├── plugwerk-spi/                  # Shared ExtensionPoint interfaces, DTOs, constants (JVM 11)
+├── plugwerk-descriptor/           # plugwerk.yml parser/validator + PF4J manifest fallback (JVM 11)
+├── plugwerk-server/
+│   ├── plugwerk-server-backend/   # Spring Boot 4.x + Kotlin REST API (JVM 21)
+│   └── plugwerk-server-frontend/  # React + TypeScript + Material UI + Zustand (embedded in server JAR)
+├── plugwerk-client-plugin/        # PF4J plugin with isolated classloader: OkHttp + Jackson (JVM 17)
+└── examples/
+    └── plugwerk-java-cli-example/ # End-to-end example: CLI app with dynamically loaded plugins
+```
+
 ## Documentation
 
+- [Interactive API Reference](http://localhost:8080/api-docs) (requires running server)
+- [Example: Java CLI Application](examples/plugwerk-java-cli-example/README.md)
 - [Product Concept (EN)](docs/concepts/concept-pf4j-marketplace-en.md)
 - [Produktkonzept (DE)](docs/concepts/concept-pf4j-marketplace-de.md)
 - [Architecture Decision Records](docs/adrs/)
@@ -183,7 +282,7 @@ Runs the full upload → catalog → download flow against a Docker Compose stac
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 - Language: **English** for all code, docs, issues, and reviews
-- Branches: `feature/<issue-id>_<short-description>` – never commit directly to `main`
+- Branches: `feature/<issue-id>_<short-description>` — never commit directly to `main`
 - Commits: [Conventional Commits](https://www.conventionalcommits.org/) format
 - Use the issue and PR templates in `.github/`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      SPRING_PROFILES_ACTIVE: dev
       PLUGWERK_DB_URL: jdbc:postgresql://postgres:5432/plugwerk
       PLUGWERK_DB_USERNAME: plugwerk
       PLUGWERK_DB_PASSWORD: plugwerk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,10 @@ services:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: dev
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/plugwerk
-      SPRING_DATASOURCE_USERNAME: plugwerk
-      SPRING_DATASOURCE_PASSWORD: plugwerk
+      PLUGWERK_DB_URL: jdbc:postgresql://postgres:5432/plugwerk
+      PLUGWERK_DB_USERNAME: plugwerk
+      PLUGWERK_DB_PASSWORD: plugwerk
+      PLUGWERK_STORAGE_ROOT: /tmp/plugwerk-artifacts
     ports:
       - "8080:8080"
 

--- a/docs/adrs/0006-auth-strategy.md
+++ b/docs/adrs/0006-auth-strategy.md
@@ -1,0 +1,37 @@
+# ADR-0006: Authentication Strategy — JWT + API Key (Phase 1), OIDC (Phase 2)
+
+## Status
+
+Accepted
+
+## Context
+
+Plugwerk needs authentication for two distinct use cases:
+
+1. **Human users** interacting via the Web UI (browser-based login)
+2. **Machine-to-machine** access from the Client SDK and CI/CD pipelines
+
+Phase 1 targets self-hosted deployments with a small number of known users and scripts. Full OIDC integration would require an external identity provider, which adds operational overhead that is not justified for MVP.
+
+## Decision
+
+**Phase 1 (MVP):**
+
+- Self-issued JWTs signed with HMAC-SHA256 (`plugwerk.auth.jwt-secret`)
+- A provisional `dev-users` list in `application.yml` for human login (no database user table)
+- API key support via `X-Api-Key` header for machine access (`ApiKeyAuthFilter`)
+- Token validity: 8 hours (configurable)
+
+**Phase 2+:**
+
+- Replace the provisional credential validator with a database-backed `UserRepository`
+- Integrate an external OIDC provider (e.g. Keycloak, Auth0) via Spring Security OAuth2 Resource Server
+- Remove `dev-users` list from configuration
+
+## Consequences
+
+- **Easier:** Zero external dependencies in Phase 1 — no identity provider to run or configure
+- **Easier:** API key flow is simple and CI/CD-friendly
+- **Harder:** `dev-users` are committed to source control — not suitable for real production use
+- **Harder:** No self-service user registration in Phase 1
+- **Risk:** `jwt-secret` must be rotated if exposed; enforced via startup validation and documented warning

--- a/docs/adrs/0007-artifact-storage.md
+++ b/docs/adrs/0007-artifact-storage.md
@@ -1,0 +1,32 @@
+# ADR-0007: Artifact Storage — Filesystem (Phase 1), S3-Compatible (Phase 2)
+
+## Status
+
+Accepted
+
+## Context
+
+Uploaded plugin JARs must be stored and retrieved reliably. Options considered:
+
+1. **Filesystem** — simplest, no additional services, works in Docker Compose
+2. **S3-compatible object storage** (AWS S3, MinIO, Garage) — scalable, cloud-native, HA-ready
+3. **Database BLOB** — easy to back up with the DB, but poor performance for large files and no streaming support
+
+The MVP targets single-node self-hosted deployments. Scalability and high availability are Phase 2 concerns.
+
+## Decision
+
+**Phase 1 (MVP):** Filesystem storage via `PlugwerkStorageService` with a configurable root directory (`plugwerk.storage.fs.root`).
+
+- Artifacts stored as `{namespace}/{pluginId}/{version}.jar`
+- SHA-256 checksum computed on upload and stored in `plugin_release.artifact_sha256`
+- Verified on download
+
+**Phase 2+:** Add a `S3StorageService` implementation of the same `StorageService` interface, switchable via `plugwerk.storage.type=s3`. No server code changes required.
+
+## Consequences
+
+- **Easier:** No additional infrastructure for Phase 1 self-hosted deployments
+- **Easier:** `StorageService` interface isolates storage concerns — swapping is a single implementation class
+- **Harder:** Filesystem storage does not survive container restarts without a persistent volume (documented in Docker Compose setup)
+- **Harder:** No built-in replication or redundancy in Phase 1

--- a/docs/adrs/0008-api-docs-scalar.md
+++ b/docs/adrs/0008-api-docs-scalar.md
@@ -1,0 +1,33 @@
+# ADR-0008: API Documentation — Scalar instead of SpringDoc/Swagger UI
+
+## Status
+
+Accepted
+
+## Context
+
+Plugwerk needs interactive API documentation accessible at a well-known URL. Common options:
+
+1. **SpringDoc OpenAPI** (`springdoc-openapi-starter-webmvc-ui`) — the standard Spring Boot Swagger UI integration
+2. **Redoc** — clean, three-panel documentation UI, embeddable via React component
+3. **Scalar** (`@scalar/api-reference-react`) — modern, visually polished API reference UI, embeddable as React component
+
+Two additional constraints shaped the decision:
+
+- **Spring Boot 4 compatibility:** SpringDoc 2.x supports Spring Boot 3.x only. As of the time of this decision, no stable SpringDoc release supports Spring Boot 4 / Spring Framework 7. A snapshot dependency would be required.
+- **Existing canonical spec:** The project is API-First. A complete, authoritative `plugwerk-api.yaml` already exists and is the single source of truth. SpringDoc's code-scanning approach would generate a second spec that could drift from the canonical one.
+
+## Decision
+
+- The backend serves the canonical `plugwerk-api.yaml` at `/api-docs/openapi.yaml` via a Gradle `processResources` copy task (no duplication in source, no extra Spring component)
+- The frontend embeds **Scalar** (`@scalar/api-reference-react`) in an `ApiDocsPage` that points to `/api-docs/openapi.yaml`
+- The "API Docs" link in the application footer navigates to `/api-docs`
+- Spring Security permits unauthenticated access to `/api-docs/**`
+
+## Consequences
+
+- **Easier:** No Spring Boot 4 compatibility issues — zero SpringDoc dependency
+- **Easier:** One canonical spec — no risk of generated vs. hand-written spec divergence
+- **Easier:** Scalar respects the app's dark/light mode preference
+- **Harder:** API docs are only available when the frontend is running (not as a standalone static page)
+- **Note:** If SpringDoc releases stable Spring Boot 4 support, this decision can be revisited (ADR-0008 superseded)

--- a/docs/concepts/concept-pf4j-marketplace-en.md
+++ b/docs/concepts/concept-pf4j-marketplace-en.md
@@ -1,4 +1,4 @@
-# PlugWerk – Plugin Marketplace for the Java Ecosystem
+# PlugWerk – Plugin Management and Marketplace Software for the Java Ecosystem
 
 **Concept Paper | Product Vision, Features, Implementation Outline & Operating Model**
 
@@ -12,7 +12,7 @@ Java applications built on PF4J (Plugin Framework for Java) lack a centralized i
 
 **PlugWerk** closes this gap as a standalone product. It consists of two artifacts:
 
-1. **PlugWerk Server** – a web application that serves as a central plugin marketplace: catalog, upload, versioning, download, and REST API.
+1. **PlugWerk Server** – a web application that serves as central plugin management and marketplace software: catalog, upload, versioning, download, and REST API.
 2. **PlugWerk Client SDK** – a Java library that can be embedded into any Java application to connect to the marketplace: plugin discovery, download, installation, update checking, and lifecycle integration with PF4J.
 
 The product is intentionally **product-agnostic**. Any Java software product that uses or wants to use PF4J can adopt PlugWerk as its plugin infrastructure – comparable to the relationship between Maven Central and Maven, but specialized for runtime plugins rather than build dependencies.
@@ -518,7 +518,7 @@ devtank42 operates the PlugWerk server as a managed service.
 | **Maven Central / Nexus** | Artifact hosting | Universal, proven | No plugin lifecycle, no compatibility matrix |
 | **OSGi (Felix, Karaf)** | Technically related | Hot-deploy, isolation, dependency mgmt | Complex stack, no marketplace aspect |
 
-**Positioning:** PlugWerk is the **only generic, product-agnostic plugin marketplace for the PF4J ecosystem**. It combines the simplicity of pf4j-update with the functionality of a full-featured marketplace.
+**Positioning:** PlugWerk is the **only generic, product-agnostic plugin management and marketplace solution for the PF4J ecosystem**. It combines the simplicity of pf4j-update with the functionality of a full-featured marketplace.
 
 ---
 

--- a/docs/design/design-briefing.md
+++ b/docs/design/design-briefing.md
@@ -1,7 +1,7 @@
 # PlugWerk – Web UI Design Briefing
 
 **Document Type:** Design Briefing for Figma and HTML Templates  
-**Project:** PlugWerk – Plugin Marketplace for the Java/PF4J Ecosystem  
+**Project:** PlugWerk – Plugin Management and Marketplace Software for the Java/PF4J Ecosystem
 **Created:** March 21, 2026 | Version 2.0  
 **Audience:** Web Designers, UI/UX Designers, Frontend Developers
 
@@ -9,7 +9,7 @@
 
 ## 1. About the Product
 
-PlugWerk is a **self-hosted** plugin marketplace for Java applications built on the PF4J framework. Organizations deploy PlugWerk on their own infrastructure (Docker / Kubernetes) to provide a central catalog where users can discover, explore, and download plugins for their PF4J-based products.
+PlugWerk is **self-hosted plugin management and marketplace software** for Java applications built on the PF4J framework. Organizations deploy PlugWerk on their own infrastructure (Docker / Kubernetes) to provide a central catalog where users can discover, explore, and download plugins for their PF4J-based products.
 
 **This is not a SaaS product.** There is no public marketing site, no pricing page, and no signup funnel. The web UI is the application itself — deployed inside an organization's network or on a public server managed by the operator. The first thing a user sees is the plugin catalog, not a landing page.
 

--- a/examples/plugwerk-java-cli-example/README.md
+++ b/examples/plugwerk-java-cli-example/README.md
@@ -72,9 +72,8 @@ Maven Local. Run once from the **main project root**:
 # Start the database
 docker compose up -d postgres
 
-# Start the server with the dev profile
-./gradlew :plugwerk-server:plugwerk-server-backend:bootRun \
-    --args='--spring.profiles.active=dev'
+# Start the server
+./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
 ```
 
 The server listens on `http://localhost:8080`.
@@ -114,7 +113,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
 echo $TOKEN   # eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-> The dev profile ships with a hardcoded user `test` / `test`.
+> The default configuration ships with a hardcoded user `test` / `test` for development. Never use these credentials in production.
 
 ### Passing the token to the CLI
 

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -9,11 +9,15 @@ info:
 
 servers:
   - url: /api/v1
-    description: Base path for all API endpoints
+    description: Versioned REST API
+  - url: /api
+    description: Authentication endpoints
 
 security: []
 
 tags:
+  - name: Auth
+    description: Authentication (login, token)
   - name: Namespaces
     description: Namespace management (authenticated)
   - name: Catalog
@@ -26,6 +30,31 @@ tags:
     description: Admin review workflow
 
 paths:
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      summary: Login with username and password
+      description: Returns a JWT Bearer token valid for 8 hours.
+      operationId: login
+      servers:
+        - url: /api
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          description: Invalid credentials
+
   /namespaces:
     get:
       tags:
@@ -516,6 +545,38 @@ components:
       description: Filter by plugin status
 
   schemas:
+    LoginRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          example: test
+        password:
+          type: string
+          format: password
+          example: test
+      required:
+        - username
+        - password
+
+    LoginResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          description: JWT Bearer token
+        tokenType:
+          type: string
+          example: Bearer
+        expiresIn:
+          type: integer
+          format: int64
+          description: Token validity in seconds
+      required:
+        - accessToken
+        - tokenType
+        - expiresIn
+
     NamespaceSummary:
       type: object
       properties:

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1,7 +1,89 @@
 openapi: 3.1.0
 info:
   title: Plugwerk API
-  description: Plugin marketplace for the Java/PF4J ecosystem
+  description: |
+    **Plugwerk** is a self-hosted plugin marketplace for the [PF4J](https://pf4j.org/) ecosystem.
+    It lets teams publish, version, and distribute Java/Kotlin plugins to their own applications
+    without relying on a public registry.
+
+    ## Core Concepts
+
+    ### Namespaces
+    A **namespace** is the top-level organisational unit. Every plugin belongs to exactly one
+    namespace. Namespaces are identified by a URL-safe **slug** (lowercase alphanumeric + hyphens,
+    2–64 characters). You might use one namespace per product, team, or customer, e.g. `acme-core`.
+
+    ### Plugins
+    A **plugin** is a logical grouping of releases for a single PF4J plugin ID. The `pluginId`
+    matches the `Plugin-Id` entry in the PF4J manifest (`MANIFEST.MF` or `plugin.properties`).
+    Each plugin can have a human-readable name, description, icon, and categorisation metadata.
+
+    ### Releases
+    A **release** is a specific versioned artifact (JAR or ZIP) for a plugin. Versions follow
+    [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). Releases go through a
+    lifecycle: `draft` → `published` → `deprecated` / `yanked`. Only `published` releases are
+    returned to catalog and update-check consumers. A namespace owner can optionally require
+    manual review before a release is published (see the **Reviews** tag).
+
+    ### Plugin Descriptor (`plugwerk.yml`)
+    When you upload a release artifact, the server reads a `plugwerk.yml` file embedded in the
+    JAR/ZIP. This descriptor extends the standard PF4J manifest with Plugwerk-specific metadata:
+    ```yaml
+    plugwerk:
+      id: com.example.my-plugin
+      version: 1.2.0
+      name: My Plugin
+      description: Does something useful
+      requires:
+        system-version: ">=2.0.0 & <4.0.0"
+        plugins:
+          - id: com.example.dependency
+            version: ">=1.0.0"
+    ```
+    If `plugwerk.yml` is absent the server falls back to the PF4J manifest headers.
+
+    ## Authentication
+
+    The API supports two authentication methods:
+
+    ### Bearer Token (JWT)
+    Obtain a short-lived JWT by calling `POST /api/auth/login` with your username and password.
+    Pass the returned token in subsequent requests:
+    ```
+    Authorization: Bearer <token>
+    ```
+    Tokens are valid for 8 hours by default.
+
+    ### API Key
+    Long-lived API keys are suitable for CI/CD pipelines. Pass the key in the request header:
+    ```
+    X-Api-Key: <your-api-key>
+    ```
+    API keys are managed by the server administrator.
+
+    ## Quick Start
+
+    1. **Login** — `POST /api/auth/login` → receive `accessToken`
+    2. **Create a namespace** — `POST /api/v1/namespaces` with `{ "slug": "my-ns" }`
+    3. **Create a plugin** — `POST /api/v1/namespaces/my-ns/plugins` with `{ "pluginId": "...", "name": "..." }`
+    4. **Upload a release** — `POST /api/v1/namespaces/my-ns/releases` (multipart, artifact field)
+    5. **Publish the release** — `PATCH /api/v1/namespaces/my-ns/plugins/{pluginId}/releases/{version}` with `{ "status": "published" }`
+    6. **Clients poll for updates** — `POST /api/v1/namespaces/my-ns/updates/check`
+
+    ## pf4j-update Compatibility
+    The `GET /namespaces/{ns}/plugins.json` endpoint returns a response that is fully compatible
+    with the [pf4j-update](https://github.com/pf4j/pf4j-update) `UpdateRepository` format.
+    You can point any existing pf4j-update client directly at this URL as a drop-in replacement.
+
+    ## Error Handling
+    All errors return an `ErrorResponse` body with a machine-readable `error` code and a
+    human-readable `message`. HTTP status codes follow REST conventions:
+    - `400 Bad Request` — validation error in the request body or parameters
+    - `401 Unauthorized` — missing or invalid authentication credentials
+    - `404 Not Found` — the requested resource does not exist
+    - `409 Conflict` — a resource with the same identifier already exists
+    - `422 Unprocessable Entity` — the artifact was uploaded successfully but the plugin
+      descriptor inside it is missing or invalid
   version: 0.1.0
   license:
     name: AGPL-3.0
@@ -9,25 +91,67 @@ info:
 
 servers:
   - url: /api/v1
-    description: Versioned REST API
+    description: Versioned REST API (all plugin/catalog/management endpoints)
   - url: /api
-    description: Authentication endpoints
+    description: Authentication endpoints (login)
 
 security: []
 
 tags:
   - name: Auth
-    description: Authentication (login, token)
+    description: |
+      Endpoints for obtaining and refreshing authentication credentials.
+
+      Call `POST /api/auth/login` to exchange a username/password pair for a short-lived JWT
+      Bearer token. Include this token in the `Authorization` header of all subsequent requests
+      that require authentication.
   - name: Namespaces
-    description: Namespace management (authenticated)
+    description: |
+      Create and list namespaces.
+
+      A namespace is the root container for plugins. Every plugin upload, catalog query, and
+      update-check is scoped to a namespace slug. Namespace slugs must be globally unique,
+      lowercase, and contain only alphanumeric characters and hyphens (pattern: `[a-z0-9][a-z0-9-]{0,62}[a-z0-9]`).
+
+      Namespace operations require authentication (Bearer token or API key).
   - name: Catalog
-    description: Plugin catalog queries (public or API-key-protected)
+    description: |
+      Read-only endpoints for discovering and downloading plugins.
+
+      These endpoints are designed to be consumed by end-user tooling (IDE plugins, CLI tools,
+      the Plugwerk client SDK). Most catalog endpoints are public (no authentication required)
+      unless the namespace owner has enabled access control.
+
+      The `plugins.json` endpoint (`GET /namespaces/{ns}/plugins.json`) is a drop-in replacement
+      for the pf4j-update `UpdateRepository` plugin feed.
   - name: Management
-    description: Plugin and release management (authenticated)
+    description: |
+      Authenticated endpoints for publishing and maintaining plugins.
+
+      Use these endpoints from your CI/CD pipeline or release tooling:
+      - **Create** a plugin entry with metadata before uploading the first release
+      - **Upload** a release artifact (JAR/ZIP); the server reads the embedded `plugwerk.yml`
+      - **Update** plugin metadata (description, categories, tags, links)
+      - **Change release status** to publish, deprecate, or yank a release
+
+      All management endpoints require an API key (`X-Api-Key` header) or Bearer token.
   - name: Updates
-    description: Update checking for client SDK
+    description: |
+      Endpoints used by the Plugwerk client SDK (and any compatible tooling) to poll for
+      available plugin updates.
+
+      Send the list of currently installed plugins with their versions; receive back only the
+      plugins that have a newer published release available. This endpoint does not require
+      authentication unless the namespace is access-controlled.
   - name: Reviews
-    description: Admin review workflow
+    description: |
+      Admin workflow for reviewing and approving plugin releases before they are published.
+
+      When review mode is enabled for a namespace, newly uploaded releases land in `draft`
+      status and appear in the pending review queue. A namespace admin calls `approve` or
+      `reject` to transition the release.
+
+      These endpoints require authentication and admin-level permissions on the namespace.
 
 paths:
   /auth/login:
@@ -35,38 +159,54 @@ paths:
       tags:
         - Auth
       summary: Login with username and password
-      description: Returns a JWT Bearer token valid for 8 hours.
+      description: |
+        Authenticates the user and returns a signed JWT Bearer token.
+
+        The token is valid for 8 hours (28 800 seconds) by default. Include it in all
+        authenticated requests as `Authorization: Bearer <token>`.
+
+        Returns `401 Unauthorized` if the username does not exist or the password is wrong.
+        The response body is intentionally empty on `401` to avoid leaking user existence.
       operationId: login
       servers:
         - url: /api
+          description: Authentication base path (no version prefix)
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LoginRequest'
+            example:
+              username: admin
+              password: changeme
       responses:
         '200':
-          description: Login successful
+          description: Login successful — returns a JWT Bearer token
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
         '401':
-          description: Invalid credentials
+          description: Invalid username or password
 
   /namespaces:
     get:
       tags:
         - Namespaces
       summary: List all namespaces
+      description: |
+        Returns all namespaces visible to the authenticated caller.
+
+        In the current MVP implementation this returns all namespaces in the system.
+        Future releases will scope this to namespaces the caller has access to.
       operationId: listNamespaces
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
       responses:
         '200':
-          description: List of namespaces
+          description: List of all namespaces
           content:
             application/json:
               schema:
@@ -74,11 +214,19 @@ paths:
                 items:
                   $ref: '#/components/schemas/NamespaceSummary'
         '401':
-          description: Unauthorized
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
         - Namespaces
       summary: Create a new namespace
+      description: |
+        Creates a new namespace with the given slug.
+
+        The slug must be unique across the system, lowercase, and contain only alphanumeric
+        characters and hyphens. It cannot start or end with a hyphen and must be at least
+        2 characters long (pattern: `^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$`).
+
+        If a namespace with the same slug already exists, `409 Conflict` is returned.
       operationId: createNamespace
       security:
         - BearerAuth: []
@@ -89,22 +237,34 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/NamespaceCreateRequest'
+            example:
+              slug: acme-core
+              ownerOrg: ACME Corporation
       responses:
         '201':
-          description: Namespace created
+          description: Namespace created successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NamespaceSummary'
         '401':
-          description: Unauthorized
+          $ref: '#/components/responses/Unauthorized'
         '409':
-          description: Namespace with this slug already exists
+          description: A namespace with this slug already exists
+
   /namespaces/{ns}/plugins:
     get:
       tags:
         - Catalog
-      summary: List plugins
+      summary: List plugins in a namespace
+      description: |
+        Returns a paginated list of plugins in the given namespace.
+
+        Results can be filtered by category, tag, and status, and searched by a full-text
+        query across plugin name, description, and tags. Only plugins with at least one
+        published release are shown by default (status `active`).
+
+        This endpoint is publicly accessible unless the namespace has access control enabled.
       operationId: listPlugins
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
@@ -117,7 +277,7 @@ paths:
         - $ref: '#/components/parameters/StatusFilter'
       responses:
         '200':
-          description: Paginated plugin list
+          description: Paginated list of plugins matching the given filters
           content:
             application/json:
               schema:
@@ -128,6 +288,18 @@ paths:
       tags:
         - Management
       summary: Create a new plugin
+      description: |
+        Registers a new plugin in the namespace with the given metadata.
+
+        The `pluginId` must match the `Plugin-Id` value in the PF4J manifest of all release
+        artifacts that will be uploaded for this plugin. It must be unique within the namespace.
+
+        Creating the plugin entry is optional if you upload a release first — the server will
+        auto-create the plugin from the descriptor embedded in the artifact. Use this endpoint
+        when you want to pre-register metadata (categories, links, description) before the first
+        release is ready.
+
+        Returns `409 Conflict` if a plugin with the same `pluginId` already exists in the namespace.
       operationId: createPlugin
       security:
         - ApiKeyAuth: []
@@ -139,9 +311,20 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PluginCreateRequest'
+            example:
+              pluginId: com.example.my-plugin
+              name: My Plugin
+              description: A useful plugin for Example App
+              author: ACME Corp
+              license: Apache-2.0
+              categories:
+                - analytics
+              tags:
+                - reporting
+                - export
       responses:
         '201':
-          description: Plugin created
+          description: Plugin created successfully
           content:
             application/json:
               schema:
@@ -151,7 +334,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '409':
-          description: Plugin with this pluginId already exists
+          description: A plugin with this pluginId already exists in the namespace
           content:
             application/json:
               schema:
@@ -162,13 +345,18 @@ paths:
       tags:
         - Catalog
       summary: Get plugin details
+      description: |
+        Returns full metadata for a single plugin, including the latest published version
+        and the latest draft version (if any).
+
+        This endpoint is publicly accessible unless the namespace has access control enabled.
       operationId: getPlugin
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
         - $ref: '#/components/parameters/PluginIdPath'
       responses:
         '200':
-          description: Plugin details
+          description: Plugin details including release summary
           content:
             application/json:
               schema:
@@ -179,6 +367,12 @@ paths:
       tags:
         - Management
       summary: Update plugin metadata
+      description: |
+        Updates the editable metadata fields of an existing plugin (name, description,
+        categories, tags, links). Only the fields present in the request body are updated —
+        omitted fields retain their current values.
+
+        Note: `pluginId` and `namespace` cannot be changed after creation.
       operationId: updatePlugin
       security:
         - ApiKeyAuth: []
@@ -193,7 +387,7 @@ paths:
               $ref: '#/components/schemas/PluginUpdateRequest'
       responses:
         '200':
-          description: Plugin updated
+          description: Plugin updated — returns the full updated plugin
           content:
             application/json:
               schema:
@@ -209,7 +403,31 @@ paths:
     post:
       tags:
         - Management
-      summary: Upload a new release (descriptor is read from the JAR)
+      summary: Upload a new release artifact
+      description: |
+        Uploads a plugin artifact (JAR or ZIP) and creates a new release.
+
+        The server reads the `plugwerk.yml` descriptor embedded in the artifact to extract
+        the plugin ID, version, and all other metadata. If `plugwerk.yml` is absent, the
+        server falls back to reading the PF4J manifest headers (`MANIFEST.MF` /
+        `plugin.properties`).
+
+        **Descriptor requirements** (`plugwerk.yml` inside the archive):
+        ```yaml
+        plugwerk:
+          id: com.example.my-plugin   # must match the registered plugin
+          version: 1.2.0              # SemVer, must be unique for this plugin
+          name: My Plugin
+          description: Short description
+        ```
+
+        The artifact SHA-256 is computed server-side and stored with the release for
+        integrity verification by the client SDK.
+
+        New releases are created with status `draft`. Publish them explicitly via
+        `PATCH /namespaces/{ns}/plugins/{pluginId}/releases/{version}`.
+
+        Returns `422 Unprocessable Entity` if the descriptor is missing or invalid.
       operationId: uploadRelease
       security:
         - ApiKeyAuth: []
@@ -223,7 +441,7 @@ paths:
               $ref: '#/components/schemas/ReleaseUploadRequest'
       responses:
         '201':
-          description: Release created
+          description: Release created with status `draft`
           content:
             application/json:
               schema:
@@ -240,6 +458,12 @@ paths:
       tags:
         - Catalog
       summary: List releases for a plugin
+      description: |
+        Returns a paginated list of all releases for the given plugin, ordered by version
+        descending (newest first) by default.
+
+        Draft releases are only included if the caller is authenticated and has management
+        access to the namespace.
       operationId: listReleases
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
@@ -248,7 +472,7 @@ paths:
         - $ref: '#/components/parameters/SizeQuery'
       responses:
         '200':
-          description: Paginated release list
+          description: Paginated list of releases for the plugin
           content:
             application/json:
               schema:
@@ -261,6 +485,9 @@ paths:
       tags:
         - Catalog
       summary: Get a specific release
+      description: |
+        Returns the full details of a single release, including the SHA-256 checksum,
+        compatibility requirements, and plugin dependencies.
       operationId: getRelease
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
@@ -279,6 +506,19 @@ paths:
       tags:
         - Management
       summary: Update release status
+      description: |
+        Transitions a release to a new lifecycle status.
+
+        Allowed transitions:
+        - `draft` → `published` — makes the release visible in the catalog and eligible for
+          update checks. If the namespace requires review, use the **Reviews** endpoints instead.
+        - `published` → `deprecated` — the release remains downloadable but update checks
+          will no longer recommend it.
+        - `published` → `yanked` — the release is hidden from the catalog and update checks.
+          Yanking is irreversible and typically used for releases with critical security issues.
+        - `deprecated` → `yanked` — same as above.
+
+        Note: `draft` → `yanked` is not allowed. Publish first, then yank if needed.
       operationId: updateReleaseStatus
       security:
         - ApiKeyAuth: []
@@ -292,9 +532,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ReleaseStatusUpdateRequest'
+            example:
+              status: published
       responses:
         '200':
-          description: Release status updated
+          description: Release status updated — returns the updated release
           content:
             application/json:
               schema:
@@ -311,6 +553,15 @@ paths:
       tags:
         - Catalog
       summary: Download release artifact
+      description: |
+        Downloads the raw plugin artifact binary (JAR or ZIP).
+
+        The response is a binary stream (`application/octet-stream`). Clients should verify
+        the downloaded file against the `artifactSha256` value from the release metadata to
+        ensure integrity. The Plugwerk client SDK performs this check automatically.
+
+        Only `published` releases can be downloaded by unauthenticated callers. Authenticated
+        callers with management access can also download `draft` releases.
       operationId: downloadRelease
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
@@ -318,7 +569,7 @@ paths:
         - $ref: '#/components/parameters/VersionPath'
       responses:
         '200':
-          description: Plugin artifact binary
+          description: Plugin artifact binary stream
           content:
             application/octet-stream:
               schema:
@@ -331,13 +582,26 @@ paths:
     get:
       tags:
         - Catalog
-      summary: pf4j-update compatible plugin list
+      summary: pf4j-update compatible plugin feed
+      description: |
+        Returns the plugin catalog in the [pf4j-update](https://github.com/pf4j/pf4j-update)
+        `plugins.json` format. This is a **drop-in replacement** for any existing
+        `UpdateRepository` URL in a pf4j-update-based application.
+
+        Only `published` releases are included. Each plugin entry contains all published
+        releases with their download URLs, SHA-512 checksums, and `requires` (minimum host
+        application version) values.
+
+        Point your pf4j-update `UpdateRepository` at:
+        ```
+        https://your-server/api/v1/namespaces/{ns}/plugins.json
+        ```
       operationId: getPluginsJson
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
       responses:
         '200':
-          description: pf4j-update compatible JSON
+          description: pf4j-update compatible plugin feed (JSON)
           content:
             application/json:
               schema:
@@ -347,7 +611,19 @@ paths:
     post:
       tags:
         - Updates
-      summary: Check for available updates
+      summary: Check for available plugin updates
+      description: |
+        Accepts the list of currently installed plugins with their versions and returns
+        only the plugins that have a newer published release available.
+
+        This endpoint is designed to be called periodically by the Plugwerk client SDK
+        (e.g. on application startup). Pass up to 500 installed plugins per request.
+
+        A plugin is considered to have an update if a published release with a higher
+        SemVer version exists in the namespace. Pre-release versions (e.g. `1.0.0-beta.1`)
+        are only suggested as updates to other pre-release versions of the same minor series.
+
+        This endpoint does not require authentication unless the namespace has access control enabled.
       operationId: checkForUpdates
       parameters:
         - $ref: '#/components/parameters/NamespaceSlug'
@@ -357,9 +633,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateCheckRequest'
+            example:
+              plugins:
+                - pluginId: com.example.my-plugin
+                  currentVersion: 1.0.0
+                - pluginId: com.example.other-plugin
+                  currentVersion: 2.3.1
       responses:
         '200':
-          description: Available updates
+          description: |
+            List of plugins that have a newer published release available.
+            Plugins that are already up to date are omitted from the response.
           content:
             application/json:
               schema:
@@ -369,7 +653,17 @@ paths:
     get:
       tags:
         - Reviews
-      summary: List pending reviews
+      summary: List releases pending review
+      description: |
+        Returns all releases in the namespace that are waiting for admin approval before
+        they can be published.
+
+        Releases appear here when:
+        - The namespace has review mode enabled, AND
+        - A new release artifact was uploaded (status is `draft`)
+
+        Releases approved via `POST /reviews/{releaseId}/approve` are automatically
+        transitioned to `published` and removed from this queue.
       operationId: listPendingReviews
       security:
         - ApiKeyAuth: []
@@ -377,7 +671,7 @@ paths:
         - $ref: '#/components/parameters/NamespaceSlug'
       responses:
         '200':
-          description: Pending review items
+          description: List of releases pending review, ordered by submission date ascending
           content:
             application/json:
               schema:
@@ -391,7 +685,14 @@ paths:
     post:
       tags:
         - Reviews
-      summary: Approve a release
+      summary: Approve a pending release
+      description: |
+        Approves a release that is pending review and transitions it to `published` status,
+        making it immediately visible in the catalog and eligible for update checks.
+
+        An optional `comment` can be included in the request body (e.g. review notes).
+
+        Returns `404 Not Found` if the release does not exist or is not in `draft` status.
       operationId: approveRelease
       security:
         - ApiKeyAuth: []
@@ -403,9 +704,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ReviewDecisionRequest'
+            example:
+              comment: Reviewed and approved. Artifact matches signed build.
       responses:
         '200':
-          description: Release approved
+          description: Release approved and transitioned to `published`
           content:
             application/json:
               schema:
@@ -419,7 +722,15 @@ paths:
     post:
       tags:
         - Reviews
-      summary: Reject a release
+      summary: Reject a pending release
+      description: |
+        Rejects a release that is pending review.
+
+        The release remains in `draft` status and is removed from the review queue.
+        The publisher can fix issues and re-submit by uploading a new release artifact.
+
+        A `comment` explaining the rejection reason is strongly recommended so the
+        publisher understands what needs to be fixed.
       operationId: rejectRelease
       security:
         - ApiKeyAuth: []
@@ -431,9 +742,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ReviewDecisionRequest'
+            example:
+              comment: Artifact contains unsigned code. Please sign and re-upload.
       responses:
         '200':
-          description: Release rejected
+          description: Release rejected — remains in `draft` status
           content:
             application/json:
               schema:
@@ -453,7 +766,9 @@ components:
         type: string
         pattern: '^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$'
         maxLength: 64
-      description: Namespace slug
+      description: |
+        The namespace slug. Must be lowercase alphanumeric with optional hyphens,
+        between 2 and 64 characters. Example: `acme-core`
 
     PluginIdPath:
       name: pluginId
@@ -463,7 +778,10 @@ components:
         type: string
         pattern: '^[a-zA-Z0-9._-]{1,128}$'
         maxLength: 128
-      description: PF4J Plugin-Id
+      description: |
+        The PF4J plugin identifier. Must match the `Plugin-Id` entry in the plugin manifest.
+        Supports alphanumeric characters, dots, underscores, and hyphens.
+        Example: `com.example.my-plugin`
 
     VersionPath:
       name: version
@@ -472,7 +790,9 @@ components:
       schema:
         type: string
         pattern: '^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'
-      description: SemVer version string
+      description: |
+        Semantic version string (`MAJOR.MINOR.PATCH`). Pre-release and build metadata
+        suffixes are supported per SemVer 2.0. Examples: `1.2.3`, `2.0.0-beta.1`, `1.0.0+build.42`
 
     ReleaseIdPath:
       name: releaseId
@@ -481,7 +801,7 @@ components:
       schema:
         type: string
         format: uuid
-      description: Release UUID
+      description: The internal UUID of the release (from `PluginReleaseDto.id`)
 
     PageQuery:
       name: page
@@ -490,7 +810,7 @@ components:
         type: integer
         default: 0
         minimum: 0
-      description: Page number (zero-based)
+      description: Zero-based page index. The first page is `0`.
 
     SizeQuery:
       name: size
@@ -500,7 +820,7 @@ components:
         default: 20
         minimum: 1
         maximum: 100
-      description: Page size
+      description: Number of items per page. Maximum is 100.
 
     SortQuery:
       name: sort
@@ -510,28 +830,36 @@ components:
         default: name,asc
         pattern: '^[a-zA-Z]{1,32},(asc|desc)$'
         maxLength: 40
-      description: Sort field and direction (e.g. name,asc)
+      description: |
+        Sort field and direction, formatted as `field,direction`.
+        Examples: `name,asc`, `downloadCount,desc`, `createdAt,desc`
 
     SearchQuery:
       name: q
       in: query
       schema:
         type: string
-      description: Full-text search query
+      description: |
+        Full-text search query. Matched against plugin name, description, and tags.
+        Example: `reporting export`
 
     CategoryFilter:
       name: category
       in: query
       schema:
         type: string
-      description: Filter by category
+      description: |
+        Filter by category slug. Only plugins that have this category assigned are returned.
+        Example: `analytics`
 
     TagFilter:
       name: tag
       in: query
       schema:
         type: string
-      description: Filter by tag
+      description: |
+        Filter by tag. Only plugins that have this tag assigned are returned.
+        Example: `export`
 
     StatusFilter:
       name: status
@@ -542,38 +870,50 @@ components:
           - active
           - suspended
           - archived
-      description: Filter by plugin status
+      description: |
+        Filter by plugin status:
+        - `active` — plugin has at least one published release (default)
+        - `suspended` — plugin is temporarily unavailable
+        - `archived` — plugin is no longer maintained
 
   schemas:
     LoginRequest:
       type: object
+      description: Credentials for password-based login
       properties:
         username:
           type: string
           minLength: 1
-          example: test
+          description: The account username
+          example: admin
         password:
           type: string
           format: password
           minLength: 1
-          example: test
+          description: The account password (transmitted over HTTPS, never stored in plain text)
+          example: changeme
       required:
         - username
         - password
 
     LoginResponse:
       type: object
+      description: Successful login response containing the access token
       properties:
         accessToken:
           type: string
-          description: JWT Bearer token
+          description: |
+            Signed JWT Bearer token. Include in subsequent requests as:
+            `Authorization: Bearer <accessToken>`
         tokenType:
           type: string
+          description: Token type, always `Bearer`
           example: Bearer
         expiresIn:
           type: integer
           format: int64
-          description: Token validity in seconds
+          description: "Token validity duration in seconds (default: 28800 = 8 hours)"
+          example: 28800
       required:
         - accessToken
         - tokenType
@@ -581,42 +921,58 @@ components:
 
     NamespaceSummary:
       type: object
+      description: Summary of a namespace
       properties:
         slug:
           type: string
-          example: myproduct
+          description: URL-safe identifier for the namespace, unique across the system
+          example: acme-core
         ownerOrg:
           type: string
-          example: My Company
+          description: Human-readable name of the organisation that owns this namespace
+          example: ACME Corporation
       required:
         - slug
         - ownerOrg
 
     NamespaceCreateRequest:
       type: object
+      description: Request body for creating a new namespace
       properties:
         slug:
           type: string
           pattern: '^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$'
-          example: myproduct
+          description: |
+            Globally unique, URL-safe namespace identifier. Lowercase alphanumeric with hyphens,
+            2–64 characters, cannot start or end with a hyphen.
+          example: acme-core
         ownerOrg:
           type: string
-          example: My Company
+          description: Human-readable name of the owning organisation (optional, for display only)
+          example: ACME Corporation
       required:
         - slug
 
     ErrorResponse:
       type: object
+      description: Standard error response body returned for all 4xx and 5xx responses
       properties:
         status:
           type: integer
+          description: HTTP status code (mirrors the response status)
+          example: 404
         error:
           type: string
+          description: Short machine-readable error code (e.g. `NOT_FOUND`, `VALIDATION_ERROR`)
+          example: NOT_FOUND
         message:
           type: string
+          description: Human-readable description of what went wrong
+          example: Plugin 'com.example.my-plugin' not found in namespace 'acme-core'
         timestamp:
           type: string
           format: date-time
+          description: ISO-8601 timestamp of when the error occurred
       required:
         - status
         - error
@@ -625,58 +981,81 @@ components:
 
     PluginDto:
       type: object
+      description: Full plugin metadata including release summary
       properties:
         id:
           type: string
           format: uuid
+          description: Internal UUID of the plugin record (immutable)
         pluginId:
           type: string
+          description: PF4J plugin identifier (e.g. `com.example.my-plugin`). Unique within the namespace.
         name:
           type: string
+          description: Human-readable display name of the plugin
         description:
           type: string
+          description: Short description of what the plugin does
         author:
           type: string
+          description: Author or maintainer name
         license:
           type: string
+          description: SPDX license identifier (e.g. `Apache-2.0`, `MIT`, `GPL-3.0-only`)
         namespace:
           type: string
+          description: Slug of the namespace this plugin belongs to
         status:
           type: string
           enum:
             - active
             - suspended
             - archived
+          description: |
+            Lifecycle status of the plugin:
+            - `active` — has at least one published release, visible in catalog
+            - `suspended` — temporarily unavailable (e.g. security review in progress)
+            - `archived` — no longer maintained, kept for historical download access
         categories:
           type: array
           items:
             type: string
+          description: List of category slugs assigned to this plugin (for catalog filtering)
         tags:
           type: array
           items:
             type: string
+          description: Free-form tags for discovery and filtering
         latestVersion:
           type: string
+          description: SemVer of the latest `published` release, or `null` if none exists
         latestDraftVersion:
           type: string
+          description: SemVer of the latest `draft` release (only visible to authenticated management callers)
         downloadCount:
           type: integer
           format: int64
+          description: Total number of artifact downloads across all releases
         icon:
           type: string
           format: uri
+          description: "URL to the plugin icon image (recommended size: 128×128 px)"
         homepage:
           type: string
           format: uri
+          description: URL of the plugin's project homepage or documentation site
         repository:
           type: string
           format: uri
+          description: URL of the source code repository (e.g. GitHub)
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the plugin was first created
         updatedAt:
           type: string
           format: date-time
+          description: Timestamp of the most recent metadata update
       required:
         - id
         - pluginId
@@ -685,30 +1064,46 @@ components:
 
     PluginReleaseDto:
       type: object
+      description: Full metadata for a single versioned plugin release
       properties:
         id:
           type: string
           format: uuid
+          description: Internal UUID of the release record (used in review endpoints)
         pluginId:
           type: string
+          description: PF4J plugin identifier this release belongs to
         version:
           type: string
+          description: SemVer version string (e.g. `1.2.3`)
         changelog:
           type: string
+          description: Release notes / changelog text for this version (Markdown supported)
         artifactSha256:
           type: string
+          description: |
+            SHA-256 hex digest of the uploaded artifact binary.
+            Clients should verify downloaded artifacts against this value.
         artifactSize:
           type: integer
           format: int64
+          description: Size of the artifact in bytes
         requiresSystemVersion:
           type: string
+          description: |
+            SemVer range expression for the minimum required host application version.
+            Uses the Maven/PF4J range syntax, e.g. `>=2.0.0 & <4.0.0`.
         requiresApiLevel:
           type: integer
           format: int32
+          description: |
+            Minimum API level integer required by the host application (alternative to
+            `requiresSystemVersion`). Use the mechanism your host application supports.
         pluginDependencies:
           type: array
           items:
             $ref: '#/components/schemas/PluginDependencyDto'
+          description: List of other plugins this release depends on (with version constraints)
         status:
           type: string
           enum:
@@ -716,15 +1111,24 @@ components:
             - published
             - deprecated
             - yanked
+          description: |
+            Lifecycle status of this release:
+            - `draft` — uploaded but not yet visible to catalog consumers
+            - `published` — visible in catalog and eligible for update checks
+            - `deprecated` — still downloadable but no longer recommended for new installations
+            - `yanked` — hidden from catalog; typically used for releases with critical issues
         publishedAt:
           type: string
           format: date-time
+          description: Timestamp when the release was transitioned to `published` status
         downloadCount:
           type: integer
           format: int64
+          description: Number of times this specific release artifact has been downloaded
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the release was created (artifact uploaded)
       required:
         - id
         - pluginId
@@ -733,87 +1137,124 @@ components:
 
     PluginDependencyDto:
       type: object
+      description: A dependency on another plugin, with a version constraint
       properties:
         id:
           type: string
+          description: PF4J plugin identifier of the required plugin
         version:
           type: string
+          description: |
+            SemVer range constraint for the required plugin version.
+            Examples: `>=1.0.0`, `>=1.0.0 & <2.0.0`
       required:
         - id
         - version
 
     PluginCreateRequest:
       type: object
+      description: Request body for creating a new plugin entry in a namespace
       properties:
         pluginId:
           type: string
+          description: |
+            PF4J plugin identifier. Must match `Plugin-Id` in the plugin manifest exactly.
+            Unique within the namespace.
+          example: com.example.my-plugin
         name:
           type: string
+          description: Human-readable display name
+          example: My Plugin
         description:
           type: string
+          description: Short description of the plugin's purpose
         author:
           type: string
+          description: Author or maintainer name or organisation
         license:
           type: string
+          description: SPDX license expression (e.g. `Apache-2.0`, `MIT`)
         categories:
           type: array
           items:
             type: string
+          description: Category slugs for catalog browsing and filtering
         tags:
           type: array
           items:
             type: string
+          description: Free-form tags for discovery
         icon:
           type: string
           format: uri
+          description: URL to plugin icon (recommended 128×128 px)
         homepage:
           type: string
           format: uri
+          description: Project homepage or documentation URL
         repository:
           type: string
           format: uri
+          description: Source code repository URL
       required:
         - pluginId
         - name
 
     PluginUpdateRequest:
       type: object
+      description: |
+        Request body for updating plugin metadata. All fields are optional — only fields
+        present in the request body are updated (partial update / PATCH semantics).
       properties:
         name:
           type: string
+          description: New display name
         description:
           type: string
+          description: New description
         categories:
           type: array
           items:
             type: string
+          description: Replaces the full list of categories (not merged)
         tags:
           type: array
           items:
             type: string
+          description: Replaces the full list of tags (not merged)
         license:
           type: string
+          description: New SPDX license expression
         icon:
           type: string
           format: uri
+          description: New icon URL
         homepage:
           type: string
           format: uri
+          description: New homepage URL
         repository:
           type: string
           format: uri
+          description: New source repository URL
 
     ReleaseUploadRequest:
       type: object
+      description: Multipart form data for uploading a plugin release artifact
       properties:
         artifact:
           type: string
           format: binary
+          description: |
+            The plugin artifact file (JAR or ZIP). Must contain a `plugwerk.yml` descriptor
+            (or a valid PF4J manifest as fallback) for the server to extract version and
+            plugin metadata.
       required:
         - artifact
 
     ReleaseStatusUpdateRequest:
       type: object
+      description: Request body for transitioning a release to a new lifecycle status
       properties:
         status:
           type: string
@@ -821,52 +1262,73 @@ components:
             - published
             - deprecated
             - yanked
+          description: |
+            Target status for the release:
+            - `published` — make the release visible in the catalog (from `draft`)
+            - `deprecated` — mark as superseded but keep it downloadable
+            - `yanked` — remove from catalog permanently (irreversible)
       required:
         - status
 
     UpdateCheckRequest:
       type: object
+      description: List of currently installed plugins to check for updates
       properties:
         plugins:
           type: array
           maxItems: 500
           items:
             $ref: '#/components/schemas/InstalledPluginInfo'
+          description: |
+            The installed plugins to check. Up to 500 entries per request.
+            Plugins not found in the namespace are silently ignored.
       required:
         - plugins
 
     InstalledPluginInfo:
       type: object
+      description: An installed plugin with its current version
       properties:
         pluginId:
           type: string
+          description: PF4J plugin identifier
         currentVersion:
           type: string
+          description: The currently installed SemVer version (e.g. `1.0.0`)
       required:
         - pluginId
         - currentVersion
 
     UpdateCheckResponse:
       type: object
+      description: Update check result — contains only plugins that have a newer version available
       properties:
         updates:
           type: array
           items:
             $ref: '#/components/schemas/PluginUpdateInfo'
+          description: |
+            List of plugins with available updates. Plugins that are already at the latest
+            published version are omitted. An empty array means everything is up to date.
       required:
         - updates
 
     PluginUpdateInfo:
       type: object
+      description: Information about an available plugin update
       properties:
         pluginId:
           type: string
+          description: PF4J plugin identifier
         currentVersion:
           type: string
+          description: The version currently installed on the client
         latestVersion:
           type: string
+          description: The latest published version available on the server
         release:
           $ref: '#/components/schemas/PluginReleaseDto'
+          description: Full release details for the latest available version
       required:
         - pluginId
         - currentVersion
@@ -875,71 +1337,97 @@ components:
 
     Pf4jPluginsJson:
       type: object
+      description: |
+        Plugin feed in the [pf4j-update](https://github.com/pf4j/pf4j-update) `plugins.json`
+        format. This is the root object returned by the `GET /plugins.json` endpoint.
       properties:
         plugins:
           type: array
           items:
             $ref: '#/components/schemas/Pf4jPluginInfo'
+          description: List of all plugins with their published releases
       required:
         - plugins
 
     Pf4jPluginInfo:
       type: object
+      description: Plugin entry in pf4j-update format
       properties:
         id:
           type: string
+          description: PF4J plugin identifier
         description:
           type: string
+          description: Short plugin description
         provider:
           type: string
+          description: Plugin author or provider name
         projectUrl:
           type: string
+          description: Homepage or project URL
         releases:
           type: array
           items:
             $ref: '#/components/schemas/Pf4jReleaseInfo'
+          description: List of published releases for this plugin, newest first
       required:
         - id
         - releases
 
     Pf4jReleaseInfo:
       type: object
+      description: Release entry in pf4j-update format
       properties:
         version:
           type: string
+          description: SemVer version string
         date:
           type: string
           format: date
+          description: Release date (ISO-8601, e.g. `2026-01-15`)
         url:
           type: string
           format: uri
+          description: Direct download URL for the release artifact
         requires:
           type: string
+          description: |
+            Minimum host application version required, in pf4j-update range format.
+            Corresponds to `requiresSystemVersion` in the Plugwerk release model.
         sha512sum:
           type: string
+          description: SHA-512 hex digest of the artifact for integrity verification
       required:
         - version
         - url
 
     ReviewItemDto:
       type: object
+      description: A release that is pending admin review
       properties:
         releaseId:
           type: string
           format: uuid
+          description: Internal UUID of the release (use this in approve/reject endpoints)
         pluginId:
           type: string
+          description: PF4J plugin identifier
         pluginName:
           type: string
+          description: Human-readable name of the plugin
         version:
           type: string
+          description: SemVer version of the release awaiting review
         submittedBy:
           type: string
+          description: Username of the account that uploaded the release
         submittedAt:
           type: string
           format: date-time
+          description: Timestamp when the artifact was uploaded
         artifactSha256:
           type: string
+          description: SHA-256 hex digest of the artifact (for manual verification before approving)
       required:
         - releaseId
         - pluginId
@@ -949,29 +1437,40 @@ components:
 
     ReviewDecisionRequest:
       type: object
+      description: Optional comment to attach to an approve or reject decision
       properties:
         comment:
           type: string
+          description: |
+            Human-readable comment explaining the decision. Strongly recommended for
+            rejections so the publisher knows what needs to be fixed.
+          example: Approved after manual artifact verification.
 
     PluginPagedResponse:
       type: object
+      description: Paginated response containing a list of plugins
       properties:
         content:
           type: array
           items:
             $ref: '#/components/schemas/PluginDto'
+          description: Plugin entries on this page
         totalElements:
           type: integer
           format: int64
+          description: Total number of plugins matching the query (across all pages)
         page:
           type: integer
           format: int32
+          description: Current zero-based page index
         size:
           type: integer
           format: int32
+          description: Number of items per page
         totalPages:
           type: integer
           format: int32
+          description: Total number of pages
       required:
         - content
         - totalElements
@@ -981,23 +1480,29 @@ components:
 
     ReleasePagedResponse:
       type: object
+      description: Paginated response containing a list of releases
       properties:
         content:
           type: array
           items:
             $ref: '#/components/schemas/PluginReleaseDto'
+          description: Release entries on this page
         totalElements:
           type: integer
           format: int64
+          description: Total number of releases matching the query (across all pages)
         page:
           type: integer
           format: int32
+          description: Current zero-based page index
         size:
           type: integer
           format: int32
+          description: Number of items per page
         totalPages:
           type: integer
           format: int32
+          description: Total number of pages
       required:
         - content
         - totalElements
@@ -1007,25 +1512,27 @@ components:
 
   responses:
     BadRequest:
-      description: Invalid request
+      description: The request body or parameters failed validation
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
     Unauthorized:
-      description: Authentication required
+      description: Authentication credentials are missing or invalid
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
     NotFound:
-      description: Resource not found
+      description: The requested resource does not exist
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
     UnprocessableEntity:
-      description: Plugin descriptor is invalid or missing
+      description: |
+        The artifact was received but the plugin descriptor is missing or invalid.
+        Check that `plugwerk.yml` is present inside the JAR/ZIP and has the correct structure.
       content:
         application/json:
           schema:
@@ -1036,7 +1543,14 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+      description: |
+        Short-lived JWT token obtained via `POST /api/auth/login`.
+        Include as `Authorization: Bearer <token>`. Default validity: 8 hours.
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-Api-Key
+      description: |
+        Long-lived API key for CI/CD pipelines and service accounts.
+        Include as `X-Api-Key: <your-api-key>` header.
+        API keys are provisioned by the server administrator.

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -14,6 +14,8 @@ servers:
 security: []
 
 tags:
+  - name: Namespaces
+    description: Namespace management (authenticated)
   - name: Catalog
     description: Plugin catalog queries (public or API-key-protected)
   - name: Management
@@ -24,6 +26,51 @@ tags:
     description: Admin review workflow
 
 paths:
+  /namespaces:
+    get:
+      tags:
+        - Namespaces
+      summary: List all namespaces
+      operationId: listNamespaces
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: List of namespaces
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NamespaceSummary'
+        '401':
+          description: Unauthorized
+    post:
+      tags:
+        - Namespaces
+      summary: Create a new namespace
+      operationId: createNamespace
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NamespaceCreateRequest'
+      responses:
+        '201':
+          description: Namespace created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceSummary'
+        '401':
+          description: Unauthorized
+        '409':
+          description: Namespace with this slug already exists
   /namespaces/{ns}/plugins:
     get:
       tags:
@@ -469,6 +516,32 @@ components:
       description: Filter by plugin status
 
   schemas:
+    NamespaceSummary:
+      type: object
+      properties:
+        slug:
+          type: string
+          example: myproduct
+        ownerOrg:
+          type: string
+          example: My Company
+      required:
+        - slug
+        - ownerOrg
+
+    NamespaceCreateRequest:
+      type: object
+      properties:
+        slug:
+          type: string
+          pattern: '^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$'
+          example: myproduct
+        ownerOrg:
+          type: string
+          example: My Company
+      required:
+        - slug
+
     ErrorResponse:
       type: object
       properties:
@@ -896,6 +969,10 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
 
   securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     ApiKeyAuth:
       type: apiKey
       in: header

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -550,10 +550,12 @@ components:
       properties:
         username:
           type: string
+          minLength: 1
           example: test
         password:
           type: string
           format: password
+          minLength: 1
           example: test
       required:
         - username

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -42,6 +42,14 @@ dependencies {
     testRuntimeOnly(libs.h2)
 }
 
+// Copy the canonical OpenAPI spec into static resources so it is served at /api-docs/openapi.yaml
+tasks.named<ProcessResources>("processResources") {
+    from(rootProject.file("plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml")) {
+        into("static/api-docs")
+        rename { "openapi.yaml" }
+    }
+}
+
 tasks.named<Test>("test") {
     useJUnitPlatform {
         excludeTags("integration")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -63,6 +63,8 @@ class SecurityConfiguration(
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     // SPA static assets are always public
                     .requestMatchers(HttpMethod.GET, "/", "/index.html", "/assets/**", "/*.svg", "/*.ico").permitAll()
+                    // OpenAPI spec is public (used by API docs page without login)
+                    .requestMatchers(HttpMethod.GET, "/api-docs/**").permitAll()
                     // Everything else requires authentication
                     // (public namespace GET requests are handled by PublicNamespaceFilter)
                     .anyRequest().authenticated()

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
@@ -17,36 +17,31 @@
  */
 package io.plugwerk.server.controller
 
+import io.plugwerk.api.AuthApi
+import io.plugwerk.api.model.LoginRequest
+import io.plugwerk.api.model.LoginResponse
 import io.plugwerk.server.security.UserCredentialValidator
 import io.plugwerk.server.service.JwtTokenService
-import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-data class LoginRequest(@field:NotBlank val username: String, @field:NotBlank val password: String)
-
-data class LoginResponse(val accessToken: String, val tokenType: String = "Bearer", val expiresIn: Long)
-
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api")
 class AuthController(
     private val credentialValidator: UserCredentialValidator,
     private val jwtTokenService: JwtTokenService,
-) {
+) : AuthApi {
 
-    @PostMapping("/login")
-    fun login(@Valid @RequestBody request: LoginRequest): ResponseEntity<LoginResponse> {
-        if (!credentialValidator.validate(request.username, request.password)) {
+    override fun login(loginRequest: LoginRequest): ResponseEntity<LoginResponse> {
+        if (!credentialValidator.validate(loginRequest.username, loginRequest.password)) {
             return ResponseEntity.status(401).build()
         }
-        val token = jwtTokenService.generateToken(request.username)
+        val token = jwtTokenService.generateToken(loginRequest.username)
         return ResponseEntity.ok(
             LoginResponse(
                 accessToken = token,
+                tokenType = "Bearer",
                 expiresIn = jwtTokenService.tokenValiditySeconds(),
             ),
         )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
@@ -17,37 +17,35 @@
  */
 package io.plugwerk.server.controller
 
+import io.plugwerk.api.NamespacesApi
+import io.plugwerk.api.model.NamespaceCreateRequest
+import io.plugwerk.api.model.NamespaceSummary
 import io.plugwerk.server.service.NamespaceAlreadyExistsException
 import io.plugwerk.server.service.NamespaceService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
-data class NamespaceSummary(val slug: String, val ownerOrg: String)
-
-data class NamespaceCreateRequest(val slug: String, val ownerOrg: String = "default")
-
 @RestController
-@RequestMapping("/api/v1/namespaces")
-class NamespaceController(private val namespaceService: NamespaceService) {
+@RequestMapping("/api/v1")
+class NamespaceController(private val namespaceService: NamespaceService) : NamespacesApi {
 
-    @GetMapping
-    fun listNamespaces(): ResponseEntity<List<NamespaceSummary>> {
+    override fun listNamespaces(): ResponseEntity<List<NamespaceSummary>> {
         val namespaces = namespaceService.findAll()
             .map { NamespaceSummary(slug = it.slug, ownerOrg = it.ownerOrg) }
         return ResponseEntity.ok(namespaces)
     }
 
-    @PostMapping
-    fun createNamespace(@RequestBody request: NamespaceCreateRequest): ResponseEntity<NamespaceSummary> = try {
-        val entity = namespaceService.create(slug = request.slug, ownerOrg = request.ownerOrg)
-        val summary = NamespaceSummary(slug = entity.slug, ownerOrg = entity.ownerOrg)
-        ResponseEntity.created(URI("/api/v1/namespaces/${entity.slug}")).body(summary)
-    } catch (ex: NamespaceAlreadyExistsException) {
-        ResponseEntity.status(409).build()
-    }
+    override fun createNamespace(namespaceCreateRequest: NamespaceCreateRequest): ResponseEntity<NamespaceSummary> =
+        try {
+            val entity = namespaceService.create(
+                slug = namespaceCreateRequest.slug,
+                ownerOrg = namespaceCreateRequest.ownerOrg ?: "default",
+            )
+            val summary = NamespaceSummary(slug = entity.slug, ownerOrg = entity.ownerOrg)
+            ResponseEntity.created(URI("/api/v1/namespaces/${entity.slug}")).body(summary)
+        } catch (ex: NamespaceAlreadyExistsException) {
+            ResponseEntity.status(409).build()
+        }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
@@ -45,7 +45,7 @@ class NamespaceController(private val namespaceService: NamespaceService) : Name
             )
             val summary = NamespaceSummary(slug = entity.slug, ownerOrg = entity.ownerOrg)
             ResponseEntity.created(URI("/api/v1/namespaces/${entity.slug}")).body(summary)
-        } catch (ex: NamespaceAlreadyExistsException) {
+        } catch (_: NamespaceAlreadyExistsException) {
             ResponseEntity.status(409).build()
         }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/SpaController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/SpaController.kt
@@ -40,7 +40,9 @@ class SpaController {
             "/403",
             "/500",
             "/503",
-            "/{namespace}/plugins/{pluginId}",
+            "/namespaces/{namespace}/plugins",
+            "/namespaces/{namespace}/plugins/{pluginId}",
+            "/api-docs",
         ],
     )
     fun spa(request: HttpServletRequest): String = "forward:/index.html"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.multipart
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.ObjectMapper
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.assertNotNull
+
+@Tag("integration")
+@Testcontainers
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SmokeTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:18-alpine")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun overrideDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var token: String
+    private val namespace = "smoke-test"
+    private val pluginId = "smoke-plugin"
+    private val pluginVersion = "1.0.0"
+
+    @BeforeAll
+    fun login() {
+        val result = mockMvc.post("/api/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(mapOf("username" to "smoke", "password" to "smoke"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.accessToken").exists()
+        }.andReturn()
+
+        val body = objectMapper.readValue(result.response.contentAsString, Map::class.java)
+        token = body["accessToken"] as String
+        assertNotNull(token)
+    }
+
+    @Test
+    fun `full upload-catalog-download flow`() {
+        val authHeader = "Bearer $token"
+
+        // ------------------------------------------------------------------ //
+        // 1. Create namespace                                                  //
+        // ------------------------------------------------------------------ //
+        mockMvc.post("/api/v1/namespaces") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(mapOf("slug" to namespace, "ownerOrg" to "Smoke Test"))
+        }.andExpect {
+            status { isCreated() }
+        }
+
+        // ------------------------------------------------------------------ //
+        // 2. Build a minimal plugin JAR in-memory                             //
+        // ------------------------------------------------------------------ //
+        val jarBytes = buildMinimalJar(pluginId, pluginVersion)
+        val expectedSha256 = sha256(jarBytes)
+
+        // ------------------------------------------------------------------ //
+        // 3. Upload plugin release                                             //
+        // ------------------------------------------------------------------ //
+        val artifact = MockMultipartFile(
+            "artifact",
+            "$pluginId-$pluginVersion.jar",
+            "application/java-archive",
+            jarBytes,
+        )
+        val uploadResult = mockMvc.multipart("/api/v1/namespaces/$namespace/releases") {
+            file(artifact)
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id").exists()
+        }.andReturn()
+
+        val uploadBody = objectMapper.readValue(uploadResult.response.contentAsString, Map::class.java)
+        assertNotNull(uploadBody["id"], "Upload response must contain release ID")
+
+        // ------------------------------------------------------------------ //
+        // 4. Query catalog — plugin must appear                                //
+        // ------------------------------------------------------------------ //
+        mockMvc.get("/api/v1/namespaces/$namespace/plugins") {
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.content[?(@.pluginId == '$pluginId')]").exists()
+        }
+
+        // ------------------------------------------------------------------ //
+        // 5. Download artifact — SHA-256 must match                           //
+        // ------------------------------------------------------------------ //
+        val downloadResult = mockMvc.get(
+            "/api/v1/namespaces/$namespace/plugins/$pluginId/releases/$pluginVersion/download",
+        ) {
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isOk() }
+        }.andReturn()
+
+        val downloadedBytes = downloadResult.response.contentAsByteArray
+        val actualSha256 = sha256(downloadedBytes)
+        kotlin.test.assertEquals(expectedSha256, actualSha256, "SHA-256 of downloaded artifact must match uploaded JAR")
+    }
+
+    // ----------------------------------------------------------------------- //
+    // Helpers                                                                   //
+    // ----------------------------------------------------------------------- //
+
+    private fun buildMinimalJar(id: String, version: String): ByteArray {
+        val descriptor = """
+            id: $id
+            version: $version
+            name: Smoke Test Plugin
+            description: Minimal plugin for E2E smoke testing
+        """.trimIndent()
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            zip.putNextEntry(ZipEntry("plugwerk.yml"))
+            zip.write(descriptor.toByteArray())
+            zip.closeEntry()
+        }
+        return out.toByteArray()
+    }
+
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -165,10 +165,11 @@ class SmokeTest {
 
     private fun buildMinimalJar(id: String, version: String): ByteArray {
         val descriptor = """
-            id: $id
-            version: $version
-            name: Smoke Test Plugin
-            description: Minimal plugin for E2E smoke testing
+            plugwerk:
+              id: $id
+              version: $version
+              name: Smoke Test Plugin
+              description: Minimal plugin for E2E smoke testing
         """.trimIndent()
         val out = ByteArrayOutputStream()
         ZipOutputStream(out).use { zip ->

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -1,0 +1,18 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  liquibase:
+    enabled: true
+
+plugwerk:
+  storage:
+    type: fs
+    fs:
+      root: ${java.io.tmpdir}/plugwerk-smoke-test
+  auth:
+    jwt-secret: integration-test-secret-min32chars-ok!!
+    dev-users:
+      - username: smoke
+        password: smoke

--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.9",
+        "@scalar/api-reference-react": "^0.8.70",
         "axios": "^1.13.6",
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
@@ -52,6 +53,69 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.13.tgz",
+      "integrity": "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.2",
+        "@ai-sdk/provider-utils": "4.0.5",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.2.tgz",
+      "integrity": "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.5.tgz",
+      "integrity": "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/vue": {
+      "version": "3.0.33",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
+      "integrity": "sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.5",
+        "ai": "6.0.33",
+        "swrv": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -392,6 +456,160 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -889,6 +1107,80 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/core/node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom/node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.9.tgz",
+      "integrity": "sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fontsource/inter": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
@@ -905,6 +1197,33 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.2.tgz",
+      "integrity": "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
+    "node_modules/@headlessui/vue": {
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1032,6 +1351,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1078,6 +1415,96 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -1087,6 +1514,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.3.9",
@@ -1504,6 +1937,15 @@
         "url": "https://opencollective.com/openapi_generator"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
@@ -1514,6 +1956,12 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@phosphor-icons/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==",
+      "license": "MIT"
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1522,6 +1970,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@replit/codemirror-css-color-picker": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-css-color-picker/-/codemirror-css-color-picker-6.3.0.tgz",
+      "integrity": "sha512-19biDANghUm7Fz7L1SNMIhK48tagaWuCOHj4oPPxc7hxPGkTVY2lU/jVZ8tsbTKQPVG7BO2CBDzs7CBwb20t4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1786,12 +2245,799 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scalar/agent-chat": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.7.3.tgz",
+      "integrity": "sha512-r8lF7vHm0Oee8y3MgYTEOKfJF8WwdiApLICuzcqKLt0YayEURiSMB36J1SPtzISO7t66WbFi3xru8MdOa3FmUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/vue": "3.0.33",
+        "@scalar/api-client": "2.31.3",
+        "@scalar/components": "0.19.15",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/icons": "0.5.3",
+        "@scalar/json-magic": "0.11.7",
+        "@scalar/openapi-types": "0.5.4",
+        "@scalar/themes": "0.14.3",
+        "@scalar/types": "0.6.10",
+        "@scalar/use-toasts": "0.9.1",
+        "@scalar/workspace-store": "0.35.3",
+        "@vueuse/core": "13.9.0",
+        "ai": "6.0.33",
+        "neverpanic": "0.0.5",
+        "truncate-json": "3.0.1",
+        "vue": "^3.5.26",
+        "whatwg-mimetype": "4.0.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/agent-chat/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scalar/analytics-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@scalar/analytics-client/-/analytics-client-1.0.1.tgz",
+      "integrity": "sha512-ai4DJuxsNLUEgJIlYDE3n8/oF47M31Rgjz3LxbefzejxE8LiidUud/fcEzMYtdxqJYi3ketzhSbTWK0o6gg4mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/api-client": {
+      "version": "2.31.3",
+      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.31.3.tgz",
+      "integrity": "sha512-Qyy7C6Vt+9GHA4hOSdn2E0DkXB/6EjyCuqW9Vn063Wg8PIlkNAyOkszZtDtDUc0KI+c4J1iwCUVelrZr5lrnwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@headlessui/tailwindcss": "^0.2.2",
+        "@headlessui/vue": "1.7.23",
+        "@scalar/analytics-client": "1.0.1",
+        "@scalar/components": "0.19.15",
+        "@scalar/draggable": "0.3.0",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/icons": "0.5.3",
+        "@scalar/import": "0.4.55",
+        "@scalar/json-magic": "0.11.7",
+        "@scalar/oas-utils": "0.8.3",
+        "@scalar/object-utils": "1.2.32",
+        "@scalar/openapi-parser": "0.24.17",
+        "@scalar/openapi-types": "0.5.4",
+        "@scalar/postman-to-openapi": "0.4.10",
+        "@scalar/sidebar": "0.7.46",
+        "@scalar/snippetz": "0.6.19",
+        "@scalar/themes": "0.14.3",
+        "@scalar/typebox": "^0.1.3",
+        "@scalar/types": "0.6.10",
+        "@scalar/use-codemirror": "0.13.50",
+        "@scalar/use-hooks": "0.3.7",
+        "@scalar/use-toasts": "0.9.1",
+        "@scalar/workspace-store": "0.35.3",
+        "@types/har-format": "^1.2.15",
+        "@vueuse/core": "13.9.0",
+        "@vueuse/integrations": "13.9.0",
+        "focus-trap": "^7",
+        "fuse.js": "^7.1.0",
+        "js-base64": "^3.7.8",
+        "microdiff": "^1.5.0",
+        "nanoid": "^5.1.6",
+        "pretty-bytes": "^7.1.0",
+        "pretty-ms": "^9.3.0",
+        "shell-quote": "^1.8.1",
+        "type-fest": "^5.3.1",
+        "vue": "^3.5.26",
+        "vue-router": "4.6.2",
+        "whatwg-mimetype": "4.0.0",
+        "yaml": "^2.8.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/api-client/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scalar/api-reference": {
+      "version": "1.46.4",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.46.4.tgz",
+      "integrity": "sha512-EpCcOG15Ry8DKNs/f5AdRA97s1B5kGPekzANpnK0j1IpyU4Sb/mfdyfB00WC+vUo7hfc4BFRSkkiPa5SSM7fng==",
+      "license": "MIT",
+      "dependencies": {
+        "@headlessui/vue": "1.7.23",
+        "@scalar/agent-chat": "0.7.3",
+        "@scalar/api-client": "2.31.3",
+        "@scalar/code-highlight": "0.2.4",
+        "@scalar/components": "0.19.15",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/icons": "0.5.3",
+        "@scalar/oas-utils": "0.8.3",
+        "@scalar/openapi-parser": "0.24.17",
+        "@scalar/openapi-types": "0.5.4",
+        "@scalar/sidebar": "0.7.46",
+        "@scalar/snippetz": "0.6.19",
+        "@scalar/themes": "0.14.3",
+        "@scalar/types": "0.6.10",
+        "@scalar/use-hooks": "0.3.7",
+        "@scalar/use-toasts": "0.9.1",
+        "@scalar/workspace-store": "0.35.3",
+        "@unhead/vue": "^2.1.4",
+        "@vueuse/core": "13.9.0",
+        "fuse.js": "^7.1.0",
+        "github-slugger": "2.0.0",
+        "microdiff": "^1.5.0",
+        "nanoid": "^5.1.6",
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/api-reference-react": {
+      "version": "0.8.70",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.8.70.tgz",
+      "integrity": "sha512-J65Qfb6/rSPGQ5JlVRPXR5JKdb4SE3tHTne4SoUaIbXooFIQnHxMO7TIEzEZl8PZecmZ7WZbQvDwuXydZccgKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/api-reference": "1.46.4",
+        "@scalar/types": "0.6.10"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@scalar/api-reference/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/code-highlight": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.2.4.tgz",
+      "integrity": "sha512-sF9kpxyeh+jwh0ZpXias9UrPBbZf0zgY8Y2nlQqYAwVdGbFdO/bIzjKTi9vWCkKS78NsBfz7rLnJsQ+UP/11rA==",
+      "license": "MIT",
+      "dependencies": {
+        "hast-util-to-text": "^4.0.2",
+        "highlight.js": "^11.11.1",
+        "highlightjs-curl": "^1.3.0",
+        "lowlight": "^3.3.0",
+        "rehype-external-links": "^3.0.0",
+        "rehype-format": "^5.0.1",
+        "rehype-parse": "^9.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "rehype-stringify": "^10.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/components": {
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.19.15.tgz",
+      "integrity": "sha512-oYK5zJarMJ5HvNGJsr6/Y7lz9TPy6Q+g3bQ1PxbaGURcKItXWlR+Yki1kZQ1A6/3b1XpBoMkMUHYp1bBOPW4KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "0.2.10",
+        "@floating-ui/vue": "1.1.9",
+        "@headlessui/vue": "1.7.23",
+        "@scalar/code-highlight": "0.2.4",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/icons": "0.5.3",
+        "@scalar/oas-utils": "0.8.3",
+        "@scalar/themes": "0.14.3",
+        "@scalar/use-hooks": "0.3.7",
+        "@vueuse/core": "13.9.0",
+        "cva": "1.0.0-beta.4",
+        "nanoid": "^5.1.6",
+        "pretty-bytes": "^7.1.0",
+        "radix-vue": "^1.9.17",
+        "vue": "^3.5.26",
+        "vue-component-type-helpers": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/components/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/draggable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.3.0.tgz",
+      "integrity": "sha512-T/79XY5HGNo9Lte7wlnrH393zjiulom4HuwW4u8RtaafWxIdtXykD2+TgiO0KTreyzCrWyWrESqiqKKJMe2nKg==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.21"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.18.tgz",
+      "integrity": "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/icons": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.5.3.tgz",
+      "integrity": "sha512-W9W4dWM9UL75+CLPgQEhds+cJVBeLaKrcUnlguV7CGzcBkdV+u6bZVeqDgiUn5o9j1zZChkoXULSfU/a605csg==",
+      "license": "MIT",
+      "dependencies": {
+        "@phosphor-icons/core": "^2.1.1",
+        "@types/node": "^22.19.3",
+        "chalk": "^5.4.1",
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/icons/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@scalar/icons/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@scalar/icons/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@scalar/import": {
+      "version": "0.4.55",
+      "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.4.55.tgz",
+      "integrity": "sha512-XCn7OwoFNWkEpIJHYMuoUvtR5gLtaKf8AXrcHVVNmQG5TcAd+PfzSYCYwNcRtPEmaBKIyt5Vc5zsgPS8wTFyBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/json-magic": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.11.7.tgz",
+      "integrity": "sha512-GVz9E0vXu+ecypkdn0biK1gbQVkK4QTTX1Hq3eMgxlLQC91wwiqWfCqwfhuX0LRu+Z5OmYhLhufDJEEh56rVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "pathe": "^2.0.3",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/oas-utils": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.8.3.tgz",
+      "integrity": "sha512-FQLZzY+c1tOkXsYtht3MyFJMpLqymhnUvrd7uk0FI659JAu5bDtcasJ1ZM2MbqALS0n7ta1u417ADEagTugPWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "@scalar/json-magic": "0.11.7",
+        "@scalar/object-utils": "1.2.32",
+        "@scalar/openapi-types": "0.5.4",
+        "@scalar/themes": "0.14.3",
+        "@scalar/types": "0.6.10",
+        "@scalar/workspace-store": "0.35.3",
+        "flatted": "^3.3.3",
+        "github-slugger": "2.0.0",
+        "type-fest": "^5.3.1",
+        "vue": "^3.5.26",
+        "yaml": "^2.8.0",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/oas-utils/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/object-utils": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.2.32.tgz",
+      "integrity": "sha512-t3qTaI2Jd4xhXS42KTS9VqKJ4YENxLidemy+E9Y1voJmVScG+A9qHn4LSkXUrS2sYhOGuwERjxRZr2P7zgCMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "flatted": "^3.3.3",
+        "just-clone": "^6.2.0",
+        "ts-deepmerge": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/openapi-parser": {
+      "version": "0.24.17",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.24.17.tgz",
+      "integrity": "sha512-aM9UVrzlMreC3X/sZbyj+7XDZmat3ecGC3RpU8dqEO/HIH+CEX0xMLuP+41DhePCYg5+9TtDomSfWuMq4x1Z1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "@scalar/json-magic": "0.11.7",
+        "@scalar/openapi-types": "0.5.4",
+        "@scalar/openapi-upgrader": "0.1.11",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
+        "jsonpointer": "^5.0.1",
+        "leven": "^4.0.0",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scalar/openapi-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@scalar/openapi-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.5.4.tgz",
+      "integrity": "sha512-2pEbhprh8lLGDfUI6mNm9EV104pjb3+aJsXrFaqfgOSre7r6NlgM5HcSbsLjzDAnTikjJhJ3IMal1Rz8WVwiOw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/openapi-upgrader": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.1.11.tgz",
+      "integrity": "sha512-ngJcHGoCHmpWgYtNy08vmzFfLdQEkMpvaCQqNPPMNKq0QEXOv89e/rn+TZJZgPnRlY7fDIoIhn9lNgr+azBW+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/openapi-types": "0.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/postman-to-openapi": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.4.10.tgz",
+      "integrity": "sha512-s7TECz1DLSXggRYEEVjoBXLxY3nKCU9n4zA7FxRywxsG485qmr2gMHqU5plFJDC59RUxcIOo+V+LbOpKo1EQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "@scalar/openapi-types": "0.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/sidebar": {
+      "version": "0.7.46",
+      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.7.46.tgz",
+      "integrity": "sha512-80+28tW2qM0mH1v/dAZu1DMmv8nj/Rz88PDW4fRY8yMP6xoNi8IpKhnFJ4dnGOBMqu7/2VsOAIGADLVA6ZC4jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/components": "0.19.15",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/icons": "0.5.3",
+        "@scalar/themes": "0.14.3",
+        "@scalar/use-hooks": "0.3.7",
+        "@scalar/workspace-store": "0.35.3",
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/snippetz": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.6.19.tgz",
+      "integrity": "sha512-eWZiCFrv2ExTgYBytSOmXbnY5zVSXRV0tGjFGtDL6ovv9TZIjOrIi0CVg6NLgcs9I1XHAYpE0JlWKQnQ+dGQYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/types": "0.6.10",
+        "js-base64": "^3.7.8",
+        "stringify-object": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/themes": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.14.3.tgz",
+      "integrity": "sha512-QZpuopwlXSX2e4sxYSSQEm3CzanPzlNIhUONVaZQOo0wUSfyaC1V4QTGMigSPzdo505ouZNyh80bR0Glmn4fag==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/themes/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/typebox": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@scalar/typebox/-/typebox-0.1.3.tgz",
+      "integrity": "sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==",
+      "license": "MIT"
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.6.10.tgz",
+      "integrity": "sha512-fZkelRwcEeAhsn4c0wjYXWrzSzLaEyfxTn/eazXJ4XfCIsgJTQyK0FD8mnOBZJ2vEIbtT2E1mBKnCbDxrJIlxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.18",
+        "nanoid": "^5.1.6",
+        "type-fest": "^5.3.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalar/use-codemirror": {
+      "version": "0.13.50",
+      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.13.50.tgz",
+      "integrity": "sha512-KaX8bixOz4sMy5a9XzjH03ffo6n905ol850bT8YRqBuPaTXoxq3M/Z0MipxvCRL+SQ/U07QiwJQnCO3jnXd+xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.3",
+        "@codemirror/commands": "^6.7.1",
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.8",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/language": "^6.10.7",
+        "@codemirror/lint": "^6.8.4",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.3",
+        "@lezer/common": "^1.2.3",
+        "@lezer/highlight": "^1.2.1",
+        "@replit/codemirror-css-color-picker": "^6.3.0",
+        "@scalar/components": "0.19.15",
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/use-hooks": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.3.7.tgz",
+      "integrity": "sha512-fhFRYKtGyCOPaLwDRHGaw5XZ3LY+ptCpcPON51r1sGXCl3O1joB2rBTkcXuh2E04uMB5vsko/71hxhWJZxSnGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/use-toasts": "0.9.1",
+        "@vueuse/core": "13.9.0",
+        "cva": "1.0.0-beta.2",
+        "tailwind-merge": "3.4.0",
+        "vue": "^3.5.26",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/use-hooks/node_modules/cva": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.2.tgz",
+      "integrity": "sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.5.5 < 6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scalar/use-toasts": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.9.1.tgz",
+      "integrity": "sha512-t8QoQO4ZWekiSdJ2O7C+PbXfv7x2fmhv3C7t/iITdNpOyLv4jAhlELGpxQHkWsU0ZwRrLU8e+rV0jJcKWE6vYA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.21",
+        "vue-sonner": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/workspace-store": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.35.3.tgz",
+      "integrity": "sha512-q/ZKiNQ+PSKiNO/2EGFJn1/+Hp75IN+E2KWyx9etS0YLLFNiW3IaKXB3sCX8hMZ8z7Tf+EL718ejrs9+Rvc92A==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/code-highlight": "0.2.4",
+        "@scalar/helpers": "0.2.18",
+        "@scalar/json-magic": "0.11.7",
+        "@scalar/object-utils": "1.2.32",
+        "@scalar/openapi-upgrader": "0.1.11",
+        "@scalar/snippetz": "0.6.19",
+        "@scalar/typebox": "0.1.3",
+        "@scalar/types": "0.6.10",
+        "github-slugger": "2.0.0",
+        "type-fest": "^5.3.1",
+        "vue": "^3.5.26",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scalar/workspace-store/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.23.tgz",
+      "integrity": "sha512-b5jPluAR6U3eOq6GWAYSpj3ugnAIZgGR0e6aGAgyRse0Yu6MVQQ0ZWm9SArSXWtageogn6bkVD8D//c4IjW3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -1976,6 +3222,12 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2071,6 +3323,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
@@ -2381,6 +3639,31 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@unhead/vue": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
+      "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1",
+        "unhead": "2.1.12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -2558,6 +3841,240 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-13.9.0.tgz",
+      "integrity": "sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2591,6 +4108,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.33",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.33.tgz",
+      "integrity": "sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.13",
+        "@ai-sdk/provider": "3.0.2",
+        "@ai-sdk/provider-utils": "4.0.5",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2607,6 +4142,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2656,6 +4230,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -3171,6 +4757,18 @@
         "node": "> 0.10"
       }
     },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -3215,6 +4813,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3256,6 +4860,26 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/cva": {
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.4.tgz",
+      "integrity": "sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.5.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -3377,6 +5001,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -3493,7 +5123,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3836,6 +5465,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3856,7 +5494,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3879,6 +5516,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4009,8 +5662,16 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -4087,6 +5748,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4131,6 +5813,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-own-enumerable-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4158,6 +5852,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -4261,6 +5961,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/guess-json-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/guess-json-indent/-/guess-json-indent-3.0.1.tgz",
+      "integrity": "sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4310,6 +6019,212 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/hast-util-sanitize": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
@@ -4319,6 +6234,29 @@
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.0.0",
         "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4352,6 +6290,41 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4359,6 +6332,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4382,6 +6372,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/highlightjs-curl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-curl/-/highlightjs-curl-1.3.0.tgz",
+      "integrity": "sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -4395,6 +6400,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/hookable": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
+      "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
@@ -4427,6 +6438,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4453,6 +6484,21 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/identifier-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.0.1.tgz",
+      "integrity": "sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==",
+      "license": "MIT",
+      "dependencies": {
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ieee754": {
@@ -4536,6 +6582,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -4636,6 +6694,34 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-identifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.0.1.tgz",
+      "integrity": "sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==",
+      "license": "MIT",
+      "dependencies": {
+        "identifier-regex": "^1.0.0",
+        "super-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -4654,6 +6740,18 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4710,6 +6808,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4844,6 +6948,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4884,6 +6994,21 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4892,6 +7017,18 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
+      "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/levn": {
@@ -5240,6 +7377,21 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5274,7 +7426,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5290,6 +7441,35 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-asynchronous/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -5321,6 +7501,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5328,6 +7518,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -5348,6 +7566,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5490,6 +7809,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "license": "MIT"
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -5557,6 +7882,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -6006,7 +8452,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6036,6 +8481,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/neverpanic": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.5.tgz",
+      "integrity": "sha512-daO+ijOQG8g2BXaAwpETa0GUvlIAfqC+1/CUdLp2Ga8qwDaUyHIieX/SM0yZoPBf7k92deq4DO7tZOWWeL063Q==",
+      "peerDependencies": {
+        "typescript": "5"
       }
     },
     "node_modules/node-fetch": {
@@ -6104,6 +8557,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6131,6 +8599,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6220,6 +8700,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6315,7 +8807,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6341,7 +8832,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6374,6 +8864,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {
@@ -6413,6 +8915,21 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6485,6 +9002,140 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/radix-vue": {
+      "version": "1.9.17",
+      "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
+      "integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.7",
+        "@floating-ui/vue": "^1.1.0",
+        "@internationalized/date": "^3.5.4",
+        "@internationalized/number": "^3.5.3",
+        "@tanstack/vue-virtual": "^3.8.1",
+        "@vueuse/core": "^10.11.0",
+        "@vueuse/shared": "^10.11.0",
+        "aria-hidden": "^1.2.4",
+        "defu": "^6.1.4",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^5.0.7"
+      },
+      "peerDependencies": {
+        "vue": ">= 3.2.0"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-vue/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/react": {
@@ -6633,6 +9284,68 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-format": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-sanitize": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
@@ -6641,6 +9354,39 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6680,6 +9426,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6694,10 +9455,21 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -6852,7 +9624,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6935,7 +9706,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6965,6 +9735,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-byte-length": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-byte-length/-/string-byte-length-3.0.1.tgz",
+      "integrity": "sha512-yJ8vP0HMwZ54CcA8S8mKoXbkezpZHANFtmafFo8lGxZThCQcAwRHjdFabuSLgOzxj9OFJcmssmiAvmcOK4O2Hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/string-byte-slice": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-byte-slice/-/string-byte-slice-3.0.1.tgz",
+      "integrity": "sha512-GWv2K4lYyd2+AhmKH3BV+OVx62xDX+99rSLfKpaqFiQU7uOMaUY1tDjdrRD4gsrCr9lTyjMgjna7tZcCOw+Smg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6992,6 +9780,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-6.0.0.tgz",
+      "integrity": "sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-keys": "^1.0.0",
+        "is-identifier": "^1.0.1",
+        "is-obj": "^3.0.0",
+        "is-regexp": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
@@ -7050,6 +9856,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7073,6 +9885,23 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
+    },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7099,12 +9928,71 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swrv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.2.0.tgz",
+      "integrity": "sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "vue": ">=3.2.26 < 4"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7239,6 +10127,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/truncate-json": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/truncate-json/-/truncate-json-3.0.1.tgz",
+      "integrity": "sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==",
+      "license": "MIT",
+      "dependencies": {
+        "guess-json-indent": "^3.0.1",
+        "string-byte-length": "^3.0.1",
+        "string-byte-slice": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -7250,6 +10152,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
+      "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/tslib": {
@@ -7288,7 +10199,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7365,6 +10275,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unhead": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
+      "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -7378,6 +10300,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7511,6 +10447,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7691,6 +10641,60 @@
         }
       }
     },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.6.tgz",
+      "integrity": "sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==",
+      "license": "MIT"
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.2.tgz",
+      "integrity": "sha512-my83mxQKXyCms9EegBXZldehOihxBjgSjZqrZwgg4vBacNGl0oBCO+xT//wgOYpLV1RW93ZfqxrjTozd+82nbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-sonner": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vue-sonner/-/vue-sonner-1.3.2.tgz",
+      "integrity": "sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -7714,6 +10718,22 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -7835,6 +10855,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7881,7 +10916,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/plugwerk-server/plugwerk-server-frontend/package.json
+++ b/plugwerk-server/plugwerk-server-frontend/package.json
@@ -20,6 +20,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
+    "@scalar/api-reference-react": "^0.8.70",
     "axios": "^1.13.6",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
 import { Box, Typography, Link } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { tokens } from '../../theme/tokens'
 
 export function Footer() {
@@ -31,9 +32,8 @@ export function Footer() {
         </Box>
 
         <Link
-          href="/api/v1"
-          target="_blank"
-          rel="noopener"
+          component={RouterLink}
+          to="/api-docs"
           sx={{
             fontSize: '0.8125rem',
             color: tokens.color.primary,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
@@ -2,21 +2,27 @@
 // Copyright (C) 2026 devtank42 GmbH
 import { ApiReferenceReact } from '@scalar/api-reference-react'
 import '@scalar/api-reference-react/style.css'
-import { useTheme } from '@mui/material'
+import { useMemo } from 'react'
+import { useUiStore } from '../stores/uiStore'
 
 export function ApiDocsPage() {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
+  const themeMode = useUiStore((s) => s.themeMode)
+  const isDark = themeMode === 'dark'
+
+  const configuration = useMemo(
+    () => ({
+      url: '/api-docs/openapi.yaml',
+      darkMode: isDark,
+      hideDownloadButton: false,
+      layout: 'modern' as const,
+    }),
+    [isDark],
+  )
 
   return (
     <ApiReferenceReact
-      key={isDark ? 'dark' : 'light'}
-      configuration={{
-        url: '/api-docs/openapi.yaml',
-        darkMode: isDark,
-        hideDownloadButton: false,
-        layout: 'modern',
-      }}
+      key={themeMode}
+      configuration={configuration}
     />
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { ApiReferenceReact } from '@scalar/api-reference-react'
+import '@scalar/api-reference-react/style.css'
+import { useTheme } from '@mui/material'
+
+export function ApiDocsPage() {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  return (
+    <ApiReferenceReact
+      configuration={{
+        url: '/api-docs/openapi.yaml',
+        darkMode: isDark,
+        hideDownloadButton: false,
+        layout: 'modern',
+      }}
+    />
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
@@ -10,6 +10,7 @@ export function ApiDocsPage() {
 
   return (
     <ApiReferenceReact
+      key={isDark ? 'dark' : 'light'}
       configuration={{
         url: '/api-docs/openapi.yaml',
         darkMode: isDark,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ApiDocsPage.tsx
@@ -2,12 +2,25 @@
 // Copyright (C) 2026 devtank42 GmbH
 import { ApiReferenceReact } from '@scalar/api-reference-react'
 import '@scalar/api-reference-react/style.css'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useUiStore } from '../stores/uiStore'
 
 export function ApiDocsPage() {
   const themeMode = useUiStore((s) => s.themeMode)
   const isDark = themeMode === 'dark'
+
+  // Scalar uses a module-level colorMode singleton and reads localStorage
+  // on init, so the darkMode prop alone is not enough to control the mode
+  // after the first render. The actual styling is driven by 'dark-mode' /
+  // 'light-mode' CSS classes on document.body — we sync them here.
+  useEffect(() => {
+    localStorage.setItem('colorMode', isDark ? 'dark' : 'light')
+    document.body.classList.toggle('dark-mode', isDark)
+    document.body.classList.toggle('light-mode', !isDark)
+    return () => {
+      document.body.classList.remove('dark-mode', 'light-mode')
+    }
+  }, [isDark])
 
   const configuration = useMemo(
     () => ({

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -16,6 +16,7 @@ import { Error403Page } from '../pages/errors/Error403Page'
 import { Error500Page } from '../pages/errors/Error500Page'
 import { Error503Page } from '../pages/errors/Error503Page'
 import { useAuthStore } from '../stores/authStore'
+import { ApiDocsPage } from '../pages/ApiDocsPage'
 
 function CatalogRedirect() {
   const namespace = useAuthStore((s) => s.namespace)
@@ -35,6 +36,7 @@ export const router = createBrowserRouter([
       { path: 'profile',                                                element: <ProtectedRoute><ProfileSettingsPage /></ProtectedRoute> },
 
       // Public routes — no login required
+      { path: 'api-docs',                     element: <ApiDocsPage /> },
       { path: 'login',                        element: <LoginPage /> },
       { path: 'register',                     element: <RegisterPage /> },
       { path: 'forgot-password',              element: <ForgotPasswordPage /> },

--- a/plugwerk-server/plugwerk-server-frontend/vite.config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/vite.config.ts
@@ -16,7 +16,10 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8080',
+      // Proxy all REST API calls and the OpenAPI YAML to the Spring Boot backend.
+      // Use '/api/' (with trailing slash) to avoid matching '/api-docs' (the SPA page).
+      '/api/': 'http://localhost:8080',
+      '/api-docs/openapi.yaml': 'http://localhost:8080',
     },
   },
 })

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Plugwerk E2E Smoke Test
+# Runs against a live Docker Compose stack and verifies the core upload/download flow.
+#
+# Usage:
+#   ./scripts/smoke-test.sh              # builds image + starts stack
+#   SKIP_BUILD=1 ./scripts/smoke-test.sh # skips docker compose build (faster for local iteration)
+set -euo pipefail
+
+BASE_URL="${PLUGWERK_BASE_URL:-http://localhost:8080}"
+USERNAME="${PLUGWERK_USERNAME:-test}"
+PASSWORD="${PLUGWERK_PASSWORD:-test}"
+NAMESPACE="smoke-$(date +%s)"
+PLUGIN_ID="smoke-plugin"
+PLUGIN_VERSION="1.0.0"
+WORKDIR="$(mktemp -d)"
+COMPOSE_FILE="$(cd "$(dirname "$0")/.." && pwd)/docker-compose.yml"
+
+cleanup() {
+  echo "--- Cleanup ---"
+  rm -rf "$WORKDIR"
+  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------- #
+# 1. Build + start stack                                                        #
+# --------------------------------------------------------------------------- #
+echo "--- Starting Docker Compose stack ---"
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  docker compose -f "$COMPOSE_FILE" build --quiet
+fi
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo "--- Waiting for server health ---"
+for i in $(seq 1 30); do
+  if curl -sf "$BASE_URL/actuator/health" | grep -q '"status":"UP"'; then
+    echo "Server is up (attempt $i)"
+    break
+  fi
+  echo "  waiting... ($i/30)"
+  sleep 5
+  if [[ $i -eq 30 ]]; then
+    echo "ERROR: Server did not become healthy in time"
+    docker compose -f "$COMPOSE_FILE" logs
+    exit 1
+  fi
+done
+
+# --------------------------------------------------------------------------- #
+# 2. Login                                                                      #
+# --------------------------------------------------------------------------- #
+echo "--- Login ---"
+TOKEN=$(curl -sf -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")
+[[ -z "$TOKEN" ]] && { echo "ERROR: Login failed"; exit 1; }
+echo "Login OK"
+
+AUTH_HEADER="Authorization: Bearer $TOKEN"
+
+# --------------------------------------------------------------------------- #
+# 3. Create namespace                                                            #
+# --------------------------------------------------------------------------- #
+echo "--- Creating namespace: $NAMESPACE ---"
+curl -sf -X POST "$BASE_URL/api/v1/namespaces" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d "{\"slug\":\"$NAMESPACE\",\"ownerOrg\":\"Smoke Test\"}" > /dev/null
+echo "Namespace created"
+
+# --------------------------------------------------------------------------- #
+# 4. Build minimal test plugin JAR                                              #
+# --------------------------------------------------------------------------- #
+echo "--- Building minimal test plugin JAR ---"
+DESCRIPTOR="$WORKDIR/plugwerk.yml"
+cat > "$DESCRIPTOR" <<YAML
+id: $PLUGIN_ID
+version: $PLUGIN_VERSION
+name: Smoke Test Plugin
+description: Minimal plugin for E2E smoke testing
+YAML
+
+JAR_FILE="$WORKDIR/$PLUGIN_ID-$PLUGIN_VERSION.jar"
+(cd "$WORKDIR" && jar cf "$JAR_FILE" plugwerk.yml)
+
+EXPECTED_SHA=$(sha256sum "$JAR_FILE" | awk '{print $1}')
+echo "JAR built: $JAR_FILE (SHA-256: $EXPECTED_SHA)"
+
+# --------------------------------------------------------------------------- #
+# 5. Upload plugin release                                                      #
+# --------------------------------------------------------------------------- #
+echo "--- Uploading plugin release ---"
+UPLOAD_RESPONSE=$(curl -sf -X POST "$BASE_URL/api/v1/namespaces/$NAMESPACE/releases" \
+  -H "$AUTH_HEADER" \
+  -F "artifact=@$JAR_FILE;type=application/java-archive")
+echo "Upload response: $UPLOAD_RESPONSE"
+RELEASE_ID=$(echo "$UPLOAD_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+[[ -z "$RELEASE_ID" ]] && { echo "ERROR: Upload failed — no release ID"; exit 1; }
+echo "Upload OK (release ID: $RELEASE_ID)"
+
+# --------------------------------------------------------------------------- #
+# 6. Query catalog                                                              #
+# --------------------------------------------------------------------------- #
+echo "--- Querying catalog ---"
+CATALOG=$(curl -sf "$BASE_URL/api/v1/namespaces/$NAMESPACE/plugins" \
+  -H "$AUTH_HEADER")
+FOUND=$(echo "$CATALOG" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+plugins = d.get('content', d) if isinstance(d, dict) else d
+print(next((p['pluginId'] for p in plugins if p['pluginId'] == '$PLUGIN_ID'), ''))
+")
+[[ "$FOUND" != "$PLUGIN_ID" ]] && { echo "ERROR: Plugin not found in catalog"; exit 1; }
+echo "Catalog OK — plugin found"
+
+# --------------------------------------------------------------------------- #
+# 7. Download artifact + verify SHA-256                                         #
+# --------------------------------------------------------------------------- #
+echo "--- Downloading artifact ---"
+DOWNLOAD_FILE="$WORKDIR/downloaded.jar"
+curl -sf "$BASE_URL/api/v1/namespaces/$NAMESPACE/plugins/$PLUGIN_ID/releases/$PLUGIN_VERSION/download" \
+  -H "$AUTH_HEADER" \
+  -o "$DOWNLOAD_FILE"
+
+ACTUAL_SHA=$(sha256sum "$DOWNLOAD_FILE" | awk '{print $1}')
+if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+  echo "ERROR: SHA-256 mismatch!"
+  echo "  expected: $EXPECTED_SHA"
+  echo "  actual:   $ACTUAL_SHA"
+  exit 1
+fi
+echo "Download OK — SHA-256 verified"
+
+# --------------------------------------------------------------------------- #
+echo ""
+echo "✓ All smoke tests passed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -76,10 +76,11 @@ echo "Namespace created"
 echo "--- Building minimal test plugin JAR ---"
 DESCRIPTOR="$WORKDIR/plugwerk.yml"
 cat > "$DESCRIPTOR" <<YAML
-id: $PLUGIN_ID
-version: $PLUGIN_VERSION
-name: Smoke Test Plugin
-description: Minimal plugin for E2E smoke testing
+plugwerk:
+  id: $PLUGIN_ID
+  version: $PLUGIN_VERSION
+  name: Smoke Test Plugin
+  description: Minimal plugin for E2E smoke testing
 YAML
 
 JAR_FILE="$WORKDIR/$PLUGIN_ID-$PLUGIN_VERSION.jar"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -28,7 +28,7 @@ trap cleanup EXIT
 # --------------------------------------------------------------------------- #
 echo "--- Starting Docker Compose stack ---"
 if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
-  docker compose -f "$COMPOSE_FILE" build --quiet
+  docker compose -f "$COMPOSE_FILE" build --progress=plain
 fi
 docker compose -f "$COMPOSE_FILE" up -d
 


### PR DESCRIPTION
Closes #19

## Summary

- **Scalar API Docs**: Interactive API reference at `/api-docs` powered by `@scalar/api-reference-react`, connected to the canonical `plugwerk-api.yaml` served at `/api-docs/openapi.yaml`; Footer "API Docs" link updated to internal route
- **E2E Shell Smoke Test**: `scripts/smoke-test.sh` — full upload → catalog → download flow against Docker Compose stack; new `e2e.yml` CI job
- **E2E JUnit Smoke Test**: `SmokeTest.kt` with `@Tag("integration")` + Testcontainers PostgreSQL — same scenario via MockMvc, runnable with `./gradlew integrationTest`
- **README**: Quick Start (self-hosted), API docs, curl examples, SDK snippet, smoke test instructions
- **ADR-0006**: Auth strategy — JWT + API Key (Phase 1), OIDC (Phase 2)
- **ADR-0007**: Artifact storage — Filesystem (Phase 1), S3-compatible (Phase 2)
- **ADR-0008**: API docs via Scalar instead of SpringDoc/Swagger UI

## Notable findings during implementation

- `TestRestTemplate` was removed in Spring Boot 4 — JUnit smoke test uses `MockMvc` + `@AutoConfigureMockMvc` instead
- Jackson 3.x (bundled with Spring Boot 4) moved packages from `com.fasterxml.jackson` to `tools.jackson`

## Test plan

- [ ] `./gradlew build` passes (unit tests + spotless)
- [ ] `./gradlew integrationTest` runs `SmokeTest` with Testcontainers (requires Docker)
- [ ] `./scripts/smoke-test.sh` runs against a live Docker Compose stack
- [ ] `/api-docs` shows Scalar UI in the browser
- [ ] `/api-docs/openapi.yaml` returns the OpenAPI spec without authentication
- [ ] Footer "API Docs" link navigates to `/api-docs`