### PR TITLE
feat: remove default namespace seed and add onboarding flow

### DIFF
--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -5,7 +5,7 @@
 --   PGPASSWORD=plugwerk psql -h localhost -U plugwerk -d plugwerk -f docs/dev/seed-testdata.sql
 --
 -- Creates:
---   2 namespaces (acme-corp, community) — 'default' already exists from migration
+--   3 namespaces (default, acme-corp, community)
 --   30 plugins per namespace (90 total)
 --   1–3 PUBLISHED releases per plugin (~180 total) with artifact sizes & download counts
 --   5 users (admin, alice, bob, charlie, diana)
@@ -31,6 +31,7 @@ ON CONFLICT (username) DO NOTHING;
 -- Namespaces
 -- ============================================================
 INSERT INTO namespace (id, slug, owner_org, public_catalog) VALUES
+  ('00000000-0000-0000-0000-000000000001', 'default',    'Plugwerk',               true),
   ('00000000-0000-0000-0000-000000000002', 'acme-corp',  'ACME Corporation',       false),
   ('00000000-0000-0000-0000-000000000003', 'community',  'Community Contributors', true)
 ON CONFLICT (slug) DO NOTHING;

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0001_initial_schema.yaml
@@ -273,12 +273,3 @@ databaseChangeLog:
               - column:
                   name: key_prefix
 
-  - changeSet:
-      id: 0001-seed-default-namespace
-      author: plugwerk
-      changes:
-        - sql:
-            sql: >
-              INSERT INTO namespace (id, slug, owner_org, public_catalog)
-              VALUES (gen_random_uuid(), 'default', 'plugwerk', true)
-              ON CONFLICT (slug) DO NOTHING;

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/ProtectedRoute.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/ProtectedRoute.tsx
@@ -30,7 +30,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const location = useLocation()
 
   useEffect(() => {
-    if (isAuthenticated && namespace === null) {
+    if (isAuthenticated && namespace === undefined) {
       initNamespace()
     }
   }, [isAuthenticated, namespace, initNamespace])

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/ProtectedRoute.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/ProtectedRoute.tsx
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import { useAuthStore } from '../../stores/authStore'
@@ -25,8 +26,14 @@ interface ProtectedRouteProps {
 }
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isAuthenticated, passwordChangeRequired } = useAuthStore()
+  const { isAuthenticated, passwordChangeRequired, namespace, initNamespace } = useAuthStore()
   const location = useLocation()
+
+  useEffect(() => {
+    if (isAuthenticated && namespace === null) {
+      initNamespace()
+    }
+  }, [isAuthenticated, namespace, initNamespace])
 
   if (!isAuthenticated) {
     return <Navigate to={`/login?from=${encodeURIComponent(location.pathname)}`} replace />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -112,39 +112,43 @@ export function TopBar() {
             aria-label="Main navigation"
             sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 0.5 }}
           >
-            {/* Namespace dropdown — left of Catalog */}
-            <Typography sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-              Namespace:
-            </Typography>
-            <FilterSelect
-              value={namespace}
-              onChange={handleNamespaceChange}
-              aria-label="Select namespace"
-              minWidth={130}
-            >
-              {namespaces.length > 0
-                ? namespaces.map((ns) => (
-                    <MenuItem key={ns.slug} value={ns.slug}>{ns.slug}</MenuItem>
-                  ))
-                : <MenuItem value={namespace}>{namespace}</MenuItem>
-              }
-            </FilterSelect>
+            {/* Namespace dropdown, Catalog, Upload — only when a namespace is selected */}
+            {namespace && (
+              <>
+                <Typography sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
+                  Namespace:
+                </Typography>
+                <FilterSelect
+                  value={namespace}
+                  onChange={handleNamespaceChange}
+                  aria-label="Select namespace"
+                  minWidth={130}
+                >
+                  {namespaces.length > 0
+                    ? namespaces.map((ns) => (
+                        <MenuItem key={ns.slug} value={ns.slug}>{ns.slug}</MenuItem>
+                      ))
+                    : <MenuItem value={namespace}>{namespace}</MenuItem>
+                  }
+                </FilterSelect>
 
-            <Button
-              component={Link}
-              to="/"
-              startIcon={<LayoutGrid size={15} color={isActive('/') ? tokens.color.primary : undefined} />}
-              sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
-            >
-              Catalog
-            </Button>
-            <Button
-              onClick={openUploadModal}
-              startIcon={<Upload size={15} />}
-              sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
-            >
-              Upload
-            </Button>
+                <Button
+                  component={Link}
+                  to="/"
+                  startIcon={<LayoutGrid size={15} color={isActive('/') ? tokens.color.primary : undefined} />}
+                  sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
+                >
+                  Catalog
+                </Button>
+                <Button
+                  onClick={openUploadModal}
+                  startIcon={<Upload size={15} />}
+                  sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
+                >
+                  Upload
+                </Button>
+              </>
+            )}
             <Button
               component={Link}
               to="/admin"

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -106,7 +106,7 @@ export function UploadModal() {
         },
       })
       addToast({ type: 'success', title: 'Release uploaded', message: 'Your release is pending review.' })
