### PR TITLE
feat(security): restrict API keys to READ_ONLY access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,19 +226,20 @@ PlugwerkUpdateRepository // Implements pf4j-update UpdateRepository (drop-in rep
 
 Two authentication methods, API key takes precedence:
 
-| Method | Config Field | HTTP Header | Use Case |
-|--------|-------------|-------------|----------|
-| **API Key** (recommended) | `apiKey` | `X-Api-Key` | CI/CD, automated consumers |
-| **Bearer Token** | `accessToken` | `Authorization: Bearer` | OIDC, pre-obtained JWT |
+| Method | Config Field | HTTP Header | Permissions | Use Case |
+|--------|-------------|-------------|-------------|----------|
+| **API Key** (recommended) | `apiKey` | `X-Api-Key` | **READ_ONLY** (list, search, download) | SDK polling, plugin discovery |
+| **Bearer Token** | `accessToken` | `Authorization: Bearer` | Per user role (ADMIN/MEMBER/READ_ONLY) | Management, upload, CI/CD |
 
 ```kotlin
-// Recommended: API Key
+// Recommended: API Key (read-only access for SDK consumers)
 val config = PlugwerkConfig.Builder("https://plugwerk.example.com", "my-namespace")
     .apiKey("pwk_...")
     .build()
 ```
 
 The SDK does **not** implement a login flow — JWTs must be obtained externally.
+API keys grant **read-only** access; write operations (upload, delete, approve) require a JWT.
 
 ### Plugin Descriptor (`MANIFEST.MF`)
 

--- a/docs/adrs/0011-client-auth-api-key-strategy.md
+++ b/docs/adrs/0011-client-auth-api-key-strategy.md
@@ -53,15 +53,35 @@ plugwerk.apiKey=pwk_...
 plugwerk.accessToken=eyJhbG...
 ```
 
+## API Key Permissions
+
+API keys grant **READ_ONLY** access to their namespace:
+
+| Operation | API Key | JWT (MEMBER+) | JWT (ADMIN) |
+|-----------|:---:|:---:|:---:|
+| List / search / download plugins | ✅ | ✅ | ✅ |
+| `plugins.json` (pf4j-update) | ✅ | ✅ | ✅ |
+| Check for updates | ✅ | ✅ | ✅ |
+| Upload releases | ❌ | ✅ | ✅ |
+| Approve / reject releases | ❌ | ❌ | ✅ |
+| Delete plugins / releases | ❌ | ❌ | ✅ |
+| Manage members | ❌ | ❌ | ✅ |
+| Manage access keys | ❌ | ❌ | ✅ |
+| Create / delete namespaces | ❌ | ❌ | ✅ (superadmin) |
+
+This is intentional: API keys are designed for **SDK polling and plugin discovery**,
+not for management operations. Write operations require a JWT Bearer token.
+
 ## Consequences
 
 ### Positive
-- Simple, secure authentication for CI/CD pipelines and automated consumers
+- Simple, secure authentication for SDK clients and automated consumers
 - No token refresh logic needed in the SDK (API keys are long-lived)
 - No risk of user credentials leaking into plugin configurations
-- Clear separation: API keys for machines, JWTs for interactive users
+- Clear separation: API keys for read-only machine access, JWTs for management
+- Principle of least privilege: keys cannot modify data
 
 ### Negative
-- Consumers who only have a JWT must pass it via `accessToken` — the SDK won't obtain it automatically
+- CI/CD pipelines that need to upload releases must use JWT, not API keys
 - Two code paths (interceptors) to maintain, though both are trivial
 - Existing consumers using `accessToken` for JWT continue to work unchanged (backwards compatible)

--- a/examples/plugwerk-java-cli-example/README.md
+++ b/examples/plugwerk-java-cli-example/README.md
@@ -185,20 +185,22 @@ java -jar *-fat.jar --server=http://localhost:8080 list
 
 ### API key vs. JWT scope
 
-| Operation | API Key (`X-Api-Key`) | JWT (`Authorization: Bearer`) |
-|-----------|:---:|:---:|
-| List / search / download plugins | ✅ | ✅ |
-| Upload plugin releases | ✅ | ✅ |
-| Approve / reject releases | ✅ | ✅ |
-| Delete plugins / releases | ✅ | ✅ |
-| Manage namespace members | ✅ | ✅ |
-| Manage access keys | ✅ | ✅ |
-| **Create / delete namespaces** | ❌ (requires superadmin) | ✅ (if superadmin) |
-| **Manage users / OIDC** | ❌ (requires superadmin) | ✅ (if superadmin) |
+API keys grant **read-only** access. Write and admin operations require a JWT.
 
-> API keys are scoped to **one namespace** and grant implicit ADMIN within that
-> namespace. Server-level administration (namespaces, users, OIDC) always requires
-> a JWT from a superadmin account.
+| Operation | API Key (`X-Api-Key`) | JWT (MEMBER+) | JWT (ADMIN) |
+|-----------|:---:|:---:|:---:|
+| List / search / download plugins | ✅ | ✅ | ✅ |
+| Check for updates / `plugins.json` | ✅ | ✅ | ✅ |
+| Upload plugin releases | ❌ | ✅ | ✅ |
+| Approve / reject releases | ❌ | ❌ | ✅ |
+| Delete plugins / releases | ❌ | ❌ | ✅ |
+| Manage namespace members | ❌ | ❌ | ✅ |
+| Manage access keys | ❌ | ❌ | ✅ |
+| Create / delete namespaces | ❌ | ❌ | ✅ (superadmin) |
+| Manage users / OIDC | ❌ | ❌ | ✅ (superadmin) |
+
+> API keys are designed for **SDK polling and plugin discovery**. All management
+> operations (upload, delete, approve, members) require a JWT Bearer token.
 
 ---
 
@@ -232,21 +234,19 @@ If the namespace already exists the server returns HTTP 409 — that is fine.
 
 ### 3. Upload the plugin releases
 
-Upload and all subsequent namespace-scoped operations can use the API key.
-The server reads the `MANIFEST.MF` metadata embedded inside the JAR
-(within the ZIP) automatically. No manual metadata entry is required.
+Uploading requires **MEMBER** or **ADMIN** role — use a JWT Bearer token:
 
 ```bash
 # Upload hello-cmd-plugin
 curl -s -X POST \
   "http://localhost:8080/api/v1/namespaces/default/plugin-releases" \
