### PR TITLE
fix: make API key name required and unique per namespace

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2466,6 +2466,7 @@ components:
           format: date-time
       required:
         - id
+        - name
         - revoked
         - createdAt
 
@@ -2475,11 +2476,13 @@ components:
       properties:
         name:
           type: string
-          description: Optional human-readable name to identify the key
+          description: Human-readable name identifying the key (must be unique within the namespace)
         expiresAt:
           type: string
           format: date-time
           description: Optional expiry date
+      required:
+        - name
 
     AccessKeyCreateResponse:
       type: object
@@ -2502,6 +2505,7 @@ components:
       required:
         - id
         - key
+        - name
         - createdAt
 
   responses:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
@@ -25,6 +25,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UuidGenerator
 import java.time.OffsetDateTime
@@ -65,7 +66,10 @@ import java.util.UUID
  * @property createdAt Creation timestamp (set automatically, immutable).
  */
 @Entity
-@Table(name = "namespace_access_key")
+@Table(
+    name = "namespace_access_key",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["namespace_id", "name"])],
+)
 class NamespaceAccessKeyEntity(
     @Id
     @UuidGenerator(style = UuidGenerator.Style.TIME)
@@ -79,8 +83,8 @@ class NamespaceAccessKeyEntity(
     @Column(name = "key_hash", nullable = false, unique = true, length = 64)
     var keyHash: String,
 
-    @Column(name = "name", length = 255)
-    var name: String? = null,
+    @Column(name = "name", nullable = false, length = 255)
+    var name: String,
 
     @Column(name = "revoked", nullable = false)
     var revoked: Boolean = false,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceAccessKeyRepository.kt
@@ -31,4 +31,6 @@ interface NamespaceAccessKeyRepository : JpaRepository<NamespaceAccessKeyEntity,
     fun findAllByNamespace(namespace: NamespaceEntity): List<NamespaceAccessKeyEntity>
 
     fun findAllByNamespaceAndRevokedFalse(namespace: NamespaceEntity): List<NamespaceAccessKeyEntity>
+
+    fun existsByNamespaceAndName(namespace: NamespaceEntity, name: String): Boolean
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/AccessKeyService.kt
@@ -67,11 +67,15 @@ class AccessKeyService(
     @Transactional
     fun create(
         namespaceSlug: String,
-        name: String?,
+        name: String,
         expiresAt: OffsetDateTime?,
     ): Pair<NamespaceAccessKeyEntity, String> {
         val namespace = namespaceRepository.findBySlug(namespaceSlug)
             .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
+
+        if (accessKeyRepository.existsByNamespaceAndName(namespace, name)) {
+            throw ConflictException("An access key named '$name' already exists in namespace '$namespaceSlug'")
+        }
 
         val plainKey = generatePlainKey()
         val keyHash = sha256Hex(plainKey)

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -241,6 +241,8 @@ databaseChangeLog:
               - column:
                   name: name
                   type: varchar(255)
+                  constraints:
+                    nullable: false
               - column:
                   name: revoked
                   type: boolean

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -411,6 +411,7 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   const [keyName, setKeyName] = useState('')
   const [expiresAt, setExpiresAt] = useState('')
   const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
   const [newKey, setNewKey] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
@@ -433,6 +434,7 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   async function handleCreate() {
     if (!keyName.trim()) return
     setCreating(true)
+    setCreateError(null)
     try {
       const parsedExpiry = expiresAt ? new Date(expiresAt).toISOString() : undefined
       const res = await accessKeysApi.createAccessKey({
@@ -448,10 +450,14 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       setCreateOpen(false)
       loadKeys()
     } catch (error: unknown) {
-      const msg = isAxiosError(error)
-        ? (error.response?.data?.message ?? error.message)
-        : 'Failed to create API key.'
-      onToast({ message: msg, severity: 'error' })
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setCreateError(`An API key named "${keyName.trim()}" already exists in this namespace.`)
+      } else {
+        const msg = isAxiosError(error)
+          ? (error.response?.data?.message ?? error.message)
+          : 'Failed to create API key.'
+        setCreateError(msg)
+      }
     } finally {
       setCreating(false)
     }
@@ -565,14 +571,15 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         </Table>
       )}
 
-      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="xs" fullWidth>
+      <Dialog open={createOpen} onClose={() => { setCreateOpen(false); setCreateError(null) }} maxWidth="xs" fullWidth>
         <DialogTitle>Generate API Key</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            {createError && <Alert severity="error">{createError}</Alert>}
             <TextField
               label="Name"
               value={keyName}
-              onChange={(e) => setKeyName(e.target.value)}
+              onChange={(e) => { setKeyName(e.target.value); setCreateError(null) }}
               size="small"
               required
               autoFocus

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -431,13 +431,15 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
   }, [loadKeys])
 
   async function handleCreate() {
+    if (!keyName.trim()) return
     setCreating(true)
     try {
+      const parsedExpiry = expiresAt ? new Date(expiresAt).toISOString() : undefined
       const res = await accessKeysApi.createAccessKey({
         ns: slug,
         accessKeyCreateRequest: {
-          name: keyName.trim() || undefined,
-          expiresAt: expiresAt || undefined,
+          name: keyName.trim(),
+          expiresAt: parsedExpiry,
         },
       })
       setNewKey(res.data.key)
@@ -445,8 +447,11 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       setExpiresAt('')
       setCreateOpen(false)
       loadKeys()
-    } catch {
-      onToast({ message: 'Failed to create API key.', severity: 'error' })
+    } catch (error: unknown) {
+      const msg = isAxiosError(error)
+        ? (error.response?.data?.message ?? error.message)
+        : 'Failed to create API key.'
+      onToast({ message: msg, severity: 'error' })
     } finally {
       setCreating(false)
     }
@@ -565,12 +570,13 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
             <TextField
-              label="Name (optional)"
+              label="Name"
               value={keyName}
               onChange={(e) => setKeyName(e.target.value)}
               size="small"
+              required
               autoFocus
-              helperText="A label to identify this key (e.g. 'CI pipeline')."
+              helperText="Unique name to identify this key (e.g. 'CI pipeline')."
             />
             <TextField
               label="Expires (optional)"
@@ -585,7 +591,7 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleCreate} disabled={creating}>
+          <Button variant="contained" onClick={handleCreate} disabled={creating || !keyName.trim()}>
             {creating ? 'Generating\u2026' : 'Generate'}
           </Button>
         </DialogActions>


### PR DESCRIPTION
## Summary

Replaces #154 (which had a dirty branch with merge artifacts).

- **Name is required** — not optional, across backend, API spec, and frontend
- **Name is unique per namespace** — 409 Conflict on duplicate
- **Expiry date** — converted to ISO 8601 UTC before sending
- **Error messages** — toast shows server error message on failure

## Changes (6 files)

| Layer | File | Change |
|-------|------|--------|
| API | `plugwerk-api.yaml` | `name` required in all 3 AccessKey schemas |
| DB | `0001_initial_schema.yaml` | `name` NOT NULL |
| Entity | `NamespaceAccessKeyEntity.kt` | `name: String` (not nullable) + unique constraint |
| Repository | `NamespaceAccessKeyRepository.kt` | `existsByNamespaceAndName` |
| Service | `AccessKeyService.kt` | `name: String`, uniqueness check → 409 |
| Frontend | `NamespaceDetailView.tsx` | Required field, disabled button, ISO date, server error toast |

## Test plan

- [ ] Generate key without name → button disabled
- [ ] Generate key with name → succeeds
- [ ] Generate key with duplicate name → 409 shown in toast
- [ ] Generate key with expiry → stored correctly
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)