### PR TITLE
fix(ui): update Scalar to fix transient share popup on API Docs page

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.9",
-        "@scalar/api-reference-react": "^0.8.70",
+        "@scalar/api-reference-react": "^0.9.20",
         "axios": "^1.13.6",
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
-      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.40.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
-      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.6.0",
@@ -1946,6 +1946,243 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
@@ -1971,6 +2208,85 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.363.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.363.2.tgz",
+      "integrity": "sha512-UcUwHEd2LXxWq4bW/I4TbwYcA+BHO/cSuHcNpGXjRCp76eJk1eOuQnm/a3MrfHtbt2X11CQu+eWpqiSgcv+X6A==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@replit/codemirror-css-color-picker": {
       "version": "6.3.0",
@@ -2246,32 +2562,33 @@
       "license": "MIT"
     },
     "node_modules/@scalar/agent-chat": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.7.3.tgz",
-      "integrity": "sha512-r8lF7vHm0Oee8y3MgYTEOKfJF8WwdiApLICuzcqKLt0YayEURiSMB36J1SPtzISO7t66WbFi3xru8MdOa3FmUw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalar/agent-chat/-/agent-chat-0.10.1.tgz",
+      "integrity": "sha512-VjGMuuqtxgdxL59eOjaTEKTc8YYiBdegwuc4wiaFMdo6LLowkUDrx4PgwfO2DBZ032uBqZyjaWQemE0DA2CsSA==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/vue": "3.0.33",
-        "@scalar/api-client": "2.31.3",
-        "@scalar/components": "0.19.15",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/icons": "0.5.3",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/themes": "0.14.3",
-        "@scalar/types": "0.6.10",
-        "@scalar/use-toasts": "0.9.1",
-        "@scalar/workspace-store": "0.35.3",
+        "@scalar/api-client": "2.41.0",
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
         "@vueuse/core": "13.9.0",
         "ai": "6.0.33",
-        "neverpanic": "0.0.5",
+        "js-base64": "^3.7.8",
+        "neverpanic": "0.0.7",
         "truncate-json": "3.0.1",
-        "vue": "^3.5.26",
+        "vue": "^3.5.30",
         "whatwg-mimetype": "4.0.0",
         "zod": "^4.3.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/agent-chat/node_modules/whatwg-mimetype": {
@@ -2283,67 +2600,57 @@
         "node": ">=18"
       }
     },
