### PR TITLE
fix(security): restrict /actuator/info to authenticated users

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -120,8 +120,8 @@ class SecurityConfiguration(
                     .requestMatchers(HttpMethod.POST, "/api/v1/namespaces/*/updates/check").permitAll()
                     // Public server config (upload limits etc.) — used by frontend without auth
                     .requestMatchers(HttpMethod.GET, "/api/v1/config").permitAll()
-                    // Actuator health and info are public
-                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    // Actuator health is public; info and prometheus require authentication
+                    .requestMatchers("/actuator/health").permitAll()
                     // SPA static assets are always public
                     .requestMatchers(HttpMethod.GET, "/", "/index.html", "/assets/**", "/*.svg", "/*.ico").permitAll()
                     // OpenAPI spec is public (used by API docs page without login)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityHeadersTest.kt
@@ -80,4 +80,20 @@ class SecurityHeadersTest {
                 header { exists("Content-Security-Policy") }
             }
     }
+
+    @Test
+    fun `actuator health is publicly accessible`() {
+        mockMvc.get("/actuator/health")
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `actuator info requires authentication`() {
+        mockMvc.get("/actuator/info")
+            .andExpect {
+                status { isUnauthorized() }
+            }
+    }
 }


### PR DESCRIPTION
## Summary
- Remove `/actuator/info` from the `permitAll()` list in `SecurityConfiguration.kt` so it requires authentication
- `/actuator/health` remains publicly accessible for health checks
- Add tests verifying `/actuator/info` returns 401 and `/actuator/health` returns 200 without auth

Closes #42

## Test plan
- [x] `SecurityHeadersTest.actuator info requires authentication` — verifies 401 without auth
- [x] `SecurityHeadersTest.actuator health is publicly accessible` — regression guard
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)