### PR TITLE
feat(ui): replace tag filter with Autocomplete for typeahead search

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
@@ -5,6 +5,7 @@ import { Box, Button, InputBase, MenuItem, ToggleButton, ToggleButtonGroup, useT
 import { LayoutGrid, List, Search } from 'lucide-react'
 import { usePluginStore } from '../../stores/pluginStore'
 import { useUiStore } from '../../stores/uiStore'
+import { FilterAutocomplete } from '../common/FilterAutocomplete'
 import { FilterSelect } from '../common/FilterSelect'
 import { tokens } from '../../theme/tokens'
 
@@ -61,17 +62,14 @@ export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
         mb: 3,
       }}
     >
-      <FilterSelect
+      <FilterAutocomplete
+        options={availableTags}
         value={filters.tag}
         onChange={(v) => handleChange('tag', v)}
+        placeholder="All Tags"
         aria-label="Filter by tag"
-        minWidth={140}
-      >
-        <MenuItem value="">All Tags</MenuItem>
-        {availableTags.map((t) => (
-          <MenuItem key={t} value={t}>{t}</MenuItem>
-        ))}
-      </FilterSelect>
+        minWidth={180}
+      />
 
       <FilterSelect
         value={filters.status}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.test.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { describe, it, expect, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithTheme } from '../../test/renderWithTheme'
+import { FilterAutocomplete } from './FilterAutocomplete'
+
+describe('FilterAutocomplete', () => {
+  const tags = ['cli', 'demo', 'export', 'monitoring', 'security', 'ui']
+
+  it('renders with placeholder when no value selected', () => {
+    renderWithTheme(
+      <FilterAutocomplete options={tags} value="" onChange={vi.fn()} placeholder="All Tags" />,
+    )
+    expect(screen.getByPlaceholderText('All Tags')).toBeInTheDocument()
+  })
+
+  it('shows options when focused', async () => {
+    const user = userEvent.setup()
+    renderWithTheme(
+      <FilterAutocomplete options={tags} value="" onChange={vi.fn()} placeholder="All Tags" />,
+    )
+
+    await user.click(screen.getByPlaceholderText('All Tags'))
+
+    const listbox = screen.getByRole('listbox')
+    expect(within(listbox).getByText('cli')).toBeInTheDocument()
+    expect(within(listbox).getByText('security')).toBeInTheDocument()
+  })
+
+  it('filters options when typing', async () => {
+    const user = userEvent.setup()
+    renderWithTheme(
+      <FilterAutocomplete options={tags} value="" onChange={vi.fn()} placeholder="All Tags" />,
+    )
+
+    await user.click(screen.getByPlaceholderText('All Tags'))
+    await user.type(screen.getByPlaceholderText('All Tags'), 'sec')
+
+    const listbox = screen.getByRole('listbox')
+    expect(within(listbox).getByText('security')).toBeInTheDocument()
+    expect(within(listbox).queryByText('cli')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange with selected value', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    renderWithTheme(
+      <FilterAutocomplete options={tags} value="" onChange={onChange} placeholder="All Tags" />,
+    )
+
+    await user.click(screen.getByPlaceholderText('All Tags'))
+    await user.click(screen.getByText('export'))
+
+    expect(onChange).toHaveBeenCalledWith('export')
+  })
+
+  it('calls onChange with empty string when cleared', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    renderWithTheme(
+      <FilterAutocomplete options={tags} value="cli" onChange={onChange} placeholder="All Tags" />,
+    )
+
+    const clearButton = screen.getByTitle('Clear')
+    await user.click(clearButton)
+
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('shows loading indicator', () => {
+    renderWithTheme(
+      <FilterAutocomplete options={[]} value="" onChange={vi.fn()} placeholder="All Tags" loading />,
+    )
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2026 devtank42 GmbH
+import { Autocomplete, CircularProgress, TextField } from '@mui/material'
+
+interface FilterAutocompleteProps {
+  options: string[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  'aria-label'?: string
+  minWidth?: number
+  loading?: boolean
+}
+
+export function FilterAutocomplete({
+  options,
+  value,
+  onChange,
+  placeholder = 'All',
+  'aria-label': ariaLabel,
+  minWidth = 180,
+  loading = false,
+}: FilterAutocompleteProps) {
+  return (
+    <Autocomplete
+      size="small"
+      options={options}
+      value={value || null}
+      onChange={(_, newValue) => onChange(newValue ?? '')}
+      loading={loading}
+      openOnFocus
+      clearOnEscape
+      sx={{ minWidth }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          slotProps={{
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading && <CircularProgress color="inherit" size={16} />}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+              sx: {
+                height: 36,
+                fontSize: '0.875rem',
+                color: 'text.secondary',
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'divider',
+                },
+                '&:hover:not(.Mui-focused) .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'text.disabled',
+                },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                  borderWidth: '1px',
+                },
+              },
+            },
+          }}
+        />
+      )}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- Replace plain MUI `Select` tag dropdown with `FilterAutocomplete` (MUI `Autocomplete`) for typeahead search
- Scales to 50+ tags without usability degradation — users can type to filter
- Clearable selection (X button returns to "All Tags")
- Loading state indicator while tags are being fetched
- Visual styling matches existing `FilterSelect` (36px height, same border/focus styles)

## Changes
- **New:** `FilterAutocomplete.tsx` — reusable Autocomplete component with search, clear, loading
- **Modified:** `FilterBar.tsx` — tag filter uses `FilterAutocomplete` instead of `FilterSelect`
- **Verified:** Category references already fully removed (PR #108)

## Note on Issue #60 scope
The original issue mentions categories, tags, and version dropdowns. Categories were removed in PR #108 and are no longer relevant. The version "dropdown" on PluginDetailPage is already a full table in VersionsTab — a separate dropdown would be redundant. This PR addresses the remaining item: dynamic tag filtering with typeahead.

## Test plan
- [ ] `FilterAutocomplete.test` — 6 tests: placeholder, options display, typeahead filtering, selection, clear, loading
- [ ] `npm run test:run` (frontend — run locally)
- [ ] Manual: open catalog → click tag filter → type partial tag → options narrow down
- [ ] Manual: select tag → catalog filters → clear tag → all plugins shown

Closes #60

### 🤖 AI Agent Disclosure
This PR was implemented with assistance from Claude Code (Claude Opus 4.6).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>