### PR TITLE
fix(security): bind PostgreSQL port to 127.0.0.1 in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: plugwerk
       POSTGRES_PASSWORD: plugwerk
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary
- Bind PostgreSQL port to `127.0.0.1:5432:5432` instead of `0.0.0.0:5432:5432`
- Prevents unintended database exposure in cloud environments
- App container still connects via internal Docker network (`postgres:5432`)

## Test plan
- [x] `docker compose config` validates successfully
- [ ] `docker compose up -d postgres` starts and is reachable from localhost
- [ ] `plugwerk-server` container connects to postgres via internal network

Closes #45

### 🤖 AI Agent Disclosure
This PR was implemented with assistance from Claude Code (Claude Opus 4.6).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>