### PR TITLE
fix(security): remove system property config from client SDK plugin

### DIFF
--- a/docs/adrs/0005-client-sdk-design.md
+++ b/docs/adrs/0005-client-sdk-design.md
@@ -44,7 +44,7 @@ instance is bound to exactly one namespace.
 - `namespace` — the namespace on that server (e.g. `acme`)
 - `accessToken` — optional Bearer token; `null` means anonymous access
 - `connectionTimeoutMs`, `readTimeoutMs` — OkHttp timeouts
-- `cacheDirectory` — optional local directory for downloaded artifacts
+- `pluginDirectory` — optional local directory for downloaded/installed plugin artifacts
 
 The namespace is **not** embedded in `serverUrl` as a path segment. Keeping it as a dedicated field
 makes it visible in logs, validatable on startup, and clearly separable from the host URL.

--- a/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/PluginManagerFactory.java
+++ b/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/PluginManagerFactory.java
@@ -1,37 +1,33 @@
 package io.plugwerk.example.cli;
 
+import io.plugwerk.client.PlugwerkConfig;
+import io.plugwerk.client.PlugwerkMarketplacePlugin;
 import io.plugwerk.spi.extension.PlugwerkMarketplace;
 import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginManager;
+import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Creates and configures the PF4J {@link PluginManager} used by the CLI host.
  *
  * <p>The {@code plugwerk-client-plugin} ZIP must be present in the plugins directory
