### PR TITLE
feat(#35): configure HTTP security headers in SecurityConfiguration

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -37,6 +37,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
 
 @Configuration
 @EnableWebSecurity
@@ -65,10 +66,42 @@ class SecurityConfiguration(
     @Bean
     fun textEncryptor(): TextEncryptor = Encryptors.text(props.auth.encryptionKey, "deadbeefcafe0000")
 
+    companion object {
+        /**
+         * Content-Security-Policy directives.
+         *
+         * - `style-src 'unsafe-inline'` is required because MUI 7 / Emotion injects `<style>`
+         *   tags at runtime. A nonce-based approach would require SSR integration.
+         * - `img-src data:` allows MUI SVG icons encoded as data URIs.
+         *
+         * TODO(Phase 3): make `frame-ancestors` configurable for embeddable UI component.
+         */
+        const val CSP_POLICY = "default-src 'self'; " +
+            "script-src 'self'; " +
+            "style-src 'self' 'unsafe-inline'; " +
+            "img-src 'self' data:; " +
+            "font-src 'self'; " +
+            "connect-src 'self'; " +
+            "frame-ancestors 'none'; " +
+            "form-action 'self'; " +
+            "base-uri 'self'; " +
+            "object-src 'none'"
+    }
+
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
+            .headers { headers ->
+                headers.contentTypeOptions { }
+                headers.frameOptions { it.deny() }
+                headers.httpStrictTransportSecurity { it.maxAgeInSeconds(31536000).includeSubDomains(true) }
+                headers.referrerPolicy {
+                    it.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
+                }
+                headers.permissionsPolicy { it.policy("camera=(), microphone=(), geolocation=(), payment=()") }
+                headers.contentSecurityPolicy { it.policyDirectives(CSP_POLICY) }
+            }
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+/**
+ * Verifies that HTTP security headers are present on responses.
+ *
+ * Uses the public `/actuator/health` endpoint so no authentication is needed.
+ *
+ * Note: `Strict-Transport-Security` (HSTS) is NOT asserted because MockMvc does not use
+ * HTTPS, and Spring Security only sends the HSTS header over secure connections.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SecurityHeadersTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `public endpoint returns all security headers`() {
+        mockMvc.get("/actuator/health")
+            .andExpect {
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("X-Frame-Options", "DENY") }
+                header { string("Referrer-Policy", "strict-origin-when-cross-origin") }
+                header {
+                    string(
+                        "Content-Security-Policy",
+                        SecurityConfiguration.CSP_POLICY,
+                    )
+                }
+                header {
+                    string(
+                        "Permissions-Policy",
+                        "camera=(), microphone=(), geolocation=(), payment=()",
+                    )
+                }
+            }
+    }
+
+    @Test
+    fun `unauthenticated API request returns security headers with 401`() {
+        mockMvc.get("/api/v1/namespaces")
+            .andExpect {
+                status { isUnauthorized() }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("X-Frame-Options", "DENY") }
+                header { exists("Content-Security-Policy") }
+            }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -36,6 +37,12 @@ import org.springframework.test.web.servlet.get
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:security-headers-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
 class SecurityHeadersTest {
 
     @Autowired

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -12,6 +12,4 @@ plugwerk:
     fs:
       root: ${java.io.tmpdir}/plugwerk-smoke-test
   auth:
-    jwt-secret: integration-test-secret-min32chars-ok!!
-    encryption-key: integ-encrypt-16
     admin-password: smoke-test-password

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
@@ -5,8 +5,3 @@ spring:
     show-sql: true
   liquibase:
     enabled: false
-
-plugwerk:
-  auth:
-    jwt-secret: test-only-secret-not-for-production-32ch
-    encryption-key: test-encrypt16c!


### PR DESCRIPTION
## Summary

- Add `.headers {}` block to `SecurityConfiguration.securityFilterChain()` configuring 6 HTTP security headers
- CSP allows `style-src 'unsafe-inline'` for MUI 7 / Emotion runtime styles and `img-src data:` for SVG icons
- HSTS with 1-year max-age and includeSubDomains (only sent over HTTPS, harmless in dev)
- Add `SecurityHeadersTest` verifying header presence on public and unauthenticated endpoints

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` |
| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'` |

## Test plan

- [x] `SecurityHeadersTest` — 2 tests verifying headers on public and 401 responses
- [x] All existing tests pass (179 tests green)
- [ ] CI E2E smoke test passes
- [ ] Manual: verify React SPA renders correctly with CSP (MUI styles work)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)