### PR TITLE
fix: auto-delete plugin when last remaining release is deleted

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -614,7 +614,8 @@ paths:
       summary: Delete a single release
       description: |
         Permanently deletes a single plugin release and its stored artifact.
-        This action is irreversible. Requires `ADMIN` role in the namespace.
+        If this is the last remaining release of the plugin, the plugin itself
+        is also deleted. This action is irreversible. Requires `ADMIN` role in the namespace.
       operationId: deleteRelease
       security:
         - ApiKeyAuth: []
@@ -624,7 +625,16 @@ paths:
         - $ref: '#/components/parameters/VersionPath'
       responses:
         '204':
-          description: Release and artifact deleted
+          description: |
+            Release and artifact deleted. If this was the last remaining release,
+            the plugin itself is also deleted.
+          headers:
+            X-Plugin-Deleted:
+              schema:
+                type: boolean
+              description: >
+                `true` if the plugin was also deleted because this was its
+                last remaining release; `false` otherwise.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
@@ -120,8 +120,10 @@ class ManagementController(
             SecurityContextHolder.getContext().authentication!!,
             NamespaceRole.ADMIN,
         )
-        releaseService.delete(ns, pluginId, version)
-        return ResponseEntity.noContent().build()
+        val pluginDeleted = releaseService.delete(ns, pluginId, version)
+        return ResponseEntity.noContent()
+            .header("X-Plugin-Deleted", pluginDeleted.toString())
+            .build()
     }
 
     private fun ReleaseStatusUpdateRequest.Status.toServiceStatus(): ReleaseStatus = when (this) {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -162,11 +162,23 @@ class PluginReleaseService(
         return releaseRepository.save(release)
     }
 
+    /**
+     * Deletes a release and its stored artifact.
+     *
+     * @return `true` if this was the last release and the plugin was also deleted
+     */
     @Transactional
-    fun delete(namespaceSlug: String, pluginId: String, version: String) {
+    fun delete(namespaceSlug: String, pluginId: String, version: String): Boolean {
         val release = findByVersion(namespaceSlug, pluginId, version)
         storageService.delete(release.artifactKey)
         releaseRepository.delete(release)
+
+        val remaining = releaseRepository.findAllByPluginOrderByCreatedAtDesc(release.plugin)
+        if (remaining.isEmpty()) {
+            pluginRepository.delete(release.plugin)
+            return true
+        }
+        return false
     }
 
     private fun resolvePlugin(namespaceSlug: String, pluginId: String): PluginEntity {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -36,6 +36,7 @@ import io.plugwerk.server.service.ReleaseNotFoundException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
@@ -243,10 +244,24 @@ class ManagementControllerTest {
     }
 
     @Test
-    fun `DELETE release returns 204`() {
+    fun `DELETE release returns 204 with X-Plugin-Deleted false when other releases exist`() {
+        whenever(releaseService.delete(eq("acme"), eq("my-plugin"), eq("1.0.0"))).thenReturn(false)
+
         mockMvc.delete("/api/v1/namespaces/acme/plugins/my-plugin/releases/1.0.0")
             .andExpect {
                 status { isNoContent() }
+                header { string("X-Plugin-Deleted", "false") }
+            }
+    }
+
+    @Test
+    fun `DELETE release returns 204 with X-Plugin-Deleted true when last release`() {
+        whenever(releaseService.delete(eq("acme"), eq("my-plugin"), eq("1.0.0"))).thenReturn(true)
+
+        mockMvc.delete("/api/v1/namespaces/acme/plugins/my-plugin/releases/1.0.0")
+            .andExpect {
+                status { isNoContent() }
+                header { string("X-Plugin-Deleted", "true") }
             }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -37,6 +37,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tools.jackson.databind.ObjectMapper
@@ -257,7 +258,34 @@ class PluginReleaseServiceTest {
     }
 
     @Test
-    fun `delete removes artifact and release entity`() {
+    fun `delete removes artifact and release entity but keeps plugin when other releases exist`() {
+        val release = PluginReleaseEntity(
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar",
+        )
+        val otherRelease = PluginReleaseEntity(
+            plugin = plugin,
+            version = "2.0.0",
+            artifactSha256 = "sha2",
+            artifactKey = "00000000-0000-0000-0000-000000000001:my-plugin:2.0.0:jar",
+        )
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findByPluginAndVersion(plugin, "1.0.0")).thenReturn(Optional.of(release))
+        whenever(releaseRepository.findAllByPluginOrderByCreatedAtDesc(plugin)).thenReturn(listOf(otherRelease))
+
+        val pluginDeleted = releaseService.delete("acme", "my-plugin", "1.0.0")
+
+        assertThat(pluginDeleted).isFalse()
+        verify(storageService).delete("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar")
+        verify(releaseRepository).delete(release)
+        verify(pluginRepository, never()).delete(any<PluginEntity>())
+    }
+
+    @Test
+    fun `delete removes plugin when last release is deleted`() {
         val release = PluginReleaseEntity(
             plugin = plugin,
             version = "1.0.0",
@@ -267,11 +295,14 @@ class PluginReleaseServiceTest {
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
         whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
         whenever(releaseRepository.findByPluginAndVersion(plugin, "1.0.0")).thenReturn(Optional.of(release))
+        whenever(releaseRepository.findAllByPluginOrderByCreatedAtDesc(plugin)).thenReturn(emptyList())
 
-        releaseService.delete("acme", "my-plugin", "1.0.0")
+        val pluginDeleted = releaseService.delete("acme", "my-plugin", "1.0.0")
 
+        assertThat(pluginDeleted).isTrue()
         verify(storageService).delete("00000000-0000-0000-0000-000000000001:my-plugin:1.0.0:jar")
         verify(releaseRepository).delete(release)
+        verify(pluginRepository).delete(plugin)
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
@@ -7,6 +7,12 @@ import { renderWithRouter } from '../../test/renderWithTheme'
 import { VersionsTab } from './VersionsTab'
 import type { PluginReleaseDto } from '../../api/generated/model'
 
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
 vi.mock('../../api/config', () => ({
   reviewsApi: { approveRelease: vi.fn() },
   managementApi: { deleteRelease: vi.fn() },
@@ -44,6 +50,7 @@ const defaultProps = {
 describe('VersionsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNavigate.mockReset()
   })
 
   it('shows delete buttons when canApprove is true (ADMIN)', () => {
@@ -74,13 +81,15 @@ describe('VersionsTab', () => {
     const deleteButtons = screen.getAllByRole('button', { name: /delete release/i })
     await user.click(deleteButtons[0])
 
-    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument()
-    expect(screen.getByText(/v1.0.0/)).toBeInTheDocument()
+    expect(screen.getByText(/are you sure you want to delete v1\.0\.0\?/i)).toBeInTheDocument()
   })
 
   it('calls managementApi.deleteRelease on confirm', async () => {
     const { managementApi } = await import('../../api/config')
-    const mockDelete = vi.mocked(managementApi.deleteRelease).mockResolvedValue({} as never)
+    const mockDelete = vi.mocked(managementApi.deleteRelease).mockResolvedValue({
+      data: undefined, status: 204, statusText: 'No Content',
+      headers: { 'x-plugin-deleted': 'false' }, config: {} as never,
+    })
     const onDeleted = vi.fn()
     const user = userEvent.setup()
 
@@ -99,5 +108,54 @@ describe('VersionsTab', () => {
 
     expect(screen.getByText('v1.0.0')).toBeInTheDocument()
     expect(screen.getByText('v2.0.0')).toBeInTheDocument()
+  })
+
+  it('shows plugin deletion warning when deleting the last release', async () => {
+    const user = userEvent.setup()
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        currentVersion="1.0.0"
+        canApprove={true}
+      />,
+    )
+
+    const deleteButton = screen.getByRole('button', { name: /delete release/i })
+    await user.click(deleteButton)
+
+    expect(screen.getByText(/the entire plugin will also be removed/i)).toBeInTheDocument()
+  })
+
+  it('navigates to catalog page when X-Plugin-Deleted header is true', async () => {
+    const { managementApi } = await import('../../api/config')
+    vi.mocked(managementApi.deleteRelease).mockResolvedValue({
+      data: undefined,
+      status: 204,
+      statusText: 'No Content',
+      headers: { 'x-plugin-deleted': 'true' },
+      config: {} as never,
+    })
+    const onDeleted = vi.fn()
+    const user = userEvent.setup()
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        currentVersion="1.0.0"
+        canApprove={true}
+        onReleaseDeleted={onDeleted}
+      />,
+    )
+
+    const deleteButton = screen.getByRole('button', { name: /delete release/i })
+    await user.click(deleteButton)
+    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/acme')
+    expect(onDeleted).not.toHaveBeenCalled()
   })
 })

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material'
 import { Download, CheckCircle, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Badge } from '../common/Badge'
 import { ConfirmDeleteDialog } from '../common/ConfirmDeleteDialog'
 import type { PluginReleaseDto } from '../../api/generated/model'
@@ -40,6 +41,7 @@ const statusToBadge: Record<string, BadgeVariant> = {
 }
 
 export function VersionsTab({ releases, namespace, pluginId, currentVersion, canApprove, onReleaseDeleted }: VersionsTabProps) {
+  const navigate = useNavigate()
   const [approvingId, setApprovingId] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<PluginReleaseDto | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -64,9 +66,15 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
     if (!deleteTarget?.version) return
     setIsDeleting(true)
     try {
-      await managementApi.deleteRelease({ ns: namespace, pluginId, version: deleteTarget.version })
-      setToast({ message: `v${deleteTarget.version} deleted.`, severity: 'success' })
-      onReleaseDeleted?.(deleteTarget.version)
+      const response = await managementApi.deleteRelease({ ns: namespace, pluginId, version: deleteTarget.version })
+      const pluginDeleted = response.headers?.['x-plugin-deleted'] === 'true'
+      if (pluginDeleted) {
+        setToast({ message: 'Plugin and release deleted.', severity: 'success' })
+        navigate(`/${namespace}`)
+      } else {
+        setToast({ message: `v${deleteTarget.version} deleted.`, severity: 'success' })
+        onReleaseDeleted?.(deleteTarget.version)
+      }
     } catch {
       setToast({ message: `Failed to delete v${deleteTarget.version}.`, severity: 'error' })
     } finally {
@@ -190,7 +198,9 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
       <ConfirmDeleteDialog
         open={!!deleteTarget}
         title="Delete Release"
-        message={`Are you sure you want to delete v${deleteTarget?.version ?? ''}? This action cannot be undone.`}
+        message={releases.length === 1
+          ? `Are you sure you want to delete v${deleteTarget?.version ?? ''}? This is the last release — the entire plugin will also be removed. This action cannot be undone.`
+          : `Are you sure you want to delete v${deleteTarget?.version ?? ''}? This action cannot be undone.`}
         onConfirm={handleDeleteRelease}
         onCancel={() => setDeleteTarget(null)}
         loading={isDeleting}


### PR DESCRIPTION
## Summary

- Deleting the last release of a plugin now cascades to delete the plugin itself
- Server signals cascade via `X-Plugin-Deleted: true` response header
- Frontend shows enhanced warning when deleting the last release and navigates to catalog on plugin deletion

Closes #111

## Changes

**Backend:**
- `PluginReleaseService.delete()` — returns `Boolean` (true = plugin also deleted), checks for remaining releases after deletion
- `ManagementController.deleteRelease()` — sets `X-Plugin-Deleted` header on 204 response

**Frontend:**
- `VersionsTab.tsx` — enhanced warning message for last release, reads `X-Plugin-Deleted` header, navigates to catalog page on plugin cascade deletion

**OpenAPI:**
- `deleteRelease` endpoint — documented cascade behavior and `X-Plugin-Deleted` response header

## Test plan

- [x] `./gradlew build` — all backend tests pass (including 2 new tests)
- [x] `VersionsTab.test.tsx` — 8/8 tests pass (including 2 new tests)
- [ ] Manual: delete the only release of a plugin → verify plugin disappears from catalog
- [ ] Manual: delete one of multiple releases → verify plugin stays in catalog
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)