### PR TITLE
fix(security): increase minimum password length to 12 characters

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2213,7 +2213,7 @@ components:
           type: string
         newPassword:
           type: string
-          minLength: 8
+          minLength: 12
       required:
         - currentPassword
         - newPassword
@@ -2261,7 +2261,7 @@ components:
           nullable: true
         password:
           type: string
-          minLength: 8
+          minLength: 12
       required:
         - username
         - password
@@ -2275,7 +2275,7 @@ components:
           nullable: true
         newPassword:
           type: string
-          minLength: 8
+          minLength: 12
           nullable: true
 
     NamespaceMembershipDto:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -165,7 +165,7 @@ class AdminUserControllerTest {
 
         mockMvc.post("/api/v1/admin/users") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"username":"bob","password":"secret123"}"""
+            content = """{"username":"bob","password":"secret123long"}"""
         }.andExpect {
             status { isCreated() }
             jsonPath("$.username") { value("bob") }
@@ -178,7 +178,7 @@ class AdminUserControllerTest {
 
         mockMvc.post("/api/v1/admin/users") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"username":"alice","password":"password123"}"""
+            content = """{"username":"alice","password":"password12345"}"""
         }.andExpect {
             status { isConflict() }
         }
@@ -260,7 +260,7 @@ class AdminUserControllerTest {
 
         mockMvc.post("/api/v1/admin/users") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"username":"eve","password":"password123"}"""
+            content = """{"username":"eve","password":"password12345"}"""
         }.andExpect {
             status { isForbidden() }
         }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.test.tsx
@@ -67,14 +67,14 @@ describe('ChangePasswordPage', () => {
     await user.type(screen.getByLabelText(/confirm new password/i), 'short')
     await user.click(screen.getByRole('button', { name: /set new password/i }))
 
-    expect(screen.getByText(/must be at least 8 characters/i)).toBeInTheDocument()
+    expect(screen.getByText(/must be at least 12 characters/i)).toBeInTheDocument()
   })
 
   it('shows validation error when passwords do not match', async () => {
     const user = userEvent.setup()
     renderWithRouter(<ChangePasswordPage />)
     await user.type(screen.getByLabelText(/current password/i), 'oldpassword')
-    await user.type(screen.getByLabelText(/^new password/i), 'newpassword1')
+    await user.type(screen.getByLabelText(/^new password/i), 'newpassword12')
     await user.type(screen.getByLabelText(/confirm new password/i), 'different123')
     await user.click(screen.getByRole('button', { name: /set new password/i }))
 
@@ -88,12 +88,12 @@ describe('ChangePasswordPage', () => {
     const user = userEvent.setup()
     renderWithRouter(<ChangePasswordPage />)
     await user.type(screen.getByLabelText(/current password/i), 'oldpassword')
-    await user.type(screen.getByLabelText(/^new password/i), 'newpassword1')
-    await user.type(screen.getByLabelText(/confirm new password/i), 'newpassword1')
+    await user.type(screen.getByLabelText(/^new password/i), 'newpassword12')
+    await user.type(screen.getByLabelText(/confirm new password/i), 'newpassword12')
     await user.click(screen.getByRole('button', { name: /set new password/i }))
 
     await waitFor(() => {
-      expect(mockChange).toHaveBeenCalledWith({ changePasswordRequest: { currentPassword: 'oldpassword', newPassword: 'newpassword1' } })
+      expect(mockChange).toHaveBeenCalledWith({ changePasswordRequest: { currentPassword: 'oldpassword', newPassword: 'newpassword12' } })
     })
   })
 
@@ -103,8 +103,8 @@ describe('ChangePasswordPage', () => {
     const user = userEvent.setup()
     renderWithRouter(<ChangePasswordPage />)
     await user.type(screen.getByLabelText(/current password/i), 'wrongold')
-    await user.type(screen.getByLabelText(/^new password/i), 'newpassword1')
-    await user.type(screen.getByLabelText(/confirm new password/i), 'newpassword1')
+    await user.type(screen.getByLabelText(/^new password/i), 'newpassword12')
+    await user.type(screen.getByLabelText(/confirm new password/i), 'newpassword12')
     await user.click(screen.getByRole('button', { name: /set new password/i }))
 
     await waitFor(() => {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
@@ -35,8 +35,8 @@ export function ChangePasswordPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (newPassword.length < 8) {
-      setError('New password must be at least 8 characters.')
+    if (newPassword.length < 12) {
+      setError('New password must be at least 12 characters.')
       return
     }
     if (newPassword !== confirmPassword) {
@@ -85,7 +85,7 @@ export function ChangePasswordPage() {
           required
           size="small"
           autoComplete="new-password"
-          helperText="At least 8 characters"
+          helperText="At least 12 characters"
         />
         <TextField
           label="Confirm New Password"


### PR DESCRIPTION
## Summary

Increase minimum password length from 8 to 12 characters per NIST SP 800-63B recommendations.

## Changes

| File | Change |
|------|--------|
| `plugwerk-api.yaml` | `minLength: 8` → `12` on 3 schemas (ChangePasswordRequest, UserCreateRequest, UserUpdateRequest) |
| `ChangePasswordPage.tsx` | Validation check `< 8` → `< 12`, helper text updated |
| `ChangePasswordPage.test.tsx` | Updated assertion regex + test passwords to ≥12 chars |
| `AdminUserControllerTest.kt` | Updated test passwords to ≥12 chars |

## Not changed (no action needed)

- `AdminInitializationRunner` — already generates 16-char random passwords
- `LoginRequest.password` — has `minLength: 1` (login accepts any password for validation against hash)
- Backend service layer — no hardcoded length checks, relies on generated `@Size` annotations

## Related

- Created plugwerk/plugwerk#153 for future password blocklist checking (NIST SP 800-63B)

## Test plan

- [x] Backend tests pass with new minimum length
- [x] Frontend tests pass (`--testTimeout=20000`)
- [ ] Manual: verify change-password page shows "At least 12 characters"
- [ ] Manual: verify short passwords (< 12 chars) are rejected

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)