### PR TITLE
fix: exclude disabled users from member autocomplete

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1010,6 +1010,13 @@ paths:
       operationId: listUsers
       security:
         - BearerAuth: []
+      parameters:
+        - name: enabled
+          in: query
+          required: false
+          description: Filter by enabled state. When omitted, all users are returned.
+          schema:
+            type: boolean
       responses:
         '200':
           description: List of all local users

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -39,11 +39,12 @@ class AdminUserController(
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
 ) : AdminUsersApi {
 
-    override fun listUsers(): ResponseEntity<List<UserDto>> {
+    override fun listUsers(enabled: Boolean?): ResponseEntity<List<UserDto>> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")
         namespaceAuthorizationService.requireSuperadmin(auth)
-        return ResponseEntity.ok(userService.findAll().map { it.toDto() })
+        val users = if (enabled != null) userService.findAllByEnabled(enabled) else userService.findAll()
+        return ResponseEntity.ok(users.map { it.toDto() })
     }
 
     override fun createUser(userCreateRequest: UserCreateRequest): ResponseEntity<UserDto> {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
@@ -28,4 +28,6 @@ interface UserRepository : JpaRepository<UserEntity, UUID> {
     fun findByUsername(username: String): Optional<UserEntity>
 
     fun existsByUsername(username: String): Boolean
+
+    fun findAllByEnabled(enabled: Boolean): List<UserEntity>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
@@ -33,6 +33,9 @@ class UserService(private val userRepository: UserRepository, private val passwo
     fun findAll(): List<UserEntity> = userRepository.findAll()
 
     @Transactional(readOnly = true)
+    fun findAllByEnabled(enabled: Boolean): List<UserEntity> = userRepository.findAllByEnabled(enabled)
+
+    @Transactional(readOnly = true)
     fun findById(id: UUID): UserEntity =
         userRepository.findById(id).orElseThrow { EntityNotFoundException("User", id.toString()) }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -112,6 +112,43 @@ class AdminUserControllerTest {
     }
 
     @Test
+    fun `GET admin users with enabled=true returns only enabled users`() {
+        val enabledUser = stubUser("alice", enabled = true)
+        whenever(userService.findAllByEnabled(true)).thenReturn(listOf(enabledUser))
+
+        mockMvc.get("/api/v1/admin/users?enabled=true").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(1) }
+            jsonPath("$[0].username") { value("alice") }
+            jsonPath("$[0].enabled") { value(true) }
+        }
+    }
+
+    @Test
+    fun `GET admin users with enabled=false returns only disabled users`() {
+        val disabledUser = stubUser("bob", enabled = false)
+        whenever(userService.findAllByEnabled(false)).thenReturn(listOf(disabledUser))
+
+        mockMvc.get("/api/v1/admin/users?enabled=false").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(1) }
+            jsonPath("$[0].username") { value("bob") }
+            jsonPath("$[0].enabled") { value(false) }
+        }
+    }
+
+    @Test
+    fun `GET admin users without enabled param returns all users`() {
+        val users = listOf(stubUser("alice", enabled = true), stubUser("bob", enabled = false))
+        whenever(userService.findAll()).thenReturn(users)
+
+        mockMvc.get("/api/v1/admin/users").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(2) }
+        }
+    }
+
+    @Test
     fun `GET admin users returns empty list when no users`() {
         whenever(userService.findAll()).thenReturn(emptyList())
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -225,7 +225,7 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
     if (!addOpen) return
     async function loadUsers() {
       try {
-        const res = await adminUsersApi.listUsers()
+        const res = await adminUsersApi.listUsers({ enabled: true })
         const existing = new Set(members.map((m) => m.userSubject))
         setUserOptions(
           res.data


### PR DESCRIPTION
## Summary

- Add optional `enabled` query parameter to `GET /api/v1/admin/users` for server-side filtering
- "Add Member" autocomplete now requests only enabled users (`?enabled=true`)
- Admin user management table continues to show all users (no parameter passed)

## Changes

| File | Change |
|------|--------|
| `plugwerk-api.yaml` | Optional `enabled` boolean query param on `listUsers` |
| `UserRepository.kt` | `findAllByEnabled(Boolean)` |
| `UserService.kt` | `findAllByEnabled(Boolean)` delegation |
| `AdminUserController.kt` | Accept `enabled?` param, delegate to filtered/unfiltered query |
| `AdminUserControllerTest.kt` | 3 new tests: `?enabled=true`, `?enabled=false`, no param |
| `NamespaceDetailView.tsx` | Pass `{ enabled: true }` to `listUsers()` in member autocomplete |

## Test plan

- [x] `GET /admin/users?enabled=true` returns only enabled users
- [x] `GET /admin/users?enabled=false` returns only disabled users
- [x] `GET /admin/users` (no param) returns all users — backward compatible
- [x] All existing tests pass (no regressions)
- [ ] Manual: disable a user, verify they don't appear in "Add Member" autocomplete
- [ ] Manual: admin user table still shows disabled users

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)