### PR TITLE
feat(ui): add namespace management section to admin area

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
@@ -27,6 +27,7 @@ import io.plugwerk.api.model.NamespaceRole
 import io.plugwerk.server.domain.NamespaceMemberEntity
 import io.plugwerk.server.repository.NamespaceMemberRepository
 import io.plugwerk.server.repository.NamespaceRepository
+import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
@@ -45,6 +46,7 @@ import io.plugwerk.server.domain.NamespaceRole as DomainRole
 class NamespaceMemberController(
     private val namespaceRepository: NamespaceRepository,
     private val namespaceMemberRepository: NamespaceMemberRepository,
+    private val userRepository: UserRepository,
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
 ) : NamespaceMembersApi {
 
@@ -89,6 +91,10 @@ class NamespaceMemberController(
             DomainRole.ADMIN,
         )
         val namespace = namespaceRepository.findBySlug(ns).orElseThrow { NamespaceNotFoundException(ns) }
+        val subject = namespaceMemberCreateRequest.userSubject
+        if (!userRepository.existsByUsername(subject)) {
+            throw EntityNotFoundException("User", subject)
+        }
         val exists = namespaceMemberRepository.findByNamespaceIdAndUserSubject(
             namespace.id!!,
             namespaceMemberCreateRequest.userSubject,

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -23,6 +23,7 @@ import { AuthApi } from './generated/api/auth-api'
 import { CatalogApi } from './generated/api/catalog-api'
 import { ManagementApi } from './generated/api/management-api'
 import { NamespaceMembersApi } from './generated/api/namespace-members-api'
+import { NamespacesApi } from './generated/api/namespaces-api'
 import { OidcProvidersApi } from './generated/api/oidc-providers-api'
 import { ReviewsApi } from './generated/api/reviews-api'
 import { UpdatesApi } from './generated/api/updates-api'
@@ -60,6 +61,7 @@ export const adminUsersApi = new AdminUsersApi(apiConfig, BASE_PATH, axiosInstan
 export const catalogApi = new CatalogApi(apiConfig, BASE_PATH, axiosInstance)
 export const managementApi = new ManagementApi(apiConfig, BASE_PATH, axiosInstance)
 export const namespaceMembersApi = new NamespaceMembersApi(apiConfig, BASE_PATH, axiosInstance)
+export const namespacesApi = new NamespacesApi(apiConfig, BASE_PATH, axiosInstance)
 export const oidcProvidersApi = new OidcProvidersApi(apiConfig, BASE_PATH, axiosInstance)
 export const reviewsApi = new ReviewsApi(apiConfig, BASE_PATH, axiosInstance)
 export const updatesApi = new UpdatesApi(apiConfig, BASE_PATH, axiosInstance)

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -18,6 +18,7 @@
  */
 import axios from 'axios'
 import { Configuration } from './generated/configuration'
+import { AccessKeysApi } from './generated/api/access-keys-api'
 import { AdminUsersApi } from './generated/api/admin-users-api'
 import { AuthApi } from './generated/api/auth-api'
 import { CatalogApi } from './generated/api/catalog-api'
@@ -56,6 +57,7 @@ axiosInstance.interceptors.response.use(
 
 const apiConfig = new Configuration({ basePath: BASE_PATH })
 
+export const accessKeysApi = new AccessKeysApi(apiConfig, BASE_PATH, axiosInstance)
 export const authApi = new AuthApi(apiConfig, BASE_PATH, axiosInstance)
 export const adminUsersApi = new AdminUsersApi(apiConfig, BASE_PATH, axiosInstance)
 export const catalogApi = new CatalogApi(apiConfig, BASE_PATH, axiosInstance)

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -17,7 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { Box, Typography } from '@mui/material'
-import { Settings, Key, Users, Shield, FileCheck, Trash2 } from 'lucide-react'
+import { Settings, Key, Users, Shield, FileCheck, Trash2, Globe } from 'lucide-react'
 import { tokens } from '../../theme/tokens'
 
 export interface AdminSection {
@@ -29,6 +29,7 @@ export interface AdminSection {
 
 export const ADMIN_SECTIONS: AdminSection[] = [
   { id: 'general',   label: 'General',          icon: <Settings size={16} /> },
+  { id: 'namespaces', label: 'Namespaces',      icon: <Globe size={16} /> },
   { id: 'api-keys',  label: 'API Keys',          icon: <Key size={16} /> },
   { id: 'users',          label: 'Users',             icon: <Users size={16} /> },
   { id: 'oidc-providers', label: 'OIDC Providers',    icon: <Shield size={16} /> },

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@mui/material'
+import { namespacesApi } from '../../api/config'
+import type { NamespaceSummary } from '../../api/generated/model'
+import { isAxiosError } from 'axios'
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/
+
+interface CreateNamespaceDialogProps {
+  open: boolean
+  onClose: () => void
+  onCreated: (ns: NamespaceSummary) => void
+  onError: (message: string) => void
+}
+
+export function CreateNamespaceDialog({ open, onClose, onCreated, onError }: CreateNamespaceDialogProps) {
+  const [slug, setSlug] = useState('')
+  const [ownerOrg, setOwnerOrg] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [slugError, setSlugError] = useState<string | null>(null)
+
+  function handleSlugChange(value: string) {
+    setSlug(value)
+    if (value && !SLUG_PATTERN.test(value)) {
+      setSlugError('Must be lowercase alphanumeric with hyphens, 2\u201364 characters.')
+    } else {
+      setSlugError(null)
+    }
+  }
+
+  function handleClose() {
+    setSlug('')
+    setOwnerOrg('')
+    setSlugError(null)
+    onClose()
+  }
+
+  async function handleCreate() {
+    if (!slug.trim() || !SLUG_PATTERN.test(slug)) return
+    setSaving(true)
+    try {
+      const res = await namespacesApi.createNamespace({
+        namespaceCreateRequest: {
+          slug: slug.trim(),
+          ownerOrg: ownerOrg.trim() || undefined,
+        },
+      })
+      onCreated(res.data)
+      handleClose()
+    } catch (error: unknown) {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setSlugError('Namespace already exists.')
+      } else {
+        onError('Failed to create namespace.')
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Create Namespace</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <TextField
+            label="Slug"
+            value={slug}
+            onChange={(e) => handleSlugChange(e.target.value)}
+            required
+            size="small"
+            autoFocus
+            error={!!slugError}
+            helperText={slugError ?? 'Lowercase alphanumeric with hyphens, 2\u201364 characters.'}
+          />
+          <TextField
+            label="Owner Organisation"
+            value={ownerOrg}
+            onChange={(e) => setOwnerOrg(e.target.value)}
+            size="small"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleCreate}
+          disabled={saving || !slug.trim() || !!slugError}
+        >
+          {saving ? 'Creating\u2026' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { axiosInstance } from '../../api/config'
+import { isAxiosError } from 'axios'
+import type { NamespaceSummary } from '../../api/generated/model'
+import { tokens } from '../../theme/tokens'
+
+interface DeleteNamespaceDialogProps {
+  namespace: NamespaceSummary | null
+  onClose: () => void
+  onDeleted: (slug: string) => void
+  onError: (message: string) => void
+}
+
+export function DeleteNamespaceDialog({ namespace, onClose, onDeleted, onError }: DeleteNamespaceDialogProps) {
+  const [confirmation, setConfirmation] = useState('')
+  const [deleting, setDeleting] = useState(false)
+
+  const slug = namespace?.slug ?? ''
+  const matches = confirmation === slug
+
+  function handleClose() {
+    setConfirmation('')
+    onClose()
+  }
+
+  async function handleDelete() {
+    if (!matches) return
+    setDeleting(true)
+    try {
+      await axiosInstance.delete(`/namespaces/${encodeURIComponent(slug)}`)
+      onDeleted(slug)
+      handleClose()
+    } catch (error: unknown) {
+      if (isAxiosError(error) && (error.response?.status === 404 || error.response?.status === 405)) {
+        onError('Namespace deletion is not yet supported by the server.')
+      } else {
+        onError(`Failed to delete namespace "${slug}".`)
+      }
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <Dialog open={!!namespace} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ color: tokens.color.danger }}>Delete Namespace</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <Typography variant="body2">
+            This will permanently delete all plugins, releases, artifacts, members, and API keys
+            in namespace &lsquo;<strong>{slug}</strong>&rsquo;. This action cannot be undone.
+          </Typography>
+          <TextField
+            label={`Type "${slug}" to confirm`}
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            size="small"
+            autoFocus
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={handleDelete}
+          disabled={deleting || !matches}
+        >
+          {deleting ? 'Deleting\u2026' : 'Delete'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
@@ -27,8 +27,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { axiosInstance } from '../../api/config'
-import { isAxiosError } from 'axios'
+import { namespacesApi } from '../../api/config'
 import type { NamespaceSummary } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 
@@ -55,15 +54,11 @@ export function DeleteNamespaceDialog({ namespace, onClose, onDeleted, onError }
     if (!matches) return
     setDeleting(true)
     try {
-      await axiosInstance.delete(`/namespaces/${encodeURIComponent(slug)}`)
+      await namespacesApi.deleteNamespace({ ns: slug })
       onDeleted(slug)
       handleClose()
-    } catch (error: unknown) {
-      if (isAxiosError(error) && (error.response?.status === 404 || error.response?.status === 405)) {
-        onError('Namespace deletion is not yet supported by the server.')
-      } else {
-        onError(`Failed to delete namespace "${slug}".`)
-      }
+    } catch {
+      onError(`Failed to delete namespace "${slug}".`)
     } finally {
       setDeleting(false)
     }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -43,9 +43,10 @@ import {
   InputLabel,
   Tabs,
   Tab,
+  Autocomplete,
 } from '@mui/material'
 import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
-import { accessKeysApi, namespaceMembersApi, namespacesApi } from '../../api/config'
+import { accessKeysApi, adminUsersApi, namespaceMembersApi, namespacesApi } from '../../api/config'
 import type { AccessKeyDto, NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
 import { NamespaceRole as NamespaceRoleEnum } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
@@ -209,6 +210,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   const [newSubject, setNewSubject] = useState('')
   const [newRole, setNewRole] = useState<NamespaceRole>(NamespaceRoleEnum.Member)
   const [addSaving, setAddSaving] = useState(false)
+  const [userOptions, setUserOptions] = useState<string[]>([])
 
   const loadMembers = useCallback(async () => {
     setLoading(true)
@@ -225,6 +227,20 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   useEffect(() => {
     loadMembers()
   }, [loadMembers])
+
+  useEffect(() => {
+    if (!addOpen) return
+    async function loadUsers() {
+      try {
+        const res = await adminUsersApi.listUsers()
+        const existing = new Set(members.map((m) => m.userSubject))
+        setUserOptions(res.data.map((u) => u.username).filter((u) => !existing.has(u)))
+      } catch {
+        setUserOptions([])
+      }
+    }
+    loadUsers()
+  }, [addOpen, members])
 
   async function handleRoleChange(member: NamespaceMemberDto, role: NamespaceRole) {
     try {
@@ -340,14 +356,21 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         <DialogTitle>Add Member</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            <TextField
-              label="Subject"
-              value={newSubject}
-              onChange={(e) => setNewSubject(e.target.value)}
-              required
-              size="small"
-              autoFocus
-              helperText="Username or OIDC subject claim."
+            <Autocomplete
+              freeSolo
+              options={userOptions}
+              inputValue={newSubject}
+              onInputChange={(_, value) => setNewSubject(value)}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="User"
+                  required
+                  size="small"
+                  autoFocus
+                  helperText="Username or OIDC subject claim."
+                />
+              )}
             />
             <FormControl size="small" required>
               <InputLabel>Role</InputLabel>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -157,7 +157,6 @@ function SettingsSection({ slug, onToast }: { slug: string; onToast: NamespaceDe
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h6">Settings</Typography>
       <TextField
         label="Owner Organisation"
         value={ownerOrg}
@@ -266,8 +265,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Typography variant="h6">Members</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', mb: 2 }}>
         <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setAddOpen(true)}>
           Add Member
         </Button>
@@ -439,8 +437,7 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Typography variant="h6">API Keys</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', mb: 2 }}>
         <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
           Generate Key
         </Button>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -57,6 +57,12 @@ interface NamespaceDetailViewProps {
   onToast: (toast: { message: string; severity: 'success' | 'error' }) => void
 }
 
+const ROLE_LABELS: Record<string, string> = {
+  ADMIN: 'Admin',
+  MEMBER: 'Member',
+  READ_ONLY: 'Read Only',
+}
+
 const ROLE_COLORS: Record<string, 'primary' | 'default' | 'secondary'> = {
   ADMIN: 'primary',
   MEMBER: 'secondary',
@@ -303,7 +309,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
                     {Object.values(NamespaceRoleEnum).map((role) => (
                       <MenuItem key={role} value={role}>
                         <Chip
-                          label={role}
+                          label={ROLE_LABELS[role] ?? role}
                           size="small"
                           color={ROLE_COLORS[role] ?? 'default'}
                           sx={{ cursor: 'pointer' }}
@@ -354,7 +360,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
                 onChange={(e) => setNewRole(e.target.value as NamespaceRole)}
               >
                 {Object.values(NamespaceRoleEnum).map((role) => (
-                  <MenuItem key={role} value={role}>{role}</MenuItem>
+                  <MenuItem key={role} value={role}>{ROLE_LABELS[role] ?? role}</MenuItem>
                 ))}
               </Select>
             </FormControl>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -234,7 +234,11 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       try {
         const res = await adminUsersApi.listUsers()
         const existing = new Set(members.map((m) => m.userSubject))
-        setUserOptions(res.data.map((u) => u.username).filter((u) => !existing.has(u)))
+        setUserOptions(
+          res.data
+            .filter((u) => !u.isSuperadmin && !existing.has(u.username))
+            .map((u) => u.username),
+        )
       } catch {
         setUserOptions([])
       }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -303,17 +303,14 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
                   <Select
                     value={member.role}
                     size="small"
+                    variant="standard"
                     onChange={(e) => handleRoleChange(member, e.target.value as NamespaceRole)}
-                    sx={{ minWidth: 120 }}
+                    sx={{ fontSize: '0.875rem' }}
+                    disableUnderline
                   >
                     {Object.values(NamespaceRoleEnum).map((role) => (
                       <MenuItem key={role} value={role}>
-                        <Chip
-                          label={ROLE_LABELS[role] ?? role}
-                          size="small"
-                          color={ROLE_COLORS[role] ?? 'default'}
-                          sx={{ cursor: 'pointer' }}
-                        />
+                        {ROLE_LABELS[role] ?? role}
                       </MenuItem>
                     ))}
                   </Select>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -42,12 +42,12 @@ import {
   FormControl,
   InputLabel,
 } from '@mui/material'
-import { ArrowLeft, Plus, Trash2 } from 'lucide-react'
-import { axiosInstance, namespaceMembersApi } from '../../api/config'
-import { isAxiosError } from 'axios'
-import type { NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
+import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
+import { accessKeysApi, namespaceMembersApi, namespacesApi } from '../../api/config'
+import type { AccessKeyDto, NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
 import { NamespaceRole as NamespaceRoleEnum } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
+import { formatDateTime } from '../../utils/formatDateTime'
 
 interface NamespaceDetailViewProps {
   slug: string
@@ -81,7 +81,7 @@ export function NamespaceDetailView({ slug, onBack, onToast }: NamespaceDetailVi
       <Divider />
       <MembersSection slug={slug} onToast={onToast} />
       <Divider />
-      <ApiKeysSection />
+      <ApiKeysSection slug={slug} onToast={onToast} />
     </Box>
   )
 }
@@ -91,28 +91,45 @@ function SettingsSection({ slug, onToast }: { slug: string; onToast: NamespaceDe
   const [publicCatalog, setPublicCatalog] = useState(false)
   const [autoApprove, setAutoApprove] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await namespacesApi.listNamespaces()
+        const ns = res.data.find((n) => n.slug === slug)
+        if (ns) {
+          setOwnerOrg(ns.ownerOrg ?? '')
+          setPublicCatalog(ns.publicCatalog ?? false)
+          const settings = ns.settings as Record<string, unknown> | undefined
+          setAutoApprove(settings?.autoApprove === true)
+        }
+      } catch { /* ignore */ }
+      setLoaded(true)
+    }
+    load()
+  }, [slug])
 
   async function handleSave() {
     setSaving(true)
     try {
-      await axiosInstance.patch(`/namespaces/${encodeURIComponent(slug)}`, {
-        ownerOrg: ownerOrg.trim() || null,
-        settings: {
+      await namespacesApi.updateNamespace({
+        ns: slug,
+        namespaceUpdateRequest: {
+          ownerOrg: ownerOrg.trim() || undefined,
           publicCatalog,
-          autoApprove,
+          settings: { autoApprove },
         },
       })
       onToast({ message: 'Namespace settings saved.', severity: 'success' })
-    } catch (error: unknown) {
-      if (isAxiosError(error) && (error.response?.status === 404 || error.response?.status === 405)) {
-        onToast({ message: 'Namespace update is not yet supported by the server.', severity: 'error' })
-      } else {
-        onToast({ message: 'Failed to save namespace settings.', severity: 'error' })
-      }
+    } catch {
+      onToast({ message: 'Failed to save namespace settings.', severity: 'error' })
     } finally {
       setSaving(false)
     }
   }
+
+  if (!loaded) return <CircularProgress size={24} />
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -336,16 +353,174 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   )
 }
 
-function ApiKeysSection() {
+function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDetailViewProps['onToast'] }) {
+  const [keys, setKeys] = useState<AccessKeyDto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [description, setDescription] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [newKey, setNewKey] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const loadKeys = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await accessKeysApi.listAccessKeys({ ns: slug })
+      setKeys(res.data)
+    } catch {
+      setKeys([])
+    } finally {
+      setLoading(false)
+    }
+  }, [slug])
+
+  useEffect(() => {
+    loadKeys()
+  }, [loadKeys])
+
+  async function handleCreate() {
+    setCreating(true)
+    try {
+      const res = await accessKeysApi.createAccessKey({
+        ns: slug,
+        accessKeyCreateRequest: { description: description.trim() || undefined },
+      })
+      setNewKey(res.data.key)
+      setDescription('')
+      setCreateOpen(false)
+      loadKeys()
+    } catch {
+      onToast({ message: 'Failed to create API key.', severity: 'error' })
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleRevoke(keyId: string) {
+    try {
+      await accessKeysApi.revokeAccessKey({ ns: slug, keyId })
+      setKeys((prev) => prev.filter((k) => k.id !== keyId))
+      onToast({ message: 'API key revoked.', severity: 'success' })
+    } catch {
+      onToast({ message: 'Failed to revoke API key.', severity: 'error' })
+    }
+  }
+
+  function handleCopyKey() {
+    if (!newKey) return
+    navigator.clipboard.writeText(newKey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h6">API Keys</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h6">API Keys</Typography>
+        <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
+          Generate Key
+        </Button>
+      </Box>
+
       <Alert severity="info">
-        API keys provide programmatic access. The key is shown only once after creation.
+        API keys provide programmatic access for CI/CD pipelines and the SDK. The key is shown only once after creation.
       </Alert>
-      <Alert severity="warning" sx={{ bgcolor: `${tokens.badge.draft.bg}`, color: tokens.badge.draft.text }}>
-        API key management coming soon.
-      </Alert>
+
+      {newKey && (
+        <Alert
+          severity="success"
+          action={
+            <Button size="small" startIcon={copied ? <Check size={14} /> : <Copy size={14} />} onClick={handleCopyKey}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          }
+          onClose={() => setNewKey(null)}
+        >
+          <Typography variant="caption" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+            {newKey}
+          </Typography>
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : keys.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">No API keys configured.</Typography>
+      ) : (
+        <Table size="small" aria-label="API keys">
+          <TableHead>
+            <TableRow>
+              <TableCell>Description</TableCell>
+              <TableCell>Key Prefix</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Created</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {keys.map((key) => (
+              <TableRow key={key.id} sx={{ opacity: key.revoked ? 0.5 : 1 }}>
+                <TableCell>
+                  <Typography variant="body2">{key.description || '—'}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                    {key.keyPrefix ?? '—'}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={key.revoked ? 'revoked' : 'active'}
+                    size="small"
+                    color={key.revoked ? 'default' : 'success'}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.disabled">
+                    {formatDateTime(key.createdAt)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  {!key.revoked && (
+                    <Button
+                      size="small"
+                      color="error"
+                      startIcon={<Trash2 size={14} />}
+                      onClick={() => handleRevoke(key.id)}
+                    >
+                      Revoke
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Generate API Key</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            <TextField
+              label="Description (optional)"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              size="small"
+              autoFocus
+              helperText="A label to identify this key (e.g. 'CI pipeline')."
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleCreate} disabled={creating}>
+            {creating ? 'Generating\u2026' : 'Generate'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -437,15 +437,14 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', mb: 2 }}>
-        <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+          API keys provide programmatic access for CI/CD pipelines and the SDK. The key is shown only once after creation.
+        </Typography>
+        <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setCreateOpen(true)} sx={{ flexShrink: 0 }}>
           Generate Key
         </Button>
       </Box>
-
-      <Alert severity="info">
-        API keys provide programmatic access for CI/CD pipelines and the SDK. The key is shown only once after creation.
-      </Alert>
 
       {newKey && (
         <Alert

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -21,7 +21,6 @@ import {
   Box,
   Typography,
   Button,
-  Divider,
   TextField,
   Switch,
   FormControlLabel,
@@ -50,7 +49,6 @@ import { accessKeysApi, adminUsersApi, namespaceMembersApi, namespacesApi } from
 import { isAxiosError } from 'axios'
 import type { AccessKeyDto, NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
 import { NamespaceRole as NamespaceRoleEnum } from '../../api/generated/model'
-import { tokens } from '../../theme/tokens'
 import { formatDateTime } from '../../utils/formatDateTime'
 
 interface NamespaceDetailViewProps {
@@ -63,12 +61,6 @@ const ROLE_LABELS: Record<string, string> = {
   ADMIN: 'Admin',
   MEMBER: 'Member',
   READ_ONLY: 'Read Only',
-}
-
-const ROLE_COLORS: Record<string, 'primary' | 'default' | 'secondary'> = {
-  ADMIN: 'primary',
-  MEMBER: 'secondary',
-  READ_ONLY: 'default',
 }
 
 const TAB_IDS = ['settings', 'members', 'api-keys'] as const

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Divider,
+  TextField,
+  Switch,
+  FormControlLabel,
+  Alert,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Chip,
+  Select,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  FormControl,
+  InputLabel,
+} from '@mui/material'
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react'
+import { axiosInstance, namespaceMembersApi } from '../../api/config'
+import { isAxiosError } from 'axios'
+import type { NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
+import { NamespaceRole as NamespaceRoleEnum } from '../../api/generated/model'
+import { tokens } from '../../theme/tokens'
+
+interface NamespaceDetailViewProps {
+  slug: string
+  onBack: () => void
+  onToast: (toast: { message: string; severity: 'success' | 'error' }) => void
+}
+
+const ROLE_COLORS: Record<string, 'primary' | 'default' | 'secondary'> = {
+  ADMIN: 'primary',
+  MEMBER: 'secondary',
+  READ_ONLY: 'default',
+}
+
+export function NamespaceDetailView({ slug, onBack, onToast }: NamespaceDetailViewProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <Box>
+        <Button
+          size="small"
+          startIcon={<ArrowLeft size={14} />}
+          onClick={onBack}
+          sx={{ mb: 1 }}
+        >
+          Back to Namespaces
+        </Button>
+        <Typography variant="h2" gutterBottom>{slug}</Typography>
+        <Divider />
+      </Box>
+
+      <SettingsSection slug={slug} onToast={onToast} />
+      <Divider />
+      <MembersSection slug={slug} onToast={onToast} />
+      <Divider />
+      <ApiKeysSection />
+    </Box>
+  )
+}
+
+function SettingsSection({ slug, onToast }: { slug: string; onToast: NamespaceDetailViewProps['onToast'] }) {
+  const [ownerOrg, setOwnerOrg] = useState('')
+  const [publicCatalog, setPublicCatalog] = useState(false)
+  const [autoApprove, setAutoApprove] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      await axiosInstance.patch(`/namespaces/${encodeURIComponent(slug)}`, {
+        ownerOrg: ownerOrg.trim() || null,
+        settings: {
+          publicCatalog,
+          autoApprove,
+        },
+      })
+      onToast({ message: 'Namespace settings saved.', severity: 'success' })
+    } catch (error: unknown) {
+      if (isAxiosError(error) && (error.response?.status === 404 || error.response?.status === 405)) {
+        onToast({ message: 'Namespace update is not yet supported by the server.', severity: 'error' })
+      } else {
+        onToast({ message: 'Failed to save namespace settings.', severity: 'error' })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Settings</Typography>
+      <TextField
+        label="Owner Organisation"
+        value={ownerOrg}
+        onChange={(e) => setOwnerOrg(e.target.value)}
+        size="small"
+        sx={{ maxWidth: 400 }}
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={publicCatalog}
+            onChange={(e) => setPublicCatalog(e.target.checked)}
+            size="small"
+          />
+        }
+        label="Public Catalog"
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={autoApprove}
+            onChange={(e) => setAutoApprove(e.target.checked)}
+            size="small"
+          />
+        }
+        label="Auto-Approve Releases"
+      />
+      <Button
+        variant="contained"
+        onClick={handleSave}
+        disabled={saving}
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        {saving ? 'Saving\u2026' : 'Save'}
+      </Button>
+    </Box>
+  )
+}
+
+function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDetailViewProps['onToast'] }) {
+  const [members, setMembers] = useState<NamespaceMemberDto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [addOpen, setAddOpen] = useState(false)
+  const [newSubject, setNewSubject] = useState('')
+  const [newRole, setNewRole] = useState<NamespaceRole>(NamespaceRoleEnum.Member)
+  const [addSaving, setAddSaving] = useState(false)
+
+  const loadMembers = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await namespaceMembersApi.listNamespaceMembers({ ns: slug })
+      setMembers(res.data)
+    } catch {
+      setMembers([])
+    } finally {
+      setLoading(false)
+    }
+  }, [slug])
+
+  useEffect(() => {
+    loadMembers()
+  }, [loadMembers])
+
+  async function handleRoleChange(member: NamespaceMemberDto, role: NamespaceRole) {
+    try {
+      const res = await namespaceMembersApi.updateNamespaceMember({
+        ns: slug,
+        userSubject: member.userSubject,
+        namespaceMemberUpdateRequest: { role },
+      })
+      setMembers((prev) => prev.map((m) => (m.userSubject === member.userSubject ? res.data : m)))
+    } catch {
+      onToast({ message: `Failed to update role for "${member.userSubject}".`, severity: 'error' })
+    }
+  }
+
+  async function handleRemove(member: NamespaceMemberDto) {
+    try {
+      await namespaceMembersApi.removeNamespaceMember({ ns: slug, userSubject: member.userSubject })
+      setMembers((prev) => prev.filter((m) => m.userSubject !== member.userSubject))
+      onToast({ message: `Member "${member.userSubject}" removed.`, severity: 'success' })
+    } catch {
+      onToast({ message: `Failed to remove member "${member.userSubject}".`, severity: 'error' })
+    }
+  }
+
+  async function handleAdd() {
+    if (!newSubject.trim()) return
+    setAddSaving(true)
+    try {
+      const res = await namespaceMembersApi.addNamespaceMember({
+        ns: slug,
+        namespaceMemberCreateRequest: { userSubject: newSubject.trim(), role: newRole },
+      })
+      setMembers((prev) => [...prev, res.data])
+      onToast({ message: `Member "${newSubject.trim()}" added.`, severity: 'success' })
+      setAddOpen(false)
+      setNewSubject('')
+      setNewRole(NamespaceRoleEnum.Member)
+    } catch {
+      onToast({ message: 'Failed to add member.', severity: 'error' })
+    } finally {
+      setAddSaving(false)
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h6">Members</Typography>
+        <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setAddOpen(true)}>
+          Add Member
+        </Button>
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : members.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">No members found.</Typography>
+      ) : (
+        <Table size="small" aria-label="Namespace members">
+          <TableHead>
+            <TableRow>
+              <TableCell>Subject</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Created</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {members.map((member) => (
+              <TableRow key={member.userSubject}>
+                <TableCell>
+                  <Typography variant="body2" fontWeight={500}>{member.userSubject}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Select
+                    value={member.role}
+                    size="small"
+                    onChange={(e) => handleRoleChange(member, e.target.value as NamespaceRole)}
+                    sx={{ minWidth: 120 }}
+                  >
+                    {Object.values(NamespaceRoleEnum).map((role) => (
+                      <MenuItem key={role} value={role}>
+                        <Chip
+                          label={role}
+                          size="small"
+                          color={ROLE_COLORS[role] ?? 'default'}
+                          sx={{ cursor: 'pointer' }}
+                        />
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.disabled">
+                    {new Date(member.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    size="small"
+                    color="error"
+                    startIcon={<Trash2 size={14} />}
+                    onClick={() => handleRemove(member)}
+                  >
+                    Remove
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Add Member</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            <TextField
+              label="Subject"
+              value={newSubject}
+              onChange={(e) => setNewSubject(e.target.value)}
+              required
+              size="small"
+              autoFocus
+              helperText="Username or OIDC subject claim."
+            />
+            <FormControl size="small" required>
+              <InputLabel>Role</InputLabel>
+              <Select
+                value={newRole}
+                label="Role"
+                onChange={(e) => setNewRole(e.target.value as NamespaceRole)}
+              >
+                {Object.values(NamespaceRoleEnum).map((role) => (
+                  <MenuItem key={role} value={role}>{role}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleAdd}
+            disabled={addSaving || !newSubject.trim()}
+          >
+            {addSaving ? 'Adding\u2026' : 'Add'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}
+
+function ApiKeysSection() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">API Keys</Typography>
+      <Alert severity="info">
+        API keys provide programmatic access. The key is shown only once after creation.
+      </Alert>
+      <Alert severity="warning" sx={{ bgcolor: `${tokens.badge.draft.bg}`, color: tokens.badge.draft.text }}>
+        API key management coming soon.
+      </Alert>
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -47,6 +47,7 @@ import {
 } from '@mui/material'
 import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
 import { accessKeysApi, adminUsersApi, namespaceMembersApi, namespacesApi } from '../../api/config'
+import { isAxiosError } from 'axios'
 import type { AccessKeyDto, NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
 import { NamespaceRole as NamespaceRoleEnum } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
@@ -210,6 +211,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   const [newSubject, setNewSubject] = useState('')
   const [newRole, setNewRole] = useState<NamespaceRole>(NamespaceRoleEnum.Member)
   const [addSaving, setAddSaving] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
   const [userOptions, setUserOptions] = useState<string[]>([])
 
   const loadMembers = useCallback(async () => {
@@ -272,6 +274,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   async function handleAdd() {
     if (!newSubject.trim()) return
     setAddSaving(true)
+    setAddError(null)
     try {
       const res = await namespaceMembersApi.addNamespaceMember({
         ns: slug,
@@ -282,8 +285,12 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       setAddOpen(false)
       setNewSubject('')
       setNewRole(NamespaceRoleEnum.Member)
-    } catch {
-      onToast({ message: 'Failed to add member.', severity: 'error' })
+    } catch (error: unknown) {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setAddError(error.response.data?.message ?? `User "${newSubject.trim()}" is already a member of this namespace.`)
+      } else {
+        setAddError('Failed to add member.')
+      }
     } finally {
       setAddSaving(false)
     }
@@ -356,15 +363,16 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         </Table>
       )}
 
-      <Dialog open={addOpen} onClose={() => setAddOpen(false)} maxWidth="xs" fullWidth>
+      <Dialog open={addOpen} onClose={() => { setAddOpen(false); setAddError(null) }} maxWidth="xs" fullWidth>
         <DialogTitle>Add Member</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            {addError && <Alert severity="error">{addError}</Alert>}
             <Autocomplete
               freeSolo
               options={userOptions}
               inputValue={newSubject}
-              onInputChange={(_, value) => setNewSubject(value)}
+              onInputChange={(_, value) => { setNewSubject(value); setAddError(null) }}
               renderInput={(params) => (
                 <TextField
                   {...params}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -41,6 +41,8 @@ import {
   DialogActions,
   FormControl,
   InputLabel,
+  Tabs,
+  Tab,
 } from '@mui/material'
 import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
 import { accessKeysApi, namespaceMembersApi, namespacesApi } from '../../api/config'
@@ -61,9 +63,13 @@ const ROLE_COLORS: Record<string, 'primary' | 'default' | 'secondary'> = {
   READ_ONLY: 'default',
 }
 
+const TAB_IDS = ['settings', 'members', 'api-keys'] as const
+
 export function NamespaceDetailView({ slug, onBack, onToast }: NamespaceDetailViewProps) {
+  const [tab, setTab] = useState(0)
+
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box>
         <Button
           size="small"
@@ -74,14 +80,32 @@ export function NamespaceDetailView({ slug, onBack, onToast }: NamespaceDetailVi
           Back to Namespaces
         </Button>
         <Typography variant="h2" gutterBottom>{slug}</Typography>
-        <Divider />
       </Box>
 
-      <SettingsSection slug={slug} onToast={onToast} />
-      <Divider />
-      <MembersSection slug={slug} onToast={onToast} />
-      <Divider />
-      <ApiKeysSection slug={slug} onToast={onToast} />
+      <Tabs
+        value={tab}
+        onChange={(_, v) => setTab(v)}
+        aria-label="Namespace settings tabs"
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="Settings"  id="ns-tab-settings"  aria-controls="ns-panel-settings" />
+        <Tab label="Members"   id="ns-tab-members"   aria-controls="ns-panel-members" />
+        <Tab label="API Keys"  id="ns-tab-api-keys"  aria-controls="ns-panel-api-keys" />
+      </Tabs>
+
+      {TAB_IDS.map((id, i) => (
+        <Box
+          key={id}
+          role="tabpanel"
+          id={`ns-panel-${id}`}
+          aria-labelledby={`ns-tab-${id}`}
+          hidden={tab !== i}
+        >
+          {tab === 0 && i === 0 && <SettingsSection slug={slug} onToast={onToast} />}
+          {tab === 1 && i === 1 && <MembersSection slug={slug} onToast={onToast} />}
+          {tab === 2 && i === 2 && <ApiKeysSection slug={slug} onToast={onToast} />}
+        </Box>
+      ))}
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Divider,
+  Snackbar,
+  Alert,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { namespacesApi } from '../../api/config'
+import type { NamespaceSummary } from '../../api/generated/model'
+import { CreateNamespaceDialog } from './CreateNamespaceDialog'
+import { DeleteNamespaceDialog } from './DeleteNamespaceDialog'
+import { NamespaceDetailView } from './NamespaceDetailView'
+
+export function NamespacesSection() {
+  const [namespaces, setNamespaces] = useState<NamespaceSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<NamespaceSummary | null>(null)
+  const [editingSlug, setEditingSlug] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+  const loadNamespaces = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await namespacesApi.listNamespaces()
+      setNamespaces(res.data)
+    } catch {
+      setNamespaces([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadNamespaces()
+  }, [loadNamespaces])
+
+  function handleCreated(ns: NamespaceSummary) {
+    setNamespaces((prev) => [...prev, ns])
+    setToast({ message: `Namespace "${ns.slug}" created.`, severity: 'success' })
+  }
+
+  function handleDeleted(slug: string) {
+    setNamespaces((prev) => prev.filter((n) => n.slug !== slug))
+    setDeleteTarget(null)
+    setToast({ message: `Namespace "${slug}" deleted.`, severity: 'success' })
+  }
+
+  if (editingSlug) {
+    return (
+      <NamespaceDetailView
+        slug={editingSlug}
+        onBack={() => setEditingSlug(null)}
+        onToast={setToast}
+      />
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box>
+          <Typography variant="h2" gutterBottom>Namespaces</Typography>
+          <Divider sx={{ mb: 3 }} />
+        </Box>
+        <Button variant="outlined" size="small" startIcon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
+          Create Namespace
+        </Button>
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : namespaces.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">No namespaces found.</Typography>
+      ) : (
+        <Table size="small" aria-label="Namespaces">
+          <TableHead>
+            <TableRow>
+              <TableCell>Slug</TableCell>
+              <TableCell>Owner</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {namespaces.map((ns) => (
+              <TableRow key={ns.slug}>
+                <TableCell>
+                  <Typography variant="body2" fontWeight={500}>{ns.slug}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.secondary">{ns.ownerOrg || '\u2014'}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                    <Button
+                      size="small"
+                      startIcon={<Pencil size={14} />}
+                      onClick={() => setEditingSlug(ns.slug)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      size="small"
+                      color="error"
+                      startIcon={<Trash2 size={14} />}
+                      onClick={() => setDeleteTarget(ns)}
+                    >
+                      Delete
+                    </Button>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <CreateNamespaceDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={handleCreated}
+        onError={(msg) => setToast({ message: msg, severity: 'error' })}
+      />
+
+      <DeleteNamespaceDialog
+        namespace={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onDeleted={handleDeleted}
+        onError={(msg) => setToast({ message: msg, severity: 'error' })}
+      />
+
+      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -45,6 +45,7 @@ import {
 } from '@mui/material'
 import { CheckCircle, Plus, Shield, Trash2 } from 'lucide-react'
 import { AdminSidebar } from '../components/admin/AdminSidebar'
+import { NamespacesSection } from '../components/admin/NamespacesSection'
 import { adminUsersApi, oidcProvidersApi, reviewsApi } from '../api/config'
 import { useAuthStore } from '../stores/authStore'
 import type { OidcProviderDto, OidcProviderType, ReviewItemDto, UserDto } from '../api/generated/model'
@@ -671,6 +672,7 @@ function DangerSection() {
 
 const sectionMap: Record<string, React.ReactNode> = {
   general: <GeneralSection />,
+  namespaces: <NamespacesSection />,
   'api-keys': <ApiKeysSection />,
   users: <UsersSection />,
   'oidc-providers': <OidcProvidersSection />,


### PR DESCRIPTION
## Summary

Adds a full namespace management UI to the admin settings area:

- **AdminSidebar**: New "Namespaces" menu item with Globe icon
- **NamespacesSection**: Table listing all namespaces (slug, owner, edit/delete actions)
- **CreateNamespaceDialog**: Form with slug validation (`^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$`), 409 conflict handling
- **NamespaceDetailView**: Edit view with three sub-sections:
  - **Settings** — owner org, public catalog toggle, auto-approve toggle
  - **Members** — add/remove members, inline role change (ADMIN/MEMBER/READ_ONLY)
  - **API Keys** — placeholder for when #125 endpoints are available
- **DeleteNamespaceDialog**: Danger-styled, type-slug-to-confirm pattern

### Graceful degradation
- PATCH/DELETE namespace endpoints (#124) may not exist yet — UI handles 404/405 with toast
- Access key endpoints (#125) not yet available — shows "coming soon" placeholder

## Dependencies
- #124 (PATCH/DELETE namespace) — UI works without, shows error toast
- #125 (access key CRUD) — placeholder section ready to wire up

## Test plan
- [ ] "Namespaces" appears in admin sidebar
- [ ] Namespace list loads and displays
- [ ] Create namespace dialog validates slug format
- [ ] Edit namespace shows settings + members sections
- [ ] Member CRUD works (add, change role, remove)
- [ ] Delete dialog requires slug confirmation

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)