### PR TITLE
refactor(api): add explicit fileFormat enum to PluginRelease

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1519,6 +1519,12 @@ components:
           type: integer
           format: int64
           description: Size of the artifact in bytes
+        fileFormat:
+          type: string
+          enum:
+            - jar
+            - zip
+          description: Artifact packaging format (jar or zip)
         requiresSystemVersion:
           type: string
           description: |

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImpl.kt
@@ -87,8 +87,10 @@ internal class PlugwerkInstallerImpl(private val client: PlugwerkClient, private
                 return InstallResult.Failure(pluginId, version, "SHA-256 checksum mismatch for $pluginId:$version")
             }
 
-            val extension = suggestedFilename?.substringAfterLast('.')?.lowercase()
-                ?.takeIf { it == "zip" || it == "jar" } ?: "jar"
+            val extension = releaseInfo.fileFormat?.value
+                ?: suggestedFilename?.substringAfterLast('.')?.lowercase()
+                    ?.takeIf { it == "zip" || it == "jar" }
+                ?: "jar"
             val finalPath = pluginDirectory.resolve("$pluginId-$version.$extension")
             Files.move(tempFile, finalPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
             log.info("Installed {}:{} to {} ({})", pluginId, version, finalPath, extension)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -138,7 +138,7 @@ class CatalogController(
         version: String,
     ): ResponseEntity<org.springframework.core.io.Resource> {
         val release = releaseService.findByVersion(ns, pluginId, version)
-        val extension = if (release.artifactKey.endsWith(":zip")) "zip" else "jar"
+        val extension = release.fileFormat.name.lowercase()
         val stream = releaseService.downloadArtifact(ns, pluginId, version)
         return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$pluginId-$version.$extension\"")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapper.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.controller.mapper
 
 import io.plugwerk.api.model.PluginDependencyDto
 import io.plugwerk.api.model.PluginReleaseDto
+import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.stereotype.Component
@@ -47,6 +48,7 @@ class PluginReleaseMapper(private val objectMapper: ObjectMapper) {
         status = entity.status.toDto(),
         artifactSha256 = entity.artifactSha256,
         artifactSize = entity.artifactSize,
+        fileFormat = entity.fileFormat.toDto(),
         requiresSystemVersion = entity.requiresSystemVersion,
         pluginDependencies = parseDependencies(entity.pluginDependencies),
         downloadCount = entity.downloadCount,
@@ -57,6 +59,11 @@ class PluginReleaseMapper(private val objectMapper: ObjectMapper) {
         if (json == null) return null
         val raw: List<Map<String, String>> = objectMapper.readValue(json, dependencyListType)
         return raw.map { PluginDependencyDto(id = it["id"]!!, version = it["version"]!!) }
+    }
+
+    private fun FileFormat.toDto(): PluginReleaseDto.FileFormat = when (this) {
+        FileFormat.JAR -> PluginReleaseDto.FileFormat.JAR
+        FileFormat.ZIP -> PluginReleaseDto.FileFormat.ZIP
     }
 
     private fun ReleaseStatus.toDto(): PluginReleaseDto.Status = when (this) {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/FileFormat.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/FileFormat.kt
@@ -1,0 +1,44 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+/**
+ * Packaging format of a plugin artifact.
+ *
+ * Stored per [PluginReleaseEntity] and determined at upload time from the original filename
+ * extension. Used to set the correct `Content-Disposition` filename on download and exposed
+ * to clients via the API so they know the artifact type before downloading.
+ */
+enum class FileFormat {
+    JAR,
+    ZIP,
+    ;
+
+    companion object {
+        /**
+         * Resolves a [FileFormat] from a file extension string.
+         *
+         * @param extension lowercase file extension without dot (e.g. `"jar"`, `"zip"`)
+         * @return the matching [FileFormat], defaulting to [JAR] for unrecognized extensions
+         */
+        fun fromExtension(extension: String): FileFormat = when (extension.lowercase()) {
+            "zip" -> ZIP
+            else -> JAR
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
@@ -112,6 +112,10 @@ class PluginReleaseEntity(
     @Column(name = "artifact_size", nullable = false)
     var artifactSize: Long = 0,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "file_format", nullable = false, length = 10)
+    var fileFormat: FileFormat = FileFormat.JAR,
+
     @Column(name = "requires_system_version", length = 255)
     var requiresSystemVersion: String? = null,
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.service
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
@@ -128,6 +129,7 @@ class PluginReleaseService(
 
         val extension = originalFilename?.substringAfterLast('.')?.lowercase()
             ?.takeIf { it == "zip" || it == "jar" } ?: "jar"
+        val fileFormat = FileFormat.fromExtension(extension)
         val artifactKey = "${plugin.namespace.id}:${descriptor.id}:${descriptor.version}:$extension"
         storageService.store(artifactKey, ByteArrayInputStream(bytes), bytes.size.toLong())
 
@@ -138,6 +140,7 @@ class PluginReleaseService(
                 artifactSha256 = sha256,
                 artifactKey = artifactKey,
                 artifactSize = bytes.size.toLong(),
+                fileFormat = fileFormat,
                 requiresSystemVersion = descriptor.requiresSystemVersion,
                 pluginDependencies = serializeDependencies(descriptor),
             ),

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -171,6 +171,12 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  name: file_format
+                  type: varchar(10)
+                  defaultValue: JAR
+                  constraints:
+                    nullable: false
+              - column:
                   name: requires_system_version
                   type: varchar(255)
               - column:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapperTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/mapper/PluginReleaseMapperTest.kt
@@ -18,6 +18,7 @@
 package io.plugwerk.server.controller.mapper
 
 import io.plugwerk.api.model.PluginReleaseDto
+import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
@@ -60,6 +61,7 @@ class PluginReleaseMapperTest {
         assertThat(dto.artifactSha256).isEqualTo("deadbeef")
         assertThat(dto.requiresSystemVersion).isEqualTo(">=2.0.0")
         assertThat(dto.status).isEqualTo(PluginReleaseDto.Status.PUBLISHED)
+        assertThat(dto.fileFormat).isEqualTo(PluginReleaseDto.FileFormat.JAR)
         assertThat(dto.downloadCount).isEqualTo(0L)
     }
 
@@ -111,6 +113,38 @@ class PluginReleaseMapperTest {
         val dto = mapper.toDto(release, "my-plugin")
 
         assertThat(dto.pluginDependencies).isNull()
+    }
+
+    @Test
+    fun `toDto maps fileFormat JAR correctly`() {
+        val release = PluginReleaseEntity(
+            id = UUID.randomUUID(),
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "abc",
+            artifactKey = "key",
+            fileFormat = FileFormat.JAR,
+        )
+
+        val dto = mapper.toDto(release, "my-plugin")
+
+        assertThat(dto.fileFormat).isEqualTo(PluginReleaseDto.FileFormat.JAR)
+    }
+
+    @Test
+    fun `toDto maps fileFormat ZIP correctly`() {
+        val release = PluginReleaseEntity(
+            id = UUID.randomUUID(),
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "abc",
+            artifactKey = "key",
+            fileFormat = FileFormat.ZIP,
+        )
+
+        val dto = mapper.toDto(release, "my-plugin")
+
+        assertThat(dto.fileFormat).isEqualTo(PluginReleaseDto.FileFormat.ZIP)
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.service
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
@@ -130,6 +131,57 @@ class PluginReleaseServiceTest {
         val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
 
         assertThat(result.artifactSize).isEqualTo(jarBytes.size.toLong())
+    }
+
+    @Test
+    fun `upload sets fileFormat to JAR for jar uploads`() {
+        val jarBytes = "fake-jar-content".toByteArray()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "1.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+
+        val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong(), "plugin.jar")
+
+        assertThat(result.fileFormat).isEqualTo(FileFormat.JAR)
+    }
+
+    @Test
+    fun `upload sets fileFormat to ZIP for zip uploads`() {
+        val zipBytes = "fake-zip-content".toByteArray()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "1.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+
+        val result = releaseService.upload("acme", ByteArrayInputStream(zipBytes), zipBytes.size.toLong(), "plugin.zip")
+
+        assertThat(result.fileFormat).isEqualTo(FileFormat.ZIP)
+    }
+
+    @Test
+    fun `upload defaults fileFormat to JAR when no filename provided`() {
+        val jarBytes = "fake-jar-content".toByteArray()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "1.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+
+        val result = releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        assertThat(result.fileFormat).isEqualTo(FileFormat.JAR)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Introduce `FileFormat` enum (`JAR`, `ZIP`) in `io.plugwerk.server.domain` with `fromExtension()` companion
- Add `file_format` column to `plugin_release` table (pre-production schema edit in `0001_initial_schema.yaml`)
- Add `fileFormat` field to `PluginReleaseEntity`, `PluginReleaseDto` (OpenAPI spec), and mapper
- Replace fragile `artifactKey.endsWith(":zip")` parsing in `CatalogController` with `release.fileFormat`
- Client SDK `PlugwerkInstallerImpl` now uses `releaseInfo.fileFormat` from API response with Content-Disposition fallback

## Test plan
- [x] `PluginReleaseServiceTest` — 3 new tests: JAR upload, ZIP upload, default without filename
- [x] `PluginReleaseMapperTest` — 2 new tests: JAR/ZIP mapping, existing base field test extended
- [x] `./gradlew spotlessApply` passes
- [x] `./gradlew build` passes (all backend tests green)

Closes #99

### 🤖 AI Agent Disclosure
This PR was implemented with assistance from Claude Code (Claude Opus 4.6).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>