### PR TITLE
feat(security): enforce upload file size limit (fixes #33)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ PLUGWERK_ENCRYPTION_KEY=
 # PLUGWERK_BASE_URL=http://localhost:8080
 # PLUGWERK_STORAGE_TYPE=fs
 # PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts
+
+# Maximum plugin artifact upload size in MB (default: 100).
+# Applied to both Spring multipart limits and application-level validation.
+# PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB=100

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -86,6 +86,7 @@ info:
     - `401 Unauthorized` — missing or invalid authentication credentials
     - `404 Not Found` — the requested resource does not exist
     - `409 Conflict` — a resource with the same identifier already exists
+    - `413 Payload Too Large` — the uploaded artifact exceeds the server's file size limit
     - `422 Unprocessable Entity` — the artifact was uploaded successfully but the plugin
       descriptor inside it is missing or invalid
   version: 0.1.0
@@ -168,6 +169,13 @@ tags:
       The `userSubject` is either a local username or an OIDC `sub` claim.
 
       Requires `ADMIN` role on the namespace.
+  - name: ServerConfig
+    description: |
+      Public, unauthenticated endpoint exposing non-sensitive server configuration.
+
+      The frontend uses this endpoint to synchronise client-side validation rules
+      (e.g. maximum upload file size) with the server without requiring authentication.
+      The values returned here mirror the operator-configurable `plugwerk.*` properties.
   - name: OidcProviders
     description: |
       Manage external OIDC / OAuth2 providers for token validation.
@@ -179,6 +187,35 @@ tags:
       All providers are disabled by default. Requires server-admin authentication.
 
 paths:
+  /config:
+    get:
+      tags:
+        - ServerConfig
+      summary: Get public server configuration
+      description: |
+        Returns non-sensitive, operator-configurable server settings that clients need
+        to enforce local validation rules — most notably the maximum allowed upload file size.
+
+        This endpoint is **public** and does not require authentication. The frontend
+        calls it when the upload dialog opens so that client-side file size validation
+        always matches the server-side limit, even when the operator has overridden the
+        default via the `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` environment variable.
+
+        The response is intentionally small and stable — it will only grow with new
+        top-level keys, never remove existing ones.
+      operationId: getServerConfig
+      security: []
+      responses:
+        '200':
+          description: Current server configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerConfigResponse'
+              example:
+                upload:
+                  maxFileSizeMb: 100
+
   /auth/login:
     post:
       tags:
@@ -420,6 +457,12 @@ paths:
         - `pluginDependencies`: max 100 entries, each ID must match the plugin ID format
         - Plain-text fields must not contain HTML/script tags
 
+        **File size limit:**
+        The server enforces a maximum artifact size (default: 100 MB, configurable via
+        `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`). Files exceeding this limit are rejected with
+        `413 Payload Too Large`. Use `GET /config` to query the current limit at runtime.
+
+        Returns `413 Payload Too Large` if the artifact exceeds the file size limit.
         Returns `422 Unprocessable Entity` if the descriptor is missing or invalid.
       operationId: uploadPluginRelease
       security:
@@ -443,6 +486,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
 
@@ -2069,6 +2114,30 @@ components:
         endpoints embedded — only clientId and clientSecret are required.
         GENERIC_OIDC and KEYCLOAK require an explicit issuerUri.
 
+    ServerConfigResponse:
+      type: object
+      description: |
+        Public, non-sensitive server configuration that clients use to enforce local
+        validation rules. This response is intentionally small and stable — new top-level
+        keys may be added in future versions, but existing keys will not be removed.
+      properties:
+        upload:
+          type: object
+          description: Upload-related configuration
+          properties:
+            maxFileSizeMb:
+              type: integer
+              description: |
+                Maximum allowed plugin artifact file size in megabytes. Files exceeding
+                this limit are rejected with HTTP 413 (Payload Too Large). The server
+                operator can change this value via the `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`
+                environment variable. Default: `100`.
+              example: 100
+          required:
+            - maxFileSizeMb
+      required:
+        - upload
+
   responses:
     BadRequest:
       description: The request body or parameters failed validation
@@ -2084,6 +2153,15 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     NotFound:
       description: The requested resource does not exist
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    PayloadTooLarge:
+      description: |
+        The uploaded artifact exceeds the server's maximum allowed file size.
+        Use `GET /config` to query the current limit. The default is 100 MB,
+        configurable via the `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` environment variable.
       content:
         application/json:
           schema:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -43,6 +43,7 @@ data class PlugwerkProperties(
     val storage: StorageProperties = StorageProperties(),
     val server: ServerProperties = ServerProperties(),
     @field:Valid val auth: AuthProperties = AuthProperties(),
+    val upload: UploadProperties = UploadProperties(),
 ) {
     /**
      * Artifact storage configuration (`plugwerk.storage.*`).
@@ -178,4 +179,21 @@ data class PlugwerkProperties(
          */
         val adminPassword: String? = null,
     )
+
+    /**
+     * Upload configuration (`plugwerk.upload.*`).
+     *
+     * Controls the maximum allowed size for plugin artifact uploads.
+     *
+     * @property maxFileSizeMb Maximum artifact file size in megabytes. Files exceeding this
+     *   limit are rejected with HTTP 413 (Payload Too Large). This limit is enforced both
+     *   at the Spring multipart layer and in the application service layer.
+     *
+     *   Environment variable: `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`
+     *
+     *   ```yaml
+     *   plugwerk.upload.max-file-size-mb: 100
+     *   ```
+     */
+    data class UploadProperties(val maxFileSizeMb: Int = 100)
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -118,6 +118,8 @@ class SecurityConfiguration(
                     .requestMatchers("/api/v1/auth/**").permitAll()
                     // Update check is public (used by client SDK without auth)
                     .requestMatchers(HttpMethod.POST, "/api/v1/namespaces/*/updates/check").permitAll()
+                    // Public server config (upload limits etc.) — used by frontend without auth
+                    .requestMatchers(HttpMethod.GET, "/api/v1/config").permitAll()
                     // Actuator health and info are public
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     // SPA static assets are always public

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -1,0 +1,42 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.PlugwerkProperties
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class ConfigController(private val properties: PlugwerkProperties) {
+
+    @GetMapping("/config")
+    fun getServerConfig(): ResponseEntity<ServerConfigResponse> = ResponseEntity.ok(
+        ServerConfigResponse(
+            upload = ServerConfigResponse.UploadConfig(
+                maxFileSizeMb = properties.upload.maxFileSizeMb,
+            ),
+        ),
+    )
+
+    data class ServerConfigResponse(val upload: UploadConfig) {
+        data class UploadConfig(val maxFileSizeMb: Int)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -25,6 +25,7 @@ import io.plugwerk.server.service.ArtifactNotFoundException
 import io.plugwerk.server.service.ArtifactStorageException
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
+import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.NamespaceAlreadyExistsException
 import io.plugwerk.server.service.NamespaceNotFoundException
@@ -40,6 +41,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 import java.time.OffsetDateTime
 
 @RestControllerAdvice
@@ -95,6 +97,14 @@ class GlobalExceptionHandler {
     )
     fun handleDescriptorError(ex: RuntimeException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, ex.message ?: "Plugin descriptor is invalid or missing")
+
+    @ExceptionHandler(FileTooLargeException::class)
+    fun handleFileTooLarge(ex: FileTooLargeException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.PAYLOAD_TOO_LARGE, ex.message ?: "File too large")
+
+    @ExceptionHandler(MaxUploadSizeExceededException::class)
+    fun handleMaxUploadSize(ex: MaxUploadSizeExceededException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.PAYLOAD_TOO_LARGE, "Upload exceeds the maximum allowed file size")
 
     @ExceptionHandler(ArtifactStorageException::class)
     fun handleStorage(ex: ArtifactStorageException): ResponseEntity<ErrorResponse> {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.service
 
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
+import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
@@ -46,6 +47,7 @@ class PluginReleaseService(
     private val storageService: ArtifactStorageService,
     private val descriptorResolver: DescriptorResolver,
     private val objectMapper: ObjectMapper,
+    private val properties: PlugwerkProperties,
 ) {
 
     fun findAllByPlugin(namespaceSlug: String, pluginId: String): List<PluginReleaseEntity> {
@@ -93,7 +95,16 @@ class PluginReleaseService(
         contentLength: Long,
         originalFilename: String? = null,
     ): PluginReleaseEntity {
-        val bytes = content.readAllBytes()
+        val maxBytes = properties.upload.maxFileSizeMb.toLong() * 1_048_576L
+
+        if (contentLength > 0 && contentLength > maxBytes) {
+            throw FileTooLargeException(contentLength, properties.upload.maxFileSizeMb)
+        }
+
+        val bytes = content.readNBytes(maxBytes.toInt() + 1)
+        if (bytes.size > maxBytes) {
+            throw FileTooLargeException(bytes.size.toLong(), properties.upload.maxFileSizeMb)
+        }
         val descriptor = descriptorResolver.resolve(ByteArrayInputStream(bytes))
         val sha256 = computeSha256(bytes)
         val plugin = findOrCreatePlugin(namespaceSlug, descriptor)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/ServiceExceptions.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/ServiceExceptions.kt
@@ -44,3 +44,8 @@ class ConflictException(message: String) : RuntimeException(message)
 class UnauthorizedException(message: String) : RuntimeException(message)
 
 class ForbiddenException(message: String) : RuntimeException(message)
+
+class FileTooLargeException(actualSizeBytes: Long, maxSizeMb: Int) :
+    RuntimeException(
+        "File size ${actualSizeBytes / 1_048_576} MB exceeds maximum allowed $maxSizeMb MB",
+    )

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -19,6 +19,11 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 
+  servlet:
+    multipart:
+      max-file-size: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}MB
+      max-request-size: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}MB
+
   jackson:
     deserialization:
       fail-on-unknown-properties: false
@@ -50,6 +55,11 @@ plugwerk:
     # No environment variable override — change this value directly when needed.
     token-validity-hours: 8
 
+  # Maximum allowed plugin artifact file size in MB.
+  # Files exceeding this limit are rejected with HTTP 413 (Payload Too Large).
+  # Env: PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB
+  upload:
+    max-file-size-mb: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}
 
 server:
   port: 8080

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PublicNamespaceFilter
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(
+    ConfigController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class ConfigControllerTest {
+
+    @MockitoBean lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean lateinit var plugwerkProperties: PlugwerkProperties
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `GET config returns upload limits`() {
+        whenever(plugwerkProperties.upload).thenReturn(
+            PlugwerkProperties.UploadProperties(maxFileSizeMb = 200),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.upload.maxFileSizeMb") { value(200) }
+            }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.server.service.PluginService
@@ -164,6 +165,22 @@ class ManagementControllerTest {
             content = """{"status":"published"}"""
         }.andExpect {
             status { isOk() }
+        }
+    }
+
+    @Test
+    fun `POST release upload returns 413 when file exceeds size limit`() {
+        val artifact =
+            MockMultipartFile("artifact", "huge.jar", "application/octet-stream", "data".toByteArray())
+        whenever(releaseService.upload(any(), any(), any(), anyOrNull()))
+            .thenThrow(FileTooLargeException(200L * 1_048_576, 100))
+
+        mockMvc.multipart("/api/v1/namespaces/acme/plugin-releases") {
+            file(artifact)
+        }.andExpect {
+            status { isPayloadTooLarge() }
+            jsonPath("$.status") { value(413) }
+            jsonPath("$.message") { value("File size 200 MB exceeds maximum allowed 100 MB") }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.service
 
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
+import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
@@ -62,6 +63,14 @@ class PluginReleaseServiceTest {
     private val namespace = NamespaceEntity(id = namespaceId, slug = "acme", ownerOrg = "ACME Corp")
     private val plugin = PluginEntity(namespace = namespace, pluginId = "my-plugin", name = "My Plugin")
 
+    private val properties = PlugwerkProperties(
+        auth = PlugwerkProperties.AuthProperties(
+            jwtSecret = "test-only-secret-not-for-production-32ch",
+            encryptionKey = "test-encrypt16c!",
+        ),
+        upload = PlugwerkProperties.UploadProperties(maxFileSizeMb = 1),
+    )
+
     @BeforeEach
     fun setUp() {
         releaseService = PluginReleaseService(
@@ -71,6 +80,7 @@ class PluginReleaseServiceTest {
             storageService,
             descriptorResolver,
             ObjectMapper(),
+            properties,
         )
     }
 
@@ -230,5 +240,40 @@ class PluginReleaseServiceTest {
         releaseService.downloadArtifact("acme", "my-plugin", "1.0.0")
 
         verify(releaseRepository).incrementDownloadCount(releaseId)
+    }
+
+    @Test
+    fun `upload throws FileTooLargeException when contentLength exceeds limit`() {
+        val oversizedLength = 2L * 1_048_576L // 2 MB, limit is 1 MB
+
+        assertFailsWith<FileTooLargeException> {
+            releaseService.upload("acme", ByteArrayInputStream(ByteArray(0)), oversizedLength)
+        }
+    }
+
+    @Test
+    fun `upload throws FileTooLargeException when stream exceeds limit regardless of contentLength`() {
+        val oversizedBytes = ByteArray(1_048_576 + 1) // 1 MB + 1 byte
+
+        assertFailsWith<FileTooLargeException> {
+            releaseService.upload("acme", ByteArrayInputStream(oversizedBytes), 0)
+        }
+    }
+
+    @Test
+    fun `upload succeeds when file is within size limit`() {
+        val jarBytes = "small-content".toByteArray()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "2.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "2.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+
+        val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        assertThat(result.version).isEqualTo("2.0.0")
     }
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
@@ -11,7 +11,10 @@ import axios from 'axios'
 import * as apiConfig from '../../api/config'
 
 vi.mock('../../api/config', () => ({
-  axiosInstance: { post: vi.fn(), get: vi.fn() },
+  axiosInstance: {
+    post: vi.fn(),
+    get: vi.fn().mockResolvedValue({ data: { upload: { maxFileSizeMb: 100 } } }),
+  },
   catalogApi: { listPlugins: vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0, totalPages: 0, page: 0, size: 24 } }) },
 }))
 
@@ -139,4 +142,39 @@ describe('UploadModal', () => {
     }, { timeout: 15000 })
     expect(vi.mocked(apiConfig.catalogApi.listPlugins)).not.toHaveBeenCalled()
   }, 20000)
+
+  it('shows error when file exceeds size limit', async () => {
+    useUiStore.setState({ uploadModalOpen: true })
+    const user = userEvent.setup()
+    renderWithRouter(<UploadModal />)
+
+    const largeFile = new File([new ArrayBuffer(101 * 1024 * 1024)], 'huge-plugin.jar', {
+      type: 'application/java-archive',
+    })
+    await user.upload(screen.getByLabelText(/select plugin jar or zip file/i), largeFile)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.getByText(/file is too large/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: /upload release/i })).toBeDisabled()
+  })
+
+  it('displays max size hint in dropzone', async () => {
+    useUiStore.setState({ uploadModalOpen: true })
+    renderWithRouter(<UploadModal />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/max\. 100 mb/i)).toBeInTheDocument()
+    })
+  })
+
+  it('fetches config when modal opens', async () => {
+    useUiStore.setState({ uploadModalOpen: true })
+    renderWithRouter(<UploadModal />)
+
+    await waitFor(() => {
+      expect(vi.mocked(apiConfig.axiosInstance.get)).toHaveBeenCalledWith('/config')
+    })
+  })
 })

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -22,6 +22,8 @@ import { useAuthStore } from '../../stores/authStore'
 import { usePluginStore } from '../../stores/pluginStore'
 import { tokens } from '../../theme/tokens'
 
