### PR TITLE
feat(api-keys): rename description to name and add expiry date UI

### DIFF
--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -56,7 +56,7 @@ ON CONFLICT DO NOTHING;
 -- ============================================================
 -- Namespace Access Keys
 -- ============================================================
-INSERT INTO namespace_access_key (id, namespace_id, key_hash, description, revoked, expires_at) VALUES
+INSERT INTO namespace_access_key (id, namespace_id, key_hash, name, revoked, expires_at) VALUES
   ('c0000000-0000-0000-0000-000000000001',
    (SELECT id FROM namespace WHERE slug = 'default'),
    'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90',

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2443,8 +2443,9 @@ components:
         id:
           type: string
           format: uuid
-        description:
+        name:
           type: string
+          description: Optional human-readable name to identify the key
         keyPrefix:
           type: string
           description: First 8 characters of the key hash for identification
@@ -2465,9 +2466,9 @@ components:
       type: object
       description: Request body for generating a new namespace access key
       properties:
-        description:
+        name:
           type: string
-          description: Optional human-readable description
+          description: Optional human-readable name to identify the key
         expiresAt:
           type: string
           format: date-time
@@ -2485,8 +2486,9 @@ components:
         key:
           type: string
           description: The plain-text access key. Only returned once — store it securely.
-        description:
+        name:
           type: string
+          description: Optional human-readable name to identify the key
         createdAt:
           type: string
           format: date-time

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
@@ -61,13 +61,13 @@ class AccessKeyController(
         )
         val (entity, plainKey) = accessKeyService.create(
             namespaceSlug = ns,
-            description = accessKeyCreateRequest.description,
+            name = accessKeyCreateRequest.name,
             expiresAt = accessKeyCreateRequest.expiresAt,
         )
         val response = AccessKeyCreateResponse(
             id = entity.id!!,
             key = plainKey,
-            description = entity.description,
+            name = entity.name,
             createdAt = entity.createdAt,
         )
         return ResponseEntity
@@ -87,7 +87,7 @@ class AccessKeyController(
 
     private fun NamespaceAccessKeyEntity.toDto() = AccessKeyDto(
         id = id!!,
-        description = description,
+        name = name,
         keyPrefix = keyHash.take(8),
         revoked = revoked,
         expiresAt = expiresAt,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
@@ -56,7 +56,7 @@ import java.util.UUID
  * @property namespace The [NamespaceEntity] this key grants access to (lazy-loaded).
  * @property keyHash SHA-256 hash of the API key (hex-encoded, 64 chars).
  *   Compared against incoming requests for authentication.
- * @property description Optional free-text description of the intended use
+ * @property name Optional human-readable name to identify the key
  *   (e.g. `CI/CD Pipeline`).
  * @property revoked `true` if the key has been manually revoked and no longer permits
  *   authentication.
@@ -79,8 +79,8 @@ class NamespaceAccessKeyEntity(
     @Column(name = "key_hash", nullable = false, unique = true, length = 64)
     var keyHash: String,
 
-    @Column(name = "description", length = 255)
-    var description: String? = null,
+    @Column(name = "name", length = 255)
+    var name: String? = null,
 
     @Column(name = "revoked", nullable = false)
     var revoked: Boolean = false,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
@@ -67,7 +67,7 @@ class AccessKeyService(
     @Transactional
     fun create(
         namespaceSlug: String,
-        description: String?,
+        name: String?,
         expiresAt: OffsetDateTime?,
     ): Pair<NamespaceAccessKeyEntity, String> {
         val namespace = namespaceRepository.findBySlug(namespaceSlug)
@@ -80,7 +80,7 @@ class AccessKeyService(
             NamespaceAccessKeyEntity(
                 namespace = namespace,
                 keyHash = keyHash,
-                description = description,
+                name = name,
                 expiresAt = expiresAt,
             ),
         )

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -239,7 +239,7 @@ databaseChangeLog:
                     unique: true
                     uniqueConstraintName: uq_namespace_access_key_hash
               - column:
-                  name: description
+                  name: name
                   type: varchar(255)
               - column:
                   name: revoked

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepositoryTest.kt
@@ -85,14 +85,14 @@ open class NamespaceAccessKeyRepositoryTest : AbstractRepositoryTest() {
                 NamespaceAccessKeyEntity(
                     namespace = namespace,
                     keyHash = "full-key-hash",
-                    description = "CI/CD key",
+                    name = "CI/CD key",
                     expiresAt = expiresAt,
                 ),
             )
 
         val found = apiKeyRepository.findById(key.id!!).orElseThrow()
 
-        assertThat(found.description).isEqualTo("CI/CD key")
+        assertThat(found.name).isEqualTo("CI/CD key")
         assertThat(found.expiresAt).isNotNull()
         assertThat(found.revoked).isFalse()
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
@@ -185,7 +185,7 @@ class NamespaceServiceIntegrationTest {
             NamespaceAccessKeyEntity(
                 namespace = namespace,
                 keyHash = "cascade-test-key-hash",
-                description = "Test key",
+                name = "Test key",
             ),
         )
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -408,7 +408,8 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   const [keys, setKeys] = useState<AccessKeyDto[]>([])
   const [loading, setLoading] = useState(true)
   const [createOpen, setCreateOpen] = useState(false)
-  const [description, setDescription] = useState('')
+  const [keyName, setKeyName] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
   const [creating, setCreating] = useState(false)
   const [newKey, setNewKey] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
@@ -434,10 +435,14 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
     try {
       const res = await accessKeysApi.createAccessKey({
         ns: slug,
-        accessKeyCreateRequest: { description: description.trim() || undefined },
+        accessKeyCreateRequest: {
+          name: keyName.trim() || undefined,
+          expiresAt: expiresAt || undefined,
+        },
       })
       setNewKey(res.data.key)
-      setDescription('')
+      setKeyName('')
+      setExpiresAt('')
       setCreateOpen(false)
       loadKeys()
     } catch {
@@ -501,9 +506,10 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         <Table size="small" aria-label="API keys">
           <TableHead>
             <TableRow>
-              <TableCell>Description</TableCell>
+              <TableCell>Name</TableCell>
               <TableCell>Key Prefix</TableCell>
               <TableCell>Status</TableCell>
+              <TableCell>Expires</TableCell>
               <TableCell>Created</TableCell>
               <TableCell />
             </TableRow>
@@ -512,7 +518,7 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
             {keys.map((key) => (
               <TableRow key={key.id} sx={{ opacity: key.revoked ? 0.5 : 1 }}>
                 <TableCell>
-                  <Typography variant="body2">{key.description || '—'}</Typography>
+                  <Typography variant="body2">{key.name || '—'}</Typography>
                 </TableCell>
                 <TableCell>
                   <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
@@ -525,6 +531,11 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
                     size="small"
                     color={key.revoked ? 'default' : 'success'}
                   />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.disabled">
+                    {key.expiresAt ? formatDateTime(key.expiresAt) : 'Never'}
+                  </Typography>
                 </TableCell>
                 <TableCell>
                   <Typography variant="caption" color="text.disabled">
@@ -554,12 +565,21 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
             <TextField
-              label="Description (optional)"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              label="Name (optional)"
+              value={keyName}
+              onChange={(e) => setKeyName(e.target.value)}
               size="small"
               autoFocus
               helperText="A label to identify this key (e.g. 'CI pipeline')."
+            />
+            <TextField
+              label="Expires (optional)"
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              size="small"
+              slotProps={{ inputLabel: { shrink: true } }}
+              helperText="Leave empty for a key that never expires."
             />
           </Box>
         </DialogContent>


### PR DESCRIPTION
## Summary

- **Rename `description` → `name`** across the entire stack: DB migration, entity, OpenAPI spec, service, controller, seed data, frontend
- **Expiry date picker** in the Generate API Key dialog (optional datetime-local field)
- **"Expires" column** in the API keys table showing formatted date or "Never"

## Changed files (8)

| File | Change |
|------|--------|
| `0001_initial_schema.yaml` | Column rename `description` → `name` in `namespace_access_key` |
| `NamespaceAccessKeyEntity.kt` | Property + annotation rename |
| `plugwerk-api.yaml` | 3 schemas updated (Dto, CreateRequest, CreateResponse) |
| `AccessKeyService.kt` | Parameter rename |
| `AccessKeyController.kt` | Mapping rename in create + toDto |
| `NamespaceAccessKeyRepositoryTest.kt` | Test field reference updated |
| `seed-testdata.sql` | Column name in INSERT |
| `NamespaceDetailView.tsx` | Name field, expiry picker, Expires column |

## Test plan

- [x] Backend build passes (`./gradlew build -x test`)
- [ ] Generate key with name + expiry date
- [ ] Generate key without expiry → shows "Never"
- [ ] Table shows Name and Expires columns
- [ ] Existing keys display correctly after migration

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)