### PR TITLE
feat(ui): clean up admin area — remove obsolete sections and widen layout

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -17,7 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { Box, Typography } from '@mui/material'
-import { Settings, Key, Users, Shield, FileCheck, Trash2, Globe } from 'lucide-react'
+import { Settings, Users, Shield, FileCheck, Globe } from 'lucide-react'
 import { tokens } from '../../theme/tokens'
 
 export interface AdminSection {
@@ -30,11 +30,9 @@ export interface AdminSection {
 export const ADMIN_SECTIONS: AdminSection[] = [
   { id: 'general',   label: 'General',          icon: <Settings size={16} /> },
   { id: 'namespaces', label: 'Namespaces',      icon: <Globe size={16} /> },
-  { id: 'api-keys',  label: 'API Keys',          icon: <Key size={16} /> },
   { id: 'users',          label: 'Users',             icon: <Users size={16} /> },
   { id: 'oidc-providers', label: 'OIDC Providers',    icon: <Shield size={16} /> },
   { id: 'reviews',        label: 'Pending Reviews',   icon: <FileCheck size={16} /> },
-  { id: 'danger',    label: 'Danger Zone',       icon: <Trash2 size={16} />, danger: true },
 ]
 
 interface AdminSidebarProps {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -57,8 +57,6 @@ function GeneralSection() {
         <Typography variant="h2" gutterBottom>General Settings</Typography>
         <Divider sx={{ mb: 3 }} />
       </Box>
-      <TextField label="Instance Name" defaultValue="ACME Corp Plugin Hub" size="small" />
-      <TextField label="Default Namespace" defaultValue="default" size="small" />
       <TextField label="Max Upload Size (MB)" type="number" defaultValue={50} size="small" />
       <FormControl size="small" sx={{ minWidth: 200 }}>
         <InputLabel>Default Language</InputLabel>
@@ -68,21 +66,6 @@ function GeneralSection() {
         </Select>
       </FormControl>
       <Button variant="contained" sx={{ alignSelf: 'flex-start' }}>Save Changes</Button>
-    </Box>
-  )
-}
-
-function ApiKeysSection() {
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <Box>
-        <Typography variant="h2" gutterBottom>API Keys</Typography>
-        <Divider sx={{ mb: 3 }} />
-      </Box>
-      <Alert severity="info">
-        API keys are used to authenticate requests from the CLI and CI/CD pipelines.
-      </Alert>
-      <Button variant="outlined" sx={{ alignSelf: 'flex-start' }}>Generate New API Key</Button>
     </Box>
   )
 }
@@ -649,35 +632,12 @@ function ReviewsSection() {
   )
 }
 
-function DangerSection() {
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <Box>
-        <Typography variant="h2" gutterBottom color="error">Danger Zone</Typography>
-        <Divider sx={{ mb: 3 }} />
-      </Box>
-      <Alert severity="warning">
-        Actions in this section are irreversible. Proceed with caution.
-      </Alert>
-      <Box sx={{ border: '1px solid', borderColor: 'error.main', borderRadius: 1, p: 2 }}>
-        <Typography variant="body2" fontWeight={600} gutterBottom>Reset namespace</Typography>
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
-          Delete all plugins and releases in the default namespace. This cannot be undone.
-        </Typography>
-        <Button variant="outlined" color="error" size="small">Reset namespace</Button>
-      </Box>
-    </Box>
-  )
-}
-
 const sectionMap: Record<string, React.ReactNode> = {
   general: <GeneralSection />,
   namespaces: <NamespacesSection />,
-  'api-keys': <ApiKeysSection />,
   users: <UsersSection />,
   'oidc-providers': <OidcProvidersSection />,
   reviews: <ReviewsSection />,
-  danger: <DangerSection />,
 }
 
 export function AdminSettingsPage() {
@@ -687,7 +647,7 @@ export function AdminSettingsPage() {
     <Box component="main" id="main-content" sx={{ flex: 1, display: 'flex' }}>
       <AdminSidebar activeSection={activeSection} onSelect={setActiveSection} />
       <Box sx={{ flex: 1, overflow: 'auto' }}>
-        <Container maxWidth="md" sx={{ py: 4, maxWidth: 800 }}>
+        <Container maxWidth="lg" sx={{ py: 4 }}>
           {sectionMap[activeSection]}
         </Container>
       </Box>


### PR DESCRIPTION
## Summary

- Remove **"API Keys"** and **"Danger Zone"** menu items from admin sidebar
- Remove **"Instance Name"** and **"Default Namespace"** fields from General Settings
- Delete `ApiKeysSection` and `DangerSection` functions
- Widen content area from `maxWidth: 800px` to `maxWidth="lg"` for full-width tables

## Changed files

| File | Change |
|------|--------|
| `AdminSidebar.tsx` | Remove 2 menu entries, clean up unused icon imports |
| `AdminSettingsPage.tsx` | Remove 2 sections + 2 fields, widen container |

## Test plan

- [ ] "API Keys" and "Danger Zone" no longer in admin sidebar
- [ ] "Instance Name" and "Default Namespace" fields gone from General
- [ ] Content area uses full width on all admin sub-pages
- [ ] No layout regressions

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)