### PR TITLE
feat(api): add namespace access key CRUD endpoints

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -174,6 +174,15 @@ tags:
       The `userSubject` is either a local username or an OIDC `sub` claim.
 
       Requires `ADMIN` role on the namespace.
+  - name: AccessKeys
+    description: |
+      Manage namespace-scoped API access keys.
+
+      Access keys are long-lived credentials suitable for CI/CD pipelines and service accounts.
+      They grant implicit ADMIN access to their namespace. The plain-text key is returned only
+      once at creation time — only the SHA-256 hash is stored on the server.
+
+      All endpoints require `ADMIN` role on the namespace.
   - name: ServerConfig
     description: |
       Public, unauthenticated endpoint exposing non-sensitive server configuration.
@@ -1207,6 +1216,92 @@ paths:
       responses:
         '204':
           description: Member removed
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /namespaces/{ns}/access-keys:
+    get:
+      tags:
+        - AccessKeys
+      summary: List access keys
+      description: Lists all access keys for the namespace. Key values are never returned — only metadata. Requires ADMIN role.
+      operationId: listAccessKeys
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+      responses:
+        '200':
+          description: List of access keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccessKeyDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags:
+        - AccessKeys
+      summary: Generate a new access key
+      description: |
+        Generates a new access key for the namespace. The plain-text key is returned
+        only in this response and cannot be retrieved later. Store it securely.
+        Requires ADMIN role.
+      operationId: createAccessKey
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccessKeyCreateRequest'
+      responses:
+        '201':
+          description: Access key created. The plain key is included only in this response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyCreateResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /namespaces/{ns}/access-keys/{keyId}:
+    delete:
+      tags:
+        - AccessKeys
+      summary: Revoke an access key
+      description: Permanently revokes an access key. Requires ADMIN role.
+      operationId: revokeAccessKey
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NamespaceSlug'
+        - name: keyId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Access key revoked
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2259,6 +2354,65 @@ components:
             - maxFileSizeMb
       required:
         - upload
+
+    AccessKeyDto:
+      type: object
+      description: Metadata for a namespace access key (the key value is never returned)
+      properties:
+        id:
+          type: string
+          format: uuid
+        description:
+          type: string
+        keyPrefix:
+          type: string
+          description: First 8 characters of the key hash for identification
+        revoked:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - revoked
+        - createdAt
+
+    AccessKeyCreateRequest:
+      type: object
+      description: Request body for generating a new namespace access key
+      properties:
+        description:
+          type: string
+          description: Optional human-readable description
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiry date
+
+    AccessKeyCreateResponse:
+      type: object
+      description: |
+        Response returned when a new access key is created. The plain-text key is included
+        only in this response and cannot be retrieved later.
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+          description: The plain-text access key. Only returned once — store it securely.
+        description:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - key
+        - createdAt
 
   responses:
     BadRequest:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AccessKeysApi
