### PR TITLE
feat(api): add PATCH and DELETE endpoints for namespace management

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -324,6 +324,63 @@ paths:
         '409':
           description: A namespace with this slug already exists
 
+  /namespaces/{ns}:
+    patch:
+      tags:
+        - Namespaces
+      summary: Update a namespace
+      description: |
+        Updates namespace properties such as owner organisation, public catalog flag, or settings.
+
+        Requires superadmin privileges or ADMIN role in the namespace.
+      operationId: updateNamespace
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NamespaceUpdateRequest'
+      responses:
+        '200':
+          description: Namespace updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Namespaces
+      summary: Delete a namespace
+      description: |
+        Permanently deletes a namespace and all its plugins, releases, artifacts, members,
+        and access keys. This action cannot be undone.
+
+        Requires superadmin privileges.
+      operationId: deleteNamespace
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+      responses:
+        '204':
+          description: Namespace deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /namespaces/{ns}/plugins:
     get:
       tags:
@@ -1496,6 +1553,17 @@ components:
           type: string
           description: Human-readable name of the organisation that owns this namespace
           example: ACME Corporation
+        publicCatalog:
+          type: boolean
+          description: Whether the catalog is publicly browsable without authentication
+        settings:
+          type: object
+          additionalProperties: true
+          description: Namespace-specific settings (e.g. auto-approve)
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when the namespace was created
       required:
         - slug
         - ownerOrg
@@ -1517,6 +1585,21 @@ components:
           example: ACME Corporation
       required:
         - slug
+
+    NamespaceUpdateRequest:
+      type: object
+      description: Request body for updating namespace properties
+      properties:
+        ownerOrg:
+          type: string
+          description: Human-readable organisation name
+        publicCatalog:
+          type: boolean
+          description: Whether the catalog is publicly browsable without authentication
+        settings:
+          type: object
+          additionalProperties: true
+          description: Namespace-specific settings (e.g. auto-approve)
 
     ErrorResponse:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
@@ -21,6 +21,9 @@ package io.plugwerk.server.controller
 import io.plugwerk.api.NamespacesApi
 import io.plugwerk.api.model.NamespaceCreateRequest
 import io.plugwerk.api.model.NamespaceSummary
+import io.plugwerk.api.model.NamespaceUpdateRequest
+import io.plugwerk.server.domain.NamespaceEntity
+import io.plugwerk.server.domain.NamespaceRole
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.NamespaceAlreadyExistsException
 import io.plugwerk.server.service.NamespaceService
@@ -29,6 +32,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import tools.jackson.databind.ObjectMapper
 import java.net.URI
 
 @RestController
@@ -36,13 +40,14 @@ import java.net.URI
 class NamespaceController(
     private val namespaceService: NamespaceService,
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
+    private val objectMapper: ObjectMapper,
 ) : NamespacesApi {
 
     override fun listNamespaces(): ResponseEntity<List<NamespaceSummary>> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")
         val namespaces = namespaceAuthorizationService.listVisibleNamespaces(auth)
-            .map { NamespaceSummary(slug = it.slug, ownerOrg = it.ownerOrg) }
+            .map { it.toSummary() }
         return ResponseEntity.ok(namespaces)
     }
 
@@ -55,10 +60,43 @@ class NamespaceController(
                 slug = namespaceCreateRequest.slug,
                 ownerOrg = namespaceCreateRequest.ownerOrg ?: "default",
             )
-            val summary = NamespaceSummary(slug = entity.slug, ownerOrg = entity.ownerOrg)
-            ResponseEntity.created(URI("/api/v1/namespaces/${entity.slug}")).body(summary)
+            ResponseEntity.created(URI("/api/v1/namespaces/${entity.slug}")).body(entity.toSummary())
         } catch (_: NamespaceAlreadyExistsException) {
             ResponseEntity.status(409).build()
         }
     }
+
+    override fun updateNamespace(
+        ns: String,
+        namespaceUpdateRequest: NamespaceUpdateRequest,
+    ): ResponseEntity<NamespaceSummary> {
+        val auth = SecurityContextHolder.getContext().authentication
+            ?: throw UnauthorizedException("Not authenticated")
+        namespaceAuthorizationService.requireRole(ns, auth, NamespaceRole.ADMIN)
+        val settingsJson = namespaceUpdateRequest.settings?.let { objectMapper.writeValueAsString(it) }
+        val entity = namespaceService.update(
+            slug = ns,
+            ownerOrg = namespaceUpdateRequest.ownerOrg,
+            publicCatalog = namespaceUpdateRequest.publicCatalog,
+            settings = settingsJson,
+        )
+        return ResponseEntity.ok(entity.toSummary())
+    }
+
+    override fun deleteNamespace(ns: String): ResponseEntity<Unit> {
+        val auth = SecurityContextHolder.getContext().authentication
+            ?: throw UnauthorizedException("Not authenticated")
+        namespaceAuthorizationService.requireSuperadmin(auth)
+        namespaceService.delete(ns)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun NamespaceEntity.toSummary(): NamespaceSummary = NamespaceSummary(
+        slug = slug,
+        ownerOrg = ownerOrg,
+        publicCatalog = publicCatalog,
+        settings = settings?.let { objectMapper.readValue(it, Map::class.java) as Map<String, Any> },
+        createdAt = createdAt,
+    )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/NamespaceService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/NamespaceService.kt
@@ -39,9 +39,15 @@ class NamespaceService(private val namespaceRepository: NamespaceRepository) {
     }
 
     @Transactional
-    fun update(slug: String, ownerOrg: String? = null, settings: String? = null): NamespaceEntity {
+    fun update(
+        slug: String,
+        ownerOrg: String? = null,
+        publicCatalog: Boolean? = null,
+        settings: String? = null,
+    ): NamespaceEntity {
         val entity = findBySlug(slug)
         ownerOrg?.let { entity.ownerOrg = it }
+        publicCatalog?.let { entity.publicCatalog = it }
         settings?.let { entity.settings = it }
         return namespaceRepository.save(entity)
     }


### PR DESCRIPTION
## Summary

Adds missing CRUD endpoints for namespace management:

- **PATCH /api/v1/namespaces/{ns}** — Update namespace properties (ownerOrg, publicCatalog, settings)
  - Requires ADMIN role in namespace (superadmin passes implicitly)
- **DELETE /api/v1/namespaces/{ns}** — Delete namespace with cascading deletion
  - Requires superadmin privileges

### Changes
- **OpenAPI spec**: Added `/namespaces/{ns}` path with PATCH + DELETE operations, `NamespaceUpdateRequest` schema
- **NamespaceSummary**: Extended with `publicCatalog`, `settings`, `createdAt` fields
- **NamespaceService**: `update()` now supports `publicCatalog` parameter
- **NamespaceController**: Implemented `updateNamespace` + `deleteNamespace`, refactored to shared `toSummary()` mapper

## Test plan
- [x] All existing tests pass
- [ ] PATCH updates ownerOrg, publicCatalog, settings
- [ ] DELETE removes namespace and cascaded resources
- [ ] Auth: only ADMIN can update, only superadmin can delete

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)