### PR TITLE
chore: update repository references to plugwerk/plugwerk

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: signatures/cla.json
-          path-to-document: https://github.com/devtank42gmbh/plugwerk/blob/main/CLA.md
+          path-to-document: https://github.com/plugwerk/plugwerk/blob/main/CLA.md
           branch: cla-signatures
           allowlist: bigpuritz,devtank42,*[bot]
           create-file-commit-message: "chore: initialize CLA signatures file"
@@ -34,7 +34,7 @@ jobs:
             Before we can merge this PR, you need to sign the **Contributor License Agreement (CLA)**.
             This is required to allow PlugWerk to offer commercial licensing alongside its open-source license.
 
-            Please read [CLA.md](https://github.com/devtank42gmbh/plugwerk/blob/main/CLA.md) — it is short and written in plain language.
+            Please read [CLA.md](https://github.com/plugwerk/plugwerk/blob/main/CLA.md) — it is short and written in plain language.
 
             Then post the following comment **in this PR**:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Project concept: `docs/concepts/concept-pf4j-marketplace-en.md`
 
 ## Project Status
 
-Phase 1 (Core) is **complete**. Phase 2 (Enterprise) is **in active development** — multi-namespace RBAC, OIDC authentication, and review workflows are implemented. Tracking issue: [#7](https://github.com/devtank42gmbh/plugwerk/issues/7).
+Phase 1 (Core) is **complete**. Phase 2 (Enterprise) is **in active development** — multi-namespace RBAC, OIDC authentication, and review workflows are implemented. Tracking issue: [#7](https://github.com/plugwerk/plugwerk/issues/7).
 
 ## Naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Your signature is recorded automatically. You only need to sign once.
 ### Setup
 
 ```bash
-git clone https://github.com/devtank42gmbh/plugwerk.git
+git clone https://github.com/plugwerk/plugwerk.git
 cd plugwerk
 docker compose up -d postgres
 ./gradlew build

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A **namespace** scopes all plugins for one product (e.g. `acme-crm`). Plugin met
 ### Start with Docker Compose
 
 ```bash
-git clone https://github.com/devtank42gmbh/plugwerk.git
+git clone https://github.com/plugwerk/plugwerk.git
 cd plugwerk
 docker compose up -d
 ```


### PR DESCRIPTION
## Summary

- Update all repository URL references from `devtank42gmbh/plugwerk` to `plugwerk/plugwerk` after the project migration

## Files changed

- `AGENTS.md` — issue tracking link
- `CONTRIBUTING.md` — clone URL
- `README.md` — clone URL
- `.github/workflows/cla.yml` — CLA document links (2×)

🤖 Generated with [Claude Code](https://claude.com/claude-code)