-    "node_modules/@scalar/analytics-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@scalar/analytics-client/-/analytics-client-1.0.1.tgz",
-      "integrity": "sha512-ai4DJuxsNLUEgJIlYDE3n8/oF47M31Rgjz3LxbefzejxE8LiidUud/fcEzMYtdxqJYi3ketzhSbTWK0o6gg4mQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.1.11"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@scalar/api-client": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.31.3.tgz",
-      "integrity": "sha512-Qyy7C6Vt+9GHA4hOSdn2E0DkXB/6EjyCuqW9Vn063Wg8PIlkNAyOkszZtDtDUc0KI+c4J1iwCUVelrZr5lrnwQ==",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@scalar/api-client/-/api-client-2.41.0.tgz",
+      "integrity": "sha512-7olL0H8zESePpKSmJwalP0u2RK00qEUHL8gHDEukIyjVF0oDZK/JCCXPSCtg94A+kWTG+e6BMtjhp0WWIqf2dg==",
       "license": "MIT",
       "dependencies": {
         "@headlessui/tailwindcss": "^0.2.2",
         "@headlessui/vue": "1.7.23",
-        "@scalar/analytics-client": "1.0.1",
-        "@scalar/components": "0.19.15",
-        "@scalar/draggable": "0.3.0",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/icons": "0.5.3",
-        "@scalar/import": "0.4.55",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/oas-utils": "0.8.3",
-        "@scalar/object-utils": "1.2.32",
-        "@scalar/openapi-parser": "0.24.17",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/postman-to-openapi": "0.4.10",
-        "@scalar/sidebar": "0.7.46",
-        "@scalar/snippetz": "0.6.19",
-        "@scalar/themes": "0.14.3",
+        "@scalar/components": "0.21.3",
+        "@scalar/draggable": "0.4.1",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/import": "0.5.4",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/oas-utils": "0.10.16",
+        "@scalar/object-utils": "1.3.4",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/postman-to-openapi": "0.6.1",
+        "@scalar/sidebar": "0.8.18",
+        "@scalar/snippetz": "0.7.8",
+        "@scalar/themes": "0.15.2",
         "@scalar/typebox": "^0.1.3",
-        "@scalar/types": "0.6.10",
-        "@scalar/use-codemirror": "0.13.50",
-        "@scalar/use-hooks": "0.3.7",
-        "@scalar/use-toasts": "0.9.1",
-        "@scalar/workspace-store": "0.35.3",
-        "@types/har-format": "^1.2.15",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-codemirror": "0.14.11",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
+        "@types/har-format": "^1.2.16",
         "@vueuse/core": "13.9.0",
         "@vueuse/integrations": "13.9.0",
-        "focus-trap": "^7",
+        "focus-trap": "^7.8.0",
         "fuse.js": "^7.1.0",
         "js-base64": "^3.7.8",
         "microdiff": "^1.5.0",
+        "monaco-editor": "0.54.0",
+        "monaco-yaml": "5.2.3",
         "nanoid": "^5.1.6",
-        "pretty-bytes": "^7.1.0",
+        "posthog-js": "1.363.2",
         "pretty-ms": "^9.3.0",
-        "shell-quote": "^1.8.1",
+        "radix-vue": "^1.9.17",
+        "shell-quote": "^1.8.3",
         "type-fest": "^5.3.1",
-        "vue": "^3.5.26",
+        "vite-plugin-monaco-editor": "^1.1.0",
+        "vue": "^3.5.30",
         "vue-router": "4.6.2",
         "whatwg-mimetype": "4.0.0",
         "yaml": "^2.8.0",
         "zod": "^4.3.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/api-client/node_modules/nanoid": {
@@ -2389,51 +2696,50 @@
       }
     },
     "node_modules/@scalar/api-reference": {
-      "version": "1.46.4",
-      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.46.4.tgz",
-      "integrity": "sha512-EpCcOG15Ry8DKNs/f5AdRA97s1B5kGPekzANpnK0j1IpyU4Sb/mfdyfB00WC+vUo7hfc4BFRSkkiPa5SSM7fng==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.51.0.tgz",
+      "integrity": "sha512-CmyvtSM9YNTPit1ZxfYhfAp7MtE+KXUxOID4sIf8+Flfr5zFOHVAu1ww1WySszugWG/8xV4BCZuJZtHGwtQyHg==",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "1.7.23",
-        "@scalar/agent-chat": "0.7.3",
-        "@scalar/api-client": "2.31.3",
-        "@scalar/code-highlight": "0.2.4",
-        "@scalar/components": "0.19.15",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/icons": "0.5.3",
-        "@scalar/oas-utils": "0.8.3",
-        "@scalar/openapi-parser": "0.24.17",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/sidebar": "0.7.46",
-        "@scalar/snippetz": "0.6.19",
-        "@scalar/themes": "0.14.3",
-        "@scalar/types": "0.6.10",
-        "@scalar/use-hooks": "0.3.7",
-        "@scalar/use-toasts": "0.9.1",
-        "@scalar/workspace-store": "0.35.3",
+        "@scalar/agent-chat": "0.10.1",
+        "@scalar/api-client": "2.41.0",
+        "@scalar/code-highlight": "0.3.2",
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/oas-utils": "0.10.16",
+        "@scalar/sidebar": "0.8.18",
+        "@scalar/snippetz": "0.7.8",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/use-toasts": "0.10.1",
+        "@scalar/workspace-store": "0.43.1",
         "@unhead/vue": "^2.1.4",
         "@vueuse/core": "13.9.0",
         "fuse.js": "^7.1.0",
         "github-slugger": "2.0.0",
         "microdiff": "^1.5.0",
         "nanoid": "^5.1.6",
-        "vue": "^3.5.26"
+        "vue": "^3.5.30",
+        "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/api-reference-react": {
-      "version": "0.8.70",
-      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.8.70.tgz",
-      "integrity": "sha512-J65Qfb6/rSPGQ5JlVRPXR5JKdb4SE3tHTne4SoUaIbXooFIQnHxMO7TIEzEZl8PZecmZ7WZbQvDwuXydZccgKA==",
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@scalar/api-reference-react/-/api-reference-react-0.9.20.tgz",
+      "integrity": "sha512-syiRHB1XRdKWM2a0fbzUCPNb5nQa/WHl/SLYu7pF/GBT5MBO27fYjPx8BSGvXA5Vdt218cWgZofiu/T1mVKFiw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/api-reference": "1.46.4",
-        "@scalar/types": "0.6.10"
+        "@scalar/api-reference": "1.51.0",
+        "@scalar/types": "0.7.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
@@ -2458,9 +2764,9 @@
       }
     },
     "node_modules/@scalar/code-highlight": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.2.4.tgz",