+const DEFAULT_MAX_FILE_SIZE_MB = 100
+
 export function UploadModal() {
   const { uploadModalOpen, closeUploadModal, addToast } = useUiStore()
   const { namespace } = useAuthStore()
@@ -29,13 +31,31 @@ export function UploadModal() {
   const [file, setFile] = useState<File | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [progress, setProgress] = useState<number | null>(null)
+  const [maxFileSizeMb, setMaxFileSizeMb] = useState(DEFAULT_MAX_FILE_SIZE_MB)
+
+  useEffect(() => {
+    if (!uploadModalOpen) return
+    axiosInstance.get('/config')
+      .then((res) => {
+        const limit = res.data?.upload?.maxFileSizeMb
+        if (typeof limit === 'number' && limit > 0) setMaxFileSizeMb(limit)
+      })
+      .catch(() => { /* use default */ })
+  }, [uploadModalOpen])
+
+  const maxFileSizeBytes = maxFileSizeMb * 1024 * 1024
 
   const onDrop = useCallback((accepted: File[]) => {
     if (accepted[0]) {
+      if (accepted[0].size > maxFileSizeBytes) {
+        setError(`File is too large (${(accepted[0].size / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is ${maxFileSizeMb} MB.`)
+        setFile(null)
+        return
+      }
       setFile(accepted[0])
       setError(null)
     }
-  }, [])
+  }, [maxFileSizeBytes, maxFileSizeMb])
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -131,7 +151,9 @@ export function UploadModal() {
                 <Typography variant="body2" fontWeight={600}>
                   {isDragActive ? 'Drop the file here…' : 'Drag & drop a .jar or .zip file here'}
                 </Typography>
-                <Typography variant="caption" color="text.disabled">or click to browse</Typography>
+                <Typography variant="caption" color="text.disabled">
+                  or click to browse · Max. {maxFileSizeMb} MB
+                </Typography>
               </>
             )}
           </Box>


### PR DESCRIPTION
## Summary

- Enforce configurable upload file size limit (default: 100 MB) to prevent OOM attacks via large artifact uploads
- Add defense-in-depth: Spring multipart limits + application-level `readNBytes()` validation + client-side check
- New public `GET /api/v1/config` endpoint returns server configuration (upload limits) so the frontend stays in sync with the backend — even when operators override the default via `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`

## Changes

### Backend
- **`PlugwerkProperties.kt`**: New `UploadProperties(maxFileSizeMb: Int = 100)` configurable via `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`
- **`application.yml`**: Spring `servlet.multipart.max-file-size` / `max-request-size` synced with env var
- **`PluginReleaseService.kt`**: Size check before `readAllBytes()` — uses `readNBytes(max + 1)` to protect against unknown content-length (chunked transfers)
- **`ServiceExceptions.kt`**: New `FileTooLargeException`
- **`GlobalExceptionHandler.kt`**: Handlers for `FileTooLargeException` and `MaxUploadSizeExceededException` → HTTP 413
- **`ConfigController.kt`**: New `GET /api/v1/config` (public, no auth) returning `{ upload: { maxFileSizeMb } }`
- **`SecurityConfiguration.kt`**: `/api/v1/config` added to public endpoints

### OpenAPI
- New `ServerConfig` tag with `GET /config` endpoint and `ServerConfigResponse` schema
- `413 PayloadTooLarge` response added to upload endpoint
- Upload description updated with file size limit documentation

### Frontend
- **`UploadModal.tsx`**: Fetches `/api/v1/config` on modal open, validates file size client-side before upload, shows "Max. X MB" hint in dropzone

### Tests
- `PluginReleaseServiceTest`: 3 new tests (contentLength exceeds limit, stream exceeds limit, within limit)
- `ManagementControllerTest`: 1 new test (413 on FileTooLargeException)
- `ConfigControllerTest`: 1 new test (GET /config returns upload limits)
- `UploadModal.test.tsx`: 3 new tests (file too large error, max size hint, config fetch)

## Test plan
- [x] Backend build + 196 tests pass
- [x] UploadModal: all 12 tests pass (9 existing + 3 new)
- [ ] CI pipeline passes
- [ ] Manual: upload a file > 100 MB → expect 413 + clear error message
- [ ] Manual: verify `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB=50` changes both server and frontend limit

Closes #33