### PR TITLE
feat(ui): unified table design with shared DataTable component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ plugwerk/
 - **API-First** – OpenAPI 3.1 spec in `plugwerk-api` is the single source of truth
 - **Transactional installation** – no partial state on failure; rollback requires retaining previous version
 - **Namespace isolation** – all resources are scoped to a namespace; one server serves multiple products/organizations
+- **Shared `DataTable` component** – all tabular views use `src/components/common/DataTable.tsx` for consistent styling (see [ADR-0004](docs/adrs/0004-frontend-conventions.md) § Tables)
 
 ### Core Data Model
 

--- a/docs/adrs/0004-frontend-conventions.md
+++ b/docs/adrs/0004-frontend-conventions.md
@@ -186,17 +186,36 @@ The frontend uses JWT Bearer tokens issued by `POST /api/v1/auth/login`.
 ### Component Conventions
 
 - **Named exports only** — no default exports from component files.
-- **License header** on every `.tsx`/`.ts` file:
-  ```typescript
-  // SPDX-License-Identifier: AGPL-3.0
-  // Copyright (C) 2026 devtank42 GmbH
-  ```
+- **License header** on every `.tsx`/`.ts` file — full AGPL block comment from `license-header.txt`.
 - **MUI `sx` prop** for styling — no CSS files, no inline `style={{}}` for complex rules.
 - **Design tokens** from `src/theme/tokens.ts` for colors, radii, and spacing constants.
   Do not hardcode hex values or pixel values that exist in `tokens`.
 - **lucide-react** for all icons. Icon size `15` in buttons, `16–18` in toolbars, `20–36` in content areas.
 - **Accessibility**: every interactive element needs an `aria-label`. Use semantic roles
   (`role="list"`, `role="search"`, `role="banner"`, `role="alert"`). Provide skip links on layout shells.
+
+### Tables
+
+All tabular data **must** use the shared `DataTable` component (`src/components/common/DataTable.tsx`).
+Do not use MUI `<Table>` directly — use `DataTable` with declarative column definitions.
+
+```tsx
+import { DataTable } from '../common/DataTable'
+import type { DataColumn } from '../common/DataTable'
+
+const columns: DataColumn<MyRow>[] = [
+  { key: 'name', header: 'Name', render: (row) => <Typography>{row.name}</Typography> },
+  { key: 'actions', header: '', align: 'right', render: (row) => <Button>Edit</Button> },
+]
+
+<DataTable columns={columns} rows={data} keyFn={(r) => r.id} ariaLabel="My table" />
+```
+
+**Rules:**
+- Column definitions inside the component function (closures over handlers).
+- Actions column: `align: 'right'`, empty header string.
+- Conditional row styling via `rowSx` prop, not per-cell hacks.
+- Empty state via `emptyMessage` prop.
 
 ### Error Handling in Components
 

--- a/docs/design/design-briefing.md
+++ b/docs/design/design-briefing.md
@@ -234,11 +234,17 @@ The plugin card is the central UI element of the catalog.
 
 ### 4.5 Tables
 
-- **Header:** `#F4F4F4` background, Bold (600), left-aligned text
-- **Rows:** Alternating row colors (`#FFFFFF` / `#F9F9F9`)
-- **Hover:** Row highlighted with `#E8E8E8`
-- **Sortable Columns:** Chevron icon in header
-- **Pagination:** At table footer, compact (< 1 2 3 ... 12 >)
+All tabular data uses the shared `DataTable` component (`src/components/common/DataTable.tsx`) for consistent styling across the application.
+
+- **Header:** No background color. Uppercase, 12px, 600 weight, `text.disabled` color, `0.04em` letter-spacing
+- **Rows:** No alternating colors. Uniform `background.paper` with `1px solid divider` bottom border
+- **Hover:** Subtle `background.default` on hover (150ms transition)
+- **Padding:** `px: 2, py: 1.5` per cell (matching the catalog list row style)
+- **Last Row:** No bottom border (`&:last-child td { borderBottom: none }`)
+- **Actions Column:** Right-aligned, consistent icon size (14px in buttons)
+- **Empty State:** Inline text message when no rows (e.g. "No members found.")
+- **Conditional Row Styling:** Via `rowSx` prop (e.g. draft highlighting, revoked opacity)
+- **Pagination:** At table footer, compact (< 1 2 3 ... 12 >) — when applicable
 
 ---
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -26,11 +26,6 @@ import {
   FormControlLabel,
   Alert,
   CircularProgress,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
   Chip,
   Select,
   MenuItem,
@@ -45,6 +40,8 @@ import {
   Autocomplete,
 } from '@mui/material'
 import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
+import { DataTable } from '../common/DataTable'
+import type { DataColumn } from '../common/DataTable'
 import { accessKeysApi, adminUsersApi, namespaceMembersApi, namespacesApi } from '../../api/config'
 import { isAxiosError } from 'axios'
 import type { AccessKeyDto, NamespaceMemberDto, NamespaceRole } from '../../api/generated/model'
@@ -287,6 +284,59 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
     }
   }
 
