### PR TITLE
fix(security): validate ZIP/JAR magic bytes on artifact upload

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.ForbiddenException
+import io.plugwerk.server.service.InvalidArtifactException
 import io.plugwerk.server.service.NamespaceAlreadyExistsException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import io.plugwerk.server.service.PluginAlreadyExistsException
@@ -98,6 +99,10 @@ class GlobalExceptionHandler {
     )
     fun handleDescriptorError(ex: RuntimeException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, ex.message ?: "Plugin descriptor is invalid or missing")
+
+    @ExceptionHandler(InvalidArtifactException::class)
+    fun handleInvalidArtifact(ex: InvalidArtifactException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, ex.message ?: "Invalid artifact")
 
     @ExceptionHandler(FileTooLargeException::class)
     fun handleFileTooLarge(ex: FileTooLargeException): ResponseEntity<ErrorResponse> =

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -131,6 +131,9 @@ class PluginReleaseService(
         if (bytes.size > maxBytes) {
             throw FileTooLargeException(bytes.size.toLong(), properties.upload.maxFileSizeMb)
         }
+        if (bytes.size < 4 || bytes[0] != 0x50.toByte() || bytes[1] != 0x4B.toByte()) {
+            throw InvalidArtifactException("Uploaded file is not a valid JAR/ZIP archive")
+        }
         val descriptor = descriptorResolver.resolve(ByteArrayInputStream(bytes))
         val sha256 = computeSha256(bytes)
         val plugin = findOrCreatePlugin(namespaceSlug, descriptor)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/ServiceExceptions.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/ServiceExceptions.kt
@@ -46,6 +46,8 @@ class UnauthorizedException(message: String) : RuntimeException(message)
 
 class ForbiddenException(message: String) : RuntimeException(message)
 
+class InvalidArtifactException(message: String) : RuntimeException(message)
+
 class FileTooLargeException(actualSizeBytes: Long, maxSizeMb: Int) :
     RuntimeException(
         "File size ${actualSizeBytes / 1_048_576} MB exceeds maximum allowed $maxSizeMb MB",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepositoryTest.kt
@@ -46,7 +46,9 @@ open class NamespaceAccessKeyRepositoryTest : AbstractRepositoryTest() {
 
     @Test
     fun `findByKeyHash returns key when hash exists`() {
-        apiKeyRepository.save(NamespaceAccessKeyEntity(namespace = namespace, keyHash = "deadbeef01234567"))
+        apiKeyRepository.save(
+            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "deadbeef01234567", name = "test-key"),
+        )
 
         val found = apiKeyRepository.findByKeyHash("deadbeef01234567")
 
@@ -64,12 +66,14 @@ open class NamespaceAccessKeyRepositoryTest : AbstractRepositoryTest() {
     @Test
     fun `findAllByNamespaceAndRevokedFalse returns only active keys`() {
         apiKeyRepository.save(
-            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-active-1", revoked = false),
+            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-active-1", name = "key-1", revoked = false),
         )
         apiKeyRepository.save(
-            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-active-2", revoked = false),
+            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-active-2", name = "key-2", revoked = false),
         )
-        apiKeyRepository.save(NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-revoked", revoked = true))
+        apiKeyRepository.save(
+            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "hash-revoked", name = "key-3", revoked = true),
+        )
 
         val activeKeys = apiKeyRepository.findAllByNamespaceAndRevokedFalse(namespace)
 
@@ -99,11 +103,15 @@ open class NamespaceAccessKeyRepositoryTest : AbstractRepositoryTest() {
 
     @Test
     fun `save fails on duplicate key_hash`() {
-        apiKeyRepository.save(NamespaceAccessKeyEntity(namespace = namespace, keyHash = "duplicate-hash"))
+        apiKeyRepository.save(
+            NamespaceAccessKeyEntity(namespace = namespace, keyHash = "duplicate-hash", name = "test-key"),
+        )
         apiKeyRepository.flush()
 
         assertFailsWith<DataIntegrityViolationException> {
-            apiKeyRepository.saveAndFlush(NamespaceAccessKeyEntity(namespace = namespace, keyHash = "duplicate-hash"))
+            apiKeyRepository.saveAndFlush(
+                NamespaceAccessKeyEntity(namespace = namespace, keyHash = "duplicate-hash", name = "test-key"),
+            )
         }
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
@@ -71,6 +71,8 @@ class DownloadEventServiceIntegrationTest {
     }
 
     companion object {
+        private val FAKE_JAR = byteArrayOf(0x50, 0x4B, 0x03, 0x04) + "fake".toByteArray()
+
         @DynamicPropertySource
         @JvmStatic
         fun configureProperties(registry: DynamicPropertyRegistry) {
@@ -101,7 +103,7 @@ class DownloadEventServiceIntegrationTest {
     fun `record persists download event with correct release FK`() {
         val descriptor = PlugwerkDescriptor(id = "evt-plugin", version = "1.0.0", name = "Event Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
-        val release = releaseService.upload("dl-event-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        val release = releaseService.upload("dl-event-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         downloadEventService.record(release, "10.20.30.40", "curl/7.88")
 
@@ -117,7 +119,7 @@ class DownloadEventServiceIntegrationTest {
     fun `cascade delete removes events when release is deleted`() {
         val descriptor = PlugwerkDescriptor(id = "cascade-plugin", version = "1.0.0", name = "Cascade Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
-        val release = releaseService.upload("dl-event-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        val release = releaseService.upload("dl-event-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         downloadEventService.record(release, "1.2.3.4", null)
         downloadEventService.record(release, "5.6.7.8", null)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
@@ -71,6 +71,8 @@ class PluginReleaseServiceIntegrationTest {
     }
 
     companion object {
+        private val FAKE_JAR = byteArrayOf(0x50, 0x4B, 0x03, 0x04) + "fake".toByteArray()
+
         @DynamicPropertySource
         @JvmStatic
         fun configureProperties(registry: DynamicPropertyRegistry) {
@@ -101,7 +103,7 @@ class PluginReleaseServiceIntegrationTest {
         val descriptor = PlugwerkDescriptor(id = "auto-plugin", version = "1.0.0", name = "Auto Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
 
-        val result = releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        val result = releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         assertThat(result.version).isEqualTo("1.0.0")
         assertThat(result.artifactKey).isEqualTo("${testNamespace.id}:auto-plugin:1.0.0:jar")
@@ -113,10 +115,10 @@ class PluginReleaseServiceIntegrationTest {
         val descriptor = PlugwerkDescriptor(id = "dup-plugin", version = "1.0.0", name = "Dup Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
 
-        releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         assertFailsWith<ReleaseAlreadyExistsException> {
-            releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+            releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
         }
     }
 
@@ -124,7 +126,7 @@ class PluginReleaseServiceIntegrationTest {
     fun `updateStatus transitions release to PUBLISHED`() {
         val descriptor = PlugwerkDescriptor(id = "pub-plugin", version = "1.0.0", name = "Pub Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
-        releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         releaseService.updateStatus("rel-int-ns", "pub-plugin", "1.0.0", ReleaseStatus.PUBLISHED)
 
@@ -138,8 +140,8 @@ class PluginReleaseServiceIntegrationTest {
         val d2 = PlugwerkDescriptor(id = "order-plugin", version = "2.0.0", name = "Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(d1).thenReturn(d2)
 
-        releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
-        releaseService.upload("rel-int-ns", ByteArrayInputStream("fake".toByteArray()), 4)
+        releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
+        releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         val releases = releaseService.findAllByPlugin("rel-int-ns", "order-plugin")
         assertThat(releases).hasSize(2)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -90,9 +90,12 @@ class PluginReleaseServiceTest {
         )
     }
 
+    private fun fakeJarBytes(content: String = "fake-jar-content"): ByteArray =
+        byteArrayOf(0x50, 0x4B, 0x03, 0x04) + content.toByteArray()
+
     @Test
     fun `upload creates release from descriptor and stores artifact`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -121,7 +124,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload stores artifact size in bytes`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -140,7 +143,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload sets fileFormat to JAR for jar uploads`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -157,7 +160,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload sets fileFormat to ZIP for zip uploads`() {
-        val zipBytes = "fake-zip-content".toByteArray()
+        val zipBytes = fakeJarBytes("fake-zip-content")
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -174,7 +177,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload defaults fileFormat to JAR when no filename provided`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -191,7 +194,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload throws ReleaseAlreadyExistsException when version exists`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "1.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
@@ -206,7 +209,7 @@ class PluginReleaseServiceTest {
 
     @Test
     fun `upload auto-creates plugin when it does not exist`() {
-        val jarBytes = "fake-jar-content".toByteArray()
+        val jarBytes = fakeJarBytes()
         val descriptor = PlugwerkDescriptor(id = "new-plugin", version = "1.0.0", name = "New Plugin")
         val newPlugin = PluginEntity(namespace = namespace, pluginId = "new-plugin", name = "New Plugin")
 
@@ -404,8 +407,26 @@ class PluginReleaseServiceTest {
     }
 
     @Test
+    fun `upload throws InvalidArtifactException when magic bytes are not ZIP or JAR`() {
+        val invalidBytes = "this-is-not-a-jar".toByteArray()
+
+        assertFailsWith<InvalidArtifactException> {
+            releaseService.upload("acme", ByteArrayInputStream(invalidBytes), invalidBytes.size.toLong())
+        }
+    }
+
+    @Test
+    fun `upload throws InvalidArtifactException when file is too short for magic bytes`() {
+        val tinyBytes = byteArrayOf(0x50)
+
+        assertFailsWith<InvalidArtifactException> {
+            releaseService.upload("acme", ByteArrayInputStream(tinyBytes), tinyBytes.size.toLong())
+        }
+    }
+
+    @Test
     fun `upload succeeds when file is within size limit`() {
-        val jarBytes = "small-content".toByteArray()
+        val jarBytes = fakeJarBytes("small-content")
         val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "2.0.0", name = "My Plugin")
 
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)


### PR DESCRIPTION
## Summary

- Validate ZIP/JAR magic bytes (`PK` / `0x504B`) before processing uploaded plugin artifacts
- Reject non-archive files early with HTTP 422 and clear error message
- New `InvalidArtifactException` mapped in `GlobalExceptionHandler`

## Changes

| File | Change |
|------|--------|
| `ServiceExceptions.kt` | New `InvalidArtifactException` |
| `PluginReleaseService.kt` | Magic byte check after size validation, before descriptor parsing |
| `GlobalExceptionHandler.kt` | Map `InvalidArtifactException` → 422 |
| `PluginReleaseServiceTest.kt` | 2 new tests + all upload fixtures use valid magic bytes |
| `*IntegrationTest.kt` | Upload fixtures use valid magic bytes |
| `NamespaceAccessKeyRepositoryTest.kt` | Fix missing `name` parameter (pre-existing issue on main) |

## Test plan

- [x] Upload with invalid magic bytes → `InvalidArtifactException` (422)
- [x] Upload with file too short for magic bytes → `InvalidArtifactException` (422)
- [x] All existing upload tests pass with valid ZIP magic byte prefix
- [x] All backend tests pass

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)