- * before calling {@link #create(Path, String, String)}. The SDK plugin is loaded and started
- * automatically; its {@link PlugwerkMarketplace} extension is then available via
+ * before calling {@link #create(Path, String, String, String)}. The SDK plugin is loaded and
+ * started automatically; its {@link PlugwerkMarketplace} instance is then available via
  * {@link #getMarketplace(PluginManager)}.
- *
- * <p>System properties consumed by the SDK plugin (set by this factory before starting plugins):
- * <ul>
- *   <li>{@code plugwerk.serverUrl} — Plugwerk server base URL</li>
- *   <li>{@code plugwerk.namespace} — namespace slug</li>
- *   <li>{@code plugwerk.cacheDirectory} — directory where installed plugin artifacts are stored</li>
- * </ul>
  */
 public class PluginManagerFactory {
 
     private static final Logger log = LoggerFactory.getLogger(PluginManagerFactory.class);
+    private static final String PLUGIN_ID = "plugwerk-client";
 
     private PluginManagerFactory() {}
 
     /**
-     * Creates a {@link DefaultPluginManager}, sets the SDK system properties, and starts all plugins.
+     * Creates a {@link DefaultPluginManager}, configures the Plugwerk SDK plugin, and starts all plugins.
      *
      * <p>{@link DefaultPluginManager} is used (not {@code JarPluginManager}) because it includes
      * {@code DefaultPluginRepository}, which automatically extracts ZIP files to directories before
@@ -41,19 +37,9 @@ public class PluginManagerFactory {
      * @param serverUrl   Plugwerk server base URL (e.g. {@code http://localhost:8080})
      * @param namespace   namespace slug (e.g. {@code default})
      * @param accessToken optional Bearer token for authenticated servers (may be null or blank)
-     * @return started plugin manager ready for extension queries
+     * @return started plugin manager ready for marketplace queries
      */
     public static PluginManager create(Path pluginsDir, String serverUrl, String namespace, String accessToken) {
-        // System properties are read by PlugwerkMarketplaceImpl's no-arg constructor,
-        // which is called by PF4J via reflection when the plugin is started.
-        // They must be set BEFORE startPlugins() is called.
-        System.setProperty("plugwerk.serverUrl", serverUrl);
-        System.setProperty("plugwerk.namespace", namespace);
-        System.setProperty("plugwerk.cacheDirectory", pluginsDir.toAbsolutePath().toString());
-        if (accessToken != null && !accessToken.isBlank()) {
-            System.setProperty("plugwerk.accessToken", accessToken);
-        }
-
         log.debug("Starting PF4J plugin manager with plugins directory: {}", pluginsDir.toAbsolutePath());
 
         DefaultPluginManager manager = new DefaultPluginManager(pluginsDir.toAbsolutePath());
@@ -64,25 +50,42 @@ public class PluginManagerFactory {
                 .map(p -> p.getPluginId() + "@" + p.getDescriptor().getVersion())
                 .toList());
 
+        // Configure the Plugwerk SDK plugin with server connection details.
+        // This must happen after startPlugins() and before getMarketplace().
+        PlugwerkConfig.Builder configBuilder = new PlugwerkConfig.Builder(serverUrl, namespace)
+                .pluginDirectory(pluginsDir.toAbsolutePath());
+        if (accessToken != null && !accessToken.isBlank()) {
+            configBuilder.accessToken(accessToken);
+        }
+
+        PluginWrapper wrapper = manager.getPlugin(PLUGIN_ID);
+        if (wrapper == null) {
+            throw new IllegalStateException("""
+                    Plugin '%s' not found.
+                    Make sure plugwerk-client-plugin-<version>.zip is present in the plugins directory.
+                    Run: cp <main-project>/plugwerk-client-plugin/build/pf4j/*.zip %s/
+                    """.formatted(PLUGIN_ID, pluginsDir.toAbsolutePath()));
+        }
+        ((PlugwerkMarketplacePlugin) wrapper.getPlugin()).configure(configBuilder.build());
+
         return manager;
     }
 
     /**
-     * Retrieves the {@link PlugwerkMarketplace} extension from the running plugin manager.
+     * Retrieves the {@link PlugwerkMarketplace} instance from the configured plugin.
      *
-     * @param manager a started {@link PluginManager}
-     * @return the first available {@link PlugwerkMarketplace} extension
-     * @throws IllegalStateException if {@code plugwerk-client-plugin} is not loaded
+     * @param manager a started and configured {@link PluginManager}
+     * @return the {@link PlugwerkMarketplace} facade
+     * @throws IllegalStateException if {@code plugwerk-client-plugin} is not loaded or not configured
      */
     public static PlugwerkMarketplace getMarketplace(PluginManager manager) {
-        List<PlugwerkMarketplace> extensions = manager.getExtensions(PlugwerkMarketplace.class);
-        if (extensions.isEmpty()) {
+        PluginWrapper wrapper = manager.getPlugin(PLUGIN_ID);
+        if (wrapper == null) {
             throw new IllegalStateException("""
-                    No PlugwerkMarketplace extension found.
+                    No '%s' plugin found.
                     Make sure plugwerk-client-plugin-<version>.zip is present in the plugins directory.
-                    Run: cp <main-project>/plugwerk-client-plugin/build/pf4j/*.zip <plugins-dir>/
-                    """);
+                    """.formatted(PLUGIN_ID));
         }
-        return extensions.get(0);
+        return ((PlugwerkMarketplacePlugin) wrapper.getPlugin()).marketplace();
     }
 }

--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -61,6 +61,33 @@ plugin.configure(
 val marketplace = plugin.marketplace()
 ```
 
+### Multiple Servers
+
+A single plugin instance can manage connections to multiple Plugwerk servers simultaneously:
+
+```kotlin
+plugin.configure("production", PlugwerkConfig.Builder("https://prod.example.com", "acme")
+    .accessToken("prod-token")
+    .pluginDirectory(Path.of("/var/app/plugins"))
+    .build())
+plugin.configure("staging", PlugwerkConfig.Builder("https://staging.example.com", "acme")
+    .accessToken("staging-token")
+    .pluginDirectory(Path.of("/var/app/plugins"))
+    .build())
+
+val prodCatalog = plugin.marketplace("production").catalog()
+val stagingInstaller = plugin.marketplace("staging").installer()
+
+// List all registered servers
+plugin.serverIds()  // ["production", "staging"]
+
+// Remove a server (closes its HTTP client)
+plugin.remove("staging")
+```
+
+The single-server `configure(config)` / `marketplace()` methods are convenience shortcuts
+that use `"default"` as the server ID.
+
 Or load from a properties file:
 
 ```properties

--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -42,21 +42,42 @@ Plugin Classloader (isolated)
 
 ## Configuration
 
+The host application configures the plugin by passing a `PlugwerkConfig` instance:
+
 ```kotlin
-val config = PlugwerkConfig.Builder()
-    .serverUrl("https://plugwerk.example.com")
-    .namespace("acme-crm")
-    .accessToken("eyJhbG...")
-    .build()
+val pluginManager = DefaultPluginManager(pluginsDir)
+pluginManager.loadPlugins()
+pluginManager.startPlugins()
+
+val plugin = pluginManager.getPlugin("plugwerk-client")
+    .plugin as PlugwerkMarketplacePlugin
+plugin.configure(
+    PlugwerkConfig.Builder("https://plugwerk.example.com", "acme-crm")
+        .accessToken("eyJhbG...")
+        .pluginDirectory(Path.of("/var/app/plugins"))
+        .build()
+)
+
+val marketplace = plugin.marketplace()
 ```
 
-Or from a properties file:
+Or load from a properties file:
 
 ```properties
-plugwerk.server-url=https://plugwerk.example.com
+plugwerk.serverUrl=https://plugwerk.example.com
 plugwerk.namespace=acme-crm
-plugwerk.access-token=eyJhbG...
+plugwerk.accessToken=eyJhbG...
+plugwerk.pluginDirectory=/var/app/plugins
 ```
+
+```kotlin
+val config = PlugwerkConfig.fromProperties(Path.of("plugwerk-client.properties"))
+plugin.configure(config)
+```
+
+> **Security:** Never pass access tokens as JVM system properties (`-Dplugwerk.accessToken=…`) —
+> they are visible in `ps aux` and `/proc/PID/cmdline`. Use the builder or a properties file
+> with restricted filesystem permissions instead.
 
 ## Compatibility
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkClient.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkClient.kt
@@ -144,6 +144,12 @@ class PlugwerkClient(internal val config: PlugwerkConfig) {
         }
     }
 
+    /** Shuts down the underlying HTTP client, releasing connection pool and dispatcher threads. */
+    fun close() {
+        httpClient.dispatcher.executorService.shutdown()
+        httpClient.connectionPool.evictAll()
+    }
+
     companion object {
         @PublishedApi
         internal val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkConfig.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkConfig.kt
@@ -28,6 +28,10 @@ import kotlin.io.path.inputStream
  * Use [Builder] for programmatic construction or [fromProperties] to load from a
  * `.properties` file.
  *
+ * **Security:** Never pass sensitive values (e.g. access tokens) as JVM system properties
+ * (`-Dplugwerk.accessToken=…`) — they are visible in `ps aux` and `/proc/PID/cmdline`.
+ * Use [Builder] or a `.properties` file with restricted filesystem permissions instead.
+ *
  * The SDK constructs API URLs as:
  * `{serverUrl}/api/v1/namespaces/{namespace}/...`
  */
@@ -37,7 +41,7 @@ data class PlugwerkConfig(
     val accessToken: String? = null,
     val connectionTimeoutMs: Long = DEFAULT_CONNECTION_TIMEOUT_MS,
     val readTimeoutMs: Long = DEFAULT_READ_TIMEOUT_MS,
-    val cacheDirectory: Path? = null,
+    val pluginDirectory: Path? = null,
 ) {
     init {
         require(serverUrl.isNotBlank()) { "serverUrl must not be blank" }
@@ -58,7 +62,7 @@ data class PlugwerkConfig(
         private const val PROP_ACCESS_TOKEN = "plugwerk.accessToken"
         private const val PROP_CONNECTION_TIMEOUT_MS = "plugwerk.connectionTimeoutMs"
         private const val PROP_READ_TIMEOUT_MS = "plugwerk.readTimeoutMs"
-        private const val PROP_CACHE_DIRECTORY = "plugwerk.cacheDirectory"
+        private const val PROP_PLUGIN_DIRECTORY = "plugwerk.pluginDirectory"
 
         /** Loads configuration from a `.properties` file on the filesystem. */
         fun fromProperties(path: Path): PlugwerkConfig = path.inputStream().use { fromProperties(it) }
@@ -73,35 +77,7 @@ data class PlugwerkConfig(
                 props.getProperty(PROP_ACCESS_TOKEN)?.let { accessToken(it) }
                 props.getProperty(PROP_CONNECTION_TIMEOUT_MS)?.let { connectionTimeoutMs(it.toLong()) }
                 props.getProperty(PROP_READ_TIMEOUT_MS)?.let { readTimeoutMs(it.toLong()) }
-                props.getProperty(PROP_CACHE_DIRECTORY)?.let { cacheDirectory(Path.of(it)) }
-            }.build()
-        }
-
-        /**
-         * Loads configuration from JVM system properties.
-         *
-         * Required system properties:
-         * - `plugwerk.serverUrl` — base URL of the Plugwerk server
-         * - `plugwerk.namespace` — namespace to connect to
-         *
-         * Optional system properties mirror the `.properties` file keys.
-         * `plugwerk.cacheDirectory` is required when using PF4J plugin mode (no-arg constructor).
-         *
-         * This factory is used by [io.plugwerk.client.PlugwerkMarketplaceImpl]'s no-arg constructor,
-         * which PF4J invokes when discovering the extension via reflection. Set the required system
-         * properties before calling `pluginManager.getExtensions(PlugwerkMarketplace::class.java)`.
-         */
-        fun fromSystemProperties(): PlugwerkConfig {
-            fun requireProp(key: String) = System.getProperty(key)?.takeIf { it.isNotBlank() }
-                ?: throw IllegalStateException("Required system property '$key' is not set or blank")
-            return Builder(
-                serverUrl = requireProp(PROP_SERVER_URL),
-                namespace = requireProp(PROP_NAMESPACE),
-            ).apply {
-                System.getProperty(PROP_ACCESS_TOKEN)?.let { accessToken(it) }
-                System.getProperty(PROP_CONNECTION_TIMEOUT_MS)?.let { connectionTimeoutMs(it.toLong()) }
-                System.getProperty(PROP_READ_TIMEOUT_MS)?.let { readTimeoutMs(it.toLong()) }
-                System.getProperty(PROP_CACHE_DIRECTORY)?.let { cacheDirectory(Path.of(it)) }
+                props.getProperty(PROP_PLUGIN_DIRECTORY)?.let { pluginDirectory(Path.of(it)) }
             }.build()
         }
 
@@ -114,7 +90,7 @@ data class PlugwerkConfig(
         private var accessToken: String? = null
         private var connectionTimeoutMs: Long = DEFAULT_CONNECTION_TIMEOUT_MS
         private var readTimeoutMs: Long = DEFAULT_READ_TIMEOUT_MS
-        private var cacheDirectory: Path? = null
+        private var pluginDirectory: Path? = null
 
         fun accessToken(token: String) = apply { this.accessToken = token }
 
@@ -122,7 +98,7 @@ data class PlugwerkConfig(
 
         fun readTimeoutMs(ms: Long) = apply { this.readTimeoutMs = ms }
 
-        fun cacheDirectory(path: Path) = apply { this.cacheDirectory = path }
+        fun pluginDirectory(path: Path) = apply { this.pluginDirectory = path }
 
         fun build(): PlugwerkConfig = PlugwerkConfig(
             serverUrl = serverUrl,
@@ -130,7 +106,7 @@ data class PlugwerkConfig(
             accessToken = accessToken,
             connectionTimeoutMs = connectionTimeoutMs,
             readTimeoutMs = readTimeoutMs,
-            cacheDirectory = cacheDirectory,
+            pluginDirectory = pluginDirectory,
         )
     }
 }

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
@@ -44,6 +44,7 @@ import io.plugwerk.spi.extension.PlugwerkUpdateChecker
  * ```
  */
 class PlugwerkMarketplaceImpl internal constructor(
+    internal val client: PlugwerkClient,
     private val catalog: PlugwerkCatalog,
     private val installer: PlugwerkInstaller,
     private val updateChecker: PlugwerkUpdateChecker,
@@ -54,6 +55,11 @@ class PlugwerkMarketplaceImpl internal constructor(
     override fun installer(): PlugwerkInstaller = installer
 
     override fun updateChecker(): PlugwerkUpdateChecker = updateChecker
+
+    /** Shuts down the underlying HTTP client, releasing connection pool and dispatcher threads. */
+    internal fun close() {
+        client.close()
+    }
 
     companion object {
         /**
@@ -69,6 +75,7 @@ class PlugwerkMarketplaceImpl internal constructor(
             )
             val client = PlugwerkClient(config)
             return PlugwerkMarketplaceImpl(
+                client = client,
                 catalog = PlugwerkCatalogImpl(client),
                 installer = PlugwerkInstallerImpl(client, pluginDir),
                 updateChecker = PlugwerkUpdateCheckerImpl(client),

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
@@ -24,59 +24,30 @@ import io.plugwerk.spi.extension.PlugwerkCatalog
 import io.plugwerk.spi.extension.PlugwerkInstaller
 import io.plugwerk.spi.extension.PlugwerkMarketplace
 import io.plugwerk.spi.extension.PlugwerkUpdateChecker
-import org.pf4j.Extension
-import java.nio.file.Path
 
 /**
- * PF4J `@Extension` facade that combines catalog, installer, and update checker into a
- * single [PlugwerkMarketplace] extension point.
+ * Facade that combines catalog, installer, and update checker into a single
+ * [PlugwerkMarketplace] implementation.
  *
- * **PF4J extension discovery (recommended):**
- * Set the required system properties, then let PF4J discover the extension:
+ * **PF4J plugin mode (recommended):**
+ * Obtain the instance via [PlugwerkMarketplacePlugin.marketplace] after configuring the plugin:
+ * ```kotlin
+ * val plugin = pluginManager.getPlugin("plugwerk-client")
+ *     .plugin as PlugwerkMarketplacePlugin
+ * plugin.configure(config)
+ * val marketplace = plugin.marketplace()
  * ```
- * System.setProperty("plugwerk.serverUrl", "https://plugins.example.com")
- * System.setProperty("plugwerk.namespace", "acme")
- * System.setProperty("plugwerk.cacheDirectory", "/var/plugwerk/plugins")
- * val marketplace = pluginManager.getExtensions(PlugwerkMarketplace::class.java).first()
- * ```
- * See [PlugwerkConfig.fromSystemProperties] for all supported properties.
  *
  * **Programmatic construction (testing / embedding without PF4J):**
  * ```kotlin
- * val marketplace = PlugwerkMarketplaceImpl.create(config, pluginDirectory)
+ * val marketplace = PlugwerkMarketplaceImpl.create(config)
  * ```
  */
-@Extension
-class PlugwerkMarketplaceImpl : PlugwerkMarketplace {
-    private val catalog: PlugwerkCatalog
-    private val installer: PlugwerkInstaller
-    private val updateChecker: PlugwerkUpdateChecker
-
-    /**
-     * No-arg constructor for PF4J extension discovery via reflection.
-     * Reads configuration from system properties via [PlugwerkConfig.fromSystemProperties].
-     */
-    constructor() {
-        val config = PlugwerkConfig.fromSystemProperties()
-        val pluginDir = config.cacheDirectory
-            ?: throw IllegalStateException(
-                "System property 'plugwerk.cacheDirectory' is required in PF4J plugin mode",
-            )
-        val client = PlugwerkClient(config)
-        catalog = PlugwerkCatalogImpl(client)
-        installer = PlugwerkInstallerImpl(client, pluginDir)
-        updateChecker = PlugwerkUpdateCheckerImpl(client)
-    }
-
-    internal constructor(
-        catalog: PlugwerkCatalog,
-        installer: PlugwerkInstaller,
-        updateChecker: PlugwerkUpdateChecker,
-    ) {
-        this.catalog = catalog
-        this.installer = installer
-        this.updateChecker = updateChecker
-    }
+class PlugwerkMarketplaceImpl internal constructor(
+    private val catalog: PlugwerkCatalog,
+    private val installer: PlugwerkInstaller,
+    private val updateChecker: PlugwerkUpdateChecker,
+) : PlugwerkMarketplace {
 
     override fun catalog(): PlugwerkCatalog = catalog
 
@@ -88,14 +59,18 @@ class PlugwerkMarketplaceImpl : PlugwerkMarketplace {
         /**
          * Creates a fully wired [PlugwerkMarketplaceImpl] from the given [config].
          *
-         * @param config server and namespace configuration
-         * @param pluginDirectory directory where plugin artifacts are stored after installation
+         * [PlugwerkConfig.pluginDirectory] must be set.
+         *
+         * @param config server, namespace, and plugin directory configuration
          */
-        fun create(config: PlugwerkConfig, pluginDirectory: Path): PlugwerkMarketplaceImpl {
+        fun create(config: PlugwerkConfig): PlugwerkMarketplaceImpl {
+            val pluginDir = config.pluginDirectory ?: throw IllegalStateException(
+                "pluginDirectory is required — set it via PlugwerkConfig.Builder.pluginDirectory()",
+            )
             val client = PlugwerkClient(config)
             return PlugwerkMarketplaceImpl(
                 catalog = PlugwerkCatalogImpl(client),
-                installer = PlugwerkInstallerImpl(client, pluginDirectory),
+                installer = PlugwerkInstallerImpl(client, pluginDir),
                 updateChecker = PlugwerkUpdateCheckerImpl(client),
             )
         }

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplacePlugin.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplacePlugin.kt
@@ -17,11 +17,9 @@
  */
 package io.plugwerk.client
 
-import io.plugwerk.client.catalog.PlugwerkCatalogImpl
-import io.plugwerk.client.installer.PlugwerkInstallerImpl
-import io.plugwerk.client.updater.PlugwerkUpdateCheckerImpl
 import io.plugwerk.spi.extension.PlugwerkMarketplace
 import org.pf4j.Plugin
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * PF4J plugin entry point for the Plugwerk Client SDK.
@@ -29,67 +27,116 @@ import org.pf4j.Plugin
  * This class is referenced in `MANIFEST.MF` via `Plugin-Class`. PF4J instantiates it
  * when the SDK JAR is loaded as a plugin.
  *
- * The host application must call [configure] before accessing the [marketplace] instance.
- * Each plugin instance carries its own [PlugwerkConfig], so multiple instances can connect
- * to different servers or namespaces within the same host application.
+ * A single plugin instance can manage connections to **multiple Plugwerk servers**
+ * simultaneously. Each server is identified by a string ID chosen by the host application.
  *
- * **Host application setup:**
+ * **Single server (convenience):**
  * ```kotlin
- * val pluginManager = DefaultPluginManager()
- * pluginManager.loadPlugins()
- * pluginManager.startPlugins()
- *
- * val plugin = pluginManager.getPlugin("plugwerk-client")
- *     .plugin as PlugwerkMarketplacePlugin
- * plugin.configure(
- *     PlugwerkConfig.Builder("https://plugwerk.example.com", "acme")
- *         .accessToken("eyJhbG...")
- *         .pluginDirectory(Path.of("/var/app/plugins"))
- *         .build()
- * )
- *
+ * plugin.configure(config)
  * val marketplace = plugin.marketplace()
+ * ```
+ *
+ * **Multiple servers:**
+ * ```kotlin
+ * plugin.configure("production", prodConfig)
+ * plugin.configure("staging", stagingConfig)
+ *
+ * val prodCatalog = plugin.marketplace("production").catalog()
+ * val stagingInstaller = plugin.marketplace("staging").installer()
+ * ```
+ *
+ * **Java:**
+ * ```java
+ * PlugwerkMarketplacePlugin plugin = (PlugwerkMarketplacePlugin)
+ *     pluginManager.getPlugin("plugwerk-client").getPlugin();
+ * plugin.configure("production", prodConfig);
+ * plugin.configure("staging", stagingConfig);
+ *
+ * PlugwerkMarketplace prod = plugin.marketplace("production");
+ * PlugwerkMarketplace staging = plugin.marketplace("staging");
  * ```
  */
 class PlugwerkMarketplacePlugin : Plugin() {
 
-    private var config: PlugwerkConfig? = null
-    private var marketplaceInstance: PlugwerkMarketplace? = null
+    private data class ServerEntry(val config: PlugwerkConfig, var marketplace: PlugwerkMarketplaceImpl? = null)
+
+    private val servers = ConcurrentHashMap<String, ServerEntry>()
 
     /**
-     * Configures this plugin instance with the given [config].
+     * Registers a server configuration under the given [serverId].
      *
-     * Must be called **before** accessing [marketplace]. Can be called again to
-     * reconfigure — the marketplace instance is recreated on the next [marketplace] call.
+     * If a server with this ID was already configured, the old marketplace instance is
+     * closed and replaced on the next [marketplace] call.
+     *
+     * @param serverId identifier chosen by the host application (e.g. `"production"`, `"vendor-a"`)
+     * @param config server URL, namespace, credentials, and plugin directory
      */
-    fun configure(config: PlugwerkConfig) {
-        this.config = config
-        this.marketplaceInstance = null
+    fun configure(serverId: String, config: PlugwerkConfig) {
+        val old = servers.put(serverId, ServerEntry(config))
+        old?.marketplace?.close()
     }
 
     /**
-     * Returns the [PlugwerkMarketplace] facade, creating it on first access.
+     * Convenience overload that registers the config under [DEFAULT_SERVER_ID].
      *
-     * @throws IllegalStateException if [configure] has not been called yet.
+     * Equivalent to `configure(DEFAULT_SERVER_ID, config)`.
+     */
+    fun configure(config: PlugwerkConfig) {
+        configure(DEFAULT_SERVER_ID, config)
+    }
+
+    /**
+     * Returns the [PlugwerkMarketplace] facade for the given [serverId], creating it lazily.
+     *
+     * @throws IllegalStateException if no server with this ID has been configured.
      * @throws IllegalStateException if [PlugwerkConfig.pluginDirectory] is not set.
      */
-    fun marketplace(): PlugwerkMarketplace {
-        marketplaceInstance?.let { return it }
+    fun marketplace(serverId: String): PlugwerkMarketplace {
+        val entry = servers[serverId] ?: throw IllegalStateException(
+            "No server configured with ID '$serverId'. " +
+                "Call plugin.configure(\"$serverId\", config) first.",
+        )
+        entry.marketplace?.let { return it }
 
-        val cfg = config ?: throw IllegalStateException(
-            "PlugwerkMarketplacePlugin has not been configured. " +
-                "Call plugin.configure(config) before accessing the marketplace.",
-        )
-        val pluginDir = cfg.pluginDirectory ?: throw IllegalStateException(
-            "pluginDirectory is required — set it via PlugwerkConfig.Builder.pluginDirectory()",
-        )
-        val client = PlugwerkClient(cfg)
-        val instance = PlugwerkMarketplaceImpl(
-            catalog = PlugwerkCatalogImpl(client),
-            installer = PlugwerkInstallerImpl(client, pluginDir),
-            updateChecker = PlugwerkUpdateCheckerImpl(client),
-        )
-        marketplaceInstance = instance
+        val instance = PlugwerkMarketplaceImpl.create(entry.config)
+        entry.marketplace = instance
         return instance
+    }
+
+    /**
+     * Convenience overload that returns the marketplace for [DEFAULT_SERVER_ID].
+     *
+     * Equivalent to `marketplace(DEFAULT_SERVER_ID)`.
+     */
+    fun marketplace(): PlugwerkMarketplace = marketplace(DEFAULT_SERVER_ID)
+
+    /** Returns an immutable snapshot of all registered server IDs. */
+    fun serverIds(): Set<String> = servers.keys.toSet()
+
+    /**
+     * Removes the server entry for the given [serverId] and closes its HTTP client.
+     *
+     * @return `true` if a server with this ID was registered, `false` otherwise.
+     */
+    fun remove(serverId: String): Boolean {
+        val entry = servers.remove(serverId)
+        entry?.marketplace?.close()
+        return entry != null
+    }
+
+    /** Removes all server entries and closes their HTTP clients. */
+    fun removeAll() {
+        val entries = servers.values.toList()
+        servers.clear()
+        entries.forEach { it.marketplace?.close() }
+    }
+
+    override fun stop() {
+        removeAll()
+    }
+
+    companion object {
+        /** Default server ID used by the single-server convenience methods. */
+        const val DEFAULT_SERVER_ID = "default"
     }
 }

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplacePlugin.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplacePlugin.kt
@@ -17,13 +17,79 @@
  */
 package io.plugwerk.client
 
+import io.plugwerk.client.catalog.PlugwerkCatalogImpl
+import io.plugwerk.client.installer.PlugwerkInstallerImpl
+import io.plugwerk.client.updater.PlugwerkUpdateCheckerImpl
+import io.plugwerk.spi.extension.PlugwerkMarketplace
 import org.pf4j.Plugin
 
 /**
  * PF4J plugin entry point for the Plugwerk Client SDK.
  *
  * This class is referenced in `MANIFEST.MF` via `Plugin-Class`. PF4J instantiates it
- * when the SDK JAR is loaded as a plugin. The actual SDK functionality is exposed through
- * [PlugwerkMarketplaceImpl], which is discovered via PF4J's `@Extension` mechanism.
+ * when the SDK JAR is loaded as a plugin.
+ *
+ * The host application must call [configure] before accessing the [marketplace] instance.
+ * Each plugin instance carries its own [PlugwerkConfig], so multiple instances can connect
+ * to different servers or namespaces within the same host application.
+ *
+ * **Host application setup:**
+ * ```kotlin
+ * val pluginManager = DefaultPluginManager()
+ * pluginManager.loadPlugins()
+ * pluginManager.startPlugins()
+ *
+ * val plugin = pluginManager.getPlugin("plugwerk-client")
+ *     .plugin as PlugwerkMarketplacePlugin
+ * plugin.configure(
+ *     PlugwerkConfig.Builder("https://plugwerk.example.com", "acme")
+ *         .accessToken("eyJhbG...")
+ *         .pluginDirectory(Path.of("/var/app/plugins"))
+ *         .build()
+ * )
+ *
+ * val marketplace = plugin.marketplace()
+ * ```
  */
-class PlugwerkMarketplacePlugin : Plugin()
+class PlugwerkMarketplacePlugin : Plugin() {
+
+    private var config: PlugwerkConfig? = null
+    private var marketplaceInstance: PlugwerkMarketplace? = null
+
+    /**
+     * Configures this plugin instance with the given [config].
+     *
+     * Must be called **before** accessing [marketplace]. Can be called again to
+     * reconfigure — the marketplace instance is recreated on the next [marketplace] call.
+     */
+    fun configure(config: PlugwerkConfig) {
+        this.config = config
+        this.marketplaceInstance = null
+    }
+
+    /**
+     * Returns the [PlugwerkMarketplace] facade, creating it on first access.
+     *
+     * @throws IllegalStateException if [configure] has not been called yet.
+     * @throws IllegalStateException if [PlugwerkConfig.pluginDirectory] is not set.
+     */
+    fun marketplace(): PlugwerkMarketplace {
+        marketplaceInstance?.let { return it }
+
+        val cfg = config ?: throw IllegalStateException(
+            "PlugwerkMarketplacePlugin has not been configured. " +
+                "Call plugin.configure(config) before accessing the marketplace.",
+        )
+        val pluginDir = cfg.pluginDirectory ?: throw IllegalStateException(
+            "pluginDirectory is required — set it via PlugwerkConfig.Builder.pluginDirectory()",
+        )
+        val client = PlugwerkClient(cfg)
+        val instance = PlugwerkMarketplaceImpl(
+            catalog = PlugwerkCatalogImpl(client),
+            installer = PlugwerkInstallerImpl(client, pluginDir),
+            updateChecker = PlugwerkUpdateCheckerImpl(client),
+        )
+        marketplaceInstance = instance
+        return instance
+    }
+}

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkConfigTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkConfigTest.kt
@@ -48,7 +48,7 @@ class PlugwerkConfigTest {
         val config = PlugwerkConfig.Builder("https://plugins.example.com", "acme").build()
 
         assertNull(config.accessToken)
-        assertNull(config.cacheDirectory)
+        assertNull(config.pluginDirectory)
         assertEquals(PlugwerkConfig.DEFAULT_CONNECTION_TIMEOUT_MS, config.connectionTimeoutMs)
         assertEquals(PlugwerkConfig.DEFAULT_READ_TIMEOUT_MS, config.readTimeoutMs)
     }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -166,6 +166,53 @@ class PlugwerkMarketplaceIntegrationTest {
         assertEquals("Bearer integration-token", request.getHeader("Authorization"))
     }
 
+    @Test
+    fun `multi-server isolation — each server receives its own requests`() {
+        val serverB = MockWebServer()
+        serverB.start()
+
+        try {
+            val plugin = PlugwerkMarketplacePlugin()
+            plugin.configure(
+                "server-a",
+                PlugwerkConfig(
+                    serverUrl = server.url("/").toString().trimEnd('/'),
+                    namespace = "ns-a",
+                    accessToken = "token-a",
+                    pluginDirectory = pluginDir,
+                ),
+            )
+            plugin.configure(
+                "server-b",
+                PlugwerkConfig(
+                    serverUrl = serverB.url("/").toString().trimEnd('/'),
+                    namespace = "ns-b",
+                    accessToken = "token-b",
+                    pluginDirectory = pluginDir,
+                ),
+            )
+
+            val emptyPage = """{"content":[],"totalElements":0,"page":0,"size":20,"totalPages":0}"""
+            server.enqueue(MockResponse().setBody(emptyPage).setResponseCode(200))
+            serverB.enqueue(MockResponse().setBody(emptyPage).setResponseCode(200))
+
+            plugin.marketplace("server-a").catalog().listPlugins()
+            plugin.marketplace("server-b").catalog().listPlugins()
+
+            val requestA = server.takeRequest()
+            assertTrue(requestA.path!!.contains("/namespaces/ns-a/"))
+            assertEquals("Bearer token-a", requestA.getHeader("Authorization"))
+
+            val requestB = serverB.takeRequest()
+            assertTrue(requestB.path!!.contains("/namespaces/ns-b/"))
+            assertEquals("Bearer token-b", requestB.getHeader("Authorization"))
+
+            plugin.removeAll()
+        } finally {
+            serverB.shutdown()
+        }
+    }
+
     private fun sha256Hex(bytes: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256")
         return digest.digest(bytes).joinToString("") { "%02x".format(it) }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -51,13 +51,12 @@ class PlugwerkMarketplaceIntegrationTest {
         server.start()
         marketplace =
             PlugwerkMarketplaceImpl.create(
-                config =
                 PlugwerkConfig(
                     serverUrl = server.url("/").toString().trimEnd('/'),
                     namespace = "test-ns",
                     accessToken = "integration-token",
+                    pluginDirectory = pluginDir,
                 ),
-                pluginDirectory = pluginDir,
             )
     }
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplacePluginTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplacePluginTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.client
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class PlugwerkMarketplacePluginTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var plugin: PlugwerkMarketplacePlugin
+
+    private fun config(serverUrl: String = "http://localhost:8080", namespace: String = "acme") =
+        PlugwerkConfig.Builder(serverUrl, namespace)
+            .pluginDirectory(tempDir)
+            .build()
+
+    @BeforeEach
+    fun setUp() {
+        plugin = PlugwerkMarketplacePlugin()
+    }
+
+    @Test
+    fun `configure and marketplace work for default server`() {
+        plugin.configure(config())
+
+        val marketplace = plugin.marketplace()
+
+        assertNotSame(null, marketplace)
+    }
+
+    @Test
+    fun `marketplace returns same instance on repeated calls`() {
+        plugin.configure(config())
+
+        val first = plugin.marketplace()
+        val second = plugin.marketplace()
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `configure multiple servers and retrieve each`() {
+        plugin.configure("server-a", config("http://server-a:8080"))
+        plugin.configure("server-b", config("http://server-b:8080"))
+
+        val a = plugin.marketplace("server-a")
+        val b = plugin.marketplace("server-b")
+
+        assertNotSame(a, b)
+    }
+
+    @Test
+    fun `marketplace throws when server ID not configured`() {
+        val ex = assertThrows(IllegalStateException::class.java) {
+            plugin.marketplace("unknown")
+        }
+        assertTrue(ex.message!!.contains("unknown"))
+    }
+
+    @Test
+    fun `marketplace throws when no default server configured`() {
+        assertThrows(IllegalStateException::class.java) {
+            plugin.marketplace()
+        }
+    }
+
+    @Test
+    fun `remove clears server entry`() {
+        plugin.configure("temp", config())
+        assertTrue(plugin.remove("temp"))
+
+        assertThrows(IllegalStateException::class.java) {
+            plugin.marketplace("temp")
+        }
+    }
+
+    @Test
+    fun `remove returns false for unknown server ID`() {
+        assertFalse(plugin.remove("nonexistent"))
+    }
+
+    @Test
+    fun `removeAll clears all entries`() {
+        plugin.configure("a", config())
+        plugin.configure("b", config())
+
+        plugin.removeAll()
+
+        assertTrue(plugin.serverIds().isEmpty())
+    }
+
+    @Test
+    fun `reconfigure same server ID replaces marketplace`() {
+        plugin.configure("s", config("http://old:8080"))
+        val old = plugin.marketplace("s")
+
+        plugin.configure("s", config("http://new:8080"))
+        val new = plugin.marketplace("s")
+
+        assertNotSame(old, new)
+    }
+
+    @Test
+    fun `serverIds returns all registered IDs`() {
+        plugin.configure("alpha", config())
+        plugin.configure("beta", config())
+        plugin.configure("gamma", config())
+
+        assertEquals(setOf("alpha", "beta", "gamma"), plugin.serverIds())
+    }
+
+    @Test
+    fun `default server convenience delegates to DEFAULT_SERVER_ID`() {
+        plugin.configure(config())
+
+        assertEquals(setOf(PlugwerkMarketplacePlugin.DEFAULT_SERVER_ID), plugin.serverIds())
+        assertSame(plugin.marketplace(), plugin.marketplace(PlugwerkMarketplacePlugin.DEFAULT_SERVER_ID))
+    }
+
+    @Test
+    fun `marketplace instances are isolated`() {
+        plugin.configure("a", config("http://server-a:8080", "ns-a"))
+        plugin.configure("b", config("http://server-b:8080", "ns-b"))
+
+        val clientA = (plugin.marketplace("a") as PlugwerkMarketplaceImpl).client
+        val clientB = (plugin.marketplace("b") as PlugwerkMarketplaceImpl).client
+
+        assertEquals("http://server-a:8080", clientA.config.serverUrl)
+        assertEquals("ns-a", clientA.config.namespace)
+        assertEquals("http://server-b:8080", clientB.config.serverUrl)
+        assertEquals("ns-b", clientB.config.namespace)
+    }
+
+    @Test
+    fun `stop cleans up all servers`() {
+        plugin.configure("a", config())
+        plugin.configure("b", config())
+
+        plugin.stop()
+
+        assertTrue(plugin.serverIds().isEmpty())
+    }
+}

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
@@ -22,15 +22,19 @@ import org.pf4j.ExtensionPoint
 /**
  * Unified facade extension point that provides access to all Plugwerk SDK capabilities.
  *
- * Host applications typically retrieve this single extension point from the PF4J plugin manager
- * instead of querying [PlugwerkCatalog], [PlugwerkInstaller], and [PlugwerkUpdateChecker]
- * individually. All three sub-components share the same server connection and configuration.
+ * Host applications retrieve this facade from the [io.plugwerk.client.PlugwerkMarketplacePlugin]
+ * after configuring it, instead of querying [PlugwerkCatalog], [PlugwerkInstaller], and
+ * [PlugwerkUpdateChecker] individually. All three sub-components share the same server connection
+ * and configuration.
  *
  * Typical usage in a host application:
  *
  * Kotlin:
  * ```kotlin
- * val marketplace = pluginManager.getExtensions(PlugwerkMarketplace::class.java).first()
+ * val plugin = pluginManager.getPlugin("plugwerk-client")
+ *     .plugin as PlugwerkMarketplacePlugin
+ * plugin.configure(config)
+ * val marketplace = plugin.marketplace()
  *
  * // Browse the catalog
  * val plugins = marketplace.catalog().listPlugins()
@@ -44,7 +48,10 @@ import org.pf4j.ExtensionPoint
  *
  * Java:
  * ```java
- * PlugwerkMarketplace marketplace = pluginManager.getExtensions(PlugwerkMarketplace.class).get(0);
+ * PlugwerkMarketplacePlugin plugin = (PlugwerkMarketplacePlugin)
+ *     pluginManager.getPlugin("plugwerk-client").getPlugin();
+ * plugin.configure(config);
+ * PlugwerkMarketplace marketplace = plugin.marketplace();
  *
  * // Browse the catalog
  * List<PluginInfo> plugins = marketplace.catalog().listPlugins();


### PR DESCRIPTION
## Summary

- Remove `PlugwerkConfig.fromSystemProperties()` — access tokens were visible in `ps aux` and `/proc/PID/cmdline`
- Introduce `PlugwerkMarketplacePlugin.configure(config)` as the single configuration entry point
- Host application configures the plugin explicitly, then retrieves the marketplace via `plugin.marketplace()`
- Rename `cacheDirectory` → `pluginDirectory` for clarity
- Remove `@Extension` annotation from `PlugwerkMarketplaceImpl` — no longer discoverable via `getExtensions()`

## Motivation

`plugwerk-client-plugin` is a PF4J plugin with its own classloader. It can be deployed **multiple times** in a host application (e.g. different namespaces/servers). Global JVM system properties cannot distinguish between plugin instances and leak secrets in process listings.

## New Host Application Flow

```kotlin
val plugin = pluginManager.getPlugin("plugwerk-client")
    .plugin as PlugwerkMarketplacePlugin
plugin.configure(
    PlugwerkConfig.Builder("https://plugwerk.example.com", "acme")
        .accessToken("eyJhbG...")
        .pluginDirectory(Path.of("/var/app/plugins"))
        .build()
)
val marketplace = plugin.marketplace()
```

## Changes

| File | Change |
|---|---|
| `PlugwerkConfig.kt` | Remove `fromSystemProperties()`, rename `cacheDirectory` → `pluginDirectory` |
| `PlugwerkMarketplacePlugin.kt` | Add `configure(config)` and `marketplace()` methods |
| `PlugwerkMarketplaceImpl.kt` | Remove no-arg constructor and `@Extension`, simplify `create()` |
| `PlugwerkMarketplace.kt` (SPI) | Update KDoc examples |
| `PluginManagerFactory.java` (example) | Use new `configure()` API instead of system properties |
| `PlugwerkConfigTest.kt` | Rename `cacheDirectory` → `pluginDirectory` |
| `PlugwerkMarketplaceIntegrationTest.kt` | Adapt to new `create()` signature |
| `README.md` | New configuration flow, security note, fix property name inconsistency |
| `ADR-0005` | Rename `cacheDirectory` → `pluginDirectory` |

## Test plan

- [x] `PlugwerkConfigTest` — builder and properties file tests pass with renamed field
- [x] `PlugwerkMarketplaceIntegrationTest` — full HTTP round-trip with new `create()` API
- [x] `./gradlew build` passes across all modules

Closes #46