### PR TITLE
fix(#41): add format and length validation to descriptor parsers

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -406,6 +406,20 @@ paths:
         New releases are created with status `draft`. Publish them explicitly via
         `PATCH /namespaces/{ns}/plugins/{pluginId}/releases/{version}`.
 
+        **Descriptor validation:**
+        All descriptor fields are validated on upload. Key constraints:
+        - `id`: `^[a-zA-Z0-9._-]{1,128}$`
+        - `version`: valid SemVer, max 100 characters
+        - `name`: max 255 characters
+        - `description`: max 10,000 characters
+        - `author`: max 255 characters
+        - `license`: max 100 characters
+        - URL fields (`homepage`, `repository`, `icon`): max 2,048 characters, must be valid http/https
+        - `categories`: max 20 entries, each max 64 characters
+        - `tags`: max 50 entries, each max 64 characters
+        - `pluginDependencies`: max 100 entries, each ID must match the plugin ID format
+        - Plain-text fields must not contain HTML/script tags
+
         Returns `422 Unprocessable Entity` if the descriptor is missing or invalid.
       operationId: uploadPluginRelease
       security:

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
@@ -17,6 +17,8 @@
  */
 package io.plugwerk.descriptor
 
+import io.plugwerk.spi.version.isValidSemVer
+
 private val PLUGIN_ID_REGEX = Regex("^[a-zA-Z0-9._-]{1,128}$")
 
 // Each range part: optional operator + version, optionally followed by a hyphen range end
@@ -26,11 +28,33 @@ private val SEMVER_RANGE_REGEX = Regex(
         "(\\s+-\\s+${SEMVER_RANGE_PART.pattern})?" +
         "(\\s+${SEMVER_RANGE_PART.pattern}(\\s+-\\s+${SEMVER_RANGE_PART.pattern})?)*\\s*$",
 )
-private const val NAME_MAX_LENGTH = 255
-private const val TAG_MAX_LENGTH = 64
+
+// Targeted patterns for dangerous HTML/script injection — not a generic "<" ban
+private val DANGEROUS_HTML_REGEX = Regex(
+    "<\\s*(script|iframe|object|embed|form|link|meta|base)\\b|" +
+        "<\\s*svg[^>]*\\bon\\w+\\s*=|" +
+        "javascript\\s*:",
+    RegexOption.IGNORE_CASE,
+)
+
 private val URL_SCHEMES = setOf("http", "https")
 
-internal object DescriptorValidator {
+object DescriptorValidator {
+
+    const val PLUGIN_ID_MAX_LENGTH = 128
+    const val VERSION_MAX_LENGTH = 100
+    const val NAME_MAX_LENGTH = 255
+    const val DESCRIPTION_MAX_LENGTH = 10_000
+    const val AUTHOR_MAX_LENGTH = 255
+    const val LICENSE_MAX_LENGTH = 100
+    const val URL_MAX_LENGTH = 2048
+    const val REQUIRES_SYSTEM_VERSION_MAX_LENGTH = 255
+    const val TAG_MAX_LENGTH = 64
+    const val DEPENDENCY_VERSION_MAX_LENGTH = 255
+    const val MAX_CATEGORIES = 20
+    const val MAX_TAGS = 50
+    const val MAX_SCREENSHOTS = 20
+    const val MAX_DEPENDENCIES = 100
 
     /**
      * Validates the given [descriptor] and throws [DescriptorValidationException] if any
@@ -39,44 +63,141 @@ internal object DescriptorValidator {
     fun validate(descriptor: PlugwerkDescriptor) {
         val violations = mutableListOf<String>()
 
+        // --- id ---
         if (!PLUGIN_ID_REGEX.matches(descriptor.id)) {
-            violations += "id '${descriptor.id}' must match pattern ${PLUGIN_ID_REGEX.pattern}"
+            violations += "id '${descriptor.id.take(200)}' must match pattern ${PLUGIN_ID_REGEX.pattern}"
         }
 
+        // --- version ---
+        if (descriptor.version.length > VERSION_MAX_LENGTH) {
+            violations += "version must not exceed $VERSION_MAX_LENGTH characters (got ${descriptor.version.length})"
+        }
+        if (!descriptor.version.isValidSemVer()) {
+            violations += "version '${descriptor.version.take(200)}' is not valid SemVer"
+        }
+
+        // --- name ---
         if (descriptor.name.length > NAME_MAX_LENGTH) {
             violations += "name must not exceed $NAME_MAX_LENGTH characters (got ${descriptor.name.length})"
         }
+        checkNoHtml("name", descriptor.name, violations)
 
+        // --- description ---
+        descriptor.description?.let { value ->
+            if (value.length > DESCRIPTION_MAX_LENGTH) {
+                violations += "description must not exceed $DESCRIPTION_MAX_LENGTH characters (got ${value.length})"
+            }
+            checkNoHtml("description", value, violations)
+        }
+
+        // --- author ---
+        descriptor.author?.let { value ->
+            if (value.length > AUTHOR_MAX_LENGTH) {
+                violations += "author must not exceed $AUTHOR_MAX_LENGTH characters (got ${value.length})"
+            }
+            checkNoHtml("author", value, violations)
+        }
+
+        // --- license ---
+        descriptor.license?.let { value ->
+            if (value.length > LICENSE_MAX_LENGTH) {
+                violations += "license must not exceed $LICENSE_MAX_LENGTH characters (got ${value.length})"
+            }
+        }
+
+        // --- URL fields ---
         descriptor.homepage?.let { url ->
-            if (!isValidHttpUrl(url)) violations += "homepage must be a valid http/https URL: '$url'"
+            checkUrlField("homepage", url, violations)
         }
         descriptor.repository?.let { url ->
-            if (!isValidHttpUrl(url)) violations += "repository must be a valid http/https URL: '$url'"
+            checkUrlField("repository", url, violations)
         }
         descriptor.icon?.let { url ->
+            if (url.length > URL_MAX_LENGTH) {
+                violations += "icon must not exceed $URL_MAX_LENGTH characters (got ${url.length})"
+            }
             if (url.startsWith("http://") || url.startsWith("https://")) {
                 if (!isValidHttpUrl(url)) violations += "icon must be a valid http/https URL or a relative path: '$url'"
             }
         }
 
+        // --- categories ---
+        if (descriptor.categories.size > MAX_CATEGORIES) {
+            violations += "categories must not exceed $MAX_CATEGORIES entries (got ${descriptor.categories.size})"
+        }
         descriptor.categories.forEachIndexed { i, cat ->
             if (cat.length > TAG_MAX_LENGTH) {
-                violations += "categories[$i] must not exceed $TAG_MAX_LENGTH characters: '$cat'"
-            }
-        }
-        descriptor.tags.forEachIndexed { i, tag ->
-            if (tag.length > TAG_MAX_LENGTH) {
-                violations += "tags[$i] must not exceed $TAG_MAX_LENGTH characters: '$tag'"
+                violations += "categories[$i] must not exceed $TAG_MAX_LENGTH characters: '${cat.take(100)}'"
             }
         }
 
+        // --- tags ---
+        if (descriptor.tags.size > MAX_TAGS) {
+            violations += "tags must not exceed $MAX_TAGS entries (got ${descriptor.tags.size})"
+        }
+        descriptor.tags.forEachIndexed { i, tag ->
+            if (tag.length > TAG_MAX_LENGTH) {
+                violations += "tags[$i] must not exceed $TAG_MAX_LENGTH characters: '${tag.take(100)}'"
+            }
+        }
+
+        // --- screenshots ---
+        if (descriptor.screenshots.size > MAX_SCREENSHOTS) {
+            violations += "screenshots must not exceed $MAX_SCREENSHOTS entries (got ${descriptor.screenshots.size})"
+        }
+        descriptor.screenshots.forEachIndexed { i, url ->
+            if (url.length > URL_MAX_LENGTH) {
+                violations += "screenshots[$i] must not exceed $URL_MAX_LENGTH characters (got ${url.length})"
+            }
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+                if (!isValidHttpUrl(url)) {
+                    violations +=
+                        "screenshots[$i] must be a valid http/https URL or a relative path: '$url'"
+                }
+            }
+        }
+
+        // --- requiresSystemVersion ---
         descriptor.requiresSystemVersion?.let { range ->
+            if (range.length > REQUIRES_SYSTEM_VERSION_MAX_LENGTH) {
+                violations +=
+                    "requiresSystemVersion must not exceed $REQUIRES_SYSTEM_VERSION_MAX_LENGTH characters (got ${range.length})"
+            }
             if (!isValidSemVerRange(range)) {
-                violations += "requiresSystemVersion '$range' is not a valid SemVer range"
+                violations += "requiresSystemVersion '${range.take(200)}' is not a valid SemVer range"
+            }
+        }
+
+        // --- pluginDependencies ---
+        if (descriptor.pluginDependencies.size > MAX_DEPENDENCIES) {
+            violations +=
+                "pluginDependencies must not exceed $MAX_DEPENDENCIES entries (got ${descriptor.pluginDependencies.size})"
+        }
+        descriptor.pluginDependencies.forEachIndexed { i, dep ->
+            if (!PLUGIN_ID_REGEX.matches(dep.id)) {
+                violations +=
+                    "pluginDependencies[$i].id '${dep.id.take(200)}' must match pattern ${PLUGIN_ID_REGEX.pattern}"
+            }
+            if (dep.version.length > DEPENDENCY_VERSION_MAX_LENGTH) {
+                violations +=
+                    "pluginDependencies[$i].version must not exceed $DEPENDENCY_VERSION_MAX_LENGTH characters (got ${dep.version.length})"
             }
         }
 
         if (violations.isNotEmpty()) throw DescriptorValidationException(violations)
+    }
+
+    private fun checkUrlField(field: String, url: String, violations: MutableList<String>) {
+        if (url.length > URL_MAX_LENGTH) {
+            violations += "$field must not exceed $URL_MAX_LENGTH characters (got ${url.length})"
+        }
+        if (!isValidHttpUrl(url)) violations += "$field must be a valid http/https URL: '${url.take(200)}'"
+    }
+
+    private fun checkNoHtml(field: String, value: String, violations: MutableList<String>) {
+        if (DANGEROUS_HTML_REGEX.containsMatchIn(value)) {
+            violations += "$field must not contain HTML or script tags"
+        }
     }
 
     private fun isValidHttpUrl(url: String): Boolean = try {

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/Pf4jManifestParser.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/Pf4jManifestParser.kt
@@ -36,7 +36,7 @@ class Pf4jManifestParser {
         val license = attrs.getValue("Plugin-License")
         val dependencies = parseDependencyString(attrs.getValue("Plugin-Dependencies"))
 
-        return PlugwerkDescriptor(
+        val descriptor = PlugwerkDescriptor(
             id = id,
             version = version,
             name = description ?: id,
@@ -46,6 +46,8 @@ class Pf4jManifestParser {
             requiresSystemVersion = requires,
             pluginDependencies = dependencies,
         )
+        DescriptorValidator.validate(descriptor)
+        return descriptor
     }
 
     fun parseProperties(properties: Properties): PlugwerkDescriptor {
@@ -59,7 +61,7 @@ class Pf4jManifestParser {
         val license = properties.getProperty("plugin.license")
         val dependencies = parseDependencyString(properties.getProperty("plugin.dependencies"))
 
-        return PlugwerkDescriptor(
+        val descriptor = PlugwerkDescriptor(
             id = id,
             version = version,
             name = description ?: id,
@@ -69,6 +71,8 @@ class Pf4jManifestParser {
             requiresSystemVersion = requires,
             pluginDependencies = dependencies,
         )
+        DescriptorValidator.validate(descriptor)
+        return descriptor
     }
 
     fun parseFromJar(jarStream: InputStream): PlugwerkDescriptor {

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParser.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParser.kt
@@ -17,7 +17,6 @@
  */
 package io.plugwerk.descriptor
 
-import io.plugwerk.spi.version.isValidSemVer
 import tools.jackson.core.JacksonException
 import tools.jackson.core.StreamReadConstraints
 import tools.jackson.dataformat.yaml.YAMLFactory
@@ -74,10 +73,6 @@ class PlugwerkDescriptorParser {
             ?: throw DescriptorParseException("Required field 'version' is missing in plugwerk.yml")
         val name = yaml.name
             ?: throw DescriptorParseException("Required field 'name' is missing in plugwerk.yml")
-
-        if (!version.isValidSemVer()) {
-            throw DescriptorParseException("Invalid SemVer version '$version' in plugwerk.yml")
-        }
 
         val dependencies = yaml.requires?.plugins?.map { dep ->
             PluginDependency(

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
@@ -188,6 +188,20 @@ class DescriptorResolverTest {
     }
 
     @Test
+    fun `resolve propagates validation error for invalid plugin id in manifest`() {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", "../traversal")
+            mainAttributes.putValue("Plugin-Version", "1.0.0")
+        }
+        val jar = createJarWithManifest(manifest)
+
+        assertThrows<DescriptorValidationException> {
+            resolver.resolve(jar)
+        }
+    }
+
+    @Test
     fun `resolve propagates parse error for malformed plugwerk yml`() {
         val badYaml = """
             plugwerk:

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
@@ -30,22 +30,32 @@ class DescriptorValidatorTest {
         id: String = "my-plugin",
         name: String = "My Plugin",
         version: String = "1.0.0",
+        description: String? = null,
+        author: String? = null,
+        license: String? = null,
         homepage: String? = null,
         repository: String? = null,
         icon: String? = null,
         categories: List<String> = emptyList(),
         tags: List<String> = emptyList(),
+        screenshots: List<String> = emptyList(),
         requiresSystemVersion: String? = null,
+        pluginDependencies: List<PluginDependency> = emptyList(),
     ) = PlugwerkDescriptor(
         id = id,
         version = version,
         name = name,
+        description = description,
+        author = author,
+        license = license,
         homepage = homepage,
         repository = repository,
         icon = icon,
         categories = categories,
         tags = tags,
+        screenshots = screenshots,
         requiresSystemVersion = requiresSystemVersion,
+        pluginDependencies = pluginDependencies,
     )
 
     @Test
@@ -85,6 +95,32 @@ class DescriptorValidatorTest {
         assertTrue(ex.violations.any { it.contains("id") })
     }
 
+    // ---- version ----
+
+    @ParameterizedTest
+    @ValueSource(strings = ["1.0.0", "0.1.0", "10.20.30", "1.0.0-beta.1", "1.0.0+build.42"])
+    fun `valid SemVer versions pass`(version: String) {
+        assertDoesNotThrow { DescriptorValidator.validate(minimalDescriptor(version = version)) }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["not-a-version", "1.0", "1", "latest", "v1.0.0.0"])
+    fun `invalid SemVer versions throw`(version: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(version = version))
+        }
+        assertTrue(ex.violations.any { it.contains("version") })
+    }
+
+    @Test
+    fun `version exceeding max length throws`() {
+        val longVersion = "1.0.0-${"a".repeat(DescriptorValidator.VERSION_MAX_LENGTH)}"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(version = longVersion))
+        }
+        assertTrue(ex.violations.any { it.contains("version") })
+    }
+
     // ---- name ----
 
     @Test
@@ -100,6 +136,67 @@ class DescriptorValidatorTest {
             DescriptorValidator.validate(minimalDescriptor(name = "a".repeat(256)))
         }
         assertTrue(ex.violations.any { it.contains("name") })
+    }
+
+    // ---- description ----
+
+    @Test
+    fun `description at max length passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(
+                minimalDescriptor(description = "a".repeat(DescriptorValidator.DESCRIPTION_MAX_LENGTH)),
+            )
+        }
+    }
+
+    @Test
+    fun `description exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(description = "a".repeat(DescriptorValidator.DESCRIPTION_MAX_LENGTH + 1)),
+            )
+        }
+        assertTrue(ex.violations.any { it.contains("description") })
+    }
+
+    // ---- author ----
+
+    @Test
+    fun `author at max length passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(author = "a".repeat(DescriptorValidator.AUTHOR_MAX_LENGTH)))
+        }
+    }
+
+    @Test
+    fun `author exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(author = "a".repeat(DescriptorValidator.AUTHOR_MAX_LENGTH + 1)),
+            )
+        }
+        assertTrue(ex.violations.any { it.contains("author") })
+    }
+
+    // ---- license ----
+
+    @Test
+    fun `license at max length passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(
+                minimalDescriptor(license = "a".repeat(DescriptorValidator.LICENSE_MAX_LENGTH)),
+            )
+        }
+    }
+
+    @Test
+    fun `license exceeding max length throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(license = "a".repeat(DescriptorValidator.LICENSE_MAX_LENGTH + 1)),
+            )
+        }
+        assertTrue(ex.violations.any { it.contains("license") })
     }
 
     // ---- URL fields ----
@@ -131,6 +228,24 @@ class DescriptorValidatorTest {
     }
 
     @Test
+    fun `homepage exceeding max URL length throws`() {
+        val longUrl = "https://example.com/${"a".repeat(DescriptorValidator.URL_MAX_LENGTH)}"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(homepage = longUrl))
+        }
+        assertTrue(ex.violations.any { it.contains("homepage") })
+    }
+
+    @Test
+    fun `repository exceeding max URL length throws`() {
+        val longUrl = "https://example.com/${"a".repeat(DescriptorValidator.URL_MAX_LENGTH)}"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(repository = longUrl))
+        }
+        assertTrue(ex.violations.any { it.contains("repository") })
+    }
+
+    @Test
     fun `icon as relative path passes without URL validation`() {
         assertDoesNotThrow {
             DescriptorValidator.validate(minimalDescriptor(icon = "icons/plugin.png"))
@@ -148,6 +263,15 @@ class DescriptorValidatorTest {
     fun `icon as invalid https URL throws`() {
         val ex = assertThrows<DescriptorValidationException> {
             DescriptorValidator.validate(minimalDescriptor(icon = "https://"))
+        }
+        assertTrue(ex.violations.any { it.contains("icon") })
+    }
+
+    @Test
+    fun `icon exceeding max URL length throws`() {
+        val longIcon = "icons/${"a".repeat(DescriptorValidator.URL_MAX_LENGTH)}.png"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(icon = longIcon))
         }
         assertTrue(ex.violations.any { it.contains("icon") })
     }
@@ -177,6 +301,61 @@ class DescriptorValidatorTest {
         assertTrue(ex.violations.any { it.contains("categories") })
     }
 
+    @Test
+    fun `categories exceeding max count throws`() {
+        val tooMany = (1..DescriptorValidator.MAX_CATEGORIES + 1).map { "cat-$it" }
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(categories = tooMany))
+        }
+        assertTrue(ex.violations.any { it.contains("categories") && it.contains("exceed") })
+    }
+
+    @Test
+    fun `tags exceeding max count throws`() {
+        val tooMany = (1..DescriptorValidator.MAX_TAGS + 1).map { "tag-$it" }
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(tags = tooMany))
+        }
+        assertTrue(ex.violations.any { it.contains("tags") && it.contains("exceed") })
+    }
+
+    // ---- screenshots ----
+
+    @Test
+    fun `valid screenshots pass`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(
+                minimalDescriptor(screenshots = listOf("screenshot.png", "https://example.com/screen.png")),
+            )
+        }
+    }
+
+    @Test
+    fun `screenshot exceeding max URL length throws`() {
+        val longUrl = "https://example.com/${"a".repeat(DescriptorValidator.URL_MAX_LENGTH)}.png"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(screenshots = listOf(longUrl)))
+        }
+        assertTrue(ex.violations.any { it.contains("screenshots") })
+    }
+
+    @Test
+    fun `screenshot with invalid URL scheme throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(screenshots = listOf("https://")))
+        }
+        assertTrue(ex.violations.any { it.contains("screenshots") })
+    }
+
+    @Test
+    fun `screenshots exceeding max count throws`() {
+        val tooMany = (1..DescriptorValidator.MAX_SCREENSHOTS + 1).map { "screen-$it.png" }
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(screenshots = tooMany))
+        }
+        assertTrue(ex.violations.any { it.contains("screenshots") && it.contains("exceed") })
+    }
+
     // ---- requiresSystemVersion ----
 
     @ParameterizedTest
@@ -194,6 +373,107 @@ class DescriptorValidatorTest {
             DescriptorValidator.validate(minimalDescriptor(requiresSystemVersion = range))
         }
         assertTrue(ex.violations.any { it.contains("requiresSystemVersion") })
+    }
+
+    @Test
+    fun `requiresSystemVersion exceeding max length throws`() {
+        val longRange = ">=1.0.0 ${"& >=1.0.0 ".repeat(50)}"
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(requiresSystemVersion = longRange))
+        }
+        assertTrue(ex.violations.any { it.contains("requiresSystemVersion") })
+    }
+
+    // ---- pluginDependencies ----
+
+    @Test
+    fun `valid plugin dependencies pass`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(
+                minimalDescriptor(
+                    pluginDependencies = listOf(PluginDependency("acme-dep", ">=1.0.0")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `dependency with invalid id format throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(
+                    pluginDependencies = listOf(PluginDependency("../traversal", ">=1.0.0")),
+                ),
+            )
+        }
+        assertTrue(ex.violations.any { it.contains("pluginDependencies[0].id") })
+    }
+
+    @Test
+    fun `dependency with oversized version throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(
+                minimalDescriptor(
+                    pluginDependencies = listOf(
+                        PluginDependency(
+                            "valid-dep",
+                            "a".repeat(DescriptorValidator.DEPENDENCY_VERSION_MAX_LENGTH + 1),
+                        ),
+                    ),
+                ),
+            )
+        }
+        assertTrue(ex.violations.any { it.contains("pluginDependencies[0].version") })
+    }
+
+    @Test
+    fun `dependencies exceeding max count throws`() {
+        val tooMany = (1..DescriptorValidator.MAX_DEPENDENCIES + 1).map { PluginDependency("dep-$it", "*") }
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(pluginDependencies = tooMany))
+        }
+        assertTrue(ex.violations.any { it.contains("pluginDependencies") && it.contains("exceed") })
+    }
+
+    // ---- HTML / script injection ----
+
+    @ParameterizedTest
+    @ValueSource(strings = ["<script>alert(1)</script>", "<iframe src=x>", "<object data=x>", "javascript:alert(1)"])
+    fun `name with HTML or script injection throws`(name: String) {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(name = name))
+        }
+        assertTrue(ex.violations.any { it.contains("HTML") || it.contains("script") })
+    }
+
+    @Test
+    fun `description with script tag throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(description = "Hello <script>alert(1)</script>"))
+        }
+        assertTrue(ex.violations.any { it.contains("description") && it.contains("HTML") })
+    }
+
+    @Test
+    fun `author with iframe tag throws`() {
+        val ex = assertThrows<DescriptorValidationException> {
+            DescriptorValidator.validate(minimalDescriptor(author = "<iframe src=evil>"))
+        }
+        assertTrue(ex.violations.any { it.contains("author") && it.contains("HTML") })
+    }
+
+    @Test
+    fun `legitimate less-than in description passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(description = "values < 10 are ignored"))
+        }
+    }
+
+    @Test
+    fun `description with harmless angle brackets passes`() {
+        assertDoesNotThrow {
+            DescriptorValidator.validate(minimalDescriptor(description = "Use <T> for generics"))
+        }
     }
 
     // ---- multiple violations reported at once ----

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/Pf4jManifestParserTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/Pf4jManifestParserTest.kt
@@ -19,6 +19,7 @@ package io.plugwerk.descriptor
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.Properties
@@ -157,6 +158,62 @@ class Pf4jManifestParserTest {
         assertEquals("props-jar", descriptor.id)
         assertEquals("2.0.0", descriptor.version)
     }
+
+    // ---- Validation via DescriptorValidator ----
+
+    @Test
+    fun `manifest with invalid plugin id throws DescriptorValidationException`() {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", "../traversal")
+            mainAttributes.putValue("Plugin-Version", "1.0.0")
+        }
+        val ex = assertThrows<DescriptorValidationException> {
+            parser.parseManifest(manifest)
+        }
+        assertTrue(ex.violations.any { it.contains("id") })
+    }
+
+    @Test
+    fun `manifest with non-SemVer version throws DescriptorValidationException`() {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", "valid-plugin")
+            mainAttributes.putValue("Plugin-Version", "not-a-version")
+        }
+        val ex = assertThrows<DescriptorValidationException> {
+            parser.parseManifest(manifest)
+        }
+        assertTrue(ex.violations.any { it.contains("version") })
+    }
+
+    @Test
+    fun `manifest with oversized author throws DescriptorValidationException`() {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", "valid-plugin")
+            mainAttributes.putValue("Plugin-Version", "1.0.0")
+            mainAttributes.putValue("Plugin-Provider", "a".repeat(256))
+        }
+        val ex = assertThrows<DescriptorValidationException> {
+            parser.parseManifest(manifest)
+        }
+        assertTrue(ex.violations.any { it.contains("author") })
+    }
+
+    @Test
+    fun `properties with plugin id exceeding 128 chars throws DescriptorValidationException`() {
+        val props = Properties().apply {
+            setProperty("plugin.id", "a".repeat(129))
+            setProperty("plugin.version", "1.0.0")
+        }
+        val ex = assertThrows<DescriptorValidationException> {
+            parser.parseProperties(props)
+        }
+        assertTrue(ex.violations.any { it.contains("id") })
+    }
+
+    // ---- parseFromJar ----
 
     @Test
     fun `parse from JAR without any descriptor throws`() {

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParserTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/PlugwerkDescriptorParserTest.kt
@@ -86,10 +86,10 @@ class PlugwerkDescriptorParserTest {
     @Test
     fun `parse throws on invalid version`() {
         val input = loadResource("plugwerk-bad-version.yml")
-        val ex = assertThrows<DescriptorParseException> {
+        val ex = assertThrows<DescriptorValidationException> {
             parser.parse(input)
         }
-        assertTrue(ex.message!!.contains("version"), "Error should mention 'version': ${ex.message}")
+        assertTrue(ex.violations.any { it.contains("version") }, "Error should mention 'version': ${ex.message}")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Centralize validation** in `DescriptorValidator`: add length constraints for `version`, `description`, `author`, `license`, URL fields; add list cardinality limits for categories, tags, screenshots, dependencies; add HTML/script injection detection; add plugin dependency ID format validation
- **Wire `Pf4jManifestParser` through validator**: both `parseManifest()` and `parseProperties()` now call `DescriptorValidator.validate()` — previously they bypassed all validation entirely
- **Move SemVer check** from `PlugwerkDescriptorParser` to `DescriptorValidator` for single point of truth
- **Document constraints** in OpenAPI spec upload endpoint description

### Field Constraint Summary

| Field | Max Length | Format | New? |
|---|---|---|---|
| `id` | 128 | `^[a-zA-Z0-9._-]+$` | Existing |
| `version` | 100 | SemVer | **New** (centralized) |
| `name` | 255 | No HTML/script | Existing + **new** HTML |
| `description` | 10,000 | No HTML/script | **New** |
| `author` | 255 | No HTML/script | **New** |
| `license` | 100 | — | **New** |
| URL fields | 2,048 | http/https | **New** length |
| `categories` | 64 / max 20 | — | **New** count |
| `tags` | 64 / max 50 | — | **New** count |
| `screenshots` | 2,048 / max 20 | URL/path | **New** |
| `pluginDependencies` | max 100 | ID regex | **New** |

Closes #41

## Test plan

- [ ] `./gradlew build` passes (all modules, all tests)
- [ ] `DescriptorValidatorTest` covers all new constraints (version, description, author, license, URL lengths, list counts, dependency validation, HTML injection)
- [ ] `Pf4jManifestParserTest` verifies that invalid IDs, non-SemVer versions, and oversized fields throw `DescriptorValidationException`
- [ ] `PlugwerkDescriptorParserTest` updated: bad version now expects `DescriptorValidationException` (was `DescriptorParseException`)
- [ ] `DescriptorResolverTest` verifies validation errors propagate through the resolver
- [ ] Smoke test still passes (valid descriptors unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)