### PR TITLE
feat(security): add rate limiting to login endpoint

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ jakarta-validation = "3.1.1"
 jakarta-annotation = "3.0.0"
 semver4j = "6.0.0"
 yasson = "3.0.4"
+bucket4j = "8.17.0"
+caffeine = "3.2.0"
 spotless = "7.0.4"
 
 [libraries]
@@ -66,6 +68,10 @@ yasson = { module = "org.eclipse:yasson", version.ref = "yasson" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger-annotations" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakarta-validation" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
+
+# Rate Limiting
+bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 
 # Logging
 # SemVer

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.spring.boot.starter.liquibase)
+    implementation(libs.bucket4j.core)
+    implementation(libs.caffeine)
 
     runtimeOnly(libs.yasson)
     runtimeOnly(libs.postgresql)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -178,7 +178,35 @@ data class PlugwerkProperties(
          * Environment variable: `PLUGWERK_AUTH_ADMIN_PASSWORD`
          */
         val adminPassword: String? = null,
-    )
+        val rateLimit: RateLimitProperties = RateLimitProperties(),
+    ) {
+        /**
+         * Login rate limiting configuration (`plugwerk.auth.rate-limit.*`).
+         *
+         * Controls IP-based brute-force protection on the login endpoint. Uses an in-memory
+         * token-bucket algorithm (Bucket4j) with per-IP buckets that auto-expire after the
+         * configured window.
+         *
+         * @property maxAttempts Maximum number of login attempts allowed per IP address within
+         *   the configured time window. Requests exceeding this limit receive HTTP 429.
+         *
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS`
+         *
+         *   ```yaml
+         *   plugwerk.auth.rate-limit.max-attempts: 10
+         *   ```
+         *
+         * @property windowSeconds Duration of the rate limit window in seconds. After this
+         *   period, the token bucket refills completely for the given IP.
+         *
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS`
+         *
+         *   ```yaml
+         *   plugwerk.auth.rate-limit.window-seconds: 60
+         *   ```
+         */
+        data class RateLimitProperties(val maxAttempts: Int = 10, val windowSeconds: Long = 60)
+    }
 
     /**
      * Upload configuration (`plugwerk.upload.*`).

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.config
 
 import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.security.DelegatingJwtDecoder
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.OidcProviderRegistry
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
@@ -42,6 +43,7 @@ import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWrite
 @Configuration
 @EnableWebSecurity
 class SecurityConfiguration(
+    private val loginRateLimitFilter: LoginRateLimitFilter,
     private val apiKeyAuthFilter: NamespaceAccessKeyAuthFilter,
     private val publicNamespaceFilter: PublicNamespaceFilter,
     private val passwordChangeRequiredFilter: PasswordChangeRequiredFilter,
@@ -130,8 +132,10 @@ class SecurityConfiguration(
                     // (public namespace GET requests are handled by PublicNamespaceFilter)
                     .anyRequest().authenticated()
             }
-            // PublicNamespaceFilter runs first — sets AnonymousAuth for public namespace GETs
-            .addFilterBefore(publicNamespaceFilter, UsernamePasswordAuthenticationFilter::class.java)
+            // LoginRateLimitFilter runs first �� blocks brute-force login attempts before any auth processing
+            .addFilterBefore(loginRateLimitFilter, UsernamePasswordAuthenticationFilter::class.java)
+            // PublicNamespaceFilter runs second — sets AnonymousAuth for public namespace GETs
+            .addFilterAfter(publicNamespaceFilter, LoginRateLimitFilter::class.java)
             // NamespaceAccessKeyAuthFilter runs after — handles machine-to-machine auth via X-Api-Key
             .addFilterAfter(apiKeyAuthFilter, PublicNamespaceFilter::class.java)
             // PasswordChangeRequiredFilter runs last — blocks all API access when passwordChangeRequired = true

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/LoginRateLimitFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/LoginRateLimitFilter.kt
@@ -1,0 +1,85 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.OffsetDateTime
+
+/**
+ * Spring Security filter that rate-limits login attempts by client IP.
+ *
+ * Only applies to `POST /api/v1/auth/login`. All other requests pass through
+ * without rate-limit checks.
+ *
+ * When the limit is exceeded, the filter short-circuits the chain and returns
+ * HTTP 429 with a `Retry-After` header and a JSON error body matching the
+ * [io.plugwerk.api.model.ErrorResponse] schema.
+ *
+ * **Reverse-proxy note:** In production the reverse proxy (nginx, ALB, etc.)
+ * should set `X-Forwarded-For` to the true client IP. The filter uses the
+ * leftmost value from `X-Forwarded-For` if present, falling back to
+ * `request.remoteAddr`.
+ */
+@Component
+class LoginRateLimitFilter(private val rateLimitService: LoginRateLimitService) : OncePerRequestFilter() {
+
+    companion object {
+        private const val LOGIN_PATH = "/api/v1/auth/login"
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+        !(request.method == "POST" && request.requestURI == LOGIN_PATH)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val clientIp = resolveClientIp(request)
+        when (val result = rateLimitService.tryConsume(clientIp)) {
+            is RateLimitResult.Allowed -> filterChain.doFilter(request, response)
+
+            is RateLimitResult.Rejected -> {
+                response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+                response.setHeader("Retry-After", result.retryAfterSeconds.toString())
+                response.contentType = MediaType.APPLICATION_JSON_VALUE
+                response.writer.write(
+                    """{"status":429,"error":"Too Many Requests","message":"Too many login attempts. Please try again later.","timestamp":"${OffsetDateTime.now()}"}""",
+                )
+            }
+        }
+    }
+
+    /**
+     * Extracts the client IP from `X-Forwarded-For` (leftmost entry) or falls
+     * back to [HttpServletRequest.getRemoteAddr].
+     */
+    private fun resolveClientIp(request: HttpServletRequest): String {
+        val forwarded = request.getHeader("X-Forwarded-For")
+        if (!forwarded.isNullOrBlank()) {
+            return forwarded.split(",").first().trim()
+        }
+        return request.remoteAddr
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/LoginRateLimitService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/LoginRateLimitService.kt
@@ -1,0 +1,70 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.plugwerk.server.PlugwerkProperties
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Result of a rate-limit check.
+ */
+sealed interface RateLimitResult {
+    data class Allowed(val remainingTokens: Long) : RateLimitResult
+    data class Rejected(val retryAfterSeconds: Long) : RateLimitResult
+}
+
+/**
+ * IP-based rate limiting for the login endpoint using Bucket4j token buckets
+ * backed by a Caffeine cache for automatic expiry.
+ */
+@Component
+class LoginRateLimitService(props: PlugwerkProperties) {
+
+    private val maxAttempts = props.auth.rateLimit.maxAttempts
+    private val windowSeconds = props.auth.rateLimit.windowSeconds
+
+    private val buckets = Caffeine.newBuilder()
+        .expireAfterWrite(windowSeconds, TimeUnit.SECONDS)
+        .maximumSize(10_000)
+        .build<String, Bucket>()
+
+    fun tryConsume(ipAddress: String): RateLimitResult {
+        val bucket = buckets.get(ipAddress) { newBucket() }
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+        return if (probe.isConsumed) {
+            RateLimitResult.Allowed(probe.remainingTokens)
+        } else {
+            val retryAfterSeconds = Duration.ofNanos(probe.nanosToWaitForRefill).toSeconds() + 1
+            RateLimitResult.Rejected(retryAfterSeconds)
+        }
+    }
+
+    private fun newBucket(): Bucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(maxAttempts.toLong())
+                .refillGreedy(maxAttempts.toLong(), Duration.ofSeconds(windowSeconds))
+                .build(),
+        )
+        .build()
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -55,6 +55,17 @@ plugwerk:
     # No environment variable override — change this value directly when needed.
     token-validity-hours: 8
 
+    # IP-based brute-force protection for the login endpoint.
+    # Uses an in-memory token bucket (Bucket4j + Caffeine).
+    # Exceeding the limit returns HTTP 429 with a Retry-After header.
+    rate-limit:
+      # Maximum login attempts per IP within the time window.
+      # Env: PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS
+      max-attempts: ${PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS:10}
+      # Time window in seconds. Buckets auto-expire after this period.
+      # Env: PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS
+      window-seconds: ${PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS:60}
+
   # Maximum allowed plugin artifact file size in MB.
   # Files exceeding this limit are rejected with HTTP 413 (Payload Too Large).
   # Env: PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -18,6 +18,7 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
@@ -56,6 +57,7 @@ import java.util.UUID
     AdminUserController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.controller
 
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
@@ -47,6 +48,7 @@ import java.util.Optional
     AuthController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
@@ -57,6 +58,7 @@ import java.util.UUID
     CatalogController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -18,6 +18,7 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
@@ -38,6 +39,7 @@ import org.springframework.test.web.servlet.get
     ConfigController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.controller.mapper.PluginReleaseMapper
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
@@ -61,6 +62,7 @@ import java.util.UUID
     ManagementController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
@@ -19,6 +19,7 @@ package io.plugwerk.server.controller
 
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
@@ -56,6 +57,7 @@ import java.util.UUID
     OidcProviderController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
@@ -21,6 +21,7 @@ import io.plugwerk.server.controller.mapper.PluginReleaseMapper
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
@@ -52,6 +53,7 @@ import java.util.UUID
     ReviewsController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
@@ -18,6 +18,7 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.api.model.UpdateCheckResponse
+import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
@@ -43,6 +44,7 @@ import org.springframework.test.web.servlet.post
     UpdateCheckController::class,
     excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
     excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/LoginRateLimitFilterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/LoginRateLimitFilterTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class LoginRateLimitFilterTest {
+
+    private val rateLimitService: LoginRateLimitService = mock()
+    private val filter = LoginRateLimitFilter(rateLimitService)
+
+    @Test
+    fun `allowed request proceeds through filter chain`() {
+        whenever(rateLimitService.tryConsume(any()))
+            .thenReturn(RateLimitResult.Allowed(remainingTokens = 9))
+
+        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals(200, response.status)
+        verify(rateLimitService).tryConsume("127.0.0.1")
+    }
+
+    @Test
+    fun `rejected request returns 429 with Retry-After header`() {
+        whenever(rateLimitService.tryConsume(any()))
+            .thenReturn(RateLimitResult.Rejected(retryAfterSeconds = 42))
+
+        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+        assertEquals("42", response.getHeader("Retry-After"))
+        assertContains(response.contentAsString, "Too many login attempts")
+        assertContains(response.contentAsString, "\"status\":429")
+    }
+
+    @Test
+    fun `non-login POST requests are not rate limited`() {
+        val request = MockHttpServletRequest("POST", "/api/v1/auth/change-password")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        verifyNoInteractions(rateLimitService)
+    }
+
+    @Test
+    fun `GET requests to login path are not rate limited`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/auth/login")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        verifyNoInteractions(rateLimitService)
+    }
+
+    @Test
+    fun `X-Forwarded-For header is used as client IP`() {
+        whenever(rateLimitService.tryConsume(any()))
+            .thenReturn(RateLimitResult.Allowed(remainingTokens = 9))
+
+        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+        request.addHeader("X-Forwarded-For", "203.0.113.50, 70.41.3.18")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        verify(rateLimitService).tryConsume("203.0.113.50")
+    }
+
+    @Test
+    fun `falls back to remoteAddr when X-Forwarded-For is absent`() {
+        whenever(rateLimitService.tryConsume(any()))
+            .thenReturn(RateLimitResult.Allowed(remainingTokens = 9))
+
+        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+        request.remoteAddr = "192.168.1.100"
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        verify(rateLimitService).tryConsume("192.168.1.100")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/LoginRateLimitServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/LoginRateLimitServiceTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Plugwerk — Plugin Marketplace for the PF4J Ecosystem
+ * Copyright (C) 2026 devtank42 GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.PlugwerkProperties
+import org.junit.jupiter.api.Test
+import kotlin.test.assertIs
+
+class LoginRateLimitServiceTest {
+
+    private fun createService(maxAttempts: Int = 5, windowSeconds: Long = 60): LoginRateLimitService {
+        val props = PlugwerkProperties(
+            auth = PlugwerkProperties.AuthProperties(
+                jwtSecret = "a".repeat(32),
+                encryptionKey = "b".repeat(16),
+                rateLimit = PlugwerkProperties.AuthProperties.RateLimitProperties(
+                    maxAttempts = maxAttempts,
+                    windowSeconds = windowSeconds,
+                ),
+            ),
+        )
+        return LoginRateLimitService(props)
+    }
+
+    @Test
+    fun `requests within limit are allowed`() {
+        val service = createService(maxAttempts = 5)
+        repeat(5) { i ->
+            val result = service.tryConsume("192.168.1.1")
+            assertIs<RateLimitResult.Allowed>(result, "Request ${i + 1} should be allowed")
+        }
+    }
+
+    @Test
+    fun `request exceeding limit is rejected`() {
+        val service = createService(maxAttempts = 3)
+        repeat(3) { service.tryConsume("10.0.0.1") }
+        val result = service.tryConsume("10.0.0.1")
+        assertIs<RateLimitResult.Rejected>(result)
+        assert(result.retryAfterSeconds > 0) { "retryAfterSeconds should be positive" }
+    }
+
+    @Test
+    fun `different IPs have independent limits`() {
+        val service = createService(maxAttempts = 2)
+        repeat(2) { service.tryConsume("10.0.0.1") }
+        assertIs<RateLimitResult.Rejected>(service.tryConsume("10.0.0.1"))
+        assertIs<RateLimitResult.Allowed>(service.tryConsume("10.0.0.2"))
+    }
+
+    @Test
+    fun `bucket refills after window expires`() {
+        val service = createService(maxAttempts = 2, windowSeconds = 1)
+        repeat(2) { service.tryConsume("10.0.0.1") }
+        assertIs<RateLimitResult.Rejected>(service.tryConsume("10.0.0.1"))
+        Thread.sleep(1_100)
+        assertIs<RateLimitResult.Allowed>(service.tryConsume("10.0.0.1"))
+    }
+
+    @Test
+    fun `remaining tokens decrease with each request`() {
+        val service = createService(maxAttempts = 5)
+        val first = service.tryConsume("10.0.0.1")
+        assertIs<RateLimitResult.Allowed>(first)
+        assert(first.remainingTokens == 4L) { "Expected 4 remaining, got ${first.remainingTokens}" }
+
+        val second = service.tryConsume("10.0.0.1")
+        assertIs<RateLimitResult.Allowed>(second)
+        assert(second.remainingTokens == 3L) { "Expected 3 remaining, got ${second.remainingTokens}" }
+    }
+}


### PR DESCRIPTION
## Summary

- Add IP-based brute-force protection to `POST /api/v1/auth/login` using Bucket4j 8.17.0 token buckets + Caffeine cache
- Max 10 login attempts per IP per minute, configurable via `plugwerk.auth.rate-limit.*`
- Returns HTTP 429 with `Retry-After` header when limit exceeded
- `LoginRateLimitFilter` runs first in the Spring Security filter chain, before any auth processing

## Changes

| File | Change |
|------|--------|
| `LoginRateLimitService.kt` | Token-bucket service with Caffeine-backed per-IP buckets |
| `LoginRateLimitFilter.kt` | `OncePerRequestFilter` — intercepts only login POST, returns 429 on excess |
| `SecurityConfiguration.kt` | Register filter before all other custom filters |
| `PlugwerkProperties.kt` | `RateLimitProperties` nested config (maxAttempts, windowSeconds) |
| `application.yml` | Documented config with env var overrides |
| `libs.versions.toml` / `build.gradle.kts` | Bucket4j 8.17.0 + Caffeine 3.2.0 dependencies |
| 8 existing controller tests | Exclude `LoginRateLimitFilter` from `@WebMvcTest` component scan |

## Test plan

- [x] `LoginRateLimitServiceTest` — 5 unit tests (limit, rejection, IP isolation, refill, remaining tokens)
- [x] `LoginRateLimitFilterTest` — 6 unit tests (allow, 429+Retry-After, path filtering, X-Forwarded-For, remoteAddr fallback)
- [x] All existing tests pass (no regressions)
- [ ] Manual: send 11 rapid `curl` requests to `/api/v1/auth/login`, verify 429 on 11th

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)