-      usePluginStore.getState().fetchPlugins(namespace)
+      if (namespace) usePluginStore.getState().fetchPlugins(namespace)
       handleClose()
     } catch (err: unknown) {
       const message = axios.isAxiosError(err)

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -563,6 +563,7 @@ function ReviewsSection() {
     async function load() {
       setLoading(true)
       try {
+        if (!namespace) return
         const res = await reviewsApi.listPendingReviews({ ns: namespace })
         setItems(res.data)
       } catch {
@@ -577,7 +578,7 @@ function ReviewsSection() {
   async function handleApprove(item: ReviewItemDto) {
     setApprovingId(item.releaseId)
     try {
-      await reviewsApi.approveRelease({ ns: namespace, releaseId: item.releaseId })
+      await reviewsApi.approveRelease({ ns: namespace!, releaseId: item.releaseId })
       setItems((prev) => prev.filter((i) => i.releaseId !== item.releaseId))
       setToast({ message: `${item.pluginName} v${item.version} approved and published.`, severity: 'success' })
     } catch {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -32,7 +32,7 @@ import { useUiStore } from '../stores/uiStore'
 import { useNamespaceStore } from '../stores/namespaceStore'
 
 export function CatalogPage() {
-  const { namespace = 'default' } = useParams<{ namespace: string }>()
+  const { namespace = '' } = useParams<{ namespace: string }>()
   const { setNamespace, namespaceRole, fetchNamespaceRole, isAuthenticated } = useAuthStore()
   const { plugins, loading, error, totalElements, pendingReviewPluginCount, resetFilters, fetchPlugins, fetchTags } = usePluginStore()
   const { searchQuery } = useUiStore()

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -43,11 +43,16 @@ export function LoginPage() {
     setLoading(true)
     try {
       await login(username.trim(), password)
-      const { passwordChangeRequired } = useAuthStore.getState()
+      await useAuthStore.getState().initNamespace()
+      const { passwordChangeRequired, namespace } = useAuthStore.getState()
       if (passwordChangeRequired) {
         navigate('/change-password', { replace: true })
+      } else if (!namespace) {
+        navigate('/onboarding', { replace: true })
       } else {
-        navigate(from, { replace: true })
+        // Only use the saved return URL if it doesn't contain a stale namespace
+        const safeFrom = from.startsWith('/namespaces/') ? '/' : from
+        navigate(safeFrom, { replace: true })
       }
     } catch {
       setError('Invalid username or password.')

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from 'react'
+import { Box, Button, Container, Typography } from '@mui/material'
+import { Puzzle, Plus } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore'
+import { CreateNamespaceDialog } from '../components/admin/CreateNamespaceDialog'
+import type { NamespaceSummary } from '../api/generated/model'
+
+export function OnboardingPage() {
+  const navigate = useNavigate()
+  const setNamespace = useAuthStore((s) => s.setNamespace)
+  const [createOpen, setCreateOpen] = useState(false)
+
+  function handleCreated(ns: NamespaceSummary) {
+    setNamespace(ns.slug)
+    navigate(`/namespaces/${ns.slug}/plugins`)
+  }
+
+  return (
+    <Box component="main" id="main-content" sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Container maxWidth="sm" sx={{ textAlign: 'center', py: 8 }}>
+        <Box sx={{ color: 'text.disabled', mb: 3 }}>
+          <Puzzle size={64} strokeWidth={1.2} />
+        </Box>
+
+        <Typography variant="h1" sx={{ fontSize: '2rem', mb: 2 }}>
+          Welcome to Plugwerk
+        </Typography>
+
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4, maxWidth: 420, mx: 'auto' }}>
+          No namespaces have been created yet. Create your first namespace to start publishing and managing plugins.
+        </Typography>
+
+        <Button
+          variant="contained"
+          size="large"
+          startIcon={<Plus size={18} />}
+          onClick={() => setCreateOpen(true)}
+        >
+          Create Namespace
+        </Button>
+
+        <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 3 }}>
+          A namespace groups your plugins and controls who can access them.
+        </Typography>
+
+        <CreateNamespaceDialog
+          open={createOpen}
+          onClose={() => setCreateOpen(false)}
+          onCreated={handleCreated}
+          onError={() => {}}
+        />
+      </Container>
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -43,7 +43,7 @@ import { useAuthStore } from '../stores/authStore'
 const TAB_IDS = ['overview', 'versions', 'changelog', 'dependencies']
 
 export function PluginDetailPage() {
-  const { namespace = 'default', pluginId = '' } = useParams<{ namespace: string; pluginId: string }>()
+  const { namespace = '', pluginId = '' } = useParams<{ namespace: string; pluginId: string }>()
   const navigate = useNavigate()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const namespaceRole = useAuthStore((s) => s.namespaceRole)

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -39,7 +39,9 @@ import { OnboardingPage } from '../pages/OnboardingPage'
 
 function CatalogRedirect() {
   const namespace = useAuthStore((s) => s.namespace)
-  if (!namespace) return <Navigate to="/onboarding" replace />
+  // undefined = still loading, null = no namespaces, string = ready
+  if (namespace === undefined) return null
+  if (namespace === null) return <Navigate to="/onboarding" replace />
   return <Navigate to={`/namespaces/${namespace}/plugins`} replace />
 }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -35,9 +35,11 @@ import { Error500Page } from '../pages/errors/Error500Page'
 import { Error503Page } from '../pages/errors/Error503Page'
 import { useAuthStore } from '../stores/authStore'
 import { ApiDocsPage } from '../pages/ApiDocsPage'
+import { OnboardingPage } from '../pages/OnboardingPage'
 
 function CatalogRedirect() {
   const namespace = useAuthStore((s) => s.namespace)
+  if (!namespace) return <Navigate to="/onboarding" replace />
   return <Navigate to={`/namespaces/${namespace}/plugins`} replace />
 }
 
@@ -62,6 +64,7 @@ export const router = createBrowserRouter([
           { path: 'reviews',          element: <ReviewsSection /> },
         ],
       },
+      { path: 'onboarding',                                              element: <ProtectedRoute><OnboardingPage /></ProtectedRoute> },
       { path: 'change-password',                                        element: <ProtectedRoute><ChangePasswordPage /></ProtectedRoute> },
       { path: 'profile',                                                element: <ProtectedRoute><ProfileSettingsPage /></ProtectedRoute> },
 

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
@@ -26,7 +26,7 @@ describe('useAuthStore', () => {
     useAuthStore.setState({
       accessToken: null,
       username: null,
-      namespace: null,
+      namespace: undefined,
       isAuthenticated: false,
     })
   })
@@ -40,8 +40,8 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().accessToken).toBeNull()
     })
 
-    it('has null namespace when nothing in localStorage', () => {
-      expect(useAuthStore.getState().namespace).toBeNull()
+    it('has undefined namespace before initialization', () => {
+      expect(useAuthStore.getState().namespace).toBeUndefined()
     })
   })
 

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
@@ -26,7 +26,7 @@ describe('useAuthStore', () => {
     useAuthStore.setState({
       accessToken: null,
       username: null,
-      namespace: 'default',
+      namespace: null,
       isAuthenticated: false,
     })
   })
@@ -40,8 +40,8 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().accessToken).toBeNull()
     })
 
-    it('has "default" namespace when nothing in localStorage', () => {
-      expect(useAuthStore.getState().namespace).toBe('default')
+    it('has null namespace when nothing in localStorage', () => {
+      expect(useAuthStore.getState().namespace).toBeNull()
     })
   })
 

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
@@ -23,7 +23,7 @@ import type { NamespaceRole } from '../api/generated/model'
 interface AuthState {
   accessToken: string | null
   username: string | null
-  namespace: string | null
+  namespace: string | null | undefined
   isAuthenticated: boolean
   passwordChangeRequired: boolean
   namespaceRole: NamespaceRole | null
@@ -42,7 +42,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: localStorage.getItem('pw-access-token'),
   username: localStorage.getItem('pw-username'),
-  namespace: localStorage.getItem('pw-namespace'),
+  namespace: undefined,
   isAuthenticated: !!localStorage.getItem('pw-access-token'),
   passwordChangeRequired: localStorage.getItem('pw-password-change-required') === 'true',
   namespaceRole: null,
@@ -81,7 +81,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     localStorage.removeItem('pw-access-token')
     localStorage.removeItem('pw-username')
     localStorage.removeItem('pw-password-change-required')
-    set({ accessToken: null, username: null, isAuthenticated: false, passwordChangeRequired: false, namespaceRole: null })
+    localStorage.removeItem('pw-namespace')
+    set({ accessToken: null, username: null, namespace: undefined, isAuthenticated: false, passwordChangeRequired: false, namespaceRole: null })
   },
 
   setNamespace(ns) {
@@ -90,21 +91,21 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   async initNamespace() {
-    const stored = localStorage.getItem('pw-namespace')
-    if (stored) {
-      set({ namespace: stored })
-      return
-    }
     try {
       const res = await namespacesApi.listNamespaces()
-      if (res.data.length > 0) {
-        const first = res.data[0].slug
-        localStorage.setItem('pw-namespace', first)
-        set({ namespace: first })
+      const slugs = res.data.map((ns) => ns.slug)
+      const stored = localStorage.getItem('pw-namespace')
+      if (stored && slugs.includes(stored)) {
+        set({ namespace: stored })
+      } else if (slugs.length > 0) {
+        localStorage.setItem('pw-namespace', slugs[0])
+        set({ namespace: slugs[0] })
       } else {
+        localStorage.removeItem('pw-namespace')
         set({ namespace: null })
       }
     } catch {
+      localStorage.removeItem('pw-namespace')
       set({ namespace: null })
     }
   },

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
@@ -17,13 +17,13 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { create } from 'zustand'
-import { namespaceMembersApi } from '../api/config'
+import { namespaceMembersApi, namespacesApi } from '../api/config'
 import type { NamespaceRole } from '../api/generated/model'
 
 interface AuthState {
   accessToken: string | null
   username: string | null
-  namespace: string
+  namespace: string | null
   isAuthenticated: boolean
   passwordChangeRequired: boolean
   namespaceRole: NamespaceRole | null
@@ -31,6 +31,7 @@ interface AuthState {
   login: (username: string, password: string) => Promise<void>
   logout: () => void
   setNamespace: (ns: string) => void
+  initNamespace: () => Promise<void>
   clearPasswordChangeRequired: () => void
   fetchNamespaceRole: (ns: string) => Promise<void>
 
@@ -41,7 +42,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: localStorage.getItem('pw-access-token'),
   username: localStorage.getItem('pw-username'),
-  namespace: localStorage.getItem('pw-namespace') ?? 'default',
+  namespace: localStorage.getItem('pw-namespace'),
   isAuthenticated: !!localStorage.getItem('pw-access-token'),
   passwordChangeRequired: localStorage.getItem('pw-password-change-required') === 'true',
   namespaceRole: null,
@@ -86,6 +87,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   setNamespace(ns) {
     localStorage.setItem('pw-namespace', ns)
     set({ namespace: ns, namespaceRole: null })
+  },
+
+  async initNamespace() {
+    const stored = localStorage.getItem('pw-namespace')
+    if (stored) {
+      set({ namespace: stored })
+      return
+    }
+    try {
+      const res = await namespacesApi.listNamespaces()
+      if (res.data.length > 0) {
+        const first = res.data[0].slug
+        localStorage.setItem('pw-namespace', first)
+        set({ namespace: first })
+      } else {
+        set({ namespace: null })
+      }
+    } catch {
+      set({ namespace: null })
+    }
   },
 
   clearPasswordChangeRequired() {


### PR DESCRIPTION
## Summary

A fresh Plugwerk installation now starts with **zero namespaces**. The admin is guided to create the first namespace via a dedicated onboarding page.

### What changed

**Backend:**
- Removed `0001-seed-default-namespace` changeset — no more auto-created namespace
- `seed-testdata.sql` explicitly creates `default` namespace (for dev testing only)

**Frontend:**
- `authStore.namespace` is now `string | null` (was always `string`)
- New `initNamespace()` action: fetches namespaces after login, sets first as active
- `ProtectedRoute` calls `initNamespace()` when namespace is null
- `CatalogRedirect` → `/onboarding` when no namespace exists
- **New `OnboardingPage`**: centered layout with "Create Namespace" CTA
- Removed hardcoded `'default'` fallback from CatalogPage and PluginDetailPage

### Fresh install flow

```
Login → initNamespace() → 
  ├── Namespaces exist → CatalogPage (first namespace)
  └── No namespaces → OnboardingPage → "Create Namespace" → CatalogPage
```

## Test plan

- [ ] Fresh install (empty DB): onboarding page appears after login
- [ ] Creating namespace from onboarding redirects to catalog
- [ ] Existing install with namespaces: normal flow unchanged
- [ ] Namespace dropdown still works when switching
- [ ] CI build passes

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)