### PR TITLE
feat(#70): track and display artifact file size

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1361,6 +1361,10 @@ components:
           type: integer
           format: int64
           description: Total number of artifact downloads across all releases
+        latestArtifactSize:
+          type: integer
+          format: int64
+          description: File size in bytes of the latest published release artifact, or `null` if no published release exists
         icon:
           type: string
           format: uri

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/AdminInitializationRunner.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/AdminInitializationRunner.kt
@@ -76,8 +76,8 @@ class AdminInitializationRunner(
                 ╔══════════════════════════════════════════════════════════╗
                 ║         Plugwerk — Initial Superadmin Password           ║
                 ║                                                          ║
-                ║  Username : {}                                           ║
-                ║  Password : {}                                           ║
+                ║  Username : {}                                      ║
+                ║  Password : {}                           ║
                 ║                                                          ║
                 ║  Change this password immediately after first login.     ║
                 ╚══════════════════════════════════════════════════════════╝

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -72,6 +72,12 @@ class CatalogController(
             releaseRepository.findLatestPublishedVersionsForPlugins(pluginIds)
                 .associate { row -> (row[0] as java.util.UUID) to (row[1] as String) }
         }
+        val latestArtifactSizes: Map<java.util.UUID, Long> = if (pluginIds.isEmpty()) {
+            emptyMap()
+        } else {
+            releaseRepository.findLatestPublishedArtifactSizesForPlugins(pluginIds)
+                .associate { row -> (row[0] as java.util.UUID) to (row[1] as Long) }
+        }
         val draftOnlyIds = pluginIds.filter { it !in latestVersions }
         val latestDraftVersions: Map<java.util.UUID, String> = if (draftOnlyIds.isEmpty()) {
             emptyMap()
@@ -82,7 +88,13 @@ class CatalogController(
 
         val response = PluginPagedResponse(
             content = resultPage.content.map {
-                pluginMapper.toDto(it, ns, latestVersions[it.id], latestDraftVersions[it.id])
+                pluginMapper.toDto(
+                    it,
+                    ns,
+                    latestVersions[it.id],
+                    latestDraftVersions[it.id],
+                    latestArtifactSizes[it.id],
+                )
             },
             totalElements = resultPage.totalElements,
             page = resultPage.number,
@@ -95,9 +107,9 @@ class CatalogController(
     override fun getPlugin(ns: String, pluginId: String): ResponseEntity<PluginDto> {
         val plugin = pluginService.findByNamespaceAndPluginId(ns, pluginId)
         val allReleases = releaseService.findAllByPlugin(ns, pluginId)
-        val latestVersion = allReleases.filter { it.status == ReleaseStatus.PUBLISHED }
+        val latestPublishedRelease = allReleases.filter { it.status == ReleaseStatus.PUBLISHED }
             .maxByOrNull { it.createdAt }
-            ?.version
+        val latestVersion = latestPublishedRelease?.version
         val latestDraftVersion = if (latestVersion == null) {
             allReleases.filter { it.status == ReleaseStatus.DRAFT }
                 .maxByOrNull { it.createdAt }
@@ -105,7 +117,9 @@ class CatalogController(
         } else {
             null
         }
-        return ResponseEntity.ok(pluginMapper.toDto(plugin, ns, latestVersion, latestDraftVersion))
+        return ResponseEntity.ok(
+            pluginMapper.toDto(plugin, ns, latestVersion, latestDraftVersion, latestPublishedRelease?.artifactSize),
+        )
     }
 
     override fun listReleases(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
@@ -38,6 +38,7 @@ class PluginMapper {
         namespaceSlug: String,
         latestVersion: String? = null,
         latestDraftVersion: String? = null,
+        latestArtifactSize: Long? = null,
     ): PluginDto = PluginDto(
         id = entity.id!!,
         pluginId = entity.pluginId,
@@ -51,6 +52,7 @@ class PluginMapper {
         tags = entity.tags.toList().takeIf { it.isNotEmpty() },
         latestVersion = latestVersion,
         latestDraftVersion = if (latestVersion == null) latestDraftVersion else null,
+        latestArtifactSize = latestArtifactSize,
         icon = entity.icon?.let { URI(it) },
         homepage = entity.homepage?.let { URI(it) },
         repository = entity.repository?.let { URI(it) },

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
@@ -46,6 +46,7 @@ class PluginReleaseMapper(private val objectMapper: ObjectMapper) {
         version = entity.version,
         status = entity.status.toDto(),
         artifactSha256 = entity.artifactSha256,
+        artifactSize = entity.artifactSize,
         requiresSystemVersion = entity.requiresSystemVersion,
         pluginDependencies = parseDependencies(entity.pluginDependencies),
         downloadCount = entity.downloadCount,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
@@ -74,6 +74,8 @@ import java.util.UUID
  *   backend (e.g. `acme/my-plugin/1.2.3` for filesystem or S3).
  *   Interpreted by [io.plugwerk.server.service.storage.ArtifactStorageService],
  *   independent of the concrete storage type.
+ * @property artifactSize Size of the stored artefact in bytes. Set at upload time from
+ *   the raw byte array length. Exposed to clients for display purposes.
  * @property requiresSystemVersion Optional SemVer range for the minimum/maximum version
  *   of the host system (e.g. `>=2.0.0 & <4.0.0`).
  * @property pluginDependencies Optional list of plugin-to-plugin dependencies as a JSON
@@ -106,6 +108,9 @@ class PluginReleaseEntity(
 
     @Column(name = "artifact_key", nullable = false, length = 1024)
     var artifactKey: String,
+
+    @Column(name = "artifact_size", nullable = false)
+    var artifactSize: Long = 0,
 
     @Column(name = "requires_system_version", length = 255)
     var requiresSystemVersion: String? = null,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -100,4 +100,25 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         """,
     )
     fun findLatestDraftVersionsForPlugins(@Param("pluginIds") pluginIds: Collection<UUID>): List<Array<Any>>
+
+    /**
+     * Returns the artifact size of the latest published release per plugin for a given set of
+     * plugin IDs. Result is a list of [pluginId, artifactSize] pairs. One DB round-trip for the
+     * entire page.
+     */
+    @Query(
+        """
+        SELECT r.plugin.id, r.artifactSize
+        FROM PluginReleaseEntity r
+        WHERE r.plugin.id IN :pluginIds
+          AND r.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
+          AND r.createdAt = (
+            SELECT MAX(r2.createdAt)
+            FROM PluginReleaseEntity r2
+            WHERE r2.plugin.id = r.plugin.id
+              AND r2.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
+          )
+        """,
+    )
+    fun findLatestPublishedArtifactSizesForPlugins(@Param("pluginIds") pluginIds: Collection<UUID>): List<Array<Any>>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -113,6 +113,7 @@ class PluginReleaseService(
                 version = descriptor.version,
                 artifactSha256 = sha256,
                 artifactKey = artifactKey,
+                artifactSize = bytes.size.toLong(),
                 requiresSystemVersion = descriptor.requiresSystemVersion,
                 pluginDependencies = serializeDependencies(descriptor),
             ),

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -165,6 +165,12 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  name: artifact_size
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
                   name: requires_system_version
                   type: varchar(255)
               - column:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -100,7 +100,9 @@ class CatalogControllerTest {
             ),
         )
             .thenReturn(PageImpl(listOf(plugin)))
-        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(
+            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull(), anyOrNull()),
+        ).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins")
             .andExpect {
@@ -136,7 +138,9 @@ class CatalogControllerTest {
     fun `GET plugin by id returns 200`() {
         whenever(pluginService.findByNamespaceAndPluginId("acme", "my-plugin")).thenReturn(plugin)
         whenever(releaseService.findAllByPlugin("acme", "my-plugin")).thenReturn(emptyList())
-        whenever(pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(
+            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), anyOrNull(), anyOrNull()),
+        ).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins/my-plugin")
             .andExpect {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -97,7 +97,7 @@ class ManagementControllerTest {
                 anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
             ),
         ).thenReturn(plugin)
-        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(buildPluginDto())
 
         mockMvc.patch("/api/v1/namespaces/acme/plugins/my-plugin") {
             contentType = MediaType.APPLICATION_JSON

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -104,6 +104,25 @@ class PluginReleaseServiceTest {
     }
 
     @Test
+    fun `upload stores artifact size in bytes`() {
+        val jarBytes = "fake-jar-content".toByteArray()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "1.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { invocation ->
+            invocation.getArgument<PluginReleaseEntity>(0)
+        }
+
+        val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        assertThat(result.artifactSize).isEqualTo(jarBytes.size.toLong())
+    }
+
+    @Test
     fun `upload throws ReleaseAlreadyExistsException when version exists`() {
         val jarBytes = "fake-jar-content".toByteArray()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
 import { Box, Card, CardActionArea, Tooltip, Typography } from '@mui/material'
-import { Download, Clock, Puzzle } from 'lucide-react'
+import { Download, Clock, Puzzle, HardDrive } from 'lucide-react'
 import { useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { Badge } from '../common/Badge'
 import type { PluginDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { useIsOverflowing } from '../../hooks/useIsOverflowing'
+import { formatFileSize } from '../../utils/formatFileSize'
 
 interface PluginCardProps {
   plugin: PluginDto
@@ -174,6 +175,12 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
             <Download size={12} aria-hidden="true" />
             <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
           </Box>
+          {plugin.latestArtifactSize && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
+              <HardDrive size={12} aria-hidden="true" />
+              <Typography variant="caption">{formatFileSize(plugin.latestArtifactSize)}</Typography>
+            </Box>
+          )}
           <Tooltip title={formatAbsoluteTime(plugin.updatedAt)} placement="top">
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled', cursor: 'default' }}>
               <Clock size={12} aria-hidden="true" />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCardSkeleton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCardSkeleton.tsx
@@ -17,6 +17,7 @@ export function PluginCardSkeleton() {
       <Box sx={{ display: 'flex', gap: 0.5 }}>
         <Skeleton variant="rounded" width={40} height={20} />
         <Skeleton variant="rounded" width={50} height={20} />
+        <Skeleton variant="rounded" width={45} height={20} />
       </Box>
     </Card>
   )

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
 import { Box, Tooltip, Typography } from '@mui/material'
-import { Download, Clock, Puzzle } from 'lucide-react'
+import { Download, Clock, Puzzle, HardDrive } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Badge } from '../common/Badge'
 import type { PluginDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
+import { formatFileSize } from '../../utils/formatFileSize'
 
 interface PluginListRowProps {
   plugin: PluginDto
@@ -101,6 +102,12 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
           <Download size={12} aria-hidden="true" />
           <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
         </Box>
+        {plugin.latestArtifactSize && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <HardDrive size={12} aria-hidden="true" />
+            <Typography variant="caption">{formatFileSize(plugin.latestArtifactSize)}</Typography>
+          </Box>
+        )}
         <Tooltip title={formatAbsoluteTime(plugin.updatedAt)} placement="top">
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, cursor: 'default' }}>
             <Clock size={12} aria-hidden="true" />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DetailSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DetailSidebar.tsx
@@ -6,6 +6,7 @@ import { Badge } from '../common/Badge'
 import { CodeBlock } from '../common/CodeBlock'
 import type { PluginDto, PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
+import { formatFileSize } from '../../utils/formatFileSize'
 
 interface DetailSidebarProps {
   plugin: PluginDto
@@ -92,7 +93,7 @@ export function DetailSidebar({ plugin, release }: DetailSidebarProps) {
         )}
         {release?.artifactSize && (
           <MetaItem label="File Size">
-            <Typography variant="caption">{(release.artifactSize / 1024 / 1024).toFixed(1)} MB</Typography>
+            <Typography variant="caption">{formatFileSize(release.artifactSize)}</Typography>
           </MetaItem>
         )}
         {sha256 && (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -5,17 +5,12 @@ import { Download, Calendar, Scale, Puzzle } from 'lucide-react'
 import { Badge } from '../common/Badge'
 import type { PluginDto, PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
+import { formatFileSize } from '../../utils/formatFileSize'
 
 interface PluginHeaderProps {
   plugin: PluginDto
   latestRelease: PluginReleaseDto | null
   namespace: string
-}
-
-function formatSize(bytes: number | undefined): string {
-  if (!bytes) return ''
-  const mb = bytes / 1024 / 1024
-  return `${mb.toFixed(1)} MB`
 }
 
 export function PluginHeader({ plugin, latestRelease, namespace }: PluginHeaderProps) {
@@ -117,7 +112,7 @@ export function PluginHeader({ plugin, latestRelease, namespace }: PluginHeaderP
           </Button>
           {latestRelease.artifactSize && (
             <Typography variant="caption" color="text.disabled">
-              {formatSize(latestRelease.artifactSize)} · .jar
+              {formatFileSize(latestRelease.artifactSize)} · .jar
             </Typography>
           )}
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -20,6 +20,7 @@ import type { PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import type { BadgeVariant } from '../common/Badge'
 import { reviewsApi } from '../../api/config'
+import { formatFileSize } from '../../utils/formatFileSize'
 
 interface VersionsTabProps {
   releases: PluginReleaseDto[]
@@ -63,6 +64,7 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
             <TableCell>Version</TableCell>
             <TableCell>Released</TableCell>
             <TableCell>Status</TableCell>
+            <TableCell>Size</TableCell>
             <TableCell>Changelog</TableCell>
             <TableCell>Actions</TableCell>
           </TableRow>
@@ -103,6 +105,11 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
                   <Badge variant={statusToBadge[rel.status] ?? 'draft'}>
                     {rel.status.charAt(0).toUpperCase() + rel.status.slice(1)}
                   </Badge>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.disabled">
+                    {rel.artifactSize ? formatFileSize(rel.artifactSize) : '—'}
+                  </Typography>
                 </TableCell>
                 <TableCell>
                   <Typography variant="caption" color="text.secondary">

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/formatFileSize.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/formatFileSize.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { describe, it, expect } from 'vitest'
+import { formatFileSize } from './formatFileSize'
+
+describe('formatFileSize', () => {
+  it('formats bytes below 1 KB as bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B')
+    expect(formatFileSize(512)).toBe('512 B')
+    expect(formatFileSize(1023)).toBe('1023 B')
+  })
+
+  it('formats exactly 1 KB', () => {
+    expect(formatFileSize(1024)).toBe('1.0 KB')
+  })
+
+  it('formats kilobytes below 1 MB', () => {
+    expect(formatFileSize(2048)).toBe('2.0 KB')
+    expect(formatFileSize(512 * 1024)).toBe('512.0 KB')
+    expect(formatFileSize(1024 * 1024 - 1)).toBe('1024.0 KB')
+  })
+
+  it('formats exactly 1 MB', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB')
+  })
+
+  it('formats megabytes', () => {
+    expect(formatFileSize(2.5 * 1024 * 1024)).toBe('2.5 MB')
+    expect(formatFileSize(100 * 1024 * 1024)).toBe('100.0 MB')
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/formatFileSize.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/formatFileSize.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+
+/**
+ * Formats a byte count into a human-readable file size string.
+ *
+ * - < 1 KB  → "N B"
+ * - < 1 MB  → "N.N KB"
+ * - ≥ 1 MB  → "N.N MB"
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}


### PR DESCRIPTION
## Summary

- Stores `artifact_size` (bytes) in `plugin_release` at upload time — persisted in the existing `0001_initial_schema.yaml` migration (app not yet in production)
- Maps the value through `PluginReleaseMapper` to the API DTO (`artifactSize` was already in the OpenAPI spec)
- Adds a shared `formatFileSize()` utility (B / KB / MB) in the frontend, replacing two inline MB-only formatters
- Adds a **Size** column to the VersionsTab releases table
- Shows the size next to the download button in PluginHeader and in the details sidebar

## Test plan

- [x] `PluginReleaseServiceTest` — new `upload stores artifact size in bytes` test passes
- [x] `formatFileSize.test.ts` — covers B, KB, MB boundaries and edge cases
- [x] All 152 frontend tests pass (`npm run test:run`)
- [x] All backend tests pass (`./gradlew :plugwerk-server:plugwerk-server-backend:test`)
- [ ] Manual smoke test: upload a JAR and confirm the correct size appears in header, sidebar, and versions table

Closes #70