### PR TITLE
feat: delete plugin — API endpoints and UI actions

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -416,6 +416,28 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Management
+      summary: Delete plugin and all releases
+      description: |
+        Permanently deletes a plugin together with all its releases and stored artifacts.
+        This action is irreversible. Requires `ADMIN` role in the namespace.
+      operationId: deletePlugin
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+        - $ref: '#/components/parameters/PluginIdPath'
+      responses:
+        '204':
+          description: Plugin and all releases deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /namespaces/{ns}/plugin-releases:
     post:
@@ -587,6 +609,29 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Management
+      summary: Delete a single release
+      description: |
+        Permanently deletes a single plugin release and its stored artifact.
+        This action is irreversible. Requires `ADMIN` role in the namespace.
+      operationId: deleteRelease
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+        - $ref: '#/components/parameters/PluginIdPath'
+        - $ref: '#/components/parameters/VersionPath'
+      responses:
+        '204':
+          description: Release and artifact deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -2151,6 +2196,12 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     Unauthorized:
       description: Authentication credentials are missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: Insufficient permissions for this operation
       content:
         application/json:
           schema:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
@@ -105,6 +105,26 @@ class ManagementController(
         return ResponseEntity.ok(releaseMapper.toDto(release, pluginId))
     }
 
+    override fun deletePlugin(ns: String, pluginId: String): ResponseEntity<Unit> {
+        namespaceAuthorizationService.requireRole(
+            ns,
+            SecurityContextHolder.getContext().authentication!!,
+            NamespaceRole.ADMIN,
+        )
+        pluginService.delete(ns, pluginId)
+        return ResponseEntity.noContent().build()
+    }
+
+    override fun deleteRelease(ns: String, pluginId: String, version: String): ResponseEntity<Unit> {
+        namespaceAuthorizationService.requireRole(
+            ns,
+            SecurityContextHolder.getContext().authentication!!,
+            NamespaceRole.ADMIN,
+        )
+        releaseService.delete(ns, pluginId, version)
+        return ResponseEntity.noContent().build()
+    }
+
     private fun ReleaseStatusUpdateRequest.Status.toServiceStatus(): ReleaseStatus = when (this) {
         ReleaseStatusUpdateRequest.Status.PUBLISHED -> ReleaseStatus.PUBLISHED
         ReleaseStatusUpdateRequest.Status.DEPRECATED -> ReleaseStatus.DEPRECATED

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginService.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.service
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
 import io.plugwerk.spi.model.PluginStatus
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.data.domain.Page
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional
 class PluginService(
     private val pluginRepository: PluginRepository,
     private val releaseRepository: PluginReleaseRepository,
+    private val storageService: ArtifactStorageService,
     private val namespaceService: NamespaceService,
 ) {
 
@@ -173,6 +175,11 @@ class PluginService(
     @Transactional
     fun delete(namespaceSlug: String, pluginId: String) {
         val entity = findByNamespaceAndPluginId(namespaceSlug, pluginId)
+        val releases = releaseRepository.findAllByPluginOrderByCreatedAtDesc(entity)
+        releases.forEach { release ->
+            storageService.delete(release.artifactKey)
+            releaseRepository.delete(release)
+        }
         pluginRepository.delete(entity)
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -32,6 +32,7 @@ import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.server.service.PluginService
+import io.plugwerk.server.service.ReleaseNotFoundException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -48,6 +49,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.multipart
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
@@ -220,6 +222,44 @@ class ManagementControllerTest {
             jsonPath("$.status") { value(422) }
             jsonPath("$.message") { value("Invalid plugin.id in MANIFEST.MF") }
         }
+    }
+
+    @Test
+    fun `DELETE plugin returns 204`() {
+        mockMvc.delete("/api/v1/namespaces/acme/plugins/my-plugin")
+            .andExpect {
+                status { isNoContent() }
+            }
+    }
+
+    @Test
+    fun `DELETE plugin returns 404 when not found`() {
+        whenever(pluginService.delete(any(), any())).thenThrow(PluginNotFoundException("acme", "missing"))
+
+        mockMvc.delete("/api/v1/namespaces/acme/plugins/missing")
+            .andExpect {
+                status { isNotFound() }
+            }
+    }
+
+    @Test
+    fun `DELETE release returns 204`() {
+        mockMvc.delete("/api/v1/namespaces/acme/plugins/my-plugin/releases/1.0.0")
+            .andExpect {
+                status { isNoContent() }
+            }
+    }
+
+    @Test
+    fun `DELETE release returns 404 when not found`() {
+        whenever(releaseService.delete(any(), any(), any())).thenThrow(
+            ReleaseNotFoundException("my-plugin", "9.9.9"),
+        )
+
+        mockMvc.delete("/api/v1/namespaces/acme/plugins/my-plugin/releases/9.9.9")
+            .andExpect {
+                status { isNotFound() }
+            }
     }
 
     private fun buildPluginDto() = io.plugwerk.api.model.PluginDto(

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceTest.kt
@@ -19,8 +19,10 @@ package io.plugwerk.server.service
 
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
+import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
 import io.plugwerk.spi.model.PluginStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -43,6 +45,9 @@ class PluginServiceTest {
 
     @Mock
     lateinit var releaseRepository: PluginReleaseRepository
+
+    @Mock
+    lateinit var storageService: ArtifactStorageService
 
     @Mock
     lateinit var namespaceService: NamespaceService
@@ -138,13 +143,42 @@ class PluginServiceTest {
     }
 
     @Test
-    fun `delete removes plugin`() {
+    fun `delete removes plugin with no releases`() {
         val plugin = PluginEntity(namespace = namespace, pluginId = "p1", name = "Plugin 1")
         whenever(namespaceService.findBySlug("acme")).thenReturn(namespace)
         whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "p1")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findAllByPluginOrderByCreatedAtDesc(plugin)).thenReturn(emptyList())
 
         pluginService.delete("acme", "p1")
 
+        verify(pluginRepository).delete(plugin)
+    }
+
+    @Test
+    fun `delete cascades to releases and artifacts`() {
+        val plugin = PluginEntity(namespace = namespace, pluginId = "p1", name = "Plugin 1")
+        val release1 = PluginReleaseEntity(
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha1",
+            artifactKey = "acme:p1:1.0.0:jar",
+        )
+        val release2 = PluginReleaseEntity(
+            plugin = plugin,
+            version = "2.0.0",
+            artifactSha256 = "sha2",
+            artifactKey = "acme:p1:2.0.0:jar",
+        )
+        whenever(namespaceService.findBySlug("acme")).thenReturn(namespace)
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "p1")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findAllByPluginOrderByCreatedAtDesc(plugin)).thenReturn(listOf(release1, release2))
+
+        pluginService.delete("acme", "p1")
+
+        verify(storageService).delete("acme:p1:1.0.0:jar")
+        verify(storageService).delete("acme:p1:2.0.0:jar")
+        verify(releaseRepository).delete(release1)
+        verify(releaseRepository).delete(release2)
         verify(pluginRepository).delete(plugin)
     }
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithTheme } from '../../test/renderWithTheme'
+import { ConfirmDeleteDialog } from './ConfirmDeleteDialog'
+
+describe('ConfirmDeleteDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: 'Delete Plugin',
+    message: 'Are you sure?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('renders title and message', () => {
+    renderWithTheme(<ConfirmDeleteDialog {...defaultProps} />)
+    expect(screen.getByText('Delete Plugin')).toBeInTheDocument()
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when delete button is clicked', async () => {
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    renderWithTheme(<ConfirmDeleteDialog {...defaultProps} onConfirm={onConfirm} />)
+
+    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+    renderWithTheme(<ConfirmDeleteDialog {...defaultProps} onCancel={onCancel} />)
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('disables buttons when loading', () => {
+    renderWithTheme(<ConfirmDeleteDialog {...defaultProps} loading />)
+
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /confirm-delete/i })).toBeDisabled()
+    expect(screen.getByText('Deleting\u2026')).toBeInTheDocument()
+  })
+
+  it('does not render when open is false', () => {
+    renderWithTheme(<ConfirmDeleteDialog {...defaultProps} open={false} />)
+    expect(screen.queryByText('Delete Plugin')).not.toBeInTheDocument()
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material'
+
+interface ConfirmDeleteDialogProps {
+  open: boolean
+  title: string
+  message: string
+  onConfirm: () => void
+  onCancel: () => void
+  loading?: boolean
+}
+
+export function ConfirmDeleteDialog({
+  open,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  loading = false,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={onConfirm}
+          disabled={loading}
+          aria-label="confirm-delete"
+        >
+          {loading ? 'Deleting\u2026' : 'Delete'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithRouter } from '../../test/renderWithTheme'
+import { VersionsTab } from './VersionsTab'
+import type { PluginReleaseDto } from '../../api/generated/model'
+
+vi.mock('../../api/config', () => ({
+  reviewsApi: { approveRelease: vi.fn() },
+  managementApi: { deleteRelease: vi.fn() },
+}))
+
+const publishedRelease: PluginReleaseDto = {
+  id: '00000000-0000-0000-0000-000000000001',
+  pluginId: 'my-plugin',
+  version: '1.0.0',
+  status: 'published',
+  artifactSha256: 'abc',
+  artifactSize: 1024,
+  downloadCount: 10,
+  createdAt: '2026-01-01T00:00:00Z',
+}
+
+const draftRelease: PluginReleaseDto = {
+  id: '00000000-0000-0000-0000-000000000002',
+  pluginId: 'my-plugin',
+  version: '2.0.0',
+  status: 'draft',
+  artifactSha256: 'def',
+  artifactSize: 2048,
+  downloadCount: 0,
+  createdAt: '2026-02-01T00:00:00Z',
+}
+
+const defaultProps = {
+  releases: [publishedRelease, draftRelease],
+  namespace: 'acme',
+  pluginId: 'my-plugin',
+  currentVersion: '1.0.0',
+}
+
+describe('VersionsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows delete buttons when canApprove is true (ADMIN)', () => {
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />)
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete release/i })
+    expect(deleteButtons).toHaveLength(2)
+  })
+
+  it('hides delete buttons when canApprove is false (non-ADMIN)', () => {
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={false} />)
+
+    const deleteButtons = screen.queryAllByRole('button', { name: /delete release/i })
+    expect(deleteButtons).toHaveLength(0)
+  })
+
+  it('hides delete buttons when canApprove is not set', () => {
+    renderWithRouter(<VersionsTab {...defaultProps} />)
+
+    const deleteButtons = screen.queryAllByRole('button', { name: /delete release/i })
+    expect(deleteButtons).toHaveLength(0)
+  })
+
+  it('opens confirmation dialog on delete button click', async () => {
+    const user = userEvent.setup()
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />)
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete release/i })
+    await user.click(deleteButtons[0])
+
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument()
+    expect(screen.getByText(/v1.0.0/)).toBeInTheDocument()
+  })
+
+  it('calls managementApi.deleteRelease on confirm', async () => {
+    const { managementApi } = await import('../../api/config')
+    const mockDelete = vi.mocked(managementApi.deleteRelease).mockResolvedValue({} as never)
+    const onDeleted = vi.fn()
+    const user = userEvent.setup()
+
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} onReleaseDeleted={onDeleted} />)
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete release/i })
+    await user.click(deleteButtons[0])
+    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+
+    expect(mockDelete).toHaveBeenCalledWith({ ns: 'acme', pluginId: 'my-plugin', version: '1.0.0' })
+    expect(onDeleted).toHaveBeenCalledWith('1.0.0')
+  })
+
+  it('renders release versions', () => {
+    renderWithRouter(<VersionsTab {...defaultProps} />)
+
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+    expect(screen.getByText('v2.0.0')).toBeInTheDocument()
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -13,13 +13,14 @@ import {
   Snackbar,
   Alert,
 } from '@mui/material'
-import { Download, CheckCircle } from 'lucide-react'
+import { Download, CheckCircle, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Badge } from '../common/Badge'
+import { ConfirmDeleteDialog } from '../common/ConfirmDeleteDialog'
 import type { PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import type { BadgeVariant } from '../common/Badge'
-import { reviewsApi } from '../../api/config'
+import { managementApi, reviewsApi } from '../../api/config'
 import { formatFileSize } from '../../utils/formatFileSize'
 
 interface VersionsTabProps {
@@ -28,6 +29,7 @@ interface VersionsTabProps {
   pluginId: string
   currentVersion?: string
   canApprove?: boolean
+  onReleaseDeleted?: (version: string) => void
 }
 
 const statusToBadge: Record<string, BadgeVariant> = {
@@ -37,8 +39,10 @@ const statusToBadge: Record<string, BadgeVariant> = {
   yanked:     'yanked',
 }
 
-export function VersionsTab({ releases, namespace, pluginId, currentVersion, canApprove }: VersionsTabProps) {
+export function VersionsTab({ releases, namespace, pluginId, currentVersion, canApprove, onReleaseDeleted }: VersionsTabProps) {
   const [approvingId, setApprovingId] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<PluginReleaseDto | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
 
   async function handleApprove(rel: PluginReleaseDto) {
@@ -53,6 +57,21 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
       setToast({ message: `Failed to approve v${rel.version}.`, severity: 'error' })
     } finally {
       setApprovingId(null)
+    }
+  }
+
+  async function handleDeleteRelease() {
+    if (!deleteTarget?.version) return
+    setIsDeleting(true)
+    try {
+      await managementApi.deleteRelease({ ns: namespace, pluginId, version: deleteTarget.version })
+      setToast({ message: `v${deleteTarget.version} deleted.`, severity: 'success' })
+      onReleaseDeleted?.(deleteTarget.version)
+    } catch {
+      setToast({ message: `Failed to delete v${deleteTarget.version}.`, severity: 'error' })
+    } finally {
+      setIsDeleting(false)
+      setDeleteTarget(null)
     }
   }
 
@@ -117,40 +136,65 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  {isDraft && canApprove ? (
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      color="success"
-                      startIcon={<CheckCircle size={14} />}
-                      loading={approvingId === rel.id}
-                      onClick={() => handleApprove(rel)}
-                    >
-                      Approve
-                    </Button>
-                  ) : isDraft ? (
-                    <Tooltip title="Awaiting review — download not available yet">
-                      <Typography variant="caption" color="text.disabled">Pending review</Typography>
-                    </Tooltip>
-                  ) : isYanked ? (
-                    <Typography variant="caption" color="text.disabled">Unavailable</Typography>
-                  ) : (
-                    <Button
-                      variant="text"
-                      size="small"
-                      startIcon={<Download size={14} />}
-                      href={`/api/v1/namespaces/${namespace}/plugins/${pluginId}/releases/${rel.version}/download`}
-                      download
-                    >
-                      .jar
-                    </Button>
-                  )}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    {isDraft && canApprove ? (
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        color="success"
+                        startIcon={<CheckCircle size={14} />}
+                        loading={approvingId === rel.id}
+                        onClick={() => handleApprove(rel)}
+                      >
+                        Approve
+                      </Button>
+                    ) : isDraft ? (
+                      <Tooltip title="Awaiting review — download not available yet">
+                        <Typography variant="caption" color="text.disabled">Pending review</Typography>
+                      </Tooltip>
+                    ) : isYanked ? (
+                      <Typography variant="caption" color="text.disabled">Unavailable</Typography>
+                    ) : (
+                      <Button
+                        variant="text"
+                        size="small"
+                        startIcon={<Download size={14} />}
+                        href={`/api/v1/namespaces/${namespace}/plugins/${pluginId}/releases/${rel.version}/download`}
+                        download
+                      >
+                        .jar
+                      </Button>
+                    )}
+                    {canApprove && (
+                      <Tooltip title="Delete release">
+                        <Button
+                          variant="text"
+                          size="small"
+                          color="error"
+                          aria-label={`delete release ${rel.version}`}
+                          onClick={() => setDeleteTarget(rel)}
+                          sx={{ minWidth: 'auto', p: 0.5 }}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </Tooltip>
+                    )}
+                  </Box>
                 </TableCell>
               </TableRow>
             )
           })}
         </TableBody>
       </Table>
+
+      <ConfirmDeleteDialog
+        open={!!deleteTarget}
+        title="Delete Release"
+        message={`Are you sure you want to delete v${deleteTarget?.version ?? ''}? This action cannot be undone.`}
+        onConfirm={handleDeleteRelease}
+        onCancel={() => setDeleteTarget(null)}
+        loading={isDeleting}
+      />
 
       <Snackbar
         open={!!toast}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 // Copyright (C) 2026 devtank42 GmbH
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import {
   Box,
+  Button,
   Container,
   Tabs,
   Tab,
@@ -10,29 +11,38 @@ import {
   Alert,
   CircularProgress,
   Link as MuiLink,
+  Snackbar,
 } from '@mui/material'
-import { ChevronRight } from 'lucide-react'
-import { Link, useParams } from 'react-router-dom'
+import { ChevronRight, Trash2 } from 'lucide-react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { PluginHeader } from '../components/plugin-detail/PluginHeader'
 import { DetailSidebar } from '../components/plugin-detail/DetailSidebar'
 import { OverviewTab } from '../components/plugin-detail/OverviewTab'
 import { VersionsTab } from '../components/plugin-detail/VersionsTab'
 import { ChangelogTab } from '../components/plugin-detail/ChangelogTab'
 import { DependenciesTab } from '../components/plugin-detail/DependenciesTab'
-import { catalogApi } from '../api/config'
+import { catalogApi, managementApi } from '../api/config'
 import type { PluginDto, PluginReleaseDto } from '../api/generated/model'
+import { ConfirmDeleteDialog } from '../components/common/ConfirmDeleteDialog'
 import { useAuthStore } from '../stores/authStore'
 
 const TAB_IDS = ['overview', 'versions', 'changelog', 'dependencies']
 
 export function PluginDetailPage() {
   const { namespace = 'default', pluginId = '' } = useParams<{ namespace: string; pluginId: string }>()
+  const navigate = useNavigate()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const namespaceRole = useAuthStore((s) => s.namespaceRole)
+  const fetchNamespaceRole = useAuthStore((s) => s.fetchNamespaceRole)
+  const isAdmin = namespaceRole === 'ADMIN'
   const [plugin, setPlugin] = useState<PluginDto | null>(null)
   const [releases, setReleases] = useState<PluginReleaseDto[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [tab, setTab] = useState(0)
+  const [showDeletePlugin, setShowDeletePlugin] = useState(false)
+  const [isDeletingPlugin, setIsDeletingPlugin] = useState(false)
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
 
   useEffect(() => {
     async function load() {
@@ -53,6 +63,28 @@ export function PluginDetailPage() {
     }
     if (pluginId) load()
   }, [namespace, pluginId])
+
+  useEffect(() => {
+    if (isAuthenticated) fetchNamespaceRole(namespace)
+  }, [isAuthenticated, namespace, fetchNamespaceRole])
+
+  const handleReleaseDeleted = useCallback((version: string) => {
+    setReleases((prev) => prev.filter((r) => r.version !== version))
+  }, [])
+
+  async function handleDeletePlugin() {
+    setIsDeletingPlugin(true)
+    try {
+      await managementApi.deletePlugin({ ns: namespace, pluginId })
+      setToast({ message: `Plugin ${pluginId} deleted.`, severity: 'success' })
+      setTimeout(() => navigate(`/${namespace}`), 1000)
+    } catch {
+      setToast({ message: `Failed to delete plugin ${pluginId}.`, severity: 'error' })
+    } finally {
+      setIsDeletingPlugin(false)
+      setShowDeletePlugin(false)
+    }
+  }
 
   const latestRelease = releases.find((r) => r.status === 'published') ?? releases[0] ?? null
 
@@ -93,7 +125,22 @@ export function PluginDetailPage() {
         </Box>
 
         {/* Plugin Header */}
-        <PluginHeader plugin={plugin} latestRelease={latestRelease} namespace={namespace} />
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+          <PluginHeader plugin={plugin} latestRelease={latestRelease} namespace={namespace} />
+          {isAdmin && (
+            <Button
+              variant="outlined"
+              color="error"
+              size="small"
+              startIcon={<Trash2 size={14} />}
+              aria-label="delete plugin"
+              onClick={() => setShowDeletePlugin(true)}
+              sx={{ mt: 1, flexShrink: 0 }}
+            >
+              Delete
+            </Button>
+          )}
+        </Box>
 
         {/* Tabs + Content */}
         <Box sx={{ mt: 2 }}>
@@ -134,7 +181,8 @@ export function PluginDetailPage() {
                       namespace={namespace}
                       pluginId={pluginId}
                       currentVersion={latestRelease?.version}
-                      canApprove={isAuthenticated}
+                      canApprove={isAdmin}
+                      onReleaseDeleted={handleReleaseDeleted}
                     />
                   )}
                   {tab === 2 && i === 2 && <ChangelogTab releases={releases} />}
@@ -150,6 +198,26 @@ export function PluginDetailPage() {
           </Box>
         </Box>
       </Container>
+
+      <ConfirmDeleteDialog
+        open={showDeletePlugin}
+        title="Delete Plugin"
+        message={`Are you sure you want to delete "${plugin.name}" and all its releases? This action cannot be undone.`}
+        onConfirm={handleDeletePlugin}
+        onCancel={() => setShowDeletePlugin(false)}
+        loading={isDeletingPlugin}
+      />
+
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- Add `DELETE /namespaces/{ns}/plugins/{pluginId}` — deletes plugin + all releases + artifacts (cascade)
- Add `DELETE /namespaces/{ns}/plugins/{pluginId}/releases/{version}` — deletes single release + artifact
- Both endpoints require **ADMIN** namespace role (superadmin has implicit ADMIN)
- Frontend: delete buttons visible only to ADMIN users, with confirmation dialogs
- Reusable `ConfirmDeleteDialog` component for future use

## Changes

### Backend
- **OpenAPI spec**: 2 DELETE operations + `Forbidden` (403) response component
- **ManagementController**: `deletePlugin()`, `deleteRelease()` with `NamespaceRole.ADMIN` check
- **PluginService.delete()**: cascade-delete all releases (artifacts from storage + DB rows) before plugin

### Frontend
- **ConfirmDeleteDialog**: shared MUI dialog with loading state
- **VersionsTab**: per-release Trash2 delete button (ADMIN only), calls `managementApi.deleteRelease()`
- **PluginDetailPage**: delete-plugin button (ADMIN only), fetches `namespaceRole`, redirects to catalog after deletion
- **Bug fix**: `canApprove` now checks `namespaceRole === 'ADMIN'` instead of just `isAuthenticated`

## Test plan
- [x] `ManagementControllerTest` — DELETE plugin 204/404, DELETE release 204/404
- [x] `PluginServiceTest` — cascade-delete with 2 releases verifies storage + repo calls
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew build` green (backend)
- [ ] `ConfirmDeleteDialog.test` — rendering, confirm, cancel, loading, hidden (5 tests)
- [ ] `VersionsTab.test` — ADMIN sees delete buttons, non-ADMIN doesn't, dialog + API call (6 tests)
- [ ] `npm run test:run` (frontend — run locally)
- [ ] Manual: login as ADMIN → delete release → success toast
- [ ] Manual: login as MEMBER → no delete buttons visible
- [ ] Manual: cURL `DELETE` as MEMBER → 403

Closes #58

### 🤖 AI Agent Disclosure
This PR was implemented with assistance from Claude Code (Claude Opus 4.6).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>