### PR TITLE
fix(security): verify namespace ownership in review endpoints (IDOR)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ReviewsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ReviewsController.kt
@@ -64,12 +64,15 @@ class ReviewsController(
         releaseId: UUID,
         reviewDecisionRequest: ReviewDecisionRequest?,
     ): ResponseEntity<PluginReleaseDto> {
-        namespaceAuthorizationService.requireRole(
+        val auth = SecurityContextHolder.getContext().authentication!!
+        namespaceAuthorizationService.requireRole(ns, auth, NamespaceRole.ADMIN)
+        val isSuperadmin = namespaceAuthorizationService.isSuperadmin(auth)
+        val release = releaseService.updateStatusByIdInNamespace(
+            releaseId,
             ns,
-            SecurityContextHolder.getContext().authentication!!,
-            NamespaceRole.ADMIN,
+            ReleaseStatus.PUBLISHED,
+            enforceNamespace = !isSuperadmin,
         )
-        val release = releaseService.updateStatusById(releaseId, ReleaseStatus.PUBLISHED)
         return ResponseEntity.ok(releaseMapper.toDto(release, release.plugin.pluginId))
     }
 
@@ -78,12 +81,15 @@ class ReviewsController(
         releaseId: UUID,
         reviewDecisionRequest: ReviewDecisionRequest?,
     ): ResponseEntity<PluginReleaseDto> {
-        namespaceAuthorizationService.requireRole(
+        val auth = SecurityContextHolder.getContext().authentication!!
+        namespaceAuthorizationService.requireRole(ns, auth, NamespaceRole.ADMIN)
+        val isSuperadmin = namespaceAuthorizationService.isSuperadmin(auth)
+        val release = releaseService.updateStatusByIdInNamespace(
+            releaseId,
             ns,
-            SecurityContextHolder.getContext().authentication!!,
-            NamespaceRole.ADMIN,
+            ReleaseStatus.YANKED,
+            enforceNamespace = !isSuperadmin,
         )
-        val release = releaseService.updateStatusById(releaseId, ReleaseStatus.YANKED)
         return ResponseEntity.ok(releaseMapper.toDto(release, release.plugin.pluginId))
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -73,9 +73,22 @@ class PluginReleaseService(
         return releaseRepository.findPendingByNamespace(namespace, ReleaseStatus.DRAFT)
     }
 
+    /**
+     * Updates the status of a release, verifying it belongs to the given namespace.
+     *
+     * @param enforceNamespace when `false` the namespace check is skipped (superadmin use-case).
+     */
     @Transactional
-    fun updateStatusById(id: UUID, status: ReleaseStatus): PluginReleaseEntity {
+    fun updateStatusByIdInNamespace(
+        id: UUID,
+        namespaceSlug: String,
+        status: ReleaseStatus,
+        enforceNamespace: Boolean = true,
+    ): PluginReleaseEntity {
         val release = findById(id)
+        if (enforceNamespace && release.plugin.namespace.slug != namespaceSlug) {
+            throw ReleaseNotFoundException("id=$id", "")
+        }
         release.status = status
         return releaseRepository.save(release)
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
@@ -113,7 +113,14 @@ class ReviewsControllerTest {
     @Test
     fun `POST approve returns 200 with published release`() {
         val published = draftRelease.apply { status = ReleaseStatus.PUBLISHED }
-        whenever(releaseService.updateStatusById(eq(releaseId), eq(ReleaseStatus.PUBLISHED))).thenReturn(published)
+        whenever(
+            releaseService.updateStatusByIdInNamespace(
+                eq(releaseId),
+                eq("acme"),
+                eq(ReleaseStatus.PUBLISHED),
+                eq(true),
+            ),
+        ).thenReturn(published)
         whenever(releaseMapper.toDto(any(), eq("my-plugin")))
             .thenReturn(buildReleaseDto(io.plugwerk.api.model.PluginReleaseDto.Status.PUBLISHED))
 
@@ -129,7 +136,7 @@ class ReviewsControllerTest {
     @Test
     fun `POST approve returns 404 when release not found`() {
         val unknownId = UUID.randomUUID()
-        whenever(releaseService.updateStatusById(eq(unknownId), any()))
+        whenever(releaseService.updateStatusByIdInNamespace(eq(unknownId), eq("acme"), any(), eq(true)))
             .thenThrow(ReleaseNotFoundException("id=$unknownId", ""))
 
         mockMvc.post("/api/v1/namespaces/acme/reviews/$unknownId/approve") {
@@ -141,9 +148,58 @@ class ReviewsControllerTest {
     }
 
     @Test
+    fun `POST approve returns 404 when release belongs to different namespace`() {
+        whenever(
+            releaseService.updateStatusByIdInNamespace(
+                eq(releaseId),
+                eq("acme"),
+                eq(ReleaseStatus.PUBLISHED),
+                eq(true),
+            ),
+        ).thenThrow(ReleaseNotFoundException("id=$releaseId", ""))
+
+        mockMvc.post("/api/v1/namespaces/acme/reviews/$releaseId/approve") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `POST approve bypasses namespace check for superadmin`() {
+        val published = draftRelease.apply { status = ReleaseStatus.PUBLISHED }
+        whenever(namespaceAuthorizationService.isSuperadmin(any())).thenReturn(true)
+        whenever(
+            releaseService.updateStatusByIdInNamespace(
+                eq(releaseId),
+                eq("acme"),
+                eq(ReleaseStatus.PUBLISHED),
+                eq(false),
+            ),
+        ).thenReturn(published)
+        whenever(releaseMapper.toDto(any(), eq("my-plugin")))
+            .thenReturn(buildReleaseDto(io.plugwerk.api.model.PluginReleaseDto.Status.PUBLISHED))
+
+        mockMvc.post("/api/v1/namespaces/acme/reviews/$releaseId/approve") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
     fun `POST reject returns 200 with yanked release`() {
         val yanked = draftRelease.apply { status = ReleaseStatus.YANKED }
-        whenever(releaseService.updateStatusById(eq(releaseId), eq(ReleaseStatus.YANKED))).thenReturn(yanked)
+        whenever(
+            releaseService.updateStatusByIdInNamespace(
+                eq(releaseId),
+                eq("acme"),
+                eq(ReleaseStatus.YANKED),
+                eq(true),
+            ),
+        ).thenReturn(yanked)
         whenever(releaseMapper.toDto(any(), eq("my-plugin")))
             .thenReturn(buildReleaseDto(io.plugwerk.api.model.PluginReleaseDto.Status.YANKED))
 
@@ -153,6 +209,25 @@ class ReviewsControllerTest {
         }.andExpect {
             status { isOk() }
             jsonPath("$.status") { value("yanked") }
+        }
+    }
+
+    @Test
+    fun `POST reject returns 404 when release belongs to different namespace`() {
+        whenever(
+            releaseService.updateStatusByIdInNamespace(
+                eq(releaseId),
+                eq("acme"),
+                eq(ReleaseStatus.YANKED),
+                eq(true),
+            ),
+        ).thenThrow(ReleaseNotFoundException("id=$releaseId", ""))
+
+        mockMvc.post("/api/v1/namespaces/acme/reviews/$releaseId/reject") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isNotFound() }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -243,6 +243,41 @@ class PluginReleaseServiceTest {
     }
 
     @Test
+    fun `updateStatusByIdInNamespace updates status when namespace matches`() {
+        val releaseId = UUID.randomUUID()
+        val release = PluginReleaseEntity(
+            id = releaseId,
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "acme:my-plugin:1.0.0:jar",
+        )
+        whenever(releaseRepository.findById(releaseId)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(release)
+
+        val result = releaseService.updateStatusByIdInNamespace(releaseId, "acme", ReleaseStatus.PUBLISHED)
+
+        assertThat(result.status).isEqualTo(ReleaseStatus.PUBLISHED)
+    }
+
+    @Test
+    fun `updateStatusByIdInNamespace throws ReleaseNotFoundException when namespace does not match`() {
+        val releaseId = UUID.randomUUID()
+        val release = PluginReleaseEntity(
+            id = releaseId,
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "acme:my-plugin:1.0.0:jar",
+        )
+        whenever(releaseRepository.findById(releaseId)).thenReturn(Optional.of(release))
+
+        assertFailsWith<ReleaseNotFoundException> {
+            releaseService.updateStatusByIdInNamespace(releaseId, "evil-namespace", ReleaseStatus.PUBLISHED)
+        }
+    }
+
+    @Test
     fun `upload throws FileTooLargeException when contentLength exceeds limit`() {
         val oversizedLength = 2L * 1_048_576L // 2 MB, limit is 1 MB
 


### PR DESCRIPTION
## Summary

- Replace global `updateStatusById` with namespace-scoped `updateStatusByIdInNamespace` that verifies the release belongs to the namespace from the URL path
- Return 404 (not 403) for mismatched namespaces to prevent information leakage about releases in other namespaces
- Superadmin bypasses the namespace check to allow cross-namespace review management

## Security Fix

Previously, `approveRelease` and `rejectRelease` in `ReviewsController` looked up releases globally by UUID. An authenticated ADMIN in namespace `evil` could approve/reject releases belonging to namespace `acme` by guessing UUIDv7 values (which are time-ordered and predictable).

## Changes

| File | Change |
|---|---|
| `PluginReleaseService.kt` | `updateStatusById` → `updateStatusByIdInNamespace` with namespace check and `enforceNamespace` parameter |
| `ReviewsController.kt` | Pass namespace slug and superadmin status to service |
| `ReviewsControllerTest.kt` | +3 new tests (IDOR approve/reject, superadmin bypass) |
| `PluginReleaseServiceTest.kt` | +2 new tests (namespace match/mismatch) |

## Test plan

- [x] Existing approve/reject tests pass with updated method signature
- [x] New test: approve returns 404 when release belongs to different namespace
- [x] New test: reject returns 404 when release belongs to different namespace
- [x] New test: superadmin bypasses namespace check
- [x] New test: service-level namespace match succeeds
- [x] New test: service-level namespace mismatch throws ReleaseNotFoundException
- [x] `./gradlew build` passes

Closes #43