-  -H "X-Api-Key: $API_KEY" \
+  -H "Authorization: Bearer $TOKEN" \
   -F "artifact=@plugwerk-java-cli-example-hello-cmd-plugin/build/pf4j/io.plugwerk.example.cli.hello-0.1.0-SNAPSHOT.zip"
 
 # Upload sysinfo-cmd-plugin
 curl -s -X POST \
   "http://localhost:8080/api/v1/namespaces/default/plugin-releases" \
-  -H "X-Api-Key: $API_KEY" \
+  -H "Authorization: Bearer $TOKEN" \
   -F "artifact=@plugwerk-java-cli-example-sysinfo-cmd-plugin/build/pf4j/io.plugwerk.example.cli.sysinfo-0.1.0-SNAPSHOT.zip"
 ```
 
@@ -255,17 +255,17 @@ A successful upload returns HTTP 201 with the release details in JSON.
 ### 4. Publish the releases (DRAFT → PUBLISHED)
 
 Newly uploaded releases have status `DRAFT` and are not visible in the catalog
-until explicitly published:
+until explicitly published. Approving requires **ADMIN** role — use a JWT:
 
 ```bash
 # Get the release ID from the upload response, or look it up:
 curl -s "http://localhost:8080/api/v1/namespaces/default/plugins/io.plugwerk.example.cli.hello/releases/0.1.0-SNAPSHOT" \
-  -H "X-Api-Key: $API_KEY" | jq .id
+  -H "Authorization: Bearer $TOKEN" | jq .id
 
 # Approve (DRAFT → PUBLISHED) — replace <release-id> with the UUID from above
 curl -s -X POST \
   "http://localhost:8080/api/v1/namespaces/default/reviews/<release-id>/approve" \