+  const memberColumns: DataColumn<NamespaceMemberDto>[] = [
+    {
+      key: 'subject',
+      header: 'Subject',
+      render: (member) => (
+        <Typography variant="body2" fontWeight={500}>{member.userSubject}</Typography>
+      ),
+    },
+    {
+      key: 'role',
+      header: 'Role',
+      render: (member) => (
+        <Select
+          value={member.role}
+          size="small"
+          variant="standard"
+          onChange={(e) => handleRoleChange(member, e.target.value as NamespaceRole)}
+          sx={{ fontSize: '0.875rem' }}
+          disableUnderline
+        >
+          {Object.values(NamespaceRoleEnum).map((role) => (
+            <MenuItem key={role} value={role}>
+              {ROLE_LABELS[role] ?? role}
+            </MenuItem>
+          ))}
+        </Select>
+      ),
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      render: (member) => (
+        <Typography variant="caption" color="text.disabled">
+          {new Date(member.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        </Typography>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (member) => (
+        <Button
+          size="small"
+          color="error"
+          startIcon={<Trash2 size={14} />}
+          onClick={() => handleRemove(member)}
+        >
+          Remove
+        </Button>
+      ),
+    },
+  ]
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', mb: 2 }}>
@@ -302,56 +352,12 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       ) : members.length === 0 ? (
         <Typography variant="body2" color="text.secondary">No members found.</Typography>
       ) : (
-        <Table size="small" aria-label="Namespace members">
-          <TableHead>
-            <TableRow>
-              <TableCell>Subject</TableCell>
-              <TableCell>Role</TableCell>
-              <TableCell>Created</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {members.map((member) => (
-              <TableRow key={member.userSubject}>
-                <TableCell>
-                  <Typography variant="body2" fontWeight={500}>{member.userSubject}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Select
-                    value={member.role}
-                    size="small"
-                    variant="standard"
-                    onChange={(e) => handleRoleChange(member, e.target.value as NamespaceRole)}
-                    sx={{ fontSize: '0.875rem' }}
-                    disableUnderline
-                  >
-                    {Object.values(NamespaceRoleEnum).map((role) => (
-                      <MenuItem key={role} value={role}>
-                        {ROLE_LABELS[role] ?? role}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {new Date(member.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Button
-                    size="small"
-                    color="error"
-                    startIcon={<Trash2 size={14} />}
-                    onClick={() => handleRemove(member)}
-                  >
-                    Remove
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<NamespaceMemberDto>
+          columns={memberColumns}
+          rows={members}
+          keyFn={(member) => member.userSubject}
+          ariaLabel="Namespace members"
+        />
       )}
 
       <Dialog open={addOpen} onClose={() => { setAddOpen(false); setAddError(null) }} maxWidth="xs" fullWidth>
@@ -480,6 +486,69 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const apiKeyColumns: DataColumn<AccessKeyDto>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (key) => (
+        <Typography variant="body2">{key.name || '—'}</Typography>
+      ),
+    },
+    {
+      key: 'keyPrefix',
+      header: 'Key Prefix',
+      render: (key) => (
+        <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+          {key.keyPrefix ?? '—'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (key) => (
+        <Chip
+          label={key.revoked ? 'revoked' : 'active'}
+          size="small"
+          color={key.revoked ? 'default' : 'success'}
+        />
+      ),
+    },
+    {
+      key: 'expires',
+      header: 'Expires',
+      render: (key) => (
+        <Typography variant="caption" color="text.disabled">
+          {key.expiresAt ? formatDateTime(key.expiresAt) : 'Never'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      render: (key) => (
+        <Typography variant="caption" color="text.disabled">
+          {formatDateTime(key.createdAt)}
+        </Typography>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (key) =>
+        !key.revoked ? (
+          <Button
+            size="small"
+            color="error"
+            startIcon={<Trash2 size={14} />}
+            onClick={() => handleRevoke(key.id)}
+          >
+            Revoke
+          </Button>
+        ) : null,
+    },
+  ]
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
@@ -514,61 +583,13 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
       ) : keys.length === 0 ? (
         <Typography variant="body2" color="text.secondary">No API keys configured.</Typography>
       ) : (
-        <Table size="small" aria-label="API keys">
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Key Prefix</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Expires</TableCell>
-              <TableCell>Created</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {keys.map((key) => (
-              <TableRow key={key.id} sx={{ opacity: key.revoked ? 0.5 : 1 }}>
-                <TableCell>
-                  <Typography variant="body2">{key.name || '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                    {key.keyPrefix ?? '—'}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip
-                    label={key.revoked ? 'revoked' : 'active'}
-                    size="small"
-                    color={key.revoked ? 'default' : 'success'}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {key.expiresAt ? formatDateTime(key.expiresAt) : 'Never'}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {formatDateTime(key.createdAt)}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  {!key.revoked && (
-                    <Button
-                      size="small"
-                      color="error"
-                      startIcon={<Trash2 size={14} />}
-                      onClick={() => handleRevoke(key.id)}
-                    >
-                      Revoke
-                    </Button>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<AccessKeyDto>
+          columns={apiKeyColumns}
+          rows={keys}
+          keyFn={(key) => key.id}
+          ariaLabel="API keys"
+          rowSx={(key) => key.revoked ? { opacity: 0.5 } : undefined}
+        />
       )}
 
       <Dialog open={createOpen} onClose={() => { setCreateOpen(false); setCreateError(null) }} maxWidth="xs" fullWidth>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -25,13 +25,10 @@ import {
   Snackbar,
   Alert,
   CircularProgress,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
 } from '@mui/material'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { DataTable } from '../common/DataTable'
+import type { DataColumn } from '../common/DataTable'
 import { namespacesApi } from '../../api/config'
 import type { NamespaceSummary } from '../../api/generated/model'
 import { CreateNamespaceDialog } from './CreateNamespaceDialog'
@@ -73,6 +70,34 @@ export function NamespacesSection() {
     setToast({ message: `Namespace "${slug}" deleted.`, severity: 'success' })
   }
 
+  const namespaceCols: DataColumn<NamespaceSummary>[] = [
+    {
+      key: 'slug',
+      header: 'Slug',
+      render: (ns) => <Typography variant="body2" fontWeight={500}>{ns.slug}</Typography>,
+    },
+    {
+      key: 'owner',
+      header: 'Owner',
+      render: (ns) => <Typography variant="caption" color="text.secondary">{ns.ownerOrg || '\u2014'}</Typography>,
+    },
+    {
+      key: 'actions',
+      header: '',
+      align: 'right',
+      render: (ns) => (
+        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+          <Button size="small" startIcon={<Pencil size={14} />} onClick={() => setEditingSlug(ns.slug)}>
+            Edit
+          </Button>
+          <Button size="small" color="error" startIcon={<Trash2 size={14} />} onClick={() => setDeleteTarget(ns)}>
+            Delete
+          </Button>
+        </Box>
+      ),
+    },
+  ]
+
   if (editingSlug) {
     return (
       <NamespaceDetailView
@@ -102,46 +127,12 @@ export function NamespacesSection() {
       ) : namespaces.length === 0 ? (
         <Typography variant="body2" color="text.secondary">No namespaces found.</Typography>
       ) : (
-        <Table size="small" aria-label="Namespaces">
-          <TableHead>
-            <TableRow>
-              <TableCell>Slug</TableCell>
-              <TableCell>Owner</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {namespaces.map((ns) => (
-              <TableRow key={ns.slug}>
-                <TableCell>
-                  <Typography variant="body2" fontWeight={500}>{ns.slug}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.secondary">{ns.ownerOrg || '\u2014'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
-                    <Button
-                      size="small"
-                      startIcon={<Pencil size={14} />}
-                      onClick={() => setEditingSlug(ns.slug)}
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      size="small"
-                      color="error"
-                      startIcon={<Trash2 size={14} />}
-                      onClick={() => setDeleteTarget(ns)}
-                    >
-                      Delete
-                    </Button>
-                  </Box>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<NamespaceSummary>
+          ariaLabel="Namespaces"
+          rows={namespaces}
+          keyFn={(ns) => ns.slug}
+          columns={namespaceCols}
+        />
       )}
 
       <CreateNamespaceDialog

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Box, Typography } from '@mui/material'
+import type { SxProps, Theme } from '@mui/material'
+
+export interface DataColumn<T> {
+  key: string
+  header: string
+  align?: 'left' | 'right' | 'center'
+  width?: string | number
+  render: (row: T) => React.ReactNode
+}
+
+interface DataTableProps<T> {
+  columns: DataColumn<T>[]
+  rows: T[]
+  keyFn: (row: T) => string
+  ariaLabel: string
+  rowSx?: (row: T) => SxProps<Theme> | undefined
+  onRowClick?: (row: T) => void
+  emptyMessage?: string
+}
+
+export function DataTable<T>({ columns, rows, keyFn, ariaLabel, rowSx, onRowClick, emptyMessage }: DataTableProps<T>) {
+  if (rows.length === 0 && emptyMessage) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 3 }}>
+        {emptyMessage}
+      </Typography>
+    )
+  }
+
+  return (
+    <Box
+      component="table"
+      role="table"
+      aria-label={ariaLabel}
+      sx={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        tableLayout: 'auto',
+      }}
+    >
+      <Box component="thead">
+        <Box component="tr">
+          {columns.map((col) => (
+            <Box
+              component="th"
+              key={col.key}
+              sx={{
+                textAlign: col.align ?? 'left',
+                width: col.width,
+                px: 2,
+                py: 1,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.disabled',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {col.header}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+      <Box component="tbody">
+        {rows.map((row) => (
+          <Box
+            component="tr"
+            key={keyFn(row)}
+            onClick={onRowClick ? () => onRowClick(row) : undefined}
+            sx={{
+              bgcolor: 'background.paper',
+              transition: 'background-color 0.15s',
+              '&:hover': { bgcolor: 'background.default' },
+              '&:last-child td': { borderBottom: 'none' },
+              ...(onRowClick && { cursor: 'pointer' }),
+              ...(rowSx?.(row) as object),
+            }}
+          >
+            {columns.map((col) => (
+              <Box
+                component="td"
+                key={col.key}
+                sx={{
+                  textAlign: col.align ?? 'left',
+                  width: col.width,
+                  px: 2,
+                  py: 1.5,
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                  fontSize: '0.875rem',
+                  verticalAlign: 'middle',
+                }}
+              >
+                {col.render(row)}
+              </Box>
+            ))}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
@@ -16,9 +16,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { Box, Table, TableBody, TableCell, TableHead, TableRow, Typography, Link } from '@mui/material'
+import { Box, Typography, Link } from '@mui/material'
 import { Badge } from '../common/Badge'
-import type { PluginReleaseDto } from '../../api/generated/model'
+import { DataTable } from '../common/DataTable'
+import type { DataColumn } from '../common/DataTable'
+import type { PluginDependencyDto, PluginReleaseDto } from '../../api/generated/model'
 
 interface DependenciesTabProps {
   release: PluginReleaseDto | null
@@ -34,37 +36,40 @@ export function DependenciesTab({ release, namespace }: DependenciesTabProps) {
     )
   }
 
+  const depColumns: DataColumn<PluginDependencyDto>[] = [
+    {
+      key: 'pluginId',
+      header: 'Plugin ID',
+      render: (dep) => (
+        <Link
+          href={`/${namespace}/plugins/${dep.id}`}
+          sx={{ fontFamily: 'monospace', fontSize: '0.8125rem', color: 'primary.main' }}
+        >
+          {dep.id}
+        </Link>
+      ),
+    },
+    {
+      key: 'version',
+      header: 'Required Version',
+      render: (dep) => (
+        <Badge variant="version">{dep.version}</Badge>
+      ),
+    },
+  ]
+
   return (
     <Box>
       <Typography variant="body2" color="text.disabled" sx={{ mb: 2 }}>
         Required plugins that must be installed alongside this plugin.
       </Typography>
       <Box sx={{ overflowX: 'auto' }}>
-        <Table aria-label="Plugin dependencies" size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Plugin ID</TableCell>
-              <TableCell>Required Version</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {deps.map((dep) => (
-              <TableRow key={dep.id}>
-                <TableCell>
-                  <Link
-                    href={`/${namespace}/plugins/${dep.id}`}
-                    sx={{ fontFamily: 'monospace', fontSize: '0.8125rem', color: 'primary.main' }}
-                  >
-                    {dep.id}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Badge variant="version">{dep.version}</Badge>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<PluginDependencyDto>
+          columns={depColumns}
+          rows={deps}
+          keyFn={(dep) => dep.id}
+          ariaLabel="Plugin dependencies"
+        />
       </Box>
     </Box>
   )

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -17,11 +17,6 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
   Button,
   Box,
   Typography,
@@ -30,6 +25,8 @@ import {
   Alert,
 } from '@mui/material'
 import { Download, CheckCircle, Trash2 } from 'lucide-react'
+import { DataTable } from '../common/DataTable'
+import type { DataColumn } from '../common/DataTable'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Badge } from '../common/Badge'
@@ -101,139 +98,166 @@ export function VersionsTab({ releases, namespace, pluginId, currentVersion, can
     }
   }
 
+  const releaseColumns: DataColumn<PluginReleaseDto>[] = [
+    {
+      key: 'version',
+      header: 'Version',
+      render: (rel) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Badge variant="version">v{rel.version}</Badge>
+          {rel.version === currentVersion && rel.status !== 'draft' && (
+            <Typography variant="caption" sx={{ color: tokens.color.primary, fontWeight: 600 }}>
+              current
+            </Typography>
+          )}
+        </Box>
+      ),
+    },
+    {
+      key: 'uploaded',
+      header: 'Uploaded',
+      render: (rel) => (
+        <Typography variant="caption" color="text.disabled">
+          {formatDateTime(rel.createdAt)}
+        </Typography>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (rel) => (
+        <Badge variant={statusToBadge[rel.status] ?? 'draft'}>
+          {rel.status.charAt(0).toUpperCase() + rel.status.slice(1)}
+        </Badge>
+      ),
+    },
+    {
+      key: 'format',
+      header: 'Format',
+      render: (rel) => (
+        <Typography variant="caption" color="text.disabled">
+          .{rel.fileFormat ?? 'jar'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'size',
+      header: 'Size',
+      render: (rel) => (
+        <Typography variant="caption" color="text.disabled">
+          {rel.artifactSize ? formatFileSize(rel.artifactSize) : '—'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'sha256',
+      header: 'SHA-256',
+      render: (rel) => (
+        <Tooltip title={rel.artifactSha256 ?? ''}>
+          <Typography variant="caption" sx={{ fontFamily: 'monospace', color: 'text.disabled' }}>
+            {rel.artifactSha256 ? rel.artifactSha256.slice(0, 12) + '…' : '—'}
+          </Typography>
+        </Tooltip>
+      ),
+    },
+    {
+      key: 'downloads',
+      header: 'Downloads',
+      align: 'right',
+      render: (rel) => (
+        <Typography variant="caption" color="text.disabled">
+          {rel.downloadCount ?? 0}
+        </Typography>
+      ),
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      width: 120,
+      render: (rel) => {
+        const isDraft = rel.status === 'draft'
+        const isYanked = rel.status === 'yanked'
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            {isDraft && canApprove ? (
+              <Button
+                variant="outlined"
+                size="small"
+                color="success"
+                startIcon={<CheckCircle size={14} />}
+                loading={approvingId === rel.id}
+                onClick={() => handleApprove(rel)}
+                sx={{ borderRadius: tokens.radius.btn }}
+              >
+                Approve
+              </Button>
+            ) : isDraft ? (
+              <Tooltip title="Awaiting review — download not available yet">
+                <Typography variant="caption" color="text.disabled">Pending review</Typography>
+              </Tooltip>
+            ) : isYanked ? (
+              <Typography variant="caption" color="text.disabled">Unavailable</Typography>
+            ) : (
+              <Tooltip title={`Download .${rel.fileFormat ?? 'jar'}`}>
+                <Button
+                  variant="text"
+                  size="small"
+                  aria-label={`download release ${rel.version}`}
+                  sx={{ minWidth: 'auto', p: 0.5, borderRadius: tokens.radius.btn }}
+                  onClick={() => {
+                    downloadArtifact(
+                      `/api/v1/namespaces/${namespace}/plugins/${pluginId}/releases/${rel.version}/download`,
+                      `${pluginId}-${rel.version}.${rel.fileFormat ?? 'jar'}`,
+                    ).catch(() => setToast({ message: 'Download failed.', severity: 'error' }))
+                  }}
+                >
+                  <Download size={14} />
+                </Button>
+              </Tooltip>
+            )}
+            {canApprove && (
+              <Tooltip title="Delete release">
+                <Button
+                  variant="text"
+                  size="small"
+                  color="error"
+                  aria-label={`delete release ${rel.version}`}
+                  onClick={() => setDeleteTarget(rel)}
+                  sx={{ minWidth: 'auto', p: 0.5, borderRadius: tokens.radius.btn }}
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </Tooltip>
+            )}
+          </Box>
+        )
+      },
+    },
+  ]
+
   return (
     <Box sx={{ overflowX: 'auto' }}>
-      <Table aria-label="Release versions" size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Version</TableCell>
-            <TableCell>Uploaded</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Format</TableCell>
-            <TableCell>Size</TableCell>
-            <TableCell>SHA-256</TableCell>
-            <TableCell align="right">Downloads</TableCell>
-            <TableCell sx={{ width: 120 }}>Actions</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {releases.map((rel) => {
-            const isCurrent = rel.version === currentVersion
-            const isDraft = rel.status === 'draft'
-            const isYanked = rel.status === 'yanked'
-            return (
-              <TableRow
-                key={rel.id}
-                sx={{
-                  opacity: isDraft ? 0.7 : 1,
-                  ...(isDraft && {
-                    borderLeft: `3px solid ${tokens.badge.draft.text}`,
-                    background: tokens.badge.draft.bg + '55',
-                  }),
-                  ...(isCurrent && !isDraft && { background: tokens.color.primaryLight + '33' }),
-                }}
-              >
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <Badge variant="version">v{rel.version}</Badge>
-                    {isCurrent && !isDraft && (
-                      <Typography variant="caption" sx={{ color: tokens.color.primary, fontWeight: 600 }}>
-                        current
-                      </Typography>
-                    )}
-                  </Box>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {formatDateTime(rel.createdAt)}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Badge variant={statusToBadge[rel.status] ?? 'draft'}>
-                    {rel.status.charAt(0).toUpperCase() + rel.status.slice(1)}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    .{rel.fileFormat ?? 'jar'}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {rel.artifactSize ? formatFileSize(rel.artifactSize) : '—'}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Tooltip title={rel.artifactSha256 ?? ''}>
-                    <Typography variant="caption" sx={{ fontFamily: 'monospace', color: 'text.disabled' }}>
-                      {rel.artifactSha256 ? rel.artifactSha256.slice(0, 12) + '…' : '—'}
-                    </Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="caption" color="text.disabled">
-                    {rel.downloadCount ?? 0}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    {isDraft && canApprove ? (
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        color="success"
-                        startIcon={<CheckCircle size={14} />}
-                        loading={approvingId === rel.id}
-                        onClick={() => handleApprove(rel)}
-                        sx={{ borderRadius: tokens.radius.btn }}
-                      >
-                        Approve
-                      </Button>
-                    ) : isDraft ? (
-                      <Tooltip title="Awaiting review — download not available yet">
-                        <Typography variant="caption" color="text.disabled">Pending review</Typography>
-                      </Tooltip>
-                    ) : isYanked ? (
-                      <Typography variant="caption" color="text.disabled">Unavailable</Typography>
-                    ) : (
-                      <Tooltip title={`Download .${rel.fileFormat ?? 'jar'}`}>
-                        <Button
-                          variant="text"
-                          size="small"
-                          aria-label={`download release ${rel.version}`}
-                          sx={{ minWidth: 'auto', p: 0.5, borderRadius: tokens.radius.btn }}
-                          onClick={() => {
-                            downloadArtifact(
-                              `/api/v1/namespaces/${namespace}/plugins/${pluginId}/releases/${rel.version}/download`,
-                              `${pluginId}-${rel.version}.${rel.fileFormat ?? 'jar'}`,
-                            ).catch(() => setToast({ message: 'Download failed.', severity: 'error' }))
-                          }}
-                        >
-                          <Download size={14} />
-                        </Button>
-                      </Tooltip>
-                    )}
-                    {canApprove && (
-                      <Tooltip title="Delete release">
-                        <Button
-                          variant="text"
-                          size="small"
-                          color="error"
-                          aria-label={`delete release ${rel.version}`}
-                          onClick={() => setDeleteTarget(rel)}
-                          sx={{ minWidth: 'auto', p: 0.5, borderRadius: tokens.radius.btn }}
-                        >
-                          <Trash2 size={14} />
-                        </Button>
-                      </Tooltip>
-                    )}
-                  </Box>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
+      <DataTable<PluginReleaseDto>
+        columns={releaseColumns}
+        rows={releases}
+        keyFn={(rel) => rel.id ?? rel.version}
+        ariaLabel="Release versions"
+        rowSx={(rel) => {
+          const isDraft = rel.status === 'draft'
+          const isCurrent = rel.version === currentVersion
+          if (isDraft) {
+            return {
+              opacity: 0.7,
+              borderLeft: `3px solid ${tokens.badge.draft.text}`,
+              background: tokens.badge.draft.bg + '55',
+            }
+          }
+          if (isCurrent) {
+            return { background: tokens.color.primaryLight + '33' }
+          }
+          return undefined
+        }}
+      />
 
       <ConfirmDeleteDialog
         open={!!deleteTarget}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -31,11 +31,6 @@ import {
   InputLabel,
   Snackbar,
   CircularProgress,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
   Chip,
   Switch,
   Dialog,
@@ -44,6 +39,8 @@ import {
   DialogActions,
 } from '@mui/material'
 import { CheckCircle, Plus, Shield, Trash2 } from 'lucide-react'
+import { DataTable } from '../components/common/DataTable'
+import type { DataColumn } from '../components/common/DataTable'
 import { AdminSidebar } from '../components/admin/AdminSidebar'
 import { NamespacesSection } from '../components/admin/NamespacesSection'
 import { adminUsersApi, oidcProvidersApi, reviewsApi } from '../api/config'
@@ -134,6 +131,87 @@ function UsersSection() {
     }
   }
 
+  const userColumns: DataColumn<UserDto>[] = [
+    {
+      key: 'username',
+      header: 'Username',
+      render: (user) => (
+        <>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+            <Typography variant="body2" fontWeight={500}>{user.username}</Typography>
+            {user.isSuperadmin && (
+              <Chip
+                icon={<Shield size={12} />}
+                label="superadmin"
+                size="small"
+                color="primary"
+                sx={{ height: 18, fontSize: '0.65rem' }}
+              />
+            )}
+          </Box>
+          {user.passwordChangeRequired && (
+            <Chip label="pw change required" size="small" color="warning" sx={{ mt: 0.5 }} />
+          )}
+        </>
+      ),
+    },
+    {
+      key: 'email',
+      header: 'Email',
+      render: (user) => (
+        <Typography variant="caption" color="text.secondary">{user.email ?? '—'}</Typography>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (user) => (
+        <Chip
+          label={user.enabled ? 'active' : 'disabled'}
+          size="small"
+          color={user.enabled ? 'success' : 'default'}
+        />
+      ),
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      render: (user) => (
+        <Typography variant="caption" color="text.disabled">
+          {new Date(user.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        </Typography>
+      ),
+    },
+    {
+      key: 'enabled',
+      header: 'Enabled',
+      render: (user) => (
+        <Switch
+          checked={user.enabled}
+          size="small"
+          onChange={() => handleToggleEnabled(user)}
+          disabled={user.isSuperadmin}
+          inputProps={{ 'aria-label': `Toggle ${user.username}` }}
+        />
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (user) => (
+        <Button
+          size="small"
+          color="error"
+          startIcon={<Trash2 size={14} />}
+          onClick={() => handleDelete(user)}
+          disabled={user.isSuperadmin}
+        >
+          Delete
+        </Button>
+      ),
+    },
+  ]
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -153,76 +231,12 @@ function UsersSection() {
       ) : users.length === 0 ? (
         <Typography variant="body2" color="text.secondary">No users found.</Typography>
       ) : (
-        <Table size="small" aria-label="Users">
-          <TableHead>
-            <TableRow>
-              <TableCell>Username</TableCell>
-              <TableCell>Email</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Created</TableCell>
-              <TableCell>Enabled</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {users.map((user) => (
-              <TableRow key={user.id}>
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
-                    <Typography variant="body2" fontWeight={500}>{user.username}</Typography>
-                    {user.isSuperadmin && (
-                      <Chip
-                        icon={<Shield size={12} />}
-                        label="superadmin"
-                        size="small"
-                        color="primary"
-                        sx={{ height: 18, fontSize: '0.65rem' }}
-                      />
-                    )}
-                  </Box>
-                  {user.passwordChangeRequired && (
-                    <Chip label="pw change required" size="small" color="warning" sx={{ mt: 0.5 }} />
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.secondary">{user.email ?? '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip
-                    label={user.enabled ? 'active' : 'disabled'}
-                    size="small"
-                    color={user.enabled ? 'success' : 'default'}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {new Date(user.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Switch
-                    checked={user.enabled}
-                    size="small"
-                    onChange={() => handleToggleEnabled(user)}
-                    disabled={user.isSuperadmin}
-                    inputProps={{ 'aria-label': `Toggle ${user.username}` }}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Button
-                    size="small"
-                    color="error"
-                    startIcon={<Trash2 size={14} />}
-                    onClick={() => handleDelete(user)}
-                    disabled={user.isSuperadmin}
-                  >
-                    Delete
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<UserDto>
+          columns={userColumns}
+          rows={users}
+          keyFn={(user) => user.id}
+          ariaLabel="Users"
+        />
       )}
 
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="xs" fullWidth>
@@ -369,6 +383,59 @@ function OidcProvidersSection() {
 
   const issuerRequired = ISSUER_REQUIRED_TYPES.has(providerType)
 
+  const oidcColumns: DataColumn<OidcProviderDto>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (provider) => (
+        <Typography variant="body2" fontWeight={500}>{provider.name}</Typography>
+      ),
+    },
+    {
+      key: 'type',
+      header: 'Type',
+      render: (provider) => (
+        <Chip label={PROVIDER_TYPE_LABELS[provider.providerType] ?? provider.providerType} size="small" />
+      ),
+    },
+    {
+      key: 'issuer',
+      header: 'Issuer / Client ID',
+      render: (provider) =>
+        provider.issuerUri ? (
+          <Typography variant="caption" color="text.secondary">{provider.issuerUri}</Typography>
+        ) : (
+          <Typography variant="caption" color="text.disabled">{provider.clientId}</Typography>
+        ),
+    },
+    {
+      key: 'enabled',
+      header: 'Enabled',
+      render: (provider) => (
+        <Switch
+          checked={provider.enabled}
+          size="small"
+          onChange={() => handleToggleEnabled(provider)}
+          inputProps={{ 'aria-label': `Toggle ${provider.name}` }}
+        />
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      render: (provider) => (
+        <Button
+          size="small"
+          color="error"
+          startIcon={<Trash2 size={14} />}
+          onClick={() => handleDelete(provider)}
+        >
+          Delete
+        </Button>
+      ),
+    },
+  ]
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -392,54 +459,12 @@ function OidcProvidersSection() {
       ) : providers.length === 0 ? (
         <Typography variant="body2" color="text.secondary">No OIDC providers configured.</Typography>
       ) : (
-        <Table size="small" aria-label="OIDC providers">
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Type</TableCell>
-              <TableCell>Issuer / Client ID</TableCell>
-              <TableCell>Enabled</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {providers.map((provider) => (
-              <TableRow key={provider.id}>
-                <TableCell>
-                  <Typography variant="body2" fontWeight={500}>{provider.name}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip label={PROVIDER_TYPE_LABELS[provider.providerType] ?? provider.providerType} size="small" />
-                </TableCell>
-                <TableCell>
-                  {provider.issuerUri ? (
-                    <Typography variant="caption" color="text.secondary">{provider.issuerUri}</Typography>
-                  ) : (
-                    <Typography variant="caption" color="text.disabled">{provider.clientId}</Typography>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Switch
-                    checked={provider.enabled}
-                    size="small"
-                    onChange={() => handleToggleEnabled(provider)}
-                    inputProps={{ 'aria-label': `Toggle ${provider.name}` }}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Button
-                    size="small"
-                    color="error"
-                    startIcon={<Trash2 size={14} />}
-                    onClick={() => handleDelete(provider)}
-                  >
-                    Delete
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<OidcProviderDto>
+          columns={oidcColumns}
+          rows={providers}
+          keyFn={(provider) => provider.id}
+          ariaLabel="OIDC providers"
+        />
       )}
 
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
@@ -562,6 +587,49 @@ function ReviewsSection() {
     }
   }
 
+  const reviewColumns: DataColumn<ReviewItemDto>[] = [
+    {
+      key: 'plugin',
+      header: 'Plugin',
+      render: (item) => (
+        <>
+          <Typography variant="body2" fontWeight={500}>{item.pluginName}</Typography>
+          <Typography variant="caption" color="text.secondary">{item.pluginId}</Typography>
+        </>
+      ),
+    },
+    {
+      key: 'version',
+      header: 'Version',
+      render: (item) => <>v{item.version}</>,
+    },
+    {
+      key: 'submitted',
+      header: 'Submitted',
+      render: (item) => (
+        <Typography variant="caption" color="text.disabled">
+          {new Date(item.submittedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        </Typography>
+      ),
+    },
+    {
+      key: 'action',
+      header: 'Action',
+      render: (item) => (
+        <Button
+          variant="outlined"
+          size="small"
+          color="success"
+          startIcon={<CheckCircle size={14} />}
+          loading={approvingId === item.releaseId}
+          onClick={() => handleApprove(item)}
+        >
+          Approve
+        </Button>
+      ),
+    },
+  ]
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box>
@@ -578,44 +646,12 @@ function ReviewsSection() {
           No releases awaiting review.
         </Typography>
       ) : (
-        <Table size="small" aria-label="Pending reviews">
-          <TableHead>
-            <TableRow>
-              <TableCell>Plugin</TableCell>
-              <TableCell>Version</TableCell>
-              <TableCell>Submitted</TableCell>
-              <TableCell>Action</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {items.map((item) => (
-              <TableRow key={item.releaseId}>
-                <TableCell>
-                  <Typography variant="body2" fontWeight={500}>{item.pluginName}</Typography>
-                  <Typography variant="caption" color="text.secondary">{item.pluginId}</Typography>
-                </TableCell>
-                <TableCell>v{item.version}</TableCell>
-                <TableCell>
-                  <Typography variant="caption" color="text.disabled">
-                    {new Date(item.submittedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    color="success"
-                    startIcon={<CheckCircle size={14} />}
-                    loading={approvingId === item.releaseId}
-                    onClick={() => handleApprove(item)}
-                  >
-                    Approve
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <DataTable<ReviewItemDto>
+          columns={reviewColumns}
+          rows={items}
+          keyFn={(item) => item.releaseId}
+          ariaLabel="Pending reviews"
+        />
       )}
 
       <Snackbar


### PR DESCRIPTION
## Summary

Introduces a shared `DataTable` component matching the catalog list style and migrates all 7 tables across the application to use it.

### DataTable component
- Declarative column definitions with render functions
- Clean divider rows, subtle hover, uppercase headers
- `rowSx` prop for conditional row styling (e.g. draft highlighting)
- `emptyMessage` prop for empty state
- `onRowClick` prop for clickable rows

### Migrated tables (7 total)

| View | File | Tables |
|------|------|--------|
| Admin — Namespaces | `NamespacesSection.tsx` | Namespace list |
| Admin — Users | `AdminSettingsPage.tsx` | User management |
| Admin — OIDC | `AdminSettingsPage.tsx` | OIDC providers |
| Admin — Reviews | `AdminSettingsPage.tsx` | Pending reviews |
| Namespace — Members | `NamespaceDetailView.tsx` | Member list |
| Namespace — API Keys | `NamespaceDetailView.tsx` | API key list |
| Plugin — Versions | `VersionsTab.tsx` | Release versions |
| Plugin — Dependencies | `DependenciesTab.tsx` | Dependencies |

## Test plan

- [ ] All tables render with consistent styling
- [ ] Hover states work on all rows
- [ ] Action buttons (edit, delete, approve, download) still functional
- [ ] Draft/current row highlighting preserved in VersionsTab
- [ ] Inline role dropdown preserved in Members table
- [ ] CI build passes

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)