### PR TITLE
feat(ui): stable URL routes for admin sub-pages

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -18,29 +18,26 @@
  */
 import { Box, Typography } from '@mui/material'
 import { Settings, Users, Shield, FileCheck, Globe } from 'lucide-react'
+import { Link, useLocation } from 'react-router-dom'
 import { tokens } from '../../theme/tokens'
 
-export interface AdminSection {
-  id: string
+interface AdminSection {
+  path: string
   label: string
   icon: React.ReactNode
-  danger?: boolean
 }
 
-export const ADMIN_SECTIONS: AdminSection[] = [
-  { id: 'general',   label: 'General',          icon: <Settings size={16} /> },
-  { id: 'namespaces', label: 'Namespaces',      icon: <Globe size={16} /> },
-  { id: 'users',          label: 'Users',             icon: <Users size={16} /> },
-  { id: 'oidc-providers', label: 'OIDC Providers',    icon: <Shield size={16} /> },
-  { id: 'reviews',        label: 'Pending Reviews',   icon: <FileCheck size={16} /> },
+const ADMIN_SECTIONS: AdminSection[] = [
+  { path: 'global-settings',  label: 'General',         icon: <Settings size={16} /> },
+  { path: 'namespaces',       label: 'Namespaces',      icon: <Globe size={16} /> },
+  { path: 'users',            label: 'Users',            icon: <Users size={16} /> },
+  { path: 'oidc-providers',   label: 'OIDC Providers',   icon: <Shield size={16} /> },
+  { path: 'reviews',          label: 'Pending Reviews',  icon: <FileCheck size={16} /> },
 ]
 
-interface AdminSidebarProps {
-  activeSection: string
-  onSelect: (id: string) => void
-}
+export function AdminSidebar() {
+  const location = useLocation()
 
-export function AdminSidebar({ activeSection, onSelect }: AdminSidebarProps) {
   return (
     <Box
       component="nav"
@@ -75,12 +72,12 @@ export function AdminSidebar({ activeSection, onSelect }: AdminSidebarProps) {
       </Typography>
 
       {ADMIN_SECTIONS.map((section) => {
-        const isActive = activeSection === section.id
+        const isActive = location.pathname === `/admin/${section.path}` || location.pathname.startsWith(`/admin/${section.path}/`)
         return (
           <Box
-            key={section.id}
-            component="button"
-            onClick={() => onSelect(section.id)}
+            key={section.path}
+            component={Link}
+            to={`/admin/${section.path}`}
             aria-current={isActive ? 'page' : undefined}
             sx={{
               display: 'flex',
@@ -90,13 +87,9 @@ export function AdminSidebar({ activeSection, onSelect }: AdminSidebarProps) {
               py: 1,
               mx: 1,
               borderRadius: tokens.radius.btn,
-              border: 'none',
-              background: isActive
-                ? (section.danger ? 'rgba(218,30,40,0.08)' : tokens.color.primaryLight)
-                : 'transparent',
-              color: isActive
-                ? (section.danger ? tokens.color.danger : tokens.color.primary)
-                : section.danger ? tokens.color.danger : 'text.secondary',
+              textDecoration: 'none',
+              background: isActive ? tokens.color.primaryLight : 'transparent',
+              color: isActive ? tokens.color.primary : 'text.secondary',
               fontWeight: isActive ? 600 : 400,
               fontSize: '0.875rem',
               cursor: 'pointer',
@@ -104,10 +97,8 @@ export function AdminSidebar({ activeSection, onSelect }: AdminSidebarProps) {
               width: 'calc(100% - 16px)',
               transition: 'background 0.15s, color 0.15s',
               '&:hover': {
-                background: section.danger
-                  ? 'rgba(218,30,40,0.08)'
-                  : isActive ? tokens.color.primaryLight : 'background.default',
-                color: section.danger ? tokens.color.danger : 'text.primary',
+                background: isActive ? tokens.color.primaryLight : 'background.default',
+                color: 'text.primary',
               },
               '&:focus-visible': { outline: `2px solid ${tokens.color.primary}`, outlineOffset: -2 },
             }}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -17,6 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { useState, useEffect } from 'react'
+import { Outlet } from 'react-router-dom'
 import {
   Box,
   Container,
@@ -42,7 +43,6 @@ import { CheckCircle, Plus, Shield, Trash2 } from 'lucide-react'
 import { DataTable } from '../components/common/DataTable'
 import type { DataColumn } from '../components/common/DataTable'
 import { AdminSidebar } from '../components/admin/AdminSidebar'
-import { NamespacesSection } from '../components/admin/NamespacesSection'
 import { adminUsersApi, oidcProvidersApi, reviewsApi } from '../api/config'
 import { useAuthStore } from '../stores/authStore'
 import type { OidcProviderDto, OidcProviderType, ReviewItemDto, UserDto } from '../api/generated/model'
@@ -668,23 +668,15 @@ function ReviewsSection() {
   )
 }
 
-const sectionMap: Record<string, React.ReactNode> = {
-  general: <GeneralSection />,
-  namespaces: <NamespacesSection />,
-  users: <UsersSection />,
-  'oidc-providers': <OidcProvidersSection />,
-  reviews: <ReviewsSection />,
-}
+export { GeneralSection, UsersSection, OidcProvidersSection, ReviewsSection }
 
 export function AdminSettingsPage() {
-  const [activeSection, setActiveSection] = useState('general')
-
   return (
     <Box component="main" id="main-content" sx={{ flex: 1, display: 'flex' }}>
-      <AdminSidebar activeSection={activeSection} onSelect={setActiveSection} />
+      <AdminSidebar />
       <Box sx={{ flex: 1, overflow: 'auto' }}>
         <Container maxWidth="lg" sx={{ py: 4 }}>
-          {sectionMap[activeSection]}
+          <Outlet />
         </Container>
       </Box>
     </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -54,7 +54,7 @@ export const router = createBrowserRouter([
         path: 'admin',
         element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute>,
         children: [
-          { index: true,              element: <Navigate to="namespaces" replace /> },
+          { index: true,              element: <Navigate to="global-settings" replace /> },
           { path: 'global-settings',  element: <GeneralSection /> },
           { path: 'namespaces',       element: <NamespacesSection /> },
           { path: 'users',            element: <UsersSection /> },

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -25,7 +25,8 @@ import { LoginPage } from '../pages/LoginPage'
 import { RegisterPage } from '../pages/RegisterPage'
 import { ForgotPasswordPage } from '../pages/ForgotPasswordPage'
 import { ResetPasswordPage } from '../pages/ResetPasswordPage'
-import { AdminSettingsPage } from '../pages/AdminSettingsPage'
+import { AdminSettingsPage, GeneralSection, UsersSection, OidcProvidersSection, ReviewsSection } from '../pages/AdminSettingsPage'
+import { NamespacesSection } from '../components/admin/NamespacesSection'
 import { ChangePasswordPage } from '../pages/ChangePasswordPage'
 import { ProfileSettingsPage } from '../pages/ProfileSettingsPage'
 import { Error404Page } from '../pages/errors/Error404Page'
@@ -49,7 +50,18 @@ export const router = createBrowserRouter([
       { index: true,                                                    element: <ProtectedRoute><CatalogRedirect /></ProtectedRoute> },
       { path: 'namespaces/:namespace/plugins',                          element: <ProtectedRoute><CatalogPage /></ProtectedRoute> },
       { path: 'namespaces/:namespace/plugins/:pluginId',                element: <ProtectedRoute><PluginDetailPage /></ProtectedRoute> },
-      { path: 'admin/*',                                                element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute> },
+      {
+        path: 'admin',
+        element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute>,
+        children: [
+          { index: true,              element: <Navigate to="namespaces" replace /> },
+          { path: 'global-settings',  element: <GeneralSection /> },
+          { path: 'namespaces',       element: <NamespacesSection /> },
+          { path: 'users',            element: <UsersSection /> },
+          { path: 'oidc-providers',   element: <OidcProvidersSection /> },
+          { path: 'reviews',          element: <ReviewsSection /> },
+        ],
+      },
       { path: 'change-password',                                        element: <ProtectedRoute><ChangePasswordPage /></ProtectedRoute> },
       { path: 'profile',                                                element: <ProtectedRoute><ProfileSettingsPage /></ProtectedRoute> },
 


### PR DESCRIPTION
## Summary

Each admin section now has a dedicated, bookmarkable URL with browser history support.

| Route | Section |
|-------|---------|
| `/admin` | Redirects to `/admin/namespaces` |
| `/admin/global-settings` | General Settings |
| `/admin/namespaces` | Namespace Management |
| `/admin/users` | User Management |
| `/admin/oidc-providers` | OIDC Providers |
| `/admin/reviews` | Pending Reviews |

### Changes (3 files)

- **Router** — nested routes under `/admin` with `<Outlet>` rendering
- **AdminSettingsPage** — replaced `useState` section switching with `<Outlet>`
- **AdminSidebar** — replaced `onSelect` callback with `<Link>` navigation, active state from `useLocation()`

## Test plan

- [ ] Direct navigation to `/admin/users` loads User Management
- [ ] Bookmarking `/admin/oidc-providers` works
- [ ] Browser back/forward navigates between admin sections
- [ ] `/admin` redirects to `/admin/namespaces`
- [ ] Sidebar highlights correct active section
- [ ] Unauthenticated access redirects to login
- [ ] CI build passes

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)