-      "integrity": "sha512-sF9kpxyeh+jwh0ZpXias9UrPBbZf0zgY8Y2nlQqYAwVdGbFdO/bIzjKTi9vWCkKS78NsBfz7rLnJsQ+UP/11rA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.3.2.tgz",
+      "integrity": "sha512-K9Cr3uQ0Rga4MEwAd3Jd4qvWy/pL7LPzL+xjdrpKEfdPj3C96W9oFE9Ok9wnNxuvuGqlN6JEqTw8Kjy3LYo45w==",
       "license": "MIT",
       "dependencies": {
         "hast-util-to-text": "^4.0.2",
@@ -2472,43 +2778,41 @@
         "rehype-parse": "^9.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
-        "rehype-stringify": "^10.0.0",
-        "remark-gfm": "^4.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.0",
+        "remark-rehype": "^11.1.2",
         "remark-stringify": "^11.0.0",
-        "unified": "^11.0.4",
-        "unist-util-visit": "^5.0.0"
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/components": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.19.15.tgz",
-      "integrity": "sha512-oYK5zJarMJ5HvNGJsr6/Y7lz9TPy6Q+g3bQ1PxbaGURcKItXWlR+Yki1kZQ1A6/3b1XpBoMkMUHYp1bBOPW4KQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.21.3.tgz",
+      "integrity": "sha512-vOQyxImr6nbMDGUkIM4vs+DF0A26l33J+zYHAV4cm1X8FQ0huPW464EPDiD7csPkg79yF9vqblhFhyqq4u2dqw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "0.2.10",
         "@floating-ui/vue": "1.1.9",
         "@headlessui/vue": "1.7.23",
-        "@scalar/code-highlight": "0.2.4",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/icons": "0.5.3",
-        "@scalar/oas-utils": "0.8.3",
-        "@scalar/themes": "0.14.3",
-        "@scalar/use-hooks": "0.3.7",
+        "@scalar/code-highlight": "0.3.2",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/themes": "0.15.2",
+        "@scalar/use-hooks": "0.4.2",
         "@vueuse/core": "13.9.0",
         "cva": "1.0.0-beta.4",
         "nanoid": "^5.1.6",
-        "pretty-bytes": "^7.1.0",
         "radix-vue": "^1.9.17",
-        "vue": "^3.5.26",
+        "vue": "^3.5.30",
         "vue-component-type-helpers": "^3.2.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/components/node_modules/nanoid": {
@@ -2530,48 +2834,39 @@
       }
     },
     "node_modules/@scalar/draggable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.3.0.tgz",