-  -H "X-Api-Key: $API_KEY"
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 Repeat for `sysinfo-cmd-plugin`. After approval both plugins appear in `list` and

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
@@ -56,11 +56,14 @@ class NamespaceMemberController(
         val namespace = namespaceRepository.findBySlug(ns)
             .orElseThrow { NamespaceNotFoundException(ns) }
 
-        // Superadmin and access keys have implicit ADMIN — no member entry needed
-        if (namespaceAuthorizationService.isSuperadmin(authentication) ||
-            authentication.name.startsWith("key:")
-        ) {
+        // Superadmin has implicit ADMIN — no member entry needed
+        if (namespaceAuthorizationService.isSuperadmin(authentication)) {
             return ResponseEntity.ok(NamespaceMembershipDto(role = NamespaceRole.ADMIN))
+        }
+
+        // Access keys have READ_ONLY access to their namespace
+        if (authentication.name.startsWith("key:")) {
+            return ResponseEntity.ok(NamespaceMembershipDto(role = NamespaceRole.READ_ONLY))
         }
 
         val member = namespaceMemberRepository.findByNamespaceIdAndUserSubject(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
@@ -36,8 +36,9 @@ import org.springframework.stereotype.Service
  * username; for OIDC tokens this is the provider's `sub` claim.
  *
  * The [namespace_access_key] auth filter sets the principal's name to the namespace slug
- * prefixed with `key:` — access keys are treated as implicit ADMIN for their namespace and
- * bypass the member table check (they are already namespace-scoped by design).
+ * prefixed with `key:` — access keys have READ_ONLY access to their namespace. They can
+ * list, search, and download plugins but cannot perform write operations (upload, delete,
+ * approve, manage members/keys). Write operations require a JWT Bearer token.
  *
  * **Superadmin:** A user with [isSuperadmin = true] implicitly holds ADMIN rights in every
  * namespace and does not need a [NamespaceMemberEntity] entry. Use [requireSuperadmin] to
@@ -76,19 +77,24 @@ class NamespaceAuthorizationService(
      *
      * Superadmin users bypass the member-table check and implicitly hold ADMIN in every namespace.
      *
-     * Namespace Access Key principals (name starts with `key:`) are treated as ADMIN for
-     * the namespace they were issued for — the filter already validated namespace scope.
+     * Namespace Access Key principals (name starts with `key:`) have READ_ONLY access to
+     * the namespace they were issued for. Write operations require a JWT Bearer token.
      *
      * @throws NamespaceNotFoundException if the namespace does not exist.
      * @throws ForbiddenException if the principal lacks the required role.
      */
     fun requireRole(namespaceSlug: String, authentication: Authentication, minimumRole: NamespaceRole) {
-        // Access keys are namespace-scoped and implicitly ADMIN — but only for their own namespace
+        // Access keys are namespace-scoped and have READ_ONLY access to their namespace
         if (authentication.name.startsWith("key:")) {
             val keyNamespaceSlug = authentication.name.removePrefix("key:")
             if (keyNamespaceSlug != namespaceSlug) {
                 throw ForbiddenException(
                     "Access key is not valid for namespace '$namespaceSlug'",
+                )
+            }
+            if (minimumRole != NamespaceRole.READ_ONLY) {
+                throw ForbiddenException(
+                    "Access keys have read-only access. This operation requires $minimumRole role.",
                 )
             }
             return

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/NamespaceAuthorizationServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/NamespaceAuthorizationServiceTest.kt
@@ -67,18 +67,30 @@ class NamespaceAuthorizationServiceTest {
     )
 
     @Test
-    fun `access key passes for its own namespace without member table check`() {
+    fun `access key passes READ_ONLY for its own namespace`() {
         val auth = auth("key:acme")
 
-        // No repository interaction expected — should pass without throwing
-        assertThatCode { service.requireRole("acme", auth, NamespaceRole.ADMIN) }.doesNotThrowAnyException()
+        assertThatCode { service.requireRole("acme", auth, NamespaceRole.READ_ONLY) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `access key is rejected for write operations on its own namespace`() {
+        val auth = auth("key:acme")
+
+        assertThatThrownBy { service.requireRole("acme", auth, NamespaceRole.MEMBER) }
+            .isInstanceOf(ForbiddenException::class.java)
+            .hasMessageContaining("read-only")
+
+        assertThatThrownBy { service.requireRole("acme", auth, NamespaceRole.ADMIN) }
+            .isInstanceOf(ForbiddenException::class.java)
+            .hasMessageContaining("read-only")
     }
 
     @Test
     fun `access key is rejected for a different namespace`() {
         val auth = auth("key:acme-production")
 
-        assertThatThrownBy { service.requireRole("acme-staging", auth, NamespaceRole.ADMIN) }
+        assertThatThrownBy { service.requireRole("acme-staging", auth, NamespaceRole.READ_ONLY) }
             .isInstanceOf(ForbiddenException::class.java)
             .hasMessageContaining("acme-staging")
     }


### PR DESCRIPTION
## Summary

API keys now grant **READ_ONLY** access instead of implicit ADMIN. Only list, search, download and update-check are permitted. All write operations require a JWT Bearer token.

| Operation | API Key | JWT |
|-----------|:---:|:---:|
| List / search / download | ✅ | ✅ |
| Upload releases | ❌ | ✅ (MEMBER+) |
| Approve / delete | ❌ | ✅ (ADMIN) |
| Manage members / keys | ❌ | ✅ (ADMIN) |

## Changes (5 files)

| File | Change |
|------|--------|
| `NamespaceAuthorizationService.kt` | `key:` principals throw 403 for anything above READ_ONLY |
| `NamespaceMemberController.kt` | `getMyMembership` returns READ_ONLY for keys |
| `ADR-0011` | Permission matrix added |
| `AGENTS.md` | Auth table updated |
| `CLI README` | Upload/approve examples use JWT, scope table corrected |

## Test plan

- [ ] API key can list/search/download plugins
- [ ] API key gets 403 on upload attempt
- [ ] API key gets 403 on approve/delete attempt
- [ ] API key gets 403 on member management
- [ ] JWT Bearer token can still do everything
- [ ] CI build passes

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)