### PR TITLE
fix(security): reject short JWT secrets instead of silent zero-padding (fixes #40)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/JwtConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/JwtConfiguration.kt
@@ -41,9 +41,8 @@ import javax.crypto.spec.SecretKeySpec
 class JwtConfiguration(private val props: PlugwerkProperties) {
 
     private val secretKey: SecretKey by lazy {
-        val bytes = props.auth.jwtSecret.toByteArray(Charsets.UTF_8).let {
-            if (it.size < 32) it.copyOf(32) else it
-        }
+        val bytes = props.auth.jwtSecret.toByteArray(Charsets.UTF_8)
+        require(bytes.size >= 32) { "PLUGWERK_JWT_SECRET must be at least 32 characters (got ${bytes.size})" }
         SecretKeySpec(bytes, "HmacSHA256")
     }
 


### PR DESCRIPTION
## Summary

- Replace silent zero-padding of short JWT secrets (`copyOf(32)`) with a hard `require()` check in `JwtConfiguration`
- Secrets shorter than 32 bytes now throw `IllegalArgumentException` instead of being silently weakened
- Defense-in-depth: `@Size(min=32)` on `PlugwerkProperties` already prevents short secrets at startup, but this ensures the signing key is never degraded if validation is bypassed

## Changes

**`JwtConfiguration.kt`** (1 file, 2 insertions, 3 deletions):
```kotlin
// Before: silent zero-padding
val bytes = props.auth.jwtSecret.toByteArray(Charsets.UTF_8).let {
    if (it.size < 32) it.copyOf(32) else it
}

// After: hard rejection
val bytes = props.auth.jwtSecret.toByteArray(Charsets.UTF_8)
require(bytes.size >= 32) { "PLUGWERK_JWT_SECRET must be at least 32 characters (got ${bytes.size})" }
```

## Test plan
- [x] Full Gradle build passes (196 tests)
- [ ] CI pipeline passes

Closes #40