-      "integrity": "sha512-T/79XY5HGNo9Lte7wlnrH393zjiulom4HuwW4u8RtaafWxIdtXykD2+TgiO0KTreyzCrWyWrESqiqKKJMe2nKg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalar/draggable/-/draggable-0.4.1.tgz",
+      "integrity": "sha512-TvTiy0tB2ulfBL7jwrpnsf7Geqlq/tWaIopkyZLii9bZPxPX5y1o6fVJXMyjtsUo0FSzvB382kN4uPi1TK/Hww==",
       "license": "MIT",
       "dependencies": {
-        "vue": "^3.5.21"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@scalar/helpers": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.18.tgz",
-      "integrity": "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@scalar/icons": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.5.3.tgz",
-      "integrity": "sha512-W9W4dWM9UL75+CLPgQEhds+cJVBeLaKrcUnlguV7CGzcBkdV+u6bZVeqDgiUn5o9j1zZChkoXULSfU/a605csg==",
-      "license": "MIT",
-      "dependencies": {
-        "@phosphor-icons/core": "^2.1.1",
-        "@types/node": "^22.19.3",
-        "chalk": "^5.4.1",
         "vue": "^3.5.26"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
-    "node_modules/@scalar/icons/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+    "node_modules/@scalar/helpers": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.3.tgz",
+      "integrity": "sha512-Gv2V7SFreLx3DltzF2lKXdaJSH5cP1LOyt9PxON1cSWGxkrs3sg93c1taEJsW24E9ckfYXkL5hjCAVLfAN3wQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/icons": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.7.2.tgz",
+      "integrity": "sha512-21L2y/D6oU7wZHHa9i6FK98cZ+XH4HX9+e69uNpvlp4awRUpz6ifNHOLlxI607bq+Yz4G313gnV0uyUHwZ/pig==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "@phosphor-icons/core": "^2.1.1",
+        "@types/node": "^24.1.0",
+        "chalk": "^5.6.2",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/icons/node_modules/chalk": {
@@ -2586,61 +2881,56 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@scalar/icons/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
     "node_modules/@scalar/import": {
-      "version": "0.4.55",
-      "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.4.55.tgz",
-      "integrity": "sha512-XCn7OwoFNWkEpIJHYMuoUvtR5gLtaKf8AXrcHVVNmQG5TcAd+PfzSYCYwNcRtPEmaBKIyt5Vc5zsgPS8wTFyBw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalar/import/-/import-0.5.4.tgz",
+      "integrity": "sha512-EwqIC+cRzbGVg6w0P1tN0K/46hfb0rbHOTNwL4n7FmKxOH6zdbO5dCvlyh41rjOoc19keVGeq7oPg6o/6D6rBA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
+        "@scalar/helpers": "0.4.3",
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.11.7.tgz",
-      "integrity": "sha512-GVz9E0vXu+ecypkdn0biK1gbQVkK4QTTX1Hq3eMgxlLQC91wwiqWfCqwfhuX0LRu+Z5OmYhLhufDJEEh56rVgA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.5.tgz",
+      "integrity": "sha512-MkGOjodEeQ7V7M78W6Oq+t3q1LaUR+SRLZLqFbU6s26Gc+12T+v89JXcHvd+3ug0xFVMg/kdczZ3O6miBhyNsA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
+        "@scalar/helpers": "0.4.3",
         "pathe": "^2.0.3",
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/oas-utils": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.8.3.tgz",
-      "integrity": "sha512-FQLZzY+c1tOkXsYtht3MyFJMpLqymhnUvrd7uk0FI659JAu5bDtcasJ1ZM2MbqALS0n7ta1u417ADEagTugPWQ==",
+      "version": "0.10.16",
+      "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.10.16.tgz",
+      "integrity": "sha512-xez3QrGYjn4Dhl6blvcUUzbVR1IOQVQhDO54UuZJwKWbOT3brEyAeZBwzttWmWDe3uGazPF160mj7qBXlT6sDQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/object-utils": "1.2.32",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/themes": "0.14.3",
-        "@scalar/types": "0.6.10",
-        "@scalar/workspace-store": "0.35.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/object-utils": "1.3.4",
+        "@scalar/openapi-parser": "0.25.8",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/themes": "0.15.2",
+        "@scalar/types": "0.7.6",
+        "@scalar/workspace-store": "0.43.1",
         "flatted": "^3.3.3",
         "github-slugger": "2.0.0",
         "type-fest": "^5.3.1",
-        "vue": "^3.5.26",
+        "vue": "^3.5.30",
         "yaml": "^2.8.0",
         "zod": "^4.3.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/oas-utils/node_modules/type-fest": {
@@ -2659,30 +2949,30 @@
       }
     },
     "node_modules/@scalar/object-utils": {
-      "version": "1.2.32",
-      "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.2.32.tgz",
-      "integrity": "sha512-t3qTaI2Jd4xhXS42KTS9VqKJ4YENxLidemy+E9Y1voJmVScG+A9qHn4LSkXUrS2sYhOGuwERjxRZr2P7zgCMqA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.3.4.tgz",
+      "integrity": "sha512-M3S6QgsMfSTgWgTQTS+m3+/pkpTlZmyWMFFUy/qWbQaD00qbR/OcftA7QIEPe6ToJgsNPHHS4+bOXzeLoJJBfQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
+        "@scalar/helpers": "0.4.3",
         "flatted": "^3.3.3",
         "just-clone": "^6.2.0",
         "ts-deepmerge": "^7.0.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.24.17",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.24.17.tgz",
-      "integrity": "sha512-aM9UVrzlMreC3X/sZbyj+7XDZmat3ecGC3RpU8dqEO/HIH+CEX0xMLuP+41DhePCYg5+9TtDomSfWuMq4x1Z1A==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.25.8.tgz",
+      "integrity": "sha512-09yGXQSMYVlxJkLIn9Nz2q7Du7/olHKhR4oU0/JgkOdcKBiixSeLmhcAm7Hmj2Z82xOYpF+ZJUTCzsh8DQv5Fg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/openapi-types": "0.5.4",
-        "@scalar/openapi-upgrader": "0.1.11",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-types": "0.7.0",
+        "@scalar/openapi-upgrader": "0.2.4",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
@@ -2691,7 +2981,7 @@
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-parser/node_modules/ajv": {
@@ -2731,84 +3021,81 @@
       "license": "MIT"
     },
     "node_modules/@scalar/openapi-types": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.5.4.tgz",
-      "integrity": "sha512-2pEbhprh8lLGDfUI6mNm9EV104pjb3+aJsXrFaqfgOSre7r6NlgM5HcSbsLjzDAnTikjJhJ3IMal1Rz8WVwiOw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
       "license": "MIT",
-      "dependencies": {
-        "zod": "^4.3.5"
-      },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-upgrader": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.1.11.tgz",
-      "integrity": "sha512-ngJcHGoCHmpWgYtNy08vmzFfLdQEkMpvaCQqNPPMNKq0QEXOv89e/rn+TZJZgPnRlY7fDIoIhn9lNgr+azBW+w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.4.tgz",
+      "integrity": "sha512-AcrF7BMxKCTHnT82SHbHun6dJO4XC9tS5gD7EJsr/7YwFkx9JtbtZCryJXtqWJ5c7i1v1KH4PRRjDga/hCULTQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/openapi-types": "0.5.4"
+        "@scalar/openapi-types": "0.7.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/postman-to-openapi": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.4.10.tgz",
-      "integrity": "sha512-s7TECz1DLSXggRYEEVjoBXLxY3nKCU9n4zA7FxRywxsG485qmr2gMHqU5plFJDC59RUxcIOo+V+LbOpKo1EQUQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.1.tgz",
+      "integrity": "sha512-YUEH33s1HCAkApSdIFNB5XUGxzp7D5U9X2kgMKlZSyN2fW+yAePonaq5S9E4wU/2swSm+PvL9B2gw02yPjecUA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
-        "@scalar/openapi-types": "0.5.4"
+        "@scalar/helpers": "0.4.3",
+        "@scalar/openapi-types": "0.7.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/sidebar": {
-      "version": "0.7.46",
-      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.7.46.tgz",
-      "integrity": "sha512-80+28tW2qM0mH1v/dAZu1DMmv8nj/Rz88PDW4fRY8yMP6xoNi8IpKhnFJ4dnGOBMqu7/2VsOAIGADLVA6ZC4jw==",
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/@scalar/sidebar/-/sidebar-0.8.18.tgz",
+      "integrity": "sha512-FtHXmSyXYXtM5Y3TPbBrVfhJgaGC3fFkJugZN/y5BzXZXQoKZyTmBMJk8jMkgaMp+0cvpEtKJfYuBJvoAxtFmA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/components": "0.19.15",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/icons": "0.5.3",
-        "@scalar/themes": "0.14.3",
-        "@scalar/use-hooks": "0.3.7",
-        "@scalar/workspace-store": "0.35.3",
-        "vue": "^3.5.26"
+        "@scalar/components": "0.21.3",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/icons": "0.7.2",
+        "@scalar/themes": "0.15.2",
+        "@scalar/use-hooks": "0.4.2",
+        "@scalar/workspace-store": "0.43.1",
+        "vue": "^3.5.30"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/snippetz": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.6.19.tgz",
-      "integrity": "sha512-eWZiCFrv2ExTgYBytSOmXbnY5zVSXRV0tGjFGtDL6ovv9TZIjOrIi0CVg6NLgcs9I1XHAYpE0JlWKQnQ+dGQYw==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.7.8.tgz",
+      "integrity": "sha512-1g037ajdeGepBKj6+At+6BGSW4OqwONq2NoonGDcpDkW01dInTJx9q8AatXT1qdVUwV1gAVOYjCHsmSxkZictw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.6.10",
+        "@scalar/types": "0.7.6",
         "js-base64": "^3.7.8",
         "stringify-object": "^6.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/themes": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.14.3.tgz",
-      "integrity": "sha512-QZpuopwlXSX2e4sxYSSQEm3CzanPzlNIhUONVaZQOo0wUSfyaC1V4QTGMigSPzdo505ouZNyh80bR0Glmn4fag==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.15.2.tgz",
+      "integrity": "sha512-GA+cM2Lojv2sqwfB6yTerBAnBTfVzIzUZ3C8T4PP9snaLyy7b0CMoHtnDEqERX/NZiRfnrIWeEYGy09cDi0w4g==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/themes/node_modules/nanoid": {
@@ -2836,18 +3123,18 @@
       "license": "MIT"
     },
     "node_modules/@scalar/types": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.6.10.tgz",
-      "integrity": "sha512-fZkelRwcEeAhsn4c0wjYXWrzSzLaEyfxTn/eazXJ4XfCIsgJTQyK0FD8mnOBZJ2vEIbtT2E1mBKnCbDxrJIlxA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.6.tgz",
+      "integrity": "sha512-n5d7neeGTY/yS36AwAv3FAyCnJbbLjMPwyuEXBLgxHcb5i8DXnNfwy1nzz8jx/EJ88i1zmQ8BuMs+207saHgNA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.2.18",
+        "@scalar/helpers": "0.4.3",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/types/node_modules/nanoid": {
@@ -2884,9 +3171,9 @@
       }
     },
     "node_modules/@scalar/use-codemirror": {
-      "version": "0.13.50",
-      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.13.50.tgz",
-      "integrity": "sha512-KaX8bixOz4sMy5a9XzjH03ffo6n905ol850bT8YRqBuPaTXoxq3M/Z0MipxvCRL+SQ/U07QiwJQnCO3jnXd+xQ==",
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@scalar/use-codemirror/-/use-codemirror-0.14.11.tgz",
+      "integrity": "sha512-5wtC4pUjzhy72j3aAueJg+fh9KflevJvXMn0YscsxiDTvqwIzeZcHe1N9VNtvzDXgLblEeBT6D0+Vs+boyExxg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -2903,28 +3190,27 @@
         "@lezer/common": "^1.2.3",
         "@lezer/highlight": "^1.2.1",
         "@replit/codemirror-css-color-picker": "^6.3.0",
-        "@scalar/components": "0.19.15",
-        "vue": "^3.5.26"
+        "vue": "^3.5.30"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/use-hooks": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.3.7.tgz",
-      "integrity": "sha512-fhFRYKtGyCOPaLwDRHGaw5XZ3LY+ptCpcPON51r1sGXCl3O1joB2rBTkcXuh2E04uMB5vsko/71hxhWJZxSnGg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.4.2.tgz",
+      "integrity": "sha512-c12RFw75aqRFc2iXQDdm9cHk0E/bT8LTelgNQDR8Bhp7950Swssr10lWC61CWdOigjRth+ES61Jo8yGi5yUBwQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/use-toasts": "0.9.1",
+        "@scalar/use-toasts": "0.10.1",
         "@vueuse/core": "13.9.0",
         "cva": "1.0.0-beta.2",
         "tailwind-merge": "3.4.0",
-        "vue": "^3.5.26",
+        "vue": "^3.5.30",
         "zod": "^4.3.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/use-hooks/node_modules/cva": {
@@ -2948,39 +3234,48 @@
       }
     },
     "node_modules/@scalar/use-toasts": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.9.1.tgz",
-      "integrity": "sha512-t8QoQO4ZWekiSdJ2O7C+PbXfv7x2fmhv3C7t/iITdNpOyLv4jAhlELGpxQHkWsU0ZwRrLU8e+rV0jJcKWE6vYA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.10.1.tgz",
+      "integrity": "sha512-8fsDd4efEDF+EydA+1+np/ac2KsAXPR1LdTYtTUxpv8Uj1l7lUMT/T5A7xnR+wNKmyVREihb9KnGp3pSjO2kYg==",
       "license": "MIT",
       "dependencies": {
-        "vue": "^3.5.21",
+        "vue": "^3.5.26",
         "vue-sonner": "^1.0.3"
       },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/validation": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.3.0.tgz",
+      "integrity": "sha512-4X/AP3JO23DuYxs1MMjn6IlT9gyrKPCuZj8ybTB9QIjC+3tSJLpQOwZg7HEyyz2HoVwOt9jdef2jO3RXW7DqTw==",
+      "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@scalar/workspace-store": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.35.3.tgz",
-      "integrity": "sha512-q/ZKiNQ+PSKiNO/2EGFJn1/+Hp75IN+E2KWyx9etS0YLLFNiW3IaKXB3sCX8hMZ8z7Tf+EL718ejrs9+Rvc92A==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.43.1.tgz",
+      "integrity": "sha512-R0V2PXMhjbfELRtiRfn6vNaLPJalo1AKUs1AkCvJZyMaCNHrGUH14rdhwAz790ahVjebY66VKdn19Q4x1t60uA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/code-highlight": "0.2.4",
-        "@scalar/helpers": "0.2.18",
-        "@scalar/json-magic": "0.11.7",
-        "@scalar/object-utils": "1.2.32",
-        "@scalar/openapi-upgrader": "0.1.11",
-        "@scalar/snippetz": "0.6.19",
+        "@scalar/helpers": "0.4.3",
+        "@scalar/json-magic": "0.12.5",
+        "@scalar/openapi-upgrader": "0.2.4",
+        "@scalar/snippetz": "0.7.8",
         "@scalar/typebox": "0.1.3",
-        "@scalar/types": "0.6.10",
+        "@scalar/types": "0.7.6",
+        "@scalar/validation": "0.3.0",
         "github-slugger": "2.0.0",
+        "js-base64": "^3.7.8",
         "type-fest": "^5.3.1",
-        "vue": "^3.5.26",
+        "vue": "^3.5.30",
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@scalar/workspace-store/node_modules/type-fest": {
@@ -3005,9 +3300,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -3273,7 +3568,6 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3318,6 +3612,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3842,13 +4143,13 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
-      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.5.30",
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -3873,26 +4174,26 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
-      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.30",
-        "@vue/shared": "3.5.30"
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
-      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/compiler-core": "3.5.30",
-        "@vue/compiler-dom": "3.5.30",
-        "@vue/compiler-ssr": "3.5.30",
-        "@vue/shared": "3.5.30",
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.8",
@@ -3906,13 +4207,13 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
-      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.30",
-        "@vue/shared": "3.5.30"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3922,53 +4223,53 @@
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
-      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.30"
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
-      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.30",
-        "@vue/shared": "3.5.30"
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
-      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.30",
-        "@vue/runtime-core": "3.5.30",
-        "@vue/shared": "3.5.30",
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
-      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.30",
-        "@vue/shared": "3.5.30"
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
-        "vue": "3.5.30"
+        "vue": "3.5.32"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
-      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
@@ -4788,6 +5089,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4823,7 +5135,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5002,9 +5313,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "license": "MIT"
     },
     "node_modules/degenerator": {
@@ -5080,6 +5391,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5551,6 +5868,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5761,12 +6084,16 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {
@@ -6757,7 +7084,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6980,6 +7306,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -7355,6 +7687,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -7509,6 +7847,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8432,6 +8782,88 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.1.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
+      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
+      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
+      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.2.3.tgz",
+      "integrity": "sha512-GEplKC+YYmS0TOlJdv0FzbqkDN/IG2FSwEw+95myECVxTlhty2amwERYjzvorvJXmIagP1grd3Lleq7aQEJpPg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^2.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8484,9 +8916,10 @@
       }
     },
     "node_modules/neverpanic": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.5.tgz",
