### PR TITLE
fix: update seed-testdata.sql to match current database schema

### DIFF
--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -30,10 +30,10 @@ ON CONFLICT (username) DO NOTHING;
 -- ============================================================
 -- Namespaces
 -- ============================================================
-INSERT INTO namespace (id, slug, owner_org, public_catalog) VALUES
-  ('00000000-0000-0000-0000-000000000001', 'default',    'Plugwerk',               true),
-  ('00000000-0000-0000-0000-000000000002', 'acme-corp',  'ACME Corporation',       false),
-  ('00000000-0000-0000-0000-000000000003', 'community',  'Community Contributors', true)
+INSERT INTO namespace (id, slug, owner_org, public_catalog, auto_approve_releases) VALUES
+  ('00000000-0000-0000-0000-000000000001', 'default',    'Plugwerk',               true,  false),
+  ('00000000-0000-0000-0000-000000000002', 'acme-corp',  'ACME Corporation',       false, true),
+  ('00000000-0000-0000-0000-000000000003', 'community',  'Community Contributors', true,  false)
 ON CONFLICT (slug) DO NOTHING;
 
 -- ============================================================
@@ -52,25 +52,25 @@ INSERT INTO namespace_member (id, namespace_id, user_subject, role) VALUES
   ('b0000000-0000-0000-0000-000000000007', '00000000-0000-0000-0000-000000000003',              'bob',     'MEMBER'),
   -- charlie → acme-corp (MEMBER)
   ('b0000000-0000-0000-0000-000000000008', '00000000-0000-0000-0000-000000000002',              'charlie', 'MEMBER')
-ON CONFLICT DO NOTHING;
+ON CONFLICT (namespace_id, user_subject) DO NOTHING;
 
 -- ============================================================
 -- Namespace Access Keys
 -- ============================================================
-INSERT INTO namespace_access_key (id, namespace_id, key_hash, name, revoked, expires_at) VALUES
+INSERT INTO namespace_access_key (id, namespace_id, key_hash, key_prefix, name, revoked, expires_at) VALUES
   ('c0000000-0000-0000-0000-000000000001',
    (SELECT id FROM namespace WHERE slug = 'default'),
    'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90',
-   'CI/CD Pipeline', false, now() + interval '365 days'),
+   'plwk_a1b2c3', 'CI/CD Pipeline', false, now() + interval '365 days'),
   ('c0000000-0000-0000-0000-000000000002',
    '00000000-0000-0000-0000-000000000002',
    'b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1',
-   'Development', false, now() + interval '180 days'),
+   'plwk_b2c3d4', 'Development', false, now() + interval '180 days'),
   ('c0000000-0000-0000-0000-000000000003',
    '00000000-0000-0000-0000-000000000003',
    'c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2',
-   'Old key (revoked)', true, now() - interval '30 days')
-ON CONFLICT DO NOTHING;
+   'plwk_c3d4e5', 'Old key (revoked)', true, now() - interval '30 days')
+ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================
 -- Plugins — default namespace


### PR DESCRIPTION
## Summary

Closes #170

- Add missing `key_prefix` column to `namespace_access_key` INSERT with realistic prefixes (`plwk_a1b2c3`, `plwk_b2c3d4`, `plwk_c3d4e5`)
- Add missing `auto_approve_releases` boolean column to `namespace` INSERT (`default`=false, `acme-corp`=true, `community`=false)
- Make `namespace_member` ON CONFLICT clause precise: `ON CONFLICT (namespace_id, user_subject) DO NOTHING`
- Make `namespace_access_key` ON CONFLICT clause precise: `ON CONFLICT (id) DO NOTHING`

## Test plan

- [ ] Apply seed SQL against a fresh local database with current Liquibase migrations applied
- [ ] Verify all INSERTs succeed without errors
- [ ] Verify re-running the script is idempotent (ON CONFLICT clauses work correctly)
- [ ] Confirm `namespace_access_key.key_prefix` values are populated for all 3 rows
- [ ] Confirm `namespace.auto_approve_releases` values match expected booleans