+import io.plugwerk.api.model.AccessKeyCreateRequest
+import io.plugwerk.api.model.AccessKeyCreateResponse
+import io.plugwerk.api.model.AccessKeyDto
+import io.plugwerk.server.domain.NamespaceAccessKeyEntity
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.service.AccessKeyService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+import java.util.UUID
+import io.plugwerk.server.domain.NamespaceRole as DomainRole
+
+@RestController
+@RequestMapping("/api/v1")
+class AccessKeyController(
+    private val accessKeyService: AccessKeyService,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AccessKeysApi {
+
+    override fun listAccessKeys(ns: String): ResponseEntity<List<AccessKeyDto>> {
+        namespaceAuthorizationService.requireRole(
+            ns,
+            SecurityContextHolder.getContext().authentication!!,
+            DomainRole.ADMIN,
+        )
+        val keys = accessKeyService.listByNamespace(ns).map { it.toDto() }
+        return ResponseEntity.ok(keys)
+    }
+
+    override fun createAccessKey(
+        ns: String,
+        accessKeyCreateRequest: AccessKeyCreateRequest,
+    ): ResponseEntity<AccessKeyCreateResponse> {
+        namespaceAuthorizationService.requireRole(
+            ns,
+            SecurityContextHolder.getContext().authentication!!,
+            DomainRole.ADMIN,
+        )
+        val (entity, plainKey) = accessKeyService.create(
+            namespaceSlug = ns,
+            description = accessKeyCreateRequest.description,
+            expiresAt = accessKeyCreateRequest.expiresAt,
+        )
+        val response = AccessKeyCreateResponse(
+            id = entity.id!!,
+            key = plainKey,
+            description = entity.description,
+            createdAt = entity.createdAt,
+        )
+        return ResponseEntity
+            .created(URI("/api/v1/namespaces/$ns/access-keys/${entity.id}"))
+            .body(response)
+    }
+
+    override fun revokeAccessKey(ns: String, keyId: UUID): ResponseEntity<Unit> {
+        namespaceAuthorizationService.requireRole(
+            ns,
+            SecurityContextHolder.getContext().authentication!!,
+            DomainRole.ADMIN,
+        )
+        accessKeyService.revoke(ns, keyId)
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun NamespaceAccessKeyEntity.toDto() = AccessKeyDto(
+        id = id!!,
+        description = description,
+        keyPrefix = keyHash.take(8),
+        revoked = revoked,
+        expiresAt = expiresAt,
+        createdAt = createdAt,
+    )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepository.kt
@@ -28,5 +28,7 @@ interface NamespaceAccessKeyRepository : JpaRepository<NamespaceAccessKeyEntity,
 
     fun findByKeyHash(keyHash: String): Optional<NamespaceAccessKeyEntity>
 
+    fun findAllByNamespace(namespace: NamespaceEntity): List<NamespaceAccessKeyEntity>
+
     fun findAllByNamespaceAndRevokedFalse(namespace: NamespaceEntity): List<NamespaceAccessKeyEntity>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service
+
+import io.plugwerk.server.domain.NamespaceAccessKeyEntity
+import io.plugwerk.server.repository.NamespaceAccessKeyRepository
+import io.plugwerk.server.repository.NamespaceRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Service for managing namespace-scoped API access keys.
+ *
+ * Access keys are long-lived credentials suitable for CI/CD pipelines and service accounts.
+ * The plain-text key is returned exactly once at creation time; only the SHA-256 hash is persisted.
+ *
+ * Generated keys use the format `pwk_<40 random alphanumeric chars>`.
+ */
+@Service
+@Transactional(readOnly = true)
+class AccessKeyService(
+    private val accessKeyRepository: NamespaceAccessKeyRepository,
+    private val namespaceRepository: NamespaceRepository,
+) {
+
+    companion object {
+        private const val KEY_PREFIX = "pwk_"
+        private const val KEY_RANDOM_LENGTH = 40
+        private val ALPHANUMERIC = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+        private val SECURE_RANDOM = SecureRandom()
+    }
+
+    /**
+     * Lists all access keys for the given namespace (active and revoked).
+     */
+    fun listByNamespace(namespaceSlug: String): List<NamespaceAccessKeyEntity> {
+        val namespace = namespaceRepository.findBySlug(namespaceSlug)
+            .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
+        return accessKeyRepository.findAllByNamespace(namespace)
+    }
+
+    /**
+     * Generates a new access key for the namespace.
+     *
+     * @return a pair of the persisted entity and the plain-text key (returned only once).
+     */
+    @Transactional
+    fun create(
+        namespaceSlug: String,
+        description: String?,
+        expiresAt: OffsetDateTime?,
+    ): Pair<NamespaceAccessKeyEntity, String> {
+        val namespace = namespaceRepository.findBySlug(namespaceSlug)
+            .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
+
+        val plainKey = generatePlainKey()
+        val keyHash = sha256Hex(plainKey)
+
+        val entity = accessKeyRepository.save(
+            NamespaceAccessKeyEntity(
+                namespace = namespace,
+                keyHash = keyHash,
+                description = description,
+                expiresAt = expiresAt,
+            ),
+        )
+        return entity to plainKey
+    }
+
+    /**
+     * Revokes an access key by setting [NamespaceAccessKeyEntity.revoked] to `true`.
+     *
+     * @throws EntityNotFoundException if no key with the given ID exists in the namespace.
+     */
+    @Transactional
+    fun revoke(namespaceSlug: String, keyId: UUID) {
+        val namespace = namespaceRepository.findBySlug(namespaceSlug)
+            .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
+
+        val key = accessKeyRepository.findById(keyId)
+            .filter { it.namespace.id == namespace.id }
+            .orElseThrow { EntityNotFoundException("AccessKey", keyId.toString()) }
+
+        key.revoked = true
+        accessKeyRepository.save(key)
+    }
+
+    private fun generatePlainKey(): String {
+        val randomPart = (1..KEY_RANDOM_LENGTH)
+            .map { ALPHANUMERIC[SECURE_RANDOM.nextInt(ALPHANUMERIC.size)] }
+            .joinToString("")
+        return "$KEY_PREFIX$randomPart"
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(input.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}


### PR DESCRIPTION
## Summary

Adds API endpoints for managing namespace-scoped access keys:

- **GET /api/v1/namespaces/{ns}/access-keys** — List keys (masked, shows key prefix from hash)
- **POST /api/v1/namespaces/{ns}/access-keys** — Generate key (`pwk_` + 40 random chars, plain key returned only once)
- **DELETE /api/v1/namespaces/{ns}/access-keys/{keyId}** — Revoke key (sets `revoked=true`, preserves audit trail)

### Changes
- **OpenAPI spec**: 3 new endpoints, `AccessKeys` tag, 3 new schemas
- **AccessKeyService**: Key generation via `SecureRandom`, SHA-256 hashing, revoke logic
- **AccessKeyController**: Implements `AccessKeysApi`, all endpoints require ADMIN role
- **NamespaceAccessKeyRepository**: Added `findAllByNamespace()` query

### Design decisions
- `keyPrefix` = first 8 chars of SHA-256 hash (no new DB column)
- Revoke sets `revoked=true` instead of deleting (audit trail)
- Key format: `pwk_<40 alphanumeric chars>`

## Test plan
- [x] Build passes, all existing tests green
- [ ] POST returns plain key only once
- [ ] GET returns list without plain keys
- [ ] DELETE sets revoked flag
- [ ] Only ADMIN role can access endpoints

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)