-      "integrity": "sha512-daO+ijOQG8g2BXaAwpETa0GUvlIAfqC+1/CUdLp2Ga8qwDaUyHIieX/SM0yZoPBf7k92deq4DO7tZOWWeL063Q==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/neverpanic/-/neverpanic-0.0.7.tgz",
+      "integrity": "sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": "5"
       }
@@ -8730,6 +9163,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8744,7 +9183,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8856,6 +9294,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.363.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.363.2.tgz",
+      "integrity": "sha512-4ZEWMrymlFzjgDSmh25VeJQT//2XUFbfKqEPDNUW4dxcqWiVMo1+gJFy5YhJgVYS46OAXLbMcJgmuZBCnDIgVg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.24.1",
+        "@posthog/types": "1.363.2",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8866,16 +9344,19 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-bytes": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
-      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
       "engines": {
-        "node": ">=20"
+        "node": ">=10.13.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -8958,6 +9439,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -9003,6 +9508,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/radix-vue": {
       "version": "1.9.17",
@@ -9601,7 +10112,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9614,7 +10124,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10272,7 +10781,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unhead": {
@@ -10559,6 +11067,15 @@
         }
       }
     },
+    "node_modules/vite-plugin-monaco-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
+      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.33.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
@@ -10641,17 +11158,54 @@
         }
       }
     },
-    "node_modules/vue": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
-      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.30",
-        "@vue/compiler-sfc": "3.5.30",
-        "@vue/runtime-dom": "3.5.30",
-        "@vue/server-renderer": "3.5.30",
-        "@vue/shared": "3.5.30"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -10729,6 +11283,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
@@ -10767,7 +11327,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/plugwerk-server/plugwerk-server-frontend/package.json
+++ b/plugwerk-server/plugwerk-server-frontend/package.json
@@ -22,7 +22,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
-    "@scalar/api-reference-react": "^0.8.70",
+    "@scalar/api-reference-react": "^0.9.20",
     "axios": "^1.13.6",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",


### PR DESCRIPTION
## Summary

- Update `@scalar/api-reference-react` from 0.8.70 to 0.9.20
- Fixes the "Unable to load the document @share/..." error popup that appeared briefly on every API Docs page load
- Root cause was a known Scalar bug (scalar/scalar#8343) fixed in scalar/scalar#8345

## Test plan

- [ ] Navigate to API Docs page — no error popup should appear
- [ ] Verify API docs render correctly in both light and dark mode
- [ ] CI build passes

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)