### PR TITLE
feat: catalog page improvements, role-based UI visibility, and profile redesign

### DIFF
--- a/docs/adrs/0012-frontend-role-based-ui-visibility.md
+++ b/docs/adrs/0012-frontend-role-based-ui-visibility.md
@@ -1,0 +1,134 @@
+# ADR-0012: Frontend Role-Based UI Visibility
+
+## Status
+
+Accepted
+
+## Context
+
+The Plugwerk frontend previously showed all UI elements (navigation items, action buttons, admin pages) to every authenticated user, regardless of their role or permissions. The backend enforced access control via API responses (401/403), but the frontend provided no visual feedback — users could navigate to pages they weren't authorized to see, and action buttons were visible even when the underlying API would reject the request.
+
+This created a confusing user experience and a potential security concern (information leakage through UI structure). Issue #176 (catalog improvements) and follow-up work required a consistent approach to role-based UI visibility across the entire frontend.
+
+## Decision
+
+### Authentication State
+
+The `LoginResponse` from the backend now includes an `isSuperadmin` boolean field. The frontend `authStore` (Zustand) persists this alongside the existing state:
+
+| State Field | Source | Persistence |
+|---|---|---|
+| `isAuthenticated` | Login success | `localStorage` |
+| `username` | Login response | `localStorage` |
+| `isSuperadmin` | Login response (`isSuperadmin`) | `localStorage` |
+| `namespaceRole` | `GET /namespaces/{ns}/members/me` | In-memory (refetched on namespace switch) |
+| `namespace` | User selection / `initNamespace()` | `localStorage` |
+
+### Role Hierarchy
+
+The system distinguishes five actor types with decreasing privileges:
+
+| Actor | `isSuperadmin` | `namespaceRole` | Description |
+|---|---|---|---|
+| System Admin | `true` | — | Full access to everything |
+| Namespace Admin | `false` | `ADMIN` | Full access within their namespace(s) |
+| Namespace Member | `false` | `MEMBER` | Read-write within namespace, no admin actions |
+| Read-Only User | `false` | `READ_ONLY` | Browse and download only |
+| Unauthenticated | — | — | Public catalog only |
+
+### UI Visibility Rules
+
+#### Navigation Items (TopBar)
+
+| Element | Visible When |
+|---|---|
+| Catalog | Always (when namespace selected) |
+| Upload | `isSuperadmin \|\| namespaceRole === 'ADMIN' \|\| namespaceRole === 'MEMBER'` |
+| Admin | `isSuperadmin \|\| namespaceRole === 'ADMIN'` |
+
+#### Route Guards
+
+| Route Pattern | Guard | Unauthorized Behavior |
+|---|---|---|
+| `/admin/*` | `AdminRoute` (wraps `ProtectedRoute`) | Redirect to `/403` |
+| All protected routes | `ProtectedRoute` | Redirect to `/login` |
+| Public routes | None | Accessible to all |
+
+`AdminRoute` is a new guard component (`src/components/auth/AdminRoute.tsx`) that checks `isSuperadmin \|\| namespaceRole === 'ADMIN'` and redirects to the 403 Forbidden error page if the condition is not met.
+
+#### Catalog Visibility (Backend-Enforced)
+
+Plugin visibility in the catalog depends on `CatalogVisibility`, determined by the caller's role:
+
+| Visibility Level | Actor | Visible Plugins | Visible Releases |
+|---|---|---|---|
+| `PUBLIC` | Unauthenticated, API Key | Only `ACTIVE` with published releases | `published`, `deprecated` |
+| `AUTHENTICATED` | Member, Read-Only | All except `SUSPENDED`, incl. draft-only | All |
+| `ADMIN` | Namespace Admin, System Admin | All statuses | All |
+
+The `CatalogController.resolveVisibility()` method determines the level from `SecurityContextHolder`:
+1. No authentication / API key (`key:` prefix) -> `PUBLIC`
+2. Superadmin -> `ADMIN`
+3. Namespace Admin -> `ADMIN`
+4. Namespace Member / Read-Only -> `AUTHENTICATED`
+5. Fallback -> `PUBLIC`
+
+This visibility is applied consistently in both `listPlugins` and `listTags` endpoints.
+
+#### Action Buttons in Plugin Details
+
+| Action | Visible When |
+|---|---|
+| Download | Always (when a release exists) |
+| Change Release Status | `namespaceRole === 'ADMIN'` (via `canApprove` prop) |
+| Delete Release | `namespaceRole === 'ADMIN'` (via `canApprove` prop) |
+| Approve Draft | `namespaceRole === 'ADMIN'` (via `canApprove` prop) |
+| Change Plugin Status | `isAdmin` prop passed from parent |
+| Delete Plugin | `isAdmin` prop passed from parent |
+
+### Implementation Pattern
+
+The frontend uses a **check-at-render** pattern rather than a centralized permission service:
+
+```tsx
+// Navigation: destructure from store, conditionally render
+const { isSuperadmin, namespaceRole } = useAuthStore()
+{(isSuperadmin || namespaceRole === 'ADMIN') && <AdminButton />}
+
+// Route guard: dedicated wrapper component
+<ProtectedRoute>
+  <AdminRoute>
+    <AdminSettingsPage />
+  </AdminRoute>
+</ProtectedRoute>
+```
+
+This approach was chosen because:
+- The permission model is simple (two dimensions: `isSuperadmin` + `namespaceRole`)
+- MUI components render conditionally with standard JSX (`{condition && <Component />}`)
+- A centralized permission service would add indirection without reducing complexity at this scale
+
+### Important: Defense in Depth
+
+Frontend visibility is a UX convenience, not a security boundary. The backend **always** enforces authorization independently:
+- API endpoints validate roles via `NamespaceAuthorizationService.requireRole()`
+- The `PublicNamespaceFilter` controls anonymous access
+- The `NamespaceAccessKeyAuthFilter` limits API key scope
+- Unauthorized API calls return 401/403 regardless of frontend state
+
+## Consequences
+
+### Positive
+
+- Users only see UI elements they can actually use, reducing confusion and support burden
+- Direct URL access to `/admin/*` by unauthorized users shows a proper 403 page instead of broken API error states
+- Catalog content matches the user's actual access level (no phantom plugins or missing tags)
+- `isSuperadmin` in `LoginResponse` avoids an extra API call after login
+- Pattern is simple and consistent across the codebase
+
+### Negative
+
+- `isSuperadmin` is cached in `localStorage` and could become stale if admin status is revoked mid-session (mitigated by token expiry and backend enforcement)
+- `namespaceRole` is refetched on namespace switch but could lag behind server-side changes within a session
+- Adding new permission dimensions (e.g., per-plugin roles) would require extending the store and all visibility checks
+- Frontend and backend visibility rules must be kept in sync manually — no shared permission definition

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -399,17 +399,19 @@ paths:
       description: |
         Returns a paginated list of plugins in the given namespace.
 
-        Results can be filtered by tag and status, and searched by a full-text
-        query across plugin name, description, and tags.
+        Results can be filtered by tag, status, and system version compatibility,
+        and searched by a full-text query across plugin name, description, and tags.
 
-        **Visibility rules:**
-        - Only plugins with at least one **published** release are returned.
-        - Default status filter is `active`.
-        - `suspended` plugins are never returned via this endpoint.
+        **Visibility rules (role-dependent):**
+        - **Anonymous / API key:** Only `active` plugins with `published` or `deprecated` releases.
+        - **Namespace member / read-only:** All plugins (incl. draft-only) except `suspended`.
+        - **Namespace admin / system admin:** All plugins, all statuses (incl. suspended and draft-only).
+
+        Plugins that have only draft releases are marked with `hasDraftOnly: true` in the response.
 
         For authenticated users with namespace access, the response includes
         `pendingReviewPluginCount` — the number of active plugins that have draft releases
-        but no published release yet (i.e. plugins not shown in the catalog).
+        but no published release yet.
 
         This endpoint is publicly accessible unless the namespace has access control enabled.
       operationId: listPlugins
@@ -421,6 +423,7 @@ paths:
         - $ref: '#/components/parameters/SearchQuery'
         - $ref: '#/components/parameters/TagFilter'
         - $ref: '#/components/parameters/StatusFilter'
+        - $ref: '#/components/parameters/VersionFilter'
       responses:
         '200':
           description: Paginated list of plugins matching the given filters
@@ -1609,12 +1612,27 @@ components:
         type: string
         enum:
           - active
+          - suspended
           - archived
       description: |
-        Filter by plugin lifecycle status. Defaults to `active` when omitted.
-        - `active` — default; only active plugins with published releases
+        Filter by plugin lifecycle status. When omitted, visibility is role-dependent:
+        - Anonymous / API key: only `active` plugins with published releases
+        - Authenticated namespace member: all statuses except `suspended`, including draft-only
+        - Namespace admin / system admin: all plugins, all statuses
+        Explicit values:
+        - `active` — only active plugins
+        - `suspended` — only suspended plugins (admin-only)
         - `archived` — deprecated/end-of-life plugins only
-        Note: `suspended` plugins are never returned via the catalog endpoint.
+
+    VersionFilter:
+      name: version
+      in: query
+      schema:
+        type: string
+      description: |
+        Filter by system version compatibility. Only plugins whose latest release
+        declares a `requiresSystemVersion` satisfying this constraint are returned.
+        Example: `>=3.0.0`
 
   schemas:
     LoginRequest:
@@ -1660,11 +1678,18 @@ components:
             When `true`, the user must change their password before accessing any resource.
             The frontend should redirect to the change-password page immediately after login.
           example: false
+        isSuperadmin:
+          type: boolean
+          description: |
+            When `true`, the user has global superadmin privileges.
+            Used by the frontend to conditionally show admin UI elements.
+          example: false
       required:
         - accessToken
         - tokenType
         - expiresIn
         - passwordChangeRequired
+        - isSuperadmin
 
     NamespaceSummary:
       type: object
@@ -1829,6 +1854,13 @@ components:
           type: string
           format: uri
           description: URL of the source code repository (e.g. GitHub)
+        hasDraftOnly:
+          type: boolean
+          nullable: true
+          description: |
+            `true` when the plugin has at least one draft release but no published release.
+            `null` or `false` for plugins with at least one published release.
+            Used to render a "Pending Review" indicator in the catalog.
         createdAt:
           type: string
           format: date-time

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
@@ -50,6 +50,7 @@ class AuthController(
         }
         val user = userRepository.findByUsername(loginRequest.username).orElse(null)
         val passwordChangeRequired = user?.passwordChangeRequired ?: false
+        val isSuperadmin = user?.isSuperadmin ?: false
         val token = jwtTokenService.generateToken(loginRequest.username)
         return ResponseEntity.ok(
             LoginResponse(
@@ -57,6 +58,7 @@ class AuthController(
                 tokenType = "Bearer",
                 expiresIn = jwtTokenService.tokenValiditySeconds(),
                 passwordChangeRequired = passwordChangeRequired,
+                isSuperadmin = isSuperadmin,
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -26,12 +26,15 @@ import io.plugwerk.api.model.PluginReleaseDto
 import io.plugwerk.api.model.ReleasePagedResponse
 import io.plugwerk.server.controller.mapper.PluginMapper
 import io.plugwerk.server.controller.mapper.PluginReleaseMapper
+import io.plugwerk.server.domain.NamespaceRole
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.Pf4jCompatibilityService
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.server.service.PluginService
+import io.plugwerk.server.service.PluginService.CatalogVisibility
 import io.plugwerk.spi.model.PluginStatus
 import io.plugwerk.spi.model.ReleaseStatus
 import jakarta.servlet.http.HttpServletRequest
@@ -53,6 +56,7 @@ class CatalogController(
     private val releaseService: PluginReleaseService,
     private val releaseRepository: PluginReleaseRepository,
     private val namespaceRepository: NamespaceRepository,
+    private val namespaceAuthService: NamespaceAuthorizationService,
     private val pf4jService: Pf4jCompatibilityService,
     private val pluginMapper: PluginMapper,
     private val releaseMapper: PluginReleaseMapper,
@@ -67,18 +71,22 @@ class CatalogController(
         q: String?,
         tag: String?,
         status: String?,
+        version: String?,
     ): ResponseEntity<PluginPagedResponse> {
-        val pluginStatus = status?.let { parsePluginStatus(it) } ?: PluginStatus.ACTIVE
+        val pluginStatus = status?.let { parsePluginStatus(it) }
+        val visibility = resolveVisibility(ns)
         val pageable = buildPageable(page, size, sort)
-        val resultPage = pluginService.findPagedByNamespace(
-            ns,
-            pluginStatus,
-            tag,
-            q,
-            pageable,
-            publishedOnly = true,
+        val catalogResult = pluginService.findPagedByNamespace(
+            namespaceSlug = ns,
+            status = pluginStatus,
+            tag = tag,
+            q = q,
+            pageable = pageable,
+            visibility = visibility,
+            version = version,
         )
 
+        val resultPage = catalogResult.page
         val pluginIds = resultPage.content.mapNotNull { it.id }
         val latestReleases: Map<UUID, PluginReleaseEntity>
         val downloadCounts: Map<UUID, Long>
@@ -96,7 +104,13 @@ class CatalogController(
 
         val response = PluginPagedResponse(
             content = resultPage.content.map {
-                pluginMapper.toDto(it, ns, latestReleases[it.id], downloadCounts[it.id] ?: 0)
+                pluginMapper.toDto(
+                    it,
+                    ns,
+                    latestReleases[it.id],
+                    downloadCounts[it.id] ?: 0,
+                    hasDraftOnly = it.id in catalogResult.draftOnlyPluginIds,
+                )
             },
             totalElements = resultPage.totalElements,
             page = resultPage.number,
@@ -160,7 +174,7 @@ class CatalogController(
     }
 
     override fun listTags(ns: String): ResponseEntity<List<String>> =
-        ResponseEntity.ok(pluginService.findDistinctTags(ns))
+        ResponseEntity.ok(pluginService.findDistinctTags(ns, resolveVisibility(ns)))
 
     override fun getPluginsJson(ns: String): ResponseEntity<Pf4jPluginsJson> =
         ResponseEntity.ok(pf4jService.buildPluginsJson(ns))
@@ -178,8 +192,33 @@ class CatalogController(
 
     private fun parsePluginStatus(value: String): PluginStatus = when (value.lowercase()) {
         "active" -> PluginStatus.ACTIVE
+        "suspended" -> PluginStatus.SUSPENDED
         "archived" -> PluginStatus.ARCHIVED
         else -> throw IllegalArgumentException("Unknown plugin status: $value")
+    }
+
+    /**
+     * Determines catalog visibility based on the caller's authentication and role.
+     */
+    private fun resolveVisibility(ns: String): CatalogVisibility {
+        val auth = SecurityContextHolder.getContext().authentication ?: return CatalogVisibility.PUBLIC
+        if (!auth.isAuthenticated) return CatalogVisibility.PUBLIC
+        // API key callers (name starts with "key:") are treated as PUBLIC visibility
+        if (auth.name.startsWith("key:")) return CatalogVisibility.PUBLIC
+        // System superadmin sees everything
+        if (namespaceAuthService.isSuperadmin(auth)) return CatalogVisibility.ADMIN
+        // Check namespace-level role
+        return try {
+            namespaceAuthService.requireRole(ns, auth, NamespaceRole.ADMIN)
+            CatalogVisibility.ADMIN
+        } catch (_: Exception) {
+            try {
+                namespaceAuthService.requireRole(ns, auth, NamespaceRole.READ_ONLY)
+                CatalogVisibility.AUTHENTICATED
+            } catch (_: Exception) {
+                CatalogVisibility.PUBLIC
+            }
+        }
     }
 
     private fun buildPageable(page: Int, size: Int, sort: String): org.springframework.data.domain.Pageable {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/mapper/PluginMapper.kt
@@ -40,6 +40,7 @@ class PluginMapper(private val releaseMapper: PluginReleaseMapper) {
         namespaceSlug: String,
         latestRelease: PluginReleaseEntity? = null,
         downloadCount: Long = 0,
+        hasDraftOnly: Boolean = false,
     ): PluginDto = PluginDto(
         id = entity.id!!,
         pluginId = entity.pluginId,
@@ -52,6 +53,7 @@ class PluginMapper(private val releaseMapper: PluginReleaseMapper) {
         tags = entity.tags.toList().takeIf { it.isNotEmpty() },
         latestRelease = latestRelease?.let { releaseMapper.toDto(it, entity.pluginId) },
         downloadCount = downloadCount,
+        hasDraftOnly = hasDraftOnly.takeIf { it },
         icon = entity.icon?.let { URI(it) },
         homepage = entity.homepage?.let { URI(it) },
         repository = entity.repository?.let { URI(it) },

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceMemberRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceMemberRepository.kt
@@ -18,9 +18,12 @@
  */
 package io.plugwerk.server.repository
 
+import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.NamespaceMemberEntity
 import io.plugwerk.server.domain.NamespaceRole
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 import java.util.UUID
 
@@ -31,6 +34,18 @@ interface NamespaceMemberRepository : JpaRepository<NamespaceMemberEntity, UUID>
     fun findAllByNamespaceId(namespaceId: UUID): List<NamespaceMemberEntity>
 
     fun findAllByUserSubject(userSubject: String): List<NamespaceMemberEntity>
+
+    /**
+     * Returns the namespaces a user is a member of, eagerly fetching the namespace entity
+     * to avoid LazyInitializationException when accessing namespace properties outside a session.
+     */
+    @Query(
+        """
+        SELECT m.namespace FROM NamespaceMemberEntity m
+        WHERE m.userSubject = :userSubject
+        """,
+    )
+    fun findNamespacesByUserSubject(@Param("userSubject") userSubject: String): List<NamespaceEntity>
 
     fun existsByNamespaceIdAndUserSubjectAndRoleIn(
         namespaceId: UUID,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -120,4 +120,26 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         """,
     )
     fun countPluginsWithOnlyDraftReleases(@Param("namespaceId") namespaceId: UUID): Long
+
+    /**
+     * Returns the IDs of active plugins in a namespace that have at least one draft release
+     * but no published release. Used to identify "pending review" plugins for catalog display.
+     */
+    @Query(
+        """
+        SELECT DISTINCT p.id
+        FROM PluginEntity p
+        JOIN PluginReleaseEntity r ON r.plugin = p
+        WHERE p.namespace.id = :namespaceId
+          AND p.status = io.plugwerk.spi.model.PluginStatus.ACTIVE
+          AND r.status = io.plugwerk.spi.model.ReleaseStatus.DRAFT
+          AND NOT EXISTS (
+            SELECT 1
+            FROM PluginReleaseEntity r2
+            WHERE r2.plugin = p
+              AND r2.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
+          )
+        """,
+    )
+    fun findPluginIdsWithOnlyDraftReleases(@Param("namespaceId") namespaceId: UUID): Set<UUID>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
@@ -141,10 +141,7 @@ class NamespaceAuthorizationService(
                 .map { listOf(it) }.orElse(emptyList())
         }
 
-        val memberSlugs = namespaceMemberRepository.findAllByUserSubject(authentication.name)
-            .map { it.namespace.slug }
-            .toSet()
-        return namespaceRepository.findAll().filter { it.slug in memberSlugs }
+        return namespaceMemberRepository.findNamespacesByUserSubject(authentication.name)
     }
 
     private fun isSuperadmin(username: String): Boolean =

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginService.kt
@@ -55,14 +55,31 @@ class PluginService(
     }
 
     /**
+     * Catalog visibility level, determined by the caller's role.
+     */
+    enum class CatalogVisibility {
+        /** Anonymous or API-key callers: only ACTIVE plugins with published releases. */
+        PUBLIC,
+
+        /** Authenticated namespace member / read-only: all statuses except SUSPENDED, incl. draft-only. */
+        AUTHENTICATED,
+
+        /** Namespace admin or system admin: all plugins, all statuses. */
+        ADMIN,
+    }
+
+    /**
+     * Result of a paged catalog query, including the set of draft-only plugin IDs
+     * so the controller can pass it to the mapper.
+     */
+    data class PagedCatalogResult(val page: Page<PluginEntity>, val draftOnlyPluginIds: Set<java.util.UUID>)
+
+    /**
      * Returns a paginated, filtered list of plugins for the given namespace.
      *
-     * Tag, full-text (q), and published-only filters are applied in-memory after
-     * the DB query, which is acceptable for MVP catalog sizes. A DB-level filter can
-     * replace this when catalog size demands it.
-     *
-     * @param publishedOnly when `true`, only plugins that have at least one PUBLISHED release
-     *   are returned. SUSPENDED plugins are always excluded regardless of this flag.
+     * Tag, full-text (q), version compatibility, and visibility filters are applied
+     * in-memory after the DB query, which is acceptable for MVP catalog sizes.
+     * A DB-level filter can replace this when catalog size demands it.
      */
     fun findPagedByNamespace(
         namespaceSlug: String,
@@ -70,41 +87,131 @@ class PluginService(
         tag: String?,
         q: String?,
         pageable: Pageable,
-        publishedOnly: Boolean = false,
-    ): Page<PluginEntity> {
+        visibility: CatalogVisibility = CatalogVisibility.PUBLIC,
+        version: String? = null,
+    ): PagedCatalogResult {
         val namespace = namespaceService.findBySlug(namespaceSlug)
+
+        // Load all plugins — optionally filtered by explicit status
         val all = if (status != null) {
             pluginRepository.findAllByNamespaceAndStatus(namespace, status)
         } else {
             pluginRepository.findAllByNamespace(namespace)
         }
 
-        val pluginIdsWithPublishedRelease: Set<java.util.UUID> = if (publishedOnly) {
-            val ids = all.mapNotNull { it.id }
-            if (ids.isEmpty()) {
-                emptySet()
-            } else {
-                releaseRepository.findLatestPublishedReleasesForPlugins(ids)
-                    .map { it.plugin.id!! }
-                    .toSet()
-            }
-        } else {
+        val allIds = all.mapNotNull { it.id }
+
+        // Determine which plugins have published releases
+        val pluginIdsWithPublishedRelease: Set<java.util.UUID> = if (allIds.isEmpty()) {
             emptySet()
+        } else {
+            releaseRepository.findLatestPublishedReleasesForPlugins(allIds)
+                .map { it.plugin.id!! }
+                .toSet()
         }
 
-        val filtered = all
-            .filter { it.status != PluginStatus.SUSPENDED }
-            .filter { plugin ->
-                (!publishedOnly || plugin.id in pluginIdsWithPublishedRelease) &&
-                    (tag == null || plugin.tags.contains(tag)) &&
-                    (
-                        q == null || plugin.name.contains(q, ignoreCase = true) ||
-                            plugin.description?.contains(q, ignoreCase = true) == true
-                        )
+        // Determine which plugins are draft-only (for AUTHENTICATED/ADMIN visibility)
+        val draftOnlyPluginIds: Set<java.util.UUID> =
+            if (visibility != CatalogVisibility.PUBLIC && namespace.id != null) {
+                releaseRepository.findPluginIdsWithOnlyDraftReleases(namespace.id!!)
+            } else {
+                emptySet()
             }
-        val offset = pageable.offset.toInt().coerceAtMost(filtered.size)
-        val page = filtered.subList(offset, (offset + pageable.pageSize).coerceAtMost(filtered.size))
-        return PageImpl(page, pageable, filtered.size.toLong())
+
+        // Apply visibility rules
+        val visibilityFiltered = all.filter { plugin ->
+            when (visibility) {
+                CatalogVisibility.PUBLIC -> {
+                    plugin.status == PluginStatus.ACTIVE && plugin.id in pluginIdsWithPublishedRelease
+                }
+
+                CatalogVisibility.AUTHENTICATED -> {
+                    plugin.status != PluginStatus.SUSPENDED &&
+                        (plugin.id in pluginIdsWithPublishedRelease || plugin.id in draftOnlyPluginIds)
+                }
+
+                CatalogVisibility.ADMIN -> true
+            }
+        }
+
+        // Apply tag and full-text search filters
+        val filtered = visibilityFiltered.filter { plugin ->
+            (tag == null || plugin.tags.contains(tag)) &&
+                (
+                    q == null || plugin.name.contains(q, ignoreCase = true) ||
+                        plugin.description?.contains(q, ignoreCase = true) == true
+                    )
+        }
+
+        // Apply version compatibility filter
+        // Filters by the plugin release version itself. Plugins whose latest release
+        // version satisfies the constraint (e.g. >=2.0.0) are included.
+        // Plugins without a published release are excluded when a version filter is active.
+        val versionFiltered = if (version.isNullOrBlank()) {
+            filtered
+        } else {
+            val latestReleases = if (allIds.isEmpty()) {
+                emptyMap()
+            } else {
+                releaseRepository.findLatestPublishedReleasesForPlugins(allIds)
+                    .associateBy { it.plugin.id!! }
+            }
+            filtered.filter { plugin ->
+                val release = latestReleases[plugin.id] ?: return@filter false
+                matchesVersionConstraint(release.version, version)
+            }
+        }
+
+        // Apply in-memory sort (fixes downloadCount and updatedAt sorts)
+        val downloadCounts: Map<java.util.UUID, Long> = if (allIds.isEmpty()) {
+            emptyMap()
+        } else {
+            releaseRepository.sumDownloadCountsByPluginIds(allIds)
+                .associate { (it[0] as java.util.UUID) to (it[1] as Long) }
+        }
+
+        val sortOrder = pageable.sort.firstOrNull()
+        val sorted = if (sortOrder != null) {
+            val comparator: Comparator<PluginEntity> = when (sortOrder.property) {
+                "downloadCount" -> compareBy { downloadCounts[it.id] ?: 0L }
+                "updatedAt" -> compareBy { it.updatedAt }
+                "createdAt" -> compareBy { it.createdAt }
+                else -> compareBy { it.name.lowercase() }
+            }
+            val directed = if (sortOrder.isDescending) comparator.reversed() else comparator
+            versionFiltered.sortedWith(directed)
+        } else {
+            versionFiltered
+        }
+
+        val offset = pageable.offset.toInt().coerceAtMost(sorted.size)
+        val page = sorted.subList(offset, (offset + pageable.pageSize).coerceAtMost(sorted.size))
+        return PagedCatalogResult(
+            page = PageImpl(page, pageable, sorted.size.toLong()),
+            draftOnlyPluginIds = draftOnlyPluginIds,
+        )
+    }
+
+    /**
+     * Checks whether a declared system version satisfies a constraint like `>=3.0.0`.
+     * Uses simple numeric prefix comparison for the presets offered by the UI.
+     */
+    private fun matchesVersionConstraint(declaredVersion: String, constraint: String): Boolean {
+        if (!constraint.startsWith(">=")) return declaredVersion == constraint
+        val minVersion = constraint.removePrefix(">=")
+        return compareVersions(declaredVersion, minVersion) >= 0
+    }
+
+    private fun compareVersions(a: String, b: String): Int {
+        val partsA = a.split(".").map { it.toIntOrNull() ?: 0 }
+        val partsB = b.split(".").map { it.toIntOrNull() ?: 0 }
+        val maxLen = maxOf(partsA.size, partsB.size)
+        for (i in 0 until maxLen) {
+            val pa = partsA.getOrElse(i) { 0 }
+            val pb = partsB.getOrElse(i) { 0 }
+            if (pa != pb) return pa.compareTo(pb)
+        }
+        return 0
     }
 
     @Transactional
@@ -167,9 +274,20 @@ class PluginService(
         return pluginRepository.save(entity)
     }
 
-    fun findDistinctTags(namespaceSlug: String): List<String> {
+    fun findDistinctTags(
+        namespaceSlug: String,
+        visibility: CatalogVisibility = CatalogVisibility.PUBLIC,
+    ): List<String> {
         val namespace = namespaceService.findBySlug(namespaceSlug)
-        return pluginRepository.findAllByNamespaceAndStatus(namespace, PluginStatus.ACTIVE)
+        val all = pluginRepository.findAllByNamespace(namespace)
+        val filtered = all.filter { plugin ->
+            when (visibility) {
+                CatalogVisibility.PUBLIC -> plugin.status == PluginStatus.ACTIVE
+                CatalogVisibility.AUTHENTICATED -> plugin.status != PluginStatus.SUSPENDED
+                CatalogVisibility.ADMIN -> true
+            }
+        }
+        return filtered
             .flatMap { it.tags.toList() }
             .distinct()
             .sorted()

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -27,6 +27,7 @@ import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.service.NamespaceNotFoundException
@@ -83,6 +84,8 @@ class CatalogControllerTest {
 
     @MockitoBean lateinit var releaseMapper: PluginReleaseMapper
 
+    @MockitoBean lateinit var namespaceAuthService: NamespaceAuthorizationService
+
     @Autowired private lateinit var mockMvc: MockMvc
 
     private val namespace = NamespaceEntity(slug = "acme", name = "ACME Corp")
@@ -103,11 +106,12 @@ class CatalogControllerTest {
                 anyOrNull(),
                 any<Pageable>(),
                 any(),
+                anyOrNull(),
             ),
         )
-            .thenReturn(PageImpl(listOf(plugin)))
+            .thenReturn(PluginService.PagedCatalogResult(PageImpl(listOf(plugin)), emptySet()))
         whenever(
-            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), any()),
+            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), any(), any()),
         ).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins")
@@ -129,6 +133,7 @@ class CatalogControllerTest {
                 anyOrNull(),
                 any<Pageable>(),
                 any(),
+                anyOrNull(),
             ),
         )
             .thenThrow(NamespaceNotFoundException("unknown"))
@@ -145,7 +150,7 @@ class CatalogControllerTest {
         whenever(pluginService.findByNamespaceAndPluginId("acme", "my-plugin")).thenReturn(plugin)
         whenever(releaseService.findAllByPlugin("acme", "my-plugin")).thenReturn(emptyList())
         whenever(
-            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), any()),
+            pluginMapper.toDto(any(), eq("acme"), anyOrNull(), any(), any()),
         ).thenReturn(buildPluginDto())
 
         mockMvc.get("/api/v1/namespaces/acme/plugins/my-plugin")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -104,7 +104,7 @@ class ManagementControllerTest {
                 anyOrNull(), anyOrNull(), anyOrNull(),
             ),
         ).thenReturn(plugin)
-        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), any())).thenReturn(buildPluginDto())
+        whenever(pluginMapper.toDto(any(), any(), anyOrNull(), any(), any())).thenReturn(buildPluginDto())
 
         mockMvc.patch("/api/v1/namespaces/acme/plugins/my-plugin") {
             contentType = MediaType.APPLICATION_JSON

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AdminRoute.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AdminRoute.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Navigate } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { useAuthStore } from '../../stores/authStore'
+
+interface AdminRouteProps {
+  children: ReactNode
+}
+
+/**
+ * Route guard that restricts access to admin pages.
+ *
+ * Access is granted when the user is either:
+ * - a system superadmin, or
+ * - an ADMIN of the currently selected namespace.
+ *
+ * All other users are redirected to the 403 Forbidden page.
+ */
+export function AdminRoute({ children }: AdminRouteProps) {
+  const { isSuperadmin, namespaceRole } = useAuthStore()
+
+  if (!isSuperadmin && namespaceRole !== 'ADMIN') {
+    return <Navigate to="/403" replace />
+  }
+
+  return <>{children}</>
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
@@ -34,6 +34,7 @@ const defaultFilters = {
   search: '',
   tag: '',
   status: '',
+  version: '',
   sort: 'name,asc',
   page: 0,
   size: 24,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState } from 'react'
 import { Box, Button, InputBase, MenuItem, ToggleButton, ToggleButtonGroup, useTheme, alpha } from '@mui/material'
 import { LayoutGrid, List, Search } from 'lucide-react'
 import { usePluginStore } from '../../stores/pluginStore'
@@ -42,6 +41,8 @@ const COMPATIBILITY_OPTIONS = [
   { value: '>=3.0.0', label: '≥ 3.0.0' },
   { value: '>=2.5.0', label: '≥ 2.5.0' },
   { value: '>=2.0.0', label: '≥ 2.0.0' },
+  { value: '>=1.5.0', label: '≥ 1.5.0' },
+  { value: '>=1.0.0', label: '≥ 1.0.0' },
 ]
 
 export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
@@ -49,8 +50,7 @@ export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
   const isDark = theme.palette.mode === 'dark'
   const { filters, setFilters, fetchPlugins, availableTags } = usePluginStore()
   const { searchQuery, setSearchQuery } = useUiStore()
-  const [compatibility, setCompatibility] = useState('')
-  const hasActiveFilters = !!(filters.tag || filters.status || compatibility)
+  const hasActiveFilters = !!(filters.tag || filters.status || filters.version)
 
   function handleChange(key: string, value: string) {
     setFilters({ [key]: value, page: 0 })
@@ -58,8 +58,7 @@ export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
   }
 
   function handleReset() {
-    setFilters({ tag: '', status: '', sort: 'name,asc', page: 0 })
-    setCompatibility('')
+    setFilters({ tag: '', status: '', version: '', sort: 'name,asc', page: 0 })
     fetchPlugins(namespace)
   }
 
@@ -93,13 +92,15 @@ export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
         aria-label="Filter by status"
         minWidth={140}
       >
-        <MenuItem value="">Active</MenuItem>
+        <MenuItem value="">Any Status</MenuItem>
+        <MenuItem value="active">Active</MenuItem>
+        <MenuItem value="suspended">Suspended</MenuItem>
         <MenuItem value="archived">Archived</MenuItem>
       </FilterSelect>
 
       <FilterSelect
-        value={compatibility}
-        onChange={setCompatibility}
+        value={filters.version}
+        onChange={(v) => handleChange('version', v)}
         aria-label="Filter by compatibility"
         minWidth={140}
       >

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
@@ -99,15 +99,34 @@ describe('PluginCard', () => {
     expect(link).toBeInTheDocument()
   })
 
-  it('shows deprecated badge for archived plugins', () => {
+  it('shows archived badge for archived plugins', () => {
     const plugin = { ...basePlugin, status: 'archived' as const }
     renderWithRouter(<PluginCard plugin={plugin} namespace="acme" />)
-    expect(screen.getByText('Deprecated')).toBeInTheDocument()
+    expect(screen.getByText('Archived')).toBeInTheDocument()
   })
 
-  it('does not show deprecated badge for active plugins', () => {
+  it('shows suspended badge for suspended plugins', () => {
+    const plugin = { ...basePlugin, status: 'suspended' as const }
+    renderWithRouter(<PluginCard plugin={plugin} namespace="acme" />)
+    expect(screen.getByText('Suspended')).toBeInTheDocument()
+  })
+
+  it('shows pending review badge for draft-only plugins', () => {
+    const plugin = { ...basePlugin, hasDraftOnly: true }
+    renderWithRouter(<PluginCard plugin={plugin} namespace="acme" />)
+    expect(screen.getByText('Pending Review')).toBeInTheDocument()
+  })
+
+  it('does not show status badge for active plugins', () => {
     renderWithRouter(<PluginCard plugin={basePlugin} namespace="acme" />)
-    expect(screen.queryByText('Deprecated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument()
+    expect(screen.queryByText('Suspended')).not.toBeInTheDocument()
+  })
+
+  it('renders plugin ID with copy button', () => {
+    renderWithRouter(<PluginCard plugin={basePlugin} namespace="acme" />)
+    expect(screen.getByText('auth-plugin')).toBeInTheDocument()
+    expect(screen.getByLabelText('Copy plugin ID')).toBeInTheDocument()
   })
 
   it('renders "—" when updatedAt is not set', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -21,11 +21,20 @@ import { Download, Clock, Puzzle, HardDrive } from 'lucide-react'
 import { useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { Badge } from '../common/Badge'
+import type { BadgeVariant } from '../common/Badge'
+import { ActionIconButton } from '../common/ActionIconButton'
+import { CopyablePluginId } from '../common/CopyablePluginId'
 import type { PluginDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { useIsOverflowing } from '../../hooks/useIsOverflowing'
 import { formatFileSize } from '../../utils/formatFileSize'
 import { formatDateTime, formatRelativeTime } from '../../utils/formatDateTime'
+import { downloadArtifact } from '../../utils/downloadArtifact'
+
+const STATUS_BADGE: Record<string, BadgeVariant> = {
+  suspended: 'suspended',
+  archived: 'archived',
+}
 
 interface PluginCardProps {
   plugin: PluginDto
@@ -40,8 +49,12 @@ function formatCount(n: number | undefined): string {
 
 
 export function PluginCard({ plugin, namespace }: PluginCardProps) {
-  const isDeprecated = plugin.status === 'archived'
+  const isDraftOnly = plugin.hasDraftOnly === true
+  const statusBadge = plugin.status ? STATUS_BADGE[plugin.status] : undefined
   const latestRelease = plugin.latestRelease
+  const downloadUrl = latestRelease
+    ? `/api/v1/namespaces/${namespace}/plugins/${plugin.pluginId}/releases/${latestRelease.version}/download`
+    : null
 
   const nameRef = useRef<HTMLElement>(null)
   const providerRef = useRef<HTMLElement>(null)
@@ -62,6 +75,7 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
         height: '100%',
         textDecoration: 'none',
         transition: 'border-color 0.15s, box-shadow 0.15s',
+        ...(isDraftOnly && { opacity: 0.6, filter: 'saturate(0.5)' }),
         '&:hover': {
           borderColor: tokens.color.primary,
           boxShadow: `0 0 0 1px ${tokens.color.primary}`,
@@ -110,23 +124,29 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
                   {plugin.name}
                 </Typography>
               </Tooltip>
+              {isDraftOnly && <Badge variant="pending-review">Pending Review</Badge>}
+              {statusBadge && (
+                <Badge variant={statusBadge}>
+                  {plugin.status!.charAt(0).toUpperCase() + plugin.status!.slice(1)}
+                </Badge>
+              )}
               {latestRelease?.version && (
                 <Badge variant="version">v{latestRelease.version}</Badge>
               )}
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Tooltip title={providerOverflowing ? (plugin.provider ?? namespace) : ''} placement="bottom">
+              <Tooltip title={providerOverflowing ? (plugin.provider ?? '') : ''} placement="bottom">
                 <Typography
                   ref={providerRef}
                   variant="caption"
                   color="text.disabled"
                   sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
                 >
-                  {plugin.provider ?? namespace}
+                  {plugin.provider ?? ''}
                 </Typography>
               </Tooltip>
-              {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
             </Box>
+            <CopyablePluginId pluginId={plugin.pluginId} />
           </Box>
         </Box>
 
@@ -164,6 +184,20 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
           sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 'auto' }}
           aria-label="Plugin statistics"
         >
+          {downloadUrl && (
+            <ActionIconButton
+              icon={Download}
+              tooltip="Download latest release"
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                downloadArtifact(
+                  downloadUrl,
+                  `${plugin.pluginId}-${latestRelease!.version}.${latestRelease!.fileFormat ?? 'jar'}`,
+                ).catch(() => {})
+              }}
+            />
+          )}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
             <Download size={12} aria-hidden="true" />
             <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -20,10 +20,19 @@ import { Box, Tooltip, Typography } from '@mui/material'
 import { Download, Clock, Puzzle, HardDrive } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Badge } from '../common/Badge'
+import type { BadgeVariant } from '../common/Badge'
+import { ActionIconButton } from '../common/ActionIconButton'
+import { CopyablePluginId } from '../common/CopyablePluginId'
 import type { PluginDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { formatFileSize } from '../../utils/formatFileSize'
 import { formatDateTime, formatRelativeTime } from '../../utils/formatDateTime'
+import { downloadArtifact } from '../../utils/downloadArtifact'
+
+const STATUS_BADGE: Record<string, BadgeVariant> = {
+  suspended: 'suspended',
+  archived: 'archived',
+}
 
 interface PluginListRowProps {
   plugin: PluginDto
@@ -36,10 +45,14 @@ function formatCount(n: number | undefined): string {
   return String(n)
 }
 
-
 export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
-  const isDeprecated = plugin.status === 'archived'
+  const isDraftOnly = plugin.hasDraftOnly === true
+  const statusBadge = plugin.status ? STATUS_BADGE[plugin.status] : undefined
   const latestRelease = plugin.latestRelease
+  const downloadUrl = latestRelease
+    ? `/api/v1/namespaces/${namespace}/plugins/${plugin.pluginId}/releases/${latestRelease.version}/download`
+    : null
+
   return (
     <Box
       component={Link}
@@ -57,6 +70,7 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         color: 'inherit',
         bgcolor: 'background.paper',
         transition: 'background-color 0.15s',
+        ...(isDraftOnly && { opacity: 0.6, filter: 'saturate(0.5)' }),
         '&:last-child': { borderBottom: 'none' },
         '&:hover': { bgcolor: 'background.default' },
       }}
@@ -81,13 +95,52 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
       </Box>
 
       <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography variant="body2" fontWeight={600} noWrap>{plugin.name}</Typography>
-        <Typography variant="caption" color="text.disabled">{plugin.provider ?? namespace}</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="body2" fontWeight={600} noWrap>{plugin.name}</Typography>
+          {isDraftOnly && <Badge variant="pending-review">Pending Review</Badge>}
+          {statusBadge && (
+            <Badge variant={statusBadge}>
+              {plugin.status!.charAt(0).toUpperCase() + plugin.status!.slice(1)}
+            </Badge>
+          )}
+          {latestRelease?.version && (
+            <Badge variant="version">v{latestRelease.version}</Badge>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {plugin.provider && (
+            <>
+              <Typography variant="caption" color="text.disabled">{plugin.provider}</Typography>
+              <Typography variant="caption" color="text.disabled">·</Typography>
+            </>
+          )}
+          <CopyablePluginId pluginId={plugin.pluginId} />
+        </Box>
       </Box>
 
-      {isDeprecated && <Badge variant="deprecated">Deprecated</Badge>}
-      {latestRelease?.version && (
-        <Badge variant="version">v{latestRelease.version}</Badge>
+      {/* Tags */}
+      {plugin.tags && plugin.tags.length > 0 && (
+        <Box sx={{ display: 'flex', gap: 0.5, flexShrink: 0 }}>
+          {plugin.tags.slice(0, 3).map((tag) => (
+            <Badge key={tag} variant="tag">{tag}</Badge>
+          ))}
+        </Box>
+      )}
+
+      {/* Quick download */}
+      {downloadUrl && (
+        <ActionIconButton
+          icon={Download}
+          tooltip="Download latest release"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            downloadArtifact(
+              downloadUrl,
+              `${plugin.pluginId}-${latestRelease!.version}.${latestRelease!.fileFormat ?? 'jar'}`,
+            ).catch(() => {})
+          }}
+        />
       )}
 
       <Box sx={{ display: 'flex', gap: 2, color: 'text.disabled', flexShrink: 0 }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Badge.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Badge.tsx
@@ -29,6 +29,9 @@ export type BadgeVariant =
   | 'yanked'
   | 'tag'
   | 'verified'
+  | 'suspended'
+  | 'archived'
+  | 'pending-review'
 
 interface BadgeProps {
   variant: BadgeVariant
@@ -41,8 +44,11 @@ const styles: Record<BadgeVariant, { bg: string; color: string }> = {
   draft:      { bg: tokens.badge.draft.bg,       color: tokens.badge.draft.text },
   deprecated: { bg: tokens.badge.deprecated.bg,  color: tokens.badge.deprecated.text },
   yanked:     { bg: tokens.badge.yanked.bg,       color: tokens.badge.yanked.text },
-  tag:        { bg: tokens.badge.tag.bg,          color: tokens.badge.tag.text },
-  verified:   { bg: tokens.badge.published.bg,    color: tokens.badge.published.text },
+  tag:            { bg: tokens.badge.tag.bg,            color: tokens.badge.tag.text },
+  verified:       { bg: tokens.badge.published.bg,      color: tokens.badge.published.text },
+  suspended:      { bg: tokens.badge.suspended.bg,      color: tokens.badge.suspended.text },
+  archived:       { bg: tokens.badge.archived.bg,       color: tokens.badge.archived.text },
+  'pending-review': { bg: tokens.badge.pendingReview.bg, color: tokens.badge.pendingReview.text },
 }
 
 export function Badge({ variant, children }: BadgeProps) {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/CopyablePluginId.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/CopyablePluginId.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from 'react'
+import { Box, Tooltip, IconButton, Typography } from '@mui/material'
+import { Copy, Check } from 'lucide-react'
+
+interface CopyablePluginIdProps {
+  pluginId: string
+}
+
+export function CopyablePluginId({ pluginId }: CopyablePluginIdProps) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy(e: React.MouseEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+    try {
+      await navigator.clipboard.writeText(pluginId)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard not available
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.25,
+        maxWidth: '100%',
+        minWidth: 0,
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          fontFamily: 'monospace',
+          fontSize: '0.7rem',
+          color: 'text.disabled',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {pluginId}
+      </Typography>
+      <Tooltip title={copied ? 'Copied!' : 'Copy plugin ID'} arrow>
+        <IconButton
+          size="small"
+          onClick={handleCopy}
+          aria-label="Copy plugin ID"
+          sx={{ p: 0.25, color: 'text.disabled' }}
+        >
+          {copied ? <Check size={11} /> : <Copy size={11} />}
+        </IconButton>
+      </Tooltip>
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -39,7 +39,7 @@ export function TopBar() {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const { toggleTheme, openUploadModal } = useUiStore()
-  const { isAuthenticated, logout, namespace, setNamespace } = useAuthStore()
+  const { isAuthenticated, logout, namespace, setNamespace, isSuperadmin, namespaceRole } = useAuthStore()
   const { namespaces } = useNamespaceStore()
   const navigate = useNavigate()
   const { pathname } = useLocation()
@@ -140,23 +140,27 @@ export function TopBar() {
                 >
                   Catalog
                 </Button>
-                <Button
-                  onClick={openUploadModal}
-                  startIcon={<Upload size={15} />}
-                  sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
-                >
-                  Upload
-                </Button>
+                {(isSuperadmin || namespaceRole === 'ADMIN' || namespaceRole === 'MEMBER') && (
+                  <Button
+                    onClick={openUploadModal}
+                    startIcon={<Upload size={15} />}
+                    sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
+                  >
+                    Upload
+                  </Button>
+                )}
               </>
             )}
-            <Button
-              component={Link}
-              to="/admin"
-              startIcon={<Settings size={15} color={isActive('/admin') ? tokens.color.primary : undefined} />}
-              sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
-            >
-              Admin
-            </Button>
+            {(isSuperadmin || namespaceRole === 'ADMIN') && (
+              <Button
+                component={Link}
+                to="/admin"
+                startIcon={<Settings size={15} color={isActive('/admin') ? tokens.color.primary : undefined} />}
+                sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}
+              >
+                Admin
+              </Button>
+            )}
           </Box>
         )}
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -21,6 +21,7 @@ import { Box, Typography, Button, Menu, MenuItem } from '@mui/material'
 import { Download, Calendar, Scale, Puzzle, Trash2, ArrowRightLeft } from 'lucide-react'
 import { Badge } from '../common/Badge'
 import type { BadgeVariant } from '../common/Badge'
+import { CopyablePluginId } from '../common/CopyablePluginId'
 import type { PluginDto, PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { formatDateTime } from '../../utils/formatDateTime'
@@ -119,11 +120,14 @@ export function PluginHeader({ plugin, latestRelease, namespace, isAdmin, onDele
           )}
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
           <Typography variant="caption" color="text.disabled">
             by <strong style={{ color: 'inherit' }}>{plugin.provider ?? namespace}</strong>
             {' · '}Namespace: <code>{namespace}</code>
           </Typography>
+        </Box>
+        <Box sx={{ mb: 1.5 }}>
+          <CopyablePluginId pluginId={plugin.pluginId} />
         </Box>
 
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
@@ -58,6 +58,7 @@ const defaultFilters = {
   search: '',
   tag: '',
   status: '',
+  version: '',
   sort: 'name,asc',
   page: 0,
   size: 24,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
@@ -20,83 +20,164 @@ import {
   Box,
   Container,
   Typography,
-  Divider,
   Select,
   MenuItem,
   FormControl,
   InputLabel,
-  TextField,
   Button,
-  Alert,
+  alpha,
+  useTheme,
 } from '@mui/material'
+import { User, Globe, FolderOpen, Lock } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
+import { useNamespaceStore } from '../stores/namespaceStore'
+import { tokens } from '../theme/tokens'
+
+interface SectionProps {
+  icon: React.ReactNode
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+function Section({ icon, title, description, children }: SectionProps) {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: tokens.radius.card,
+        background: isDark ? alpha('#ffffff', 0.02) : tokens.color.white,
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 3,
+          py: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          background: isDark ? alpha('#ffffff', 0.03) : tokens.color.gray10,
+        }}
+      >
+        <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
+        <Box>
+          <Typography variant="subtitle1" fontWeight={600}>{title}</Typography>
+          {description && (
+            <Typography variant="caption" color="text.secondary">{description}</Typography>
+          )}
+        </Box>
+      </Box>
+      <Box sx={{ px: 3, py: 2.5 }}>
+        {children}
+      </Box>
+    </Box>
+  )
+}
+
+interface InfoRowProps {
+  label: string
+  value: string
+}
+
+function InfoRow({ label, value }: InfoRowProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 2, py: 0.75 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ minWidth: 80, flexShrink: 0, fontWeight: 500 }}
+      >
+        {label}
+      </Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  )
+}
 
 export function ProfileSettingsPage() {
-  const { apiKey, namespace } = useAuthStore()
+  const { username, namespace, setNamespace } = useAuthStore()
+  const { namespaces } = useNamespaceStore()
 
   return (
     <Box component="main" id="main-content" sx={{ flex: 1, py: 4 }}>
       <Container maxWidth="sm">
-        <Typography variant="h1" gutterBottom>Profile Settings</Typography>
-        <Divider sx={{ mb: 4 }} />
+        <Typography variant="h1" sx={{ mb: 0.5 }}>Profile Settings</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
+          Manage your account preferences and workspace configuration.
+        </Typography>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
 
-          {/* Language preference */}
-          <Box>
-            <Typography variant="h4" gutterBottom>Language</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Your preferred UI language. Overrides the system default set by the administrator.
-            </Typography>
-            <FormControl size="small" sx={{ minWidth: 200 }}>
+          {/* Personal Information */}
+          <Section icon={<User size={18} />} title="Personal Information">
+            <InfoRow label="Username" value={username ?? '—'} />
+            <InfoRow label="Email" value="Not set" />
+          </Section>
+
+          {/* Security */}
+          <Section
+            icon={<Lock size={18} />}
+            title="Security"
+            description="Manage your password"
+          >
+            <Button
+              component={Link}
+              to="/change-password"
+              variant="outlined"
+              size="small"
+              sx={{ borderRadius: tokens.radius.btn }}
+            >
+              Change Password
+            </Button>
+          </Section>
+
+          {/* Language */}
+          <Section
+            icon={<Globe size={18} />}
+            title="Language"
+            description="Overrides the system default set by the administrator"
+          >
+            <FormControl size="small" sx={{ minWidth: 220 }}>
               <InputLabel>Language</InputLabel>
               <Select defaultValue="en" label="Language">
                 <MenuItem value="en">English</MenuItem>
                 <MenuItem value="de">Deutsch</MenuItem>
               </Select>
             </FormControl>
-          </Box>
+          </Section>
 
-          <Divider />
+          {/* Default Namespace */}
+          <Section
+            icon={<FolderOpen size={18} />}
+            title="Default Namespace"
+            description="Used by default for catalog and upload operations"
+          >
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel>Namespace</InputLabel>
+              <Select
+                value={namespace ?? ''}
+                label="Namespace"
+                onChange={(e) => setNamespace(e.target.value)}
+              >
+                {namespaces.map((ns) => (
+                  <MenuItem key={ns.slug} value={ns.slug}>{ns.name} ({ns.slug})</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Section>
 
-          {/* Active namespace */}
-          <Box>
-            <Typography variant="h4" gutterBottom>Active Namespace</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              The namespace used for all catalog and upload operations.
-            </Typography>
-            <TextField
-              size="small"
-              label="Namespace"
-              defaultValue={namespace}
-              sx={{ minWidth: 200 }}
-            />
-          </Box>
-
-          <Divider />
-
-          {/* API Key */}
-          <Box>
-            <Typography variant="h4" gutterBottom>API Key</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Your personal API key for authenticating CLI and CI/CD requests.
-            </Typography>
-            {apiKey ? (
-              <TextField
-                size="small"
-                label="API Key"
-                type="password"
-                value={apiKey}
-                InputProps={{ readOnly: true }}
-                sx={{ minWidth: 320 }}
-              />
-            ) : (
-              <Alert severity="info">No API key set. Log in to configure one.</Alert>
-            )}
-          </Box>
-
-          <Box>
-            <Button variant="contained" sx={{ alignSelf: 'flex-start' }}>Save Changes</Button>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button variant="contained" sx={{ borderRadius: tokens.radius.btn }}>
+              Save Changes
+            </Button>
           </Box>
         </Box>
       </Container>

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -18,6 +18,7 @@
  */
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { AppShell } from '../AppShell'
+import { AdminRoute } from '../components/auth/AdminRoute'
 import { ProtectedRoute } from '../components/auth/ProtectedRoute'
 import { CatalogPage } from '../pages/CatalogPage'
 import { PluginDetailPage } from '../pages/PluginDetailPage'
@@ -56,7 +57,7 @@ export const router = createBrowserRouter([
       { path: 'namespaces/:namespace/plugins/:pluginId',                element: <ProtectedRoute><PluginDetailPage /></ProtectedRoute> },
       {
         path: 'admin',
-        element: <ProtectedRoute><AdminSettingsPage /></ProtectedRoute>,
+        element: <ProtectedRoute><AdminRoute><AdminSettingsPage /></AdminRoute></ProtectedRoute>,
         children: [
           { index: true,              element: <Navigate to="global-settings" replace /> },
           { path: 'global-settings',  element: <GeneralSection /> },

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
@@ -26,6 +26,7 @@ interface AuthState {
   namespace: string | null | undefined
   isAuthenticated: boolean
   passwordChangeRequired: boolean
+  isSuperadmin: boolean
   namespaceRole: NamespaceRole | null
 
   login: (username: string, password: string) => Promise<void>
@@ -45,6 +46,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   namespace: undefined,
   isAuthenticated: !!localStorage.getItem('pw-access-token'),
   passwordChangeRequired: localStorage.getItem('pw-password-change-required') === 'true',
+  isSuperadmin: localStorage.getItem('pw-is-superadmin') === 'true',
   namespaceRole: null,
 
   get apiKey() {
@@ -62,6 +64,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
     const data = await response.json()
     const passwordChangeRequired = data.passwordChangeRequired === true
+    const isSuperadmin = data.isSuperadmin === true
     localStorage.setItem('pw-access-token', data.accessToken)
     localStorage.setItem('pw-username', username)
     if (passwordChangeRequired) {
@@ -69,11 +72,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     } else {
       localStorage.removeItem('pw-password-change-required')
     }
+    if (isSuperadmin) {
+      localStorage.setItem('pw-is-superadmin', 'true')
+    } else {
+      localStorage.removeItem('pw-is-superadmin')
+    }
     set({
       accessToken: data.accessToken,
       username,
       isAuthenticated: true,
       passwordChangeRequired,
+      isSuperadmin,
     })
   },
 
@@ -88,8 +97,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     localStorage.removeItem('pw-access-token')
     localStorage.removeItem('pw-username')
     localStorage.removeItem('pw-password-change-required')
+    localStorage.removeItem('pw-is-superadmin')
     localStorage.removeItem('pw-namespace')
-    set({ accessToken: null, username: null, namespace: undefined, isAuthenticated: false, passwordChangeRequired: false, namespaceRole: null })
+    set({ accessToken: null, username: null, namespace: undefined, isAuthenticated: false, passwordChangeRequired: false, isSuperadmin: false, namespaceRole: null })
   },
 
   setNamespace(ns) {

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.test.ts
@@ -42,6 +42,7 @@ const defaultFilters = {
   search: '',
   tag: '',
   status: '',
+  version: '',
   sort: 'name,asc',
   page: 0,
   size: 24,
@@ -109,7 +110,7 @@ describe('usePluginStore', () => {
   describe('resetFilters', () => {
     it('resets all filters to defaults', () => {
       usePluginStore.setState({
-        filters: { search: 'foo', tag: 'baz', status: 'active', sort: 'downloads,desc', page: 5, size: 12 },
+        filters: { search: 'foo', tag: 'baz', status: 'active', version: '', sort: 'downloads,desc', page: 5, size: 12 },
       })
       act(() => { usePluginStore.getState().resetFilters() })
       expect(usePluginStore.getState().filters).toEqual(defaultFilters)

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.ts
@@ -25,6 +25,7 @@ interface PluginFilters {
   search: string
   tag: string
   status: string
+  version: string
   sort: string
   page: number
   size: number
@@ -50,6 +51,7 @@ const defaultFilters: PluginFilters = {
   search: '',
   tag: '',
   status: '',
+  version: '',
   sort: 'name,asc',
   page: 0,
   size: 24,
@@ -87,6 +89,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         q: filters.search || undefined,
         tag: filters.tag || undefined,
         status: (filters.status || undefined) as ListPluginsStatusEnum | undefined,
+        version: filters.version || undefined,
       })
       const data: PluginPagedResponse = response.data
       set({

--- a/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
@@ -39,12 +39,15 @@ export const tokens = {
   },
 
   badge: {
-    published: { bg: '#DEFBE6', text: '#198038' },
-    draft:     { bg: '#FFE8CC', text: '#A84400' },
-    deprecated:{ bg: '#FFF1C7', text: '#8A6A00' },
-    yanked:    { bg: '#FFD7D9', text: '#DA1E28' },
-    tag:       { bg: '#D0E2FF', text: '#0043CE' },
-    version:   { bg: '#F4F4F4', text: '#161616' },
+    published:     { bg: '#DEFBE6', text: '#198038' },
+    draft:         { bg: '#FFE8CC', text: '#A84400' },
+    deprecated:    { bg: '#FFF1C7', text: '#8A6A00' },
+    yanked:        { bg: '#FFD7D9', text: '#DA1E28' },
+    tag:           { bg: '#D0E2FF', text: '#0043CE' },
+    version:       { bg: '#F4F4F4', text: '#161616' },
+    suspended:     { bg: '#FFD7D9', text: '#DA1E28' },
+    archived:      { bg: '#FFF1C7', text: '#8A6A00' },
+    pendingReview: { bg: '#FFE8CC', text: '#A84400' },
   },
 
   radius: {


### PR DESCRIPTION
## Summary

Closes #176

- **Role-based catalog visibility**: Backend enforces `PUBLIC`/`AUTHENTICATED`/`ADMIN` visibility levels for plugin listings and tag filters based on caller's role (anonymous, API key, member, namespace admin, superadmin)
- **Status badges**: New `suspended`, `archived`, and `pending-review` badge variants in PluginCard and PluginListRow; draft-only plugins rendered grayed out
- **Plugin ID with copy**: New `CopyablePluginId` component shown in Card, Row, and Detail views
- **Quick download**: Download icon button in PluginCard and PluginListRow for one-click artifact download
- **Filter fixes**: Status filter expanded (Active/Suspended/Archived/Any Status), version filter wired to backend and fixed to compare release versions, tag dropdown respects role-based visibility
- **Sort fix**: In-memory sort for `downloadCount` and `updatedAt` now works correctly
- **LazyInitializationException fix**: `NamespaceAuthorizationService.listVisibleNamespaces()` replaced with direct namespace query to avoid Hibernate lazy-loading outside session
- **Admin access control**: `isSuperadmin` added to `LoginResponse` and `authStore`; new `AdminRoute` guard redirects unauthorized users to `/403`; Admin and Upload nav items conditionally visible based on role
- **Profile page redesign**: Card-based section layout with icons, removed API Key section, added Personal Information and Security sections, Default Namespace dropdown
- **ADR-0012**: Documents all frontend role-based UI visibility rules and patterns

## Test plan

- [ ] Backend: all 251 tests pass (`./gradlew :plugwerk-server:plugwerk-server-backend:test`)
- [ ] Frontend: `npm run build` compiles without errors; PluginCard, pluginStore, CatalogPage tests pass
- [ ] Manual: browse catalog as anonymous, member, namespace admin, superadmin — verify correct plugin visibility
- [ ] Manual: verify Admin nav item hidden for non-admin users; direct `/admin` URL shows 403
- [ ] Manual: verify Upload nav item hidden for READ_ONLY users
- [ ] Manual: verify version filter returns correct results (e.g. `>=1.0.0`)
- [ ] Manual: verify sort by "Most Downloads" and "Newest" works
- [ ] Manual: verify profile page layout with card sections