### PR TITLE
fix: resolve LazyInitializationException when approving/rejecting releases

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -58,6 +58,9 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         @Param("status") status: ReleaseStatus,
     ): List<PluginReleaseEntity>
 
+    @Query("SELECT r FROM PluginReleaseEntity r JOIN FETCH r.plugin WHERE r.id = :id")
+    fun findByIdWithPlugin(@Param("id") id: UUID): Optional<PluginReleaseEntity>
+
     /**
      * Returns the full latest published release entity per plugin for a given set of plugin IDs.
      * Replaces the three individual queries for version, draft version, and artifact size.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -68,6 +68,9 @@ class PluginReleaseService(
     fun findById(id: UUID): PluginReleaseEntity = releaseRepository.findById(id)
         .orElseThrow { ReleaseNotFoundException("id=$id", "") }
 
+    fun findByIdWithPlugin(id: UUID): PluginReleaseEntity = releaseRepository.findByIdWithPlugin(id)
+        .orElseThrow { ReleaseNotFoundException("id=$id", "") }
+
     fun findPendingByNamespace(namespaceSlug: String): List<PluginReleaseEntity> {
         val namespace = namespaceRepository.findBySlug(namespaceSlug)
             .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
@@ -86,7 +89,7 @@ class PluginReleaseService(
         status: ReleaseStatus,
         enforceNamespace: Boolean = true,
     ): PluginReleaseEntity {
-        val release = findById(id)
+        val release = findByIdWithPlugin(id)
         if (enforceNamespace && release.plugin.namespace.slug != namespaceSlug) {
             throw ReleaseNotFoundException("id=$id", "")
         }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -304,7 +304,7 @@ class PluginReleaseServiceTest {
             artifactSha256 = "sha",
             artifactKey = "acme:my-plugin:1.0.0:jar",
         )
-        whenever(releaseRepository.findById(releaseId)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.findByIdWithPlugin(releaseId)).thenReturn(Optional.of(release))
         whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(release)
 
         val result = releaseService.updateStatusByIdInNamespace(releaseId, "acme", ReleaseStatus.PUBLISHED)
@@ -322,7 +322,7 @@ class PluginReleaseServiceTest {
             artifactSha256 = "sha",
             artifactKey = "acme:my-plugin:1.0.0:jar",
         )
-        whenever(releaseRepository.findById(releaseId)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.findByIdWithPlugin(releaseId)).thenReturn(Optional.of(release))
 
         assertFailsWith<ReleaseNotFoundException> {
             releaseService.updateStatusByIdInNamespace(releaseId, "evil-namespace", ReleaseStatus.PUBLISHED)


### PR DESCRIPTION
## Summary
- Add `findByIdWithPlugin()` query with `JOIN FETCH r.plugin` to `PluginReleaseRepository`
- Add corresponding `findByIdWithPlugin()` method to `PluginReleaseService`
- `updateStatusByIdInNamespace()` now uses the new query instead of `findById()`, ensuring the `plugin` association is eagerly loaded before the transaction closes
- Fixes `LazyInitializationException` in `ReviewsController.approveRelease()` and `rejectRelease()` when accessing `release.plugin.pluginId` after the `@Transactional` boundary

## Root cause
`JpaRepository.findById()` does not eagerly fetch the lazy `plugin` association. After `updateStatusByIdInNamespace()` returns (closing the Hibernate session), the controller accesses `release.plugin.pluginId`, triggering a proxy initialization outside a session.

## Test plan
- [x] Existing `updateStatusByIdInNamespace` unit tests updated and passing
- [x] `ReviewsControllerTest` tests pass (mock-based, unchanged)
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew build` green
- [ ] Manual: upload draft release → approve via UI → no 500 error

Closes #74

### 🤖 AI Agent Disclosure
This PR was implemented with assistance from Claude Code (Claude Opus 4.6).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>