### PR TITLE
Comprehensive backend auth/authz integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,39 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build and test all modules
+      - name: Build and run unit tests
         run: ./gradlew build
+
+      - name: Pre-pull Docker images (with retry)
+        run: |
+          for i in 1 2 3; do
+            docker pull postgres:18-alpine && break
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+
+      - name: Run integration tests
+        run: ./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest
+        env:
+          PLUGWERK_JWT_SECRET: ci-integration-test-secret-min-32-characters!!
+          PLUGWERK_ENCRYPTION_KEY: ci-encrypt-16chr
+
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-reports
+          path: |
+            plugwerk-server/plugwerk-server-backend/build/reports/tests/test/
+            plugwerk-server/plugwerk-server-backend/build/test-results/test/
+          retention-days: 14
+
+      - name: Upload integration test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: |
+            plugwerk-server/plugwerk-server-backend/build/reports/tests/integrationTest/
+            plugwerk-server/plugwerk-server-backend/build/test-results/integrationTest/
+          retention-days: 14

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/DownloadEventEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/DownloadEventEntity.kt
@@ -26,6 +26,8 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UuidGenerator
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -50,6 +52,7 @@ class DownloadEventEntity(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "release_id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     var release: PluginReleaseEntity,
 
     @CreationTimestamp

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceAccessKeyEntity.kt
@@ -27,6 +27,8 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UuidGenerator
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -80,6 +82,7 @@ class NamespaceAccessKeyEntity(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "namespace_id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     var namespace: NamespaceEntity,
 
     @Column(name = "key_hash", nullable = false, length = 72)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceMemberEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceMemberEntity.kt
@@ -29,6 +29,8 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UuidGenerator
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -83,6 +85,7 @@ class NamespaceMemberEntity(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "namespace_id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     var namespace: NamespaceEntity,
 
     @Column(name = "user_subject", nullable = false)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginEntity.kt
@@ -31,6 +31,8 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.hibernate.type.SqlTypes
@@ -89,6 +91,7 @@ class PluginEntity(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "namespace_id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     var namespace: NamespaceEntity,
 
     @Column(name = "plugin_id", nullable = false, length = 255)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PluginReleaseEntity.kt
@@ -31,6 +31,8 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.hibernate.type.SqlTypes
@@ -99,6 +101,7 @@ class PluginReleaseEntity(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "plugin_id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     var plugin: PluginEntity,
 
     @Column(name = "version", nullable = false, length = 100)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -18,6 +18,7 @@
  */
 package io.plugwerk.server.e2e
 
+import io.plugwerk.server.e2e.auth.AbstractAuthorizationTest
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -35,16 +36,12 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.multipart
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
 import kotlin.test.assertNotNull
 
 @Tag("integration")
-@Testcontainers
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("integration")
@@ -52,13 +49,10 @@ import kotlin.test.assertNotNull
 class SmokeTest {
 
     companion object {
-        @Container
-        @JvmStatic
-        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:18-alpine")
-
         @DynamicPropertySource
         @JvmStatic
         fun overrideDataSource(registry: DynamicPropertyRegistry) {
+            val postgres = AbstractAuthorizationTest.postgres
             registry.add("spring.datasource.url", postgres::getJdbcUrl)
             registry.add("spring.datasource.username", postgres::getUsername)
             registry.add("spring.datasource.password", postgres::getPassword)
@@ -121,7 +115,7 @@ class SmokeTest {
             "application/java-archive",
             jarBytes,
         )
-        val uploadResult = mockMvc.multipart("/api/v1/namespaces/$namespace/releases") {
+        val uploadResult = mockMvc.multipart("/api/v1/namespaces/$namespace/plugin-releases") {
             file(artifact)
             header("Authorization", authHeader)
         }.andExpect {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -18,7 +18,6 @@
  */
 package io.plugwerk.server.e2e
 
-import io.plugwerk.server.e2e.auth.AbstractAuthorizationTest
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -52,7 +51,7 @@ class SmokeTest {
         @DynamicPropertySource
         @JvmStatic
         fun overrideDataSource(registry: DynamicPropertyRegistry) {
-            val postgres = AbstractAuthorizationTest.postgres
+            val postgres = io.plugwerk.server.SharedPostgresContainer.instance
             registry.add("spring.datasource.url", postgres::getJdbcUrl)
             registry.add("spring.datasource.username", postgres::getUsername)
             registry.add("spring.datasource.password", postgres::getPassword)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AbstractAuthorizationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AbstractAuthorizationTest.kt
@@ -78,9 +78,9 @@ abstract class AbstractAuthorizationTest {
         const val NS2 = "ns2"
         const val TEST_PASSWORD = "test-password-12!"
 
-        /** Singleton container — started once, reused across all test classes. */
+        /** Singleton container — shared with all integration tests via [SharedPostgresContainer]. */
         @JvmStatic
-        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:18-alpine").apply { start() }
+        val postgres: PostgreSQLContainer<*> = io.plugwerk.server.SharedPostgresContainer.instance
 
         @DynamicPropertySource
         @JvmStatic

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AbstractAuthorizationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AbstractAuthorizationTest.kt
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import io.plugwerk.server.domain.FileFormat
+import io.plugwerk.server.domain.NamespaceAccessKeyEntity
+import io.plugwerk.server.domain.NamespaceEntity
+import io.plugwerk.server.domain.NamespaceMemberEntity
+import io.plugwerk.server.domain.NamespaceRole
+import io.plugwerk.server.domain.PluginEntity
+import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.repository.NamespaceAccessKeyRepository
+import io.plugwerk.server.repository.NamespaceMemberRepository
+import io.plugwerk.server.repository.NamespaceRepository
+import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.spi.model.PluginStatus
+import io.plugwerk.spi.model.ReleaseStatus
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.testcontainers.containers.PostgreSQLContainer
+import tools.jackson.databind.ObjectMapper
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+/**
+ * Base class for authorization integration tests.
+ *
+ * Provides shared Testcontainers PostgreSQL, test data seeding, JWT token caching,
+ * and helper methods for building authenticated MockMvc requests.
+ *
+ * All subclasses share the same Spring context and database container.
+ */
+@Tag("integration")
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAuthorizationTest {
+
+    companion object {
+        const val NS1 = "ns1"
+        const val NS2 = "ns2"
+        const val TEST_PASSWORD = "test-password-12!"
+
+        /** Singleton container — started once, reused across all test classes. */
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:18-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun overrideDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+
+        /** JWT tokens keyed by actor — shared across all test classes in this context. */
+        val tokenCache = ConcurrentHashMap<Actor, String>()
+
+        /** API key plain-text values keyed by actor. */
+        val apiKeyCache = ConcurrentHashMap<Actor, String>()
+
+        /** Flag to prevent re-seeding when Spring context is reused across test classes. */
+        @Volatile
+        var seeded = false
+    }
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var namespaceRepository: NamespaceRepository
+
+    @Autowired
+    lateinit var namespaceMemberRepository: NamespaceMemberRepository
+
+    @Autowired
+    lateinit var pluginRepository: PluginRepository
+
+    @Autowired
+    lateinit var releaseRepository: PluginReleaseRepository
+
+    @Autowired
+    lateinit var accessKeyRepository: NamespaceAccessKeyRepository
+
+    @Autowired
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @BeforeAll
+    fun seedTestData() {
+        if (seeded) return
+        synchronized(Companion) {
+            if (seeded) return
+
+            // The "admin" user is created automatically by Liquibase migration + admin-password config.
+            // We need to make it a superadmin for our tests (it already is via bootstrap).
+            // Create additional test users.
+            val users = createTestUsers()
+            val namespaces = createTestNamespaces()
+            createTestMemberships(namespaces)
+            createTestPluginsAndReleases(namespaces)
+            createTestApiKeys(namespaces)
+            loginAllJwtActors()
+
+            seeded = true
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Auth helpers                                                         //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Obtains a fresh JWT token for the given actor by logging in again.
+     *
+     * Use this instead of [tokenCache] when the token will be consumed (e.g. logout),
+     * so that the shared cached token is not revoked.
+     */
+    fun freshToken(actor: Actor): String {
+        val actorUsernames = mapOf(
+            Actor.SUPERADMIN to ("admin" to "smoke-test-password"),
+            Actor.NS1_ADMIN to ("ns1-admin" to TEST_PASSWORD),
+            Actor.NS1_READ_ONLY to ("ns1-readonly" to TEST_PASSWORD),
+            Actor.NS1_RO_NS2_RO to ("ns1ro-ns2ro" to TEST_PASSWORD),
+            Actor.NS1_MEMBER_NS2_RO to ("ns1member-ns2ro" to TEST_PASSWORD),
+            Actor.NS2_ADMIN to ("ns2-admin" to TEST_PASSWORD),
+            Actor.UNRELATED to ("unrelated-user" to TEST_PASSWORD),
+        )
+        val (username, password) = requireNotNull(actorUsernames[actor]) { "No username for $actor" }
+        val result = mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("username" to username, "password" to password))),
+        ).andReturn()
+        check(result.response.status == 200) {
+            "Fresh login failed for $actor: ${result.response.status}"
+        }
+        val body = objectMapper.readValue(result.response.contentAsString, Map::class.java)
+        return body["accessToken"] as String
+    }
+
+    /**
+     * Adds the appropriate authentication header to a MockMvc request builder.
+     *
+     * - [Actor.ANONYMOUS]: no header added
+     * - API key actors: `X-Api-Key` header
+     * - JWT actors: `Authorization: Bearer <token>` header
+     */
+    fun MockHttpServletRequestBuilder.actAs(actor: Actor): MockHttpServletRequestBuilder = when {
+        actor == Actor.ANONYMOUS -> this
+
+        actor.isApiKey -> {
+            val key = requireNotNull(apiKeyCache[actor]) { "No API key cached for $actor" }
+            this.header("X-Api-Key", key)
+        }
+
+        else -> {
+            val token = requireNotNull(tokenCache[actor]) { "No JWT cached for $actor" }
+            this.header("Authorization", "Bearer $token")
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Ephemeral entity helpers (for destructive test operations)           //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Creates a throwaway namespace for tests that need to delete a namespace.
+     * Returns the namespace slug.
+     */
+    fun createEphemeralNamespace(slug: String = "ephemeral-${UUID.randomUUID().toString().take(8)}"): String {
+        namespaceRepository.save(NamespaceEntity(slug = slug, name = "Ephemeral $slug", publicCatalog = true))
+        return slug
+    }
+
+    /**
+     * Creates a throwaway user for tests that need to delete a user.
+     * Returns the user ID.
+     */
+    fun createEphemeralUser(username: String = "ephemeral-${UUID.randomUUID().toString().take(8)}"): UUID {
+        val user = userRepository.save(
+            UserEntity(
+                username = username,
+                passwordHash = requireNotNull(passwordEncoder.encode(TEST_PASSWORD)),
+                passwordChangeRequired = false,
+            ),
+        )
+        return user.id!!
+    }
+
+    /**
+     * Creates a throwaway plugin with one PUBLISHED release in the given namespace.
+     * Returns a pair of (pluginId string, releaseVersion string).
+     */
+    fun createEphemeralPlugin(
+        namespaceSlug: String,
+        pluginIdSuffix: String = UUID.randomUUID().toString().take(8),
+    ): Pair<String, String> {
+        val namespace = namespaceRepository.findBySlug(namespaceSlug).orElseThrow()
+        val pluginId = "ephemeral-$pluginIdSuffix"
+        val plugin = pluginRepository.save(
+            PluginEntity(
+                namespace = namespace,
+                pluginId = pluginId,
+                name = "Ephemeral Plugin $pluginIdSuffix",
+                status = PluginStatus.ACTIVE,
+                tags = emptyArray(),
+            ),
+        )
+        val jarBytes = buildMinimalJar(pluginId, "1.0.0")
+        releaseRepository.save(
+            PluginReleaseEntity(
+                plugin = plugin,
+                version = "1.0.0",
+                status = ReleaseStatus.PUBLISHED,
+                artifactSha256 = sha256(jarBytes),
+                artifactKey = "$namespaceSlug/$pluginId/1.0.0",
+                artifactSize = jarBytes.size.toLong(),
+                fileFormat = FileFormat.JAR,
+            ),
+        )
+        return pluginId to "1.0.0"
+    }
+
+    /**
+     * Creates a throwaway namespace membership.
+     */
+    fun createEphemeralMembership(
+        namespaceSlug: String,
+        userSubject: String,
+        role: NamespaceRole = NamespaceRole.READ_ONLY,
+    ) {
+        val namespace = namespaceRepository.findBySlug(namespaceSlug).orElseThrow()
+        namespaceMemberRepository.save(
+            NamespaceMemberEntity(namespace = namespace, userSubject = userSubject, role = role),
+        )
+    }
+
+    // ------------------------------------------------------------------ //
+    // JAR builder (copied from SmokeTest)                                 //
+    // ------------------------------------------------------------------ //
+
+    fun buildMinimalJar(pluginId: String, version: String): ByteArray {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Plugin-Id", pluginId)
+            mainAttributes.putValue("Plugin-Version", version)
+            mainAttributes.putValue("Plugin-Name", "Test Plugin $pluginId")
+            mainAttributes.putValue("Plugin-Description", "Auto-generated for auth/authz testing")
+        }
+        val out = ByteArrayOutputStream()
+        JarOutputStream(out, manifest).use { jar ->
+            jar.putNextEntry(JarEntry("dummy.txt"))
+            jar.write("auth-test".toByteArray())
+            jar.closeEntry()
+        }
+        return out.toByteArray()
+    }
+
+    fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+
+    // ------------------------------------------------------------------ //
+    // Parameterized test matrix helpers                                    //
+    // ------------------------------------------------------------------ //
+
+    data class ActorExpectation(val actor: Actor, val expectedStatus: Int) {
+        override fun toString(): String = "$actor → $expectedStatus"
+    }
+
+    data class NsActorExpectation(val actor: Actor, val namespace: String, val expectedStatus: Int) {
+        override fun toString(): String = "$actor on $namespace → $expectedStatus"
+    }
+
+    // ------------------------------------------------------------------ //
+    // Private seeding methods                                             //
+    // ------------------------------------------------------------------ //
+
+    private fun createTestUsers(): Map<String, UserEntity> {
+        // The "admin" user already exists from bootstrap (application-integration.yml admin-password).
+        // Rename it to "superadmin" by updating. Actually, the bootstrap creates "admin" with the
+        // configured password. For our tests we use "admin" as superadmin and map Actor.SUPERADMIN to it.
+        // Let's just use the existing admin user and create additional users.
+
+        val users = mutableMapOf<String, UserEntity>()
+
+        // The built-in admin user (created by Liquibase + plugwerk.auth.admin-password)
+        val admin = userRepository.findByUsername("admin").orElseThrow {
+            IllegalStateException("Bootstrap admin user not found — check application-integration.yml")
+        }
+        // Ensure isSuperadmin is true
+        if (!admin.isSuperadmin) {
+            admin.isSuperadmin = true
+            userRepository.save(admin)
+        }
+        // Ensure passwordChangeRequired is false so we can use the admin account
+        if (admin.passwordChangeRequired) {
+            admin.passwordChangeRequired = false
+            userRepository.save(admin)
+        }
+        users["admin"] = admin
+
+        // Create regular test users
+        val userSpecs = listOf(
+            "ns1-admin" to false,
+            "ns1-readonly" to false,
+            "ns1ro-ns2ro" to false,
+            "ns1member-ns2ro" to false,
+            "ns2-admin" to false,
+            "unrelated-user" to false,
+        )
+
+        for ((username, isSuperadmin) in userSpecs) {
+            if (userRepository.findByUsername(username).isPresent) continue
+            val user = userRepository.save(
+                UserEntity(
+                    username = username,
+                    passwordHash = requireNotNull(passwordEncoder.encode(TEST_PASSWORD)),
+                    passwordChangeRequired = false,
+                    isSuperadmin = isSuperadmin,
+                ),
+            )
+            users[username] = user
+        }
+
+        return users
+    }
+
+    private fun createTestNamespaces(): Map<String, NamespaceEntity> {
+        val namespaces = mutableMapOf<String, NamespaceEntity>()
+
+        if (!namespaceRepository.existsBySlug(NS1)) {
+            namespaces[NS1] = namespaceRepository.save(
+                NamespaceEntity(slug = NS1, name = "Public Namespace", publicCatalog = true),
+            )
+        } else {
+            namespaces[NS1] = namespaceRepository.findBySlug(NS1).orElseThrow()
+        }
+
+        if (!namespaceRepository.existsBySlug(NS2)) {
+            namespaces[NS2] = namespaceRepository.save(
+                NamespaceEntity(slug = NS2, name = "Private Namespace", publicCatalog = false),
+            )
+        } else {
+            namespaces[NS2] = namespaceRepository.findBySlug(NS2).orElseThrow()
+        }
+
+        return namespaces
+    }
+
+    private fun createTestMemberships(namespaces: Map<String, NamespaceEntity>) {
+        val ns1 = namespaces.getValue(NS1)
+        val ns2 = namespaces.getValue(NS2)
+
+        val memberships = listOf(
+            Triple("ns1-admin", ns1, NamespaceRole.ADMIN),
+            Triple("ns1-readonly", ns1, NamespaceRole.READ_ONLY),
+            Triple("ns1ro-ns2ro", ns1, NamespaceRole.READ_ONLY),
+            Triple("ns1ro-ns2ro", ns2, NamespaceRole.READ_ONLY),
+            Triple("ns1member-ns2ro", ns1, NamespaceRole.MEMBER),
+            Triple("ns1member-ns2ro", ns2, NamespaceRole.READ_ONLY),
+            Triple("ns2-admin", ns2, NamespaceRole.ADMIN),
+        )
+
+        for ((subject, namespace, role) in memberships) {
+            val exists = namespaceMemberRepository.findByNamespaceIdAndUserSubject(namespace.id!!, subject).isPresent
+            if (!exists) {
+                namespaceMemberRepository.save(
+                    NamespaceMemberEntity(namespace = namespace, userSubject = subject, role = role),
+                )
+            }
+        }
+    }
+
+    private fun createTestPluginsAndReleases(namespaces: Map<String, NamespaceEntity>) {
+        for ((nsSlug, namespace) in namespaces) {
+            val plugins = listOf(
+                Triple("$nsSlug-pl1-active", PluginStatus.ACTIVE, arrayOf("tag-a")),
+                Triple("$nsSlug-pl2-suspended", PluginStatus.SUSPENDED, arrayOf("tag-b")),
+                Triple("$nsSlug-pl3-archived", PluginStatus.ARCHIVED, arrayOf("tag-a", "tag-c")),
+                Triple("$nsSlug-pl4-draftonly", PluginStatus.ACTIVE, arrayOf("tag-d")),
+            )
+
+            for ((pluginId, status, tags) in plugins) {
+                if (pluginRepository.existsByNamespaceAndPluginId(namespace, pluginId)) continue
+
+                val plugin = pluginRepository.save(
+                    PluginEntity(
+                        namespace = namespace,
+                        pluginId = pluginId,
+                        name = "Test Plugin $pluginId",
+                        status = status,
+                        tags = tags,
+                    ),
+                )
+
+                val releases = if (pluginId.endsWith("-draftonly")) {
+                    listOf("0.1.0" to ReleaseStatus.DRAFT)
+                } else {
+                    listOf(
+                        "1.0.0" to ReleaseStatus.DRAFT,
+                        "1.1.0" to ReleaseStatus.PUBLISHED,
+                        "1.2.0" to ReleaseStatus.DEPRECATED,
+                        "1.3.0" to ReleaseStatus.YANKED,
+                    )
+                }
+
+                for ((version, releaseStatus) in releases) {
+                    val jarBytes = buildMinimalJar(pluginId, version)
+                    releaseRepository.save(
+                        PluginReleaseEntity(
+                            plugin = plugin,
+                            version = version,
+                            status = releaseStatus,
+                            artifactSha256 = sha256(jarBytes),
+                            artifactKey = "$nsSlug/$pluginId/$version",
+                            artifactSize = jarBytes.size.toLong(),
+                            fileFormat = FileFormat.JAR,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun createTestApiKeys(namespaces: Map<String, NamespaceEntity>) {
+        if (apiKeyCache.containsKey(Actor.API_KEY_NS1)) return
+
+        val ns1 = namespaces.getValue(NS1)
+        val ns2 = namespaces.getValue(NS2)
+
+        // Create API keys directly via repository (AccessKeyService requires auth context)
+        for ((actor, namespace, keyName) in listOf(
+            Triple(Actor.API_KEY_NS1, ns1, "ci-key-ns1"),
+            Triple(Actor.API_KEY_NS2, ns2, "ci-key-ns2"),
+        )) {
+            val plainKey =
+                "pwk_" +
+                    (1..40).map {
+                        "abcdefghijklmnopqrstuvwxyz0123456789"[(it * 7 + actor.ordinal) % 36]
+                    }.joinToString("")
+            val keyHash = requireNotNull(passwordEncoder.encode(plainKey))
+            accessKeyRepository.save(
+                NamespaceAccessKeyEntity(
+                    namespace = namespace,
+                    keyHash = keyHash,
+                    keyPrefix = plainKey.take(8),
+                    name = keyName,
+                ),
+            )
+            apiKeyCache[actor] = plainKey
+        }
+    }
+
+    private fun loginAllJwtActors() {
+        // Map Actor enum to actual usernames used for login
+        val actorUsernames = mapOf(
+            Actor.SUPERADMIN to "admin",
+            Actor.NS1_ADMIN to "ns1-admin",
+            Actor.NS1_READ_ONLY to "ns1-readonly",
+            Actor.NS1_RO_NS2_RO to "ns1ro-ns2ro",
+            Actor.NS1_MEMBER_NS2_RO to "ns1member-ns2ro",
+            Actor.NS2_ADMIN to "ns2-admin",
+            Actor.UNRELATED to "unrelated-user",
+        )
+
+        for ((actor, username) in actorUsernames) {
+            if (tokenCache.containsKey(actor)) continue
+
+            val password = if (actor == Actor.SUPERADMIN) "smoke-test-password" else TEST_PASSWORD
+
+            val result = mockMvc.perform(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("username" to username, "password" to password))),
+            ).andReturn()
+
+            check(result.response.status == 200) {
+                "Login failed for actor $actor (username=$username): ${result.response.status} - ${result.response.contentAsString}"
+            }
+
+            val body = objectMapper.readValue(result.response.contentAsString, Map::class.java)
+            val token = body["accessToken"] as String
+            tokenCache[actor] = token
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AccessKeyEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AccessKeyEndpointAuthzTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class AccessKeyEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /access-keys {0}")
+    @MethodSource("listAccessKeysMatrix")
+    fun `list access keys authorization`(case: NsActorExpectation) {
+        mockMvc.perform(
+            get("/api/v1/namespaces/${case.namespace}/access-keys").actAs(case.actor),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "POST /access-keys {0}")
+    @MethodSource("createAccessKeyDeniedMatrix")
+    fun `create access key denied for unauthorized actors`(case: NsActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/namespaces/${case.namespace}/access-keys")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf("name" to "test-key-${UUID.randomUUID().toString().take(8)}"),
+                    ),
+                ),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "DELETE /access-keys {0}")
+    @MethodSource("revokeAccessKeyDeniedMatrix")
+    fun `revoke access key denied for unauthorized actors`(case: NsActorExpectation) {
+        mockMvc.perform(
+            delete("/api/v1/namespaces/${case.namespace}/access-keys/${UUID.randomUUID()}")
+                .actAs(case.actor),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    companion object {
+
+        // All access key endpoints require ADMIN in the namespace
+        @JvmStatic
+        fun listAccessKeysMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+            // NS2
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 403),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 403),
+        )
+
+        @JvmStatic
+        fun createAccessKeyDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        @JvmStatic
+        fun revokeAccessKeyDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/Actor.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/Actor.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+/**
+ * Represents the actors (user roles / auth mechanisms) used in authorization integration tests.
+ *
+ * @property username The username for JWT-authenticated actors. Empty for anonymous and API key actors.
+ * @property isSuperadmin Whether the actor is a system superadmin.
+ * @property isApiKey Whether this actor authenticates via `X-Api-Key` header instead of JWT.
+ */
+enum class Actor(val username: String, val isSuperadmin: Boolean = false, val isApiKey: Boolean = false) {
+    /** No credentials — unauthenticated requests. */
+    ANONYMOUS(""),
+
+    /** System superadmin with full access to everything. */
+    SUPERADMIN("superadmin", isSuperadmin = true),
+
+    /** Namespace admin for NS1 (public). */
+    NS1_ADMIN("ns1-admin"),
+
+    /** Read-only member of NS1 only. */
+    NS1_READ_ONLY("ns1-readonly"),
+
+    /** Read-only in both NS1 and NS2. */
+    NS1_RO_NS2_RO("ns1ro-ns2ro"),
+
+    /** Member in NS1, read-only in NS2. */
+    NS1_MEMBER_NS2_RO("ns1member-ns2ro"),
+
+    /** Namespace admin for NS2 (private). */
+    NS2_ADMIN("ns2-admin"),
+
+    /** Authenticated user with no namespace memberships. */
+    UNRELATED("unrelated-user"),
+
+    /** API key scoped to NS1 — authenticates via X-Api-Key header. */
+    API_KEY_NS1("", isApiKey = true),
+
+    /** API key scoped to NS2 — authenticates via X-Api-Key header. */
+    API_KEY_NS2("", isApiKey = true),
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminUserEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminUserEndpointAuthzTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class AdminUserEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /admin/users {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `list users denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/admin/users").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can list users`() {
+        mockMvc.perform(get("/api/v1/admin/users").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+    }
+
+    @ParameterizedTest(name = "POST /admin/users {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `create user denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/admin/users")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "username" to "denied-${UUID.randomUUID().toString().take(8)}",
+                            "password" to TEST_PASSWORD,
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can create user`() {
+        mockMvc.perform(
+            post("/api/v1/admin/users")
+                .actAs(Actor.SUPERADMIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "username" to "created-${UUID.randomUUID().toString().take(8)}",
+                            "password" to TEST_PASSWORD,
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(status().isCreated)
+    }
+
+    @ParameterizedTest(name = "PATCH /admin/users/[id] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `update user denied for non-superadmins`(case: ActorExpectation) {
+        val userId = createEphemeralUser()
+        mockMvc.perform(
+            patch("/api/v1/admin/users/$userId")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("enabled" to false))),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can update user`() {
+        val userId = createEphemeralUser()
+        mockMvc.perform(
+            patch("/api/v1/admin/users/$userId")
+                .actAs(Actor.SUPERADMIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("enabled" to false))),
+        )
+            .andExpect(status().isOk)
+    }
+
+    @ParameterizedTest(name = "DELETE /admin/users/[id] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `delete user denied for non-superadmins`(case: ActorExpectation) {
+        val userId = createEphemeralUser()
+        mockMvc.perform(delete("/api/v1/admin/users/$userId").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can delete user`() {
+        val userId = createEphemeralUser()
+        mockMvc.perform(delete("/api/v1/admin/users/$userId").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isNoContent)
+    }
+
+    companion object {
+        @JvmStatic
+        fun superadminOnlyDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ApiKeyEdgeCaseTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ApiKeyEdgeCaseTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import io.plugwerk.server.domain.NamespaceAccessKeyEntity
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Edge-case tests specific to API key authentication:
+ * revoked keys, expired keys, cross-namespace access, malformed keys, and write operations.
+ */
+class ApiKeyEdgeCaseTest : AbstractAuthorizationTest() {
+
+    @Test
+    fun `valid NS1 API key can access NS1 catalog`() {
+        val key = requireNotNull(apiKeyCache[Actor.API_KEY_NS1])
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS1/plugins")
+                .header("X-Api-Key", key),
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `valid NS1 API key on NS2 catalog returns PUBLIC visibility`() {
+        // API keys for a different namespace are authenticated but resolveVisibility returns PUBLIC,
+        // so NS2 returns its public plugins (200) rather than 403.
+        val key = requireNotNull(apiKeyCache[Actor.API_KEY_NS1])
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS2/plugins")
+                .header("X-Api-Key", key),
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `NS2 API key can access NS2 private catalog`() {
+        val key = requireNotNull(apiKeyCache[Actor.API_KEY_NS2])
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS2/plugins")
+                .header("X-Api-Key", key),
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `revoked API key is treated as anonymous`() {
+        // Create a key, then revoke it
+        val namespace = namespaceRepository.findBySlug(NS1).orElseThrow()
+        val plainKey = "pwk_revoked" + (1..32).map { "abcdefghijklmnopqrstuvwxyz"[it % 26] }.joinToString("")
+        val keyHash = requireNotNull(passwordEncoder.encode(plainKey))
+        accessKeyRepository.save(
+            NamespaceAccessKeyEntity(
+                namespace = namespace,
+                keyHash = keyHash,
+                keyPrefix = plainKey.take(8),
+                name = "revoked-test-key-${UUID.randomUUID().toString().take(8)}",
+                revoked = true,
+            ),
+        )
+
+        // Revoked key on public NS1 → falls through as anonymous → 401 (Spring Security 6 rejects anonymous)
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS1/plugins")
+                .header("X-Api-Key", plainKey),
+        )
+            .andExpect(status().isUnauthorized)
+
+        // Revoked key on private NS2 → anonymous → 401 (no PublicNamespaceFilter for private)
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS2/plugins")
+                .header("X-Api-Key", plainKey),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `expired API key is treated as anonymous`() {
+        val namespace = namespaceRepository.findBySlug(NS1).orElseThrow()
+        val plainKey = "pwk_expired" + (1..31).map { "abcdefghijklmnopqrstuvwxyz"[it % 26] }.joinToString("")
+        val keyHash = requireNotNull(passwordEncoder.encode(plainKey))
+        accessKeyRepository.save(
+            NamespaceAccessKeyEntity(
+                namespace = namespace,
+                keyHash = keyHash,
+                keyPrefix = plainKey.take(8),
+                name = "expired-test-key-${UUID.randomUUID().toString().take(8)}",
+                expiresAt = OffsetDateTime.now().minusDays(1),
+            ),
+        )
+
+        // Expired key on public NS1 → anonymous → 401 (Spring Security 6 rejects anonymous)
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS1/plugins")
+                .header("X-Api-Key", plainKey),
+        )
+            .andExpect(status().isUnauthorized)
+
+        // Expired key on private NS2 → anonymous → 401
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS2/plugins")
+                .header("X-Api-Key", plainKey),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `unknown API key is treated as anonymous`() {
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS1/plugins")
+                .header("X-Api-Key", "pwk_unknownkeyvaluethatdoesnotexistindb12345678"),
+        )
+            .andExpect(status().isUnauthorized) // Unknown key → anonymous → 401 (Spring Security 6)
+
+        mockMvc.perform(
+            get("/api/v1/namespaces/$NS2/plugins")
+                .header("X-Api-Key", "pwk_unknownkeyvaluethatdoesnotexistindb12345678"),
+        )
+            .andExpect(status().isUnauthorized) // Private NS2 → no anonymous access
+    }
+
+    @Test
+    fun `API key cannot perform write operations`() {
+        val key = requireNotNull(apiKeyCache[Actor.API_KEY_NS1])
+        val jarBytes = buildMinimalJar("api-key-write-test", "1.0.0")
+        val artifact = MockMultipartFile("artifact", "test.jar", "application/java-archive", jarBytes)
+
+        val request = multipart("/api/v1/namespaces/$NS1/plugin-releases")
+            .file(artifact)
+        mockMvc.perform(
+            request.header("X-Api-Key", key),
+        )
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `API key cannot access admin endpoints`() {
+        val key = requireNotNull(apiKeyCache[Actor.API_KEY_NS1])
+        mockMvc.perform(
+            get("/api/v1/admin/users")
+                .header("X-Api-Key", key),
+        )
+            .andExpect(status().isForbidden)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AuthEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AuthEndpointAuthzTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+class AuthEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // POST /auth/login                                                    //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    fun `login with valid credentials returns 200 and token`() {
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "username" to "admin",
+                            "password" to "smoke-test-password",
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.accessToken").isNotEmpty)
+            .andExpect(jsonPath("$.isSuperadmin").value(true))
+    }
+
+    @Test
+    fun `login with valid non-superadmin credentials returns isSuperadmin false`() {
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(mapOf("username" to "ns1-admin", "password" to TEST_PASSWORD)),
+                ),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.isSuperadmin").value(false))
+    }
+
+    @Test
+    fun `login with wrong password returns 401`() {
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("username" to "admin", "password" to "wrong-password"))),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `login with unknown user returns 401`() {
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("username" to "nonexistent", "password" to "whatever"))),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /auth/logout                                                   //
+    // ------------------------------------------------------------------ //
+
+    @ParameterizedTest(name = "logout as {0}")
+    @MethodSource("logoutMatrix")
+    fun `logout authorization`(expectation: ActorExpectation) {
+        // Use a fresh token so that revoking it does not break other tests that
+        // rely on the shared tokenCache entries.
+        val request = post("/api/v1/auth/logout")
+        val authenticatedRequest = when {
+            expectation.actor == Actor.ANONYMOUS -> request
+
+            expectation.actor.isApiKey -> {
+                val key = requireNotNull(apiKeyCache[expectation.actor])
+                request.header("X-Api-Key", key)
+            }
+
+            else -> {
+                val token = freshToken(expectation.actor)
+                request.header("Authorization", "Bearer $token")
+            }
+        }
+        mockMvc.perform(authenticatedRequest)
+            .andExpect(status().`is`(expectation.expectedStatus))
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /auth/change-password                                          //
+    // ------------------------------------------------------------------ //
+
+    @ParameterizedTest(name = "change-password as {0}")
+    @MethodSource("changePasswordDeniedMatrix")
+    fun `change-password denied for unauthorized actors`(expectation: ActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/auth/change-password")
+                .actAs(expectation.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf("currentPassword" to "wrong", "newPassword" to "new-password-12345!"),
+                    ),
+                ),
+        )
+            .andExpect(status().`is`(expectation.expectedStatus))
+    }
+
+    // ------------------------------------------------------------------ //
+    // Method sources                                                      //
+    // ------------------------------------------------------------------ //
+
+    companion object {
+        @JvmStatic
+        fun logoutMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            // logout returns 204 No Content on success
+            ActorExpectation(Actor.SUPERADMIN, 204),
+            ActorExpectation(Actor.NS1_ADMIN, 204),
+            ActorExpectation(Actor.NS1_READ_ONLY, 204),
+            ActorExpectation(Actor.UNRELATED, 204),
+            ActorExpectation(Actor.API_KEY_NS1, 401),
+        )
+
+        @JvmStatic
+        fun changePasswordDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            // change-password is under /auth/** (permitAll), so security passes.
+            // The controller then looks up the user by name (anonymous / key principal)
+            // and fails with EntityNotFoundException → 404.
+            ActorExpectation(Actor.ANONYMOUS, 404),
+            ActorExpectation(Actor.API_KEY_NS1, 404),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/CatalogEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/CatalogEndpointAuthzTest.kt
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+/**
+ * Tests catalog endpoint authorization: plugin visibility, release visibility,
+ * download access, tag visibility, and plugins.json feed per actor and namespace.
+ */
+class CatalogEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/plugins — Plugin list visibility               //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class PluginListVisibility {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#pluginVisibilityNs1")
+        fun `plugin visibility in NS1 (public)`(case: PluginVisibilityCase) {
+            val result = mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/plugins?size=50").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+
+            if (case.expectedStatus == 200) {
+                val response = result.andReturn()
+                val body = objectMapper.readValue(response.response.contentAsString, Map::class.java)
+
+                @Suppress("UNCHECKED_CAST")
+                val content = body["content"] as List<Map<String, Any>>
+                val returnedIds = content.map { it["pluginId"] as String }.toSet()
+
+                assert(returnedIds == case.expectedPluginIds) {
+                    "Actor ${case.actor} on ${case.namespace}: expected ${case.expectedPluginIds}, got $returnedIds"
+                }
+
+                // Check hasDraftOnly flag for draft-only plugin if it's visible
+                if (case.hasDraftOnlyVisible) {
+                    val draftOnlyPlugin = content.find { (it["pluginId"] as String).endsWith("-draftonly") }
+                    assert(draftOnlyPlugin != null) { "Draft-only plugin should be visible for ${case.actor}" }
+                    assert(draftOnlyPlugin!!["hasDraftOnly"] == true) {
+                        "hasDraftOnly should be true for draft-only plugin, actor ${case.actor}"
+                    }
+                }
+            }
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#pluginVisibilityNs2")
+        fun `plugin visibility in NS2 (private)`(case: PluginVisibilityCase) {
+            val result = mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/plugins?size=50").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+
+            if (case.expectedStatus == 200) {
+                val response = result.andReturn()
+                val body = objectMapper.readValue(response.response.contentAsString, Map::class.java)
+
+                @Suppress("UNCHECKED_CAST")
+                val content = body["content"] as List<Map<String, Any>>
+                val returnedIds = content.map { it["pluginId"] as String }.toSet()
+
+                assert(returnedIds == case.expectedPluginIds) {
+                    "Actor ${case.actor} on ${case.namespace}: expected ${case.expectedPluginIds}, got $returnedIds"
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/plugins/{pluginId} — Single plugin             //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class SinglePluginAccess {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#singlePluginCases")
+        fun `single plugin access`(case: SinglePluginCase) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/plugins/${case.pluginId}").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/plugins/{pluginId}/releases — Release list     //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class ReleaseVisibility {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#releaseVisibilityCases")
+        fun `release visibility per actor`(case: ReleaseVisibilityCase) {
+            val result = mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/plugins/${case.pluginId}/releases?size=50").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+
+            if (case.expectedStatus == 200) {
+                val response = result.andReturn()
+                val body = objectMapper.readValue(response.response.contentAsString, Map::class.java)
+
+                @Suppress("UNCHECKED_CAST")
+                val content = body["content"] as List<Map<String, Any>>
+                val returnedVersions = content.map { it["version"] as String }.toSet()
+
+                assert(returnedVersions == case.expectedVersions) {
+                    "Actor ${case.actor}: expected versions ${case.expectedVersions}, got $returnedVersions"
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/tags                                           //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class TagVisibility {
+
+        @ParameterizedTest(name = "tags as {0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#tagVisibilityCases")
+        fun `tag visibility per actor`(case: NsActorExpectation) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/tags").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/plugins.json                                   //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class PluginsJsonFeed {
+
+        @ParameterizedTest(name = "plugins.json as {0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.CatalogEndpointAuthzTest#pluginsJsonCases")
+        fun `plugins json access per actor`(case: NsActorExpectation) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/plugins.json").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Method sources                                                      //
+    // ------------------------------------------------------------------ //
+
+    companion object {
+
+        /**
+         * Each test case specifies an actor, namespace, and the set of plugin IDs expected to be visible.
+         */
+        data class PluginVisibilityCase(
+            val actor: Actor,
+            val namespace: String,
+            val expectedPluginIds: Set<String>,
+            val expectedStatus: Int = 200,
+            val hasDraftOnlyVisible: Boolean = false,
+        ) {
+            override fun toString(): String =
+                "$actor on $namespace → ${if (expectedStatus != 200) "$expectedStatus" else expectedPluginIds.joinToString()}"
+        }
+
+        data class SinglePluginCase(
+            val actor: Actor,
+            val namespace: String,
+            val pluginId: String,
+            val expectedStatus: Int,
+        ) {
+            override fun toString(): String = "$actor → $namespace/$pluginId → $expectedStatus"
+        }
+
+        data class ReleaseVisibilityCase(
+            val actor: Actor,
+            val namespace: String,
+            val pluginId: String,
+            val expectedVersions: Set<String>,
+            val expectedStatus: Int = 200,
+        ) {
+            override fun toString(): String =
+                "$actor → $namespace/$pluginId releases → ${if (expectedStatus != 200) "$expectedStatus" else expectedVersions.joinToString()}"
+        }
+
+        // -- Plugin list visibility in NS1 (public) --
+
+        private val NS1_PUBLIC_PLUGINS = setOf("ns1-pl1-active")
+        private val NS1_AUTHENTICATED_PLUGINS = setOf("ns1-pl1-active", "ns1-pl3-archived", "ns1-pl4-draftonly")
+        private val NS1_ADMIN_PLUGINS =
+            setOf("ns1-pl1-active", "ns1-pl2-suspended", "ns1-pl3-archived", "ns1-pl4-draftonly")
+
+        @JvmStatic
+        fun pluginVisibilityNs1(): Stream<PluginVisibilityCase> = Stream.of(
+            // ANONYMOUS: PublicNamespaceFilter sets AnonymousAuth, but Spring Security 6
+            // anyRequest().authenticated() rejects anonymous tokens → 401
+            PluginVisibilityCase(Actor.ANONYMOUS, NS1, emptySet(), expectedStatus = 401),
+            PluginVisibilityCase(Actor.SUPERADMIN, NS1, NS1_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(Actor.NS1_ADMIN, NS1, NS1_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(Actor.NS1_READ_ONLY, NS1, NS1_AUTHENTICATED_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(Actor.NS1_RO_NS2_RO, NS1, NS1_AUTHENTICATED_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(
+                Actor.NS1_MEMBER_NS2_RO,
+                NS1,
+                NS1_AUTHENTICATED_PLUGINS,
+                hasDraftOnlyVisible = true,
+            ),
+            // NS2_ADMIN has no membership in NS1 → resolveVisibility falls through to PUBLIC
+            PluginVisibilityCase(Actor.NS2_ADMIN, NS1, NS1_PUBLIC_PLUGINS),
+            // UNRELATED has no membership in NS1 → resolveVisibility falls through to PUBLIC
+            PluginVisibilityCase(Actor.UNRELATED, NS1, NS1_PUBLIC_PLUGINS),
+            PluginVisibilityCase(Actor.API_KEY_NS1, NS1, NS1_PUBLIC_PLUGINS),
+            // API_KEY_NS2 on NS1: resolveVisibility returns PUBLIC for all API keys → 200
+            PluginVisibilityCase(Actor.API_KEY_NS2, NS1, NS1_PUBLIC_PLUGINS),
+        )
+
+        // -- Plugin list visibility in NS2 (private) --
+
+        private val NS2_AUTHENTICATED_PLUGINS = setOf("ns2-pl1-active", "ns2-pl3-archived", "ns2-pl4-draftonly")
+        private val NS2_ADMIN_PLUGINS =
+            setOf("ns2-pl1-active", "ns2-pl2-suspended", "ns2-pl3-archived", "ns2-pl4-draftonly")
+        private val NS2_PUBLIC_PLUGINS = setOf("ns2-pl1-active")
+
+        @JvmStatic
+        fun pluginVisibilityNs2(): Stream<PluginVisibilityCase> = Stream.of(
+            // ANONYMOUS on private NS2: Spring Security 6 rejects anonymous tokens → 401
+            PluginVisibilityCase(Actor.ANONYMOUS, NS2, emptySet(), expectedStatus = 401),
+            PluginVisibilityCase(Actor.SUPERADMIN, NS2, NS2_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
+            // Non-members on NS2: resolveVisibility catches ForbiddenException → falls through to PUBLIC
+            // NS2 has public plugins (ns2-pl1-active) so they get 200 with PUBLIC visibility
+            PluginVisibilityCase(Actor.NS1_ADMIN, NS2, NS2_PUBLIC_PLUGINS),
+            PluginVisibilityCase(Actor.NS1_READ_ONLY, NS2, NS2_PUBLIC_PLUGINS),
+            PluginVisibilityCase(Actor.NS1_RO_NS2_RO, NS2, NS2_AUTHENTICATED_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(
+                Actor.NS1_MEMBER_NS2_RO,
+                NS2,
+                NS2_AUTHENTICATED_PLUGINS,
+                hasDraftOnlyVisible = true,
+            ),
+            PluginVisibilityCase(Actor.NS2_ADMIN, NS2, NS2_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
+            PluginVisibilityCase(Actor.UNRELATED, NS2, NS2_PUBLIC_PLUGINS),
+            // API keys: resolveVisibility returns PUBLIC for all API key callers
+            PluginVisibilityCase(Actor.API_KEY_NS1, NS2, NS2_PUBLIC_PLUGINS),
+            PluginVisibilityCase(Actor.API_KEY_NS2, NS2, NS2_PUBLIC_PLUGINS),
+        )
+
+        // -- Single plugin access --
+
+        @JvmStatic
+        fun singlePluginCases(): Stream<SinglePluginCase> = Stream.of(
+            // ANONYMOUS gets 401 (Spring Security 6 rejects anonymous tokens)
+            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", 401),
+            SinglePluginCase(Actor.SUPERADMIN, NS1, "ns1-pl1-active", 200),
+            SinglePluginCase(Actor.API_KEY_NS1, NS1, "ns1-pl1-active", 200),
+            // SUSPENDED plugin in NS1 — getPlugin has no visibility check → 200 for all authenticated users
+            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl2-suspended", 401),
+            SinglePluginCase(Actor.NS1_READ_ONLY, NS1, "ns1-pl2-suspended", 200),
+            SinglePluginCase(Actor.NS1_ADMIN, NS1, "ns1-pl2-suspended", 200),
+            SinglePluginCase(Actor.SUPERADMIN, NS1, "ns1-pl2-suspended", 200),
+            SinglePluginCase(Actor.API_KEY_NS1, NS1, "ns1-pl2-suspended", 200),
+            // Plugin in NS2 — getPlugin has no access check → 200 for any authenticated user, 401 for anonymous
+            SinglePluginCase(Actor.ANONYMOUS, NS2, "ns2-pl1-active", 401),
+            SinglePluginCase(Actor.NS1_ADMIN, NS2, "ns2-pl1-active", 200),
+            SinglePluginCase(Actor.API_KEY_NS1, NS2, "ns2-pl1-active", 200),
+            SinglePluginCase(Actor.NS2_ADMIN, NS2, "ns2-pl1-active", 200),
+            SinglePluginCase(Actor.API_KEY_NS2, NS2, "ns2-pl1-active", 200),
+        )
+
+        // -- Release visibility --
+
+        private val ALL_VERSIONS = setOf("1.0.0", "1.1.0", "1.2.0", "1.3.0")
+        private val PUBLIC_VERSIONS = setOf("1.1.0", "1.2.0") // PUBLISHED + DEPRECATED
+
+        @JvmStatic
+        fun releaseVisibilityCases(): Stream<ReleaseVisibilityCase> = Stream.of(
+            // NS1 PL1 (ACTIVE) — release visibility by actor
+            // ANONYMOUS on NS1: Spring Security 6 authenticated() rejects anonymous → 401
+            ReleaseVisibilityCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", emptySet(), expectedStatus = 401),
+            ReleaseVisibilityCase(Actor.SUPERADMIN, NS1, "ns1-pl1-active", ALL_VERSIONS),
+            ReleaseVisibilityCase(Actor.NS1_ADMIN, NS1, "ns1-pl1-active", ALL_VERSIONS),
+            ReleaseVisibilityCase(Actor.NS1_READ_ONLY, NS1, "ns1-pl1-active", ALL_VERSIONS),
+            ReleaseVisibilityCase(Actor.UNRELATED, NS1, "ns1-pl1-active", ALL_VERSIONS),
+            // API keys: listReleases has no visibility filter → returns ALL versions
+            ReleaseVisibilityCase(Actor.API_KEY_NS1, NS1, "ns1-pl1-active", ALL_VERSIONS),
+            // NS2 — ANONYMOUS gets 401, not 403 (no auth set for private namespace)
+            ReleaseVisibilityCase(Actor.ANONYMOUS, NS2, "ns2-pl1-active", emptySet(), expectedStatus = 401),
+            ReleaseVisibilityCase(Actor.NS2_ADMIN, NS2, "ns2-pl1-active", ALL_VERSIONS),
+            // API keys: listReleases has no visibility filter → returns ALL versions
+            ReleaseVisibilityCase(Actor.API_KEY_NS2, NS2, "ns2-pl1-active", ALL_VERSIONS),
+        )
+
+        // -- Tag visibility --
+
+        @JvmStatic
+        fun tagVisibilityCases(): Stream<NsActorExpectation> = Stream.of(
+            // NS1 (public) — ANONYMOUS gets 401: Spring Security 6 authenticated() rejects anonymous tokens
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 200),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 200),
+            // API_KEY_NS2 on NS1: resolveVisibility returns PUBLIC, list tags returns 200
+            NsActorExpectation(Actor.API_KEY_NS2, NS1, 200),
+            // NS2 (private) — ANONYMOUS gets 401; non-members get 200 (resolveVisibility → PUBLIC)
+            NsActorExpectation(Actor.ANONYMOUS, NS2, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS1_RO_NS2_RO, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.API_KEY_NS1, NS2, 200),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 200),
+        )
+
+        // -- plugins.json feed --
+
+        @JvmStatic
+        fun pluginsJsonCases(): Stream<NsActorExpectation> = Stream.of(
+            // ANONYMOUS on NS1: Spring Security 6 authenticated() rejects anonymous tokens → 401
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 200),
+            // API_KEY_NS2 on NS1: Pf4jCompatibilityService has no namespace-level key restriction → 200
+            NsActorExpectation(Actor.API_KEY_NS2, NS1, 200),
+            // ANONYMOUS on NS2: no anonymous auth for private namespace → 401
+            NsActorExpectation(Actor.ANONYMOUS, NS2, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 200),
+            // buildPluginsJson has no namespace access check → 200 for any authenticated user
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 200),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ConfigEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ConfigEndpointAuthzTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+class ConfigEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /config as {0}")
+    @MethodSource("allActors")
+    fun `config endpoint is public for all actors`(expectation: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/config").actAs(expectation.actor))
+            .andExpect(status().isOk)
+    }
+
+    companion object {
+        @JvmStatic
+        fun allActors(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 200),
+            ActorExpectation(Actor.SUPERADMIN, 200),
+            ActorExpectation(Actor.NS1_ADMIN, 200),
+            ActorExpectation(Actor.NS1_READ_ONLY, 200),
+            ActorExpectation(Actor.UNRELATED, 200),
+            ActorExpectation(Actor.API_KEY_NS1, 200),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ManagementEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ManagementEndpointAuthzTest.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+/**
+ * Tests management endpoint authorization: upload, update plugin/release, delete plugin/release.
+ */
+class ManagementEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // POST /namespaces/{ns}/plugin-releases — Upload                      //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class UploadRelease {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#uploadMatrix")
+        fun `upload release authorization`(case: NsActorExpectation) {
+            val uniqueId = "upload-${UUID.randomUUID().toString().take(8)}"
+            val jarBytes = buildMinimalJar(uniqueId, "1.0.0")
+            val artifact = MockMultipartFile("artifact", "$uniqueId-1.0.0.jar", "application/java-archive", jarBytes)
+
+            // MockMultipartHttpServletRequestBuilder cannot be cast to MockHttpServletRequestBuilder
+            // in Spring Boot 4 / Spring 6 — add auth header directly without casting.
+            val builder = multipart("/api/v1/namespaces/${case.namespace}/plugin-releases").file(artifact)
+            when {
+                case.actor == Actor.ANONYMOUS -> Unit
+
+                case.actor.isApiKey -> {
+                    val key = requireNotNull(apiKeyCache[case.actor])
+                    builder.header("X-Api-Key", key)
+                }
+
+                else -> {
+                    val token = requireNotNull(tokenCache[case.actor])
+                    builder.header("Authorization", "Bearer $token")
+                }
+            }
+            mockMvc.perform(builder)
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // PATCH /namespaces/{ns}/plugins/{pluginId} — Update metadata         //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class UpdatePlugin {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#updatePluginMetadataMatrix")
+        fun `update plugin metadata authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                patch("/api/v1/namespaces/${case.namespace}/plugins/${case.namespace}-pl1-active")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("name" to "Updated Name"))),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#updatePluginStatusMatrix")
+        fun `update plugin status requires ADMIN`(case: NsActorExpectation) {
+            mockMvc.perform(
+                patch("/api/v1/namespaces/${case.namespace}/plugins/${case.namespace}-pl1-active")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("status" to "active"))),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // PATCH /namespaces/{ns}/plugins/{id}/releases/{version} — Status     //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class UpdateReleaseStatus {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#updateReleaseStatusMatrix")
+        fun `update release status authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                patch("/api/v1/namespaces/${case.namespace}/plugins/${case.namespace}-pl1-active/releases/1.1.0")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("status" to "published"))),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // DELETE /namespaces/{ns}/plugins/{id}                                //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class DeletePlugin {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#deletePluginDeniedMatrix")
+        fun `delete plugin denied for unauthorized actors`(case: NsActorExpectation) {
+            // Use the existing shared plugin — denied actors can't actually delete it
+            mockMvc.perform(
+                delete("/api/v1/namespaces/${case.namespace}/plugins/${case.namespace}-pl1-active")
+                    .actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#deletePluginAllowedMatrix")
+        fun `delete plugin allowed for authorized actors`(case: NsActorExpectation) {
+            // Create an ephemeral plugin so the shared fixture stays intact
+            val (pluginId, _) = createEphemeralPlugin(case.namespace)
+            mockMvc.perform(
+                delete("/api/v1/namespaces/${case.namespace}/plugins/$pluginId")
+                    .actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // DELETE /namespaces/{ns}/plugins/{id}/releases/{version}             //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class DeleteRelease {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ManagementEndpointAuthzTest#deleteReleaseDeniedMatrix")
+        fun `delete release denied for unauthorized actors`(case: NsActorExpectation) {
+            mockMvc.perform(
+                delete("/api/v1/namespaces/${case.namespace}/plugins/${case.namespace}-pl1-active/releases/1.3.0")
+                    .actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Method sources                                                      //
+    // ------------------------------------------------------------------ //
+
+    companion object {
+
+        // Upload: requires MEMBER in own namespace
+        @JvmStatic
+        fun uploadMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 201),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 201),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 201),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS2, NS1, 403),
+            // NS2
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 201),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 201),
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS2, 403),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 403),
+        )
+
+        // Update plugin metadata: requires MEMBER
+        @JvmStatic
+        fun updatePluginMetadataMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        // Update plugin status: requires ADMIN (even if metadata only needs MEMBER)
+        @JvmStatic
+        fun updatePluginStatusMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        // Update release status: requires ADMIN
+        @JvmStatic
+        fun updateReleaseStatusMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        // Delete plugin: denied actors
+        @JvmStatic
+        fun deletePluginDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        // Delete plugin: allowed actors (use ephemeral plugins)
+        @JvmStatic
+        fun deletePluginAllowedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 204),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 204),
+        )
+
+        // Delete release: denied actors
+        @JvmStatic
+        fun deleteReleaseDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/NamespaceEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/NamespaceEndpointAuthzTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class NamespaceEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces                                                     //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class ListNamespaces {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceEndpointAuthzTest#listNamespacesMatrix")
+        fun `list namespaces authorization`(case: ActorExpectation) {
+            mockMvc.perform(get("/api/v1/namespaces").actAs(case.actor))
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `superadmin sees all namespaces`() {
+            val result = mockMvc.perform(get("/api/v1/namespaces").actAs(Actor.SUPERADMIN))
+                .andExpect(status().isOk)
+                .andReturn()
+
+            val body = objectMapper.readValue(result.response.contentAsString, List::class.java)
+
+            @Suppress("UNCHECKED_CAST")
+            val slugs = (body as List<Map<String, Any>>).map { it["slug"] }
+            assert(slugs.contains(NS1) && slugs.contains(NS2)) {
+                "Superadmin should see both ns1 and ns2, got $slugs"
+            }
+        }
+
+        @Test
+        fun `NS1 admin only sees NS1`() {
+            val result = mockMvc.perform(get("/api/v1/namespaces").actAs(Actor.NS1_ADMIN))
+                .andExpect(status().isOk)
+                .andReturn()
+
+            val body = objectMapper.readValue(result.response.contentAsString, List::class.java)
+
+            @Suppress("UNCHECKED_CAST")
+            val slugs = (body as List<Map<String, Any>>).map { it["slug"] }
+            assert(slugs.contains(NS1) && !slugs.contains(NS2)) {
+                "NS1 admin should see ns1 but not ns2, got $slugs"
+            }
+        }
+
+        @Test
+        fun `unrelated user sees empty list`() {
+            val result = mockMvc.perform(get("/api/v1/namespaces").actAs(Actor.UNRELATED))
+                .andExpect(status().isOk)
+                .andReturn()
+
+            val body = objectMapper.readValue(result.response.contentAsString, List::class.java)
+            assert(body.isEmpty()) { "Unrelated user should see no namespaces, got $body" }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /namespaces                                                    //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class CreateNamespace {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceEndpointAuthzTest#createNamespaceDeniedMatrix")
+        fun `create namespace denied for non-superadmins`(case: ActorExpectation) {
+            mockMvc.perform(
+                post("/api/v1/namespaces")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            mapOf("slug" to "denied-${UUID.randomUUID().toString().take(8)}", "name" to "Denied"),
+                        ),
+                    ),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `superadmin can create namespace`() {
+            val slug = "ephemeral-${UUID.randomUUID().toString().take(8)}"
+            mockMvc.perform(
+                post("/api/v1/namespaces")
+                    .actAs(Actor.SUPERADMIN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("slug" to slug, "name" to "Ephemeral NS"))),
+            )
+                .andExpect(status().isCreated)
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // PATCH /namespaces/{ns}                                              //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class UpdateNamespace {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceEndpointAuthzTest#updateNamespaceMatrix")
+        fun `update namespace authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                patch("/api/v1/namespaces/${case.namespace}")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("name" to "Updated Name"))),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // DELETE /namespaces/{ns}                                             //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class DeleteNamespace {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceEndpointAuthzTest#deleteNamespaceDeniedMatrix")
+        fun `delete namespace denied for non-superadmins`(case: ActorExpectation) {
+            mockMvc.perform(delete("/api/v1/namespaces/$NS1").actAs(case.actor))
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `superadmin can delete namespace`() {
+            val slug = createEphemeralNamespace()
+            mockMvc.perform(delete("/api/v1/namespaces/$slug").actAs(Actor.SUPERADMIN))
+                .andExpect(status().isNoContent)
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun listNamespacesMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.SUPERADMIN, 200),
+            ActorExpectation(Actor.NS1_ADMIN, 200),
+            ActorExpectation(Actor.NS1_READ_ONLY, 200),
+            ActorExpectation(Actor.UNRELATED, 200),
+            ActorExpectation(Actor.API_KEY_NS1, 200),
+        )
+
+        @JvmStatic
+        fun createNamespaceDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+
+        @JvmStatic
+        fun updateNamespaceMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+            // NS2
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 403),
+        )
+
+        @JvmStatic
+        fun deleteNamespaceDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/NamespaceMemberEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/NamespaceMemberEndpointAuthzTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class NamespaceMemberEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/members/me                                     //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class GetMyMembership {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceMemberEndpointAuthzTest#getMyMembershipMatrix")
+        fun `get my membership authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/members/me").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/members                                        //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class ListMembers {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceMemberEndpointAuthzTest#listMembersMatrix")
+        fun `list members authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/members").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /namespaces/{ns}/members                                       //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class AddMember {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceMemberEndpointAuthzTest#addMemberDeniedMatrix")
+        fun `add member denied for unauthorized actors`(case: NsActorExpectation) {
+            mockMvc.perform(
+                post("/api/v1/namespaces/${case.namespace}/members")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(mapOf("userSubject" to "nonexistent", "role" to "READ_ONLY")),
+                    ),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `NS1 admin can add member to NS1`() {
+            val userId = createEphemeralUser()
+            val user = userRepository.findById(userId).orElseThrow()
+            mockMvc.perform(
+                post("/api/v1/namespaces/$NS1/members")
+                    .actAs(Actor.NS1_ADMIN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(mapOf("userSubject" to user.username, "role" to "READ_ONLY")),
+                    ),
+            )
+                .andExpect(status().isCreated)
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // PUT /namespaces/{ns}/members/{userSubject}                          //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class UpdateMember {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceMemberEndpointAuthzTest#updateMemberDeniedMatrix")
+        fun `update member denied for unauthorized actors`(case: NsActorExpectation) {
+            mockMvc.perform(
+                put("/api/v1/namespaces/${case.namespace}/members/ns1-readonly")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("role" to "READ_ONLY"))),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `NS1 admin can update member role`() {
+            mockMvc.perform(
+                put("/api/v1/namespaces/$NS1/members/ns1-readonly")
+                    .actAs(Actor.NS1_ADMIN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("role" to "READ_ONLY"))),
+            )
+                .andExpect(status().isOk)
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // DELETE /namespaces/{ns}/members/{userSubject}                        //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class RemoveMember {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.NamespaceMemberEndpointAuthzTest#removeMemberDeniedMatrix")
+        fun `remove member denied for unauthorized actors`(case: NsActorExpectation) {
+            mockMvc.perform(
+                delete("/api/v1/namespaces/${case.namespace}/members/ns1-readonly")
+                    .actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @Test
+        fun `NS1 admin can remove member`() {
+            // Create an ephemeral membership to delete
+            val userId = createEphemeralUser()
+            val user = userRepository.findById(userId).orElseThrow()
+            createEphemeralMembership(NS1, user.username)
+
+            mockMvc.perform(
+                delete("/api/v1/namespaces/$NS1/members/${user.username}")
+                    .actAs(Actor.NS1_ADMIN),
+            )
+                .andExpect(status().isNoContent)
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun getMyMembershipMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 200),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 200),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 200),
+        )
+
+        @JvmStatic
+        fun listMembersMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        @JvmStatic
+        fun addMemberDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        @JvmStatic
+        fun updateMemberDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+
+        @JvmStatic
+        fun removeMemberDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEndpointAuthzTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class OidcProviderEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /admin/oidc-providers {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `list OIDC providers denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/admin/oidc-providers").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can list OIDC providers`() {
+        mockMvc.perform(get("/api/v1/admin/oidc-providers").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+    }
+
+    @ParameterizedTest(name = "POST /admin/oidc-providers {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `create OIDC provider denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/admin/oidc-providers")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "name" to "denied-${UUID.randomUUID().toString().take(8)}",
+                            "providerType" to "GENERIC_OIDC",
+                            "clientId" to "test-client-id",
+                            "clientSecret" to "test-client-secret",
+                            "issuerUri" to "https://example.com",
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "PATCH /admin/oidc-providers/[id] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `update OIDC provider denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            patch("/api/v1/admin/oidc-providers/${UUID.randomUUID()}")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("enabled" to false))),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "DELETE /admin/oidc-providers/[id] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `delete OIDC provider denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            delete("/api/v1/admin/oidc-providers/${UUID.randomUUID()}")
+                .actAs(case.actor),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    companion object {
+        @JvmStatic
+        fun superadminOnlyDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ReviewsEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ReviewsEndpointAuthzTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+class ReviewsEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    // ------------------------------------------------------------------ //
+    // GET /namespaces/{ns}/reviews/pending                                //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class ListPendingReviews {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ReviewsEndpointAuthzTest#listPendingMatrix")
+        fun `list pending reviews authorization`(case: NsActorExpectation) {
+            mockMvc.perform(
+                get("/api/v1/namespaces/${case.namespace}/reviews/pending").actAs(case.actor),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /namespaces/{ns}/reviews/{releaseId}/approve                   //
+    // POST /namespaces/{ns}/reviews/{releaseId}/reject                    //
+    // ------------------------------------------------------------------ //
+
+    @Nested
+    inner class ApproveRejectReview {
+
+        @ParameterizedTest(name = "approve as {0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ReviewsEndpointAuthzTest#approveRejectDeniedMatrix")
+        fun `approve review denied for unauthorized actors`(case: NsActorExpectation) {
+            // Use a random UUID — the auth check happens before the release lookup
+            val fakeReleaseId = UUID.randomUUID()
+            mockMvc.perform(
+                post("/api/v1/namespaces/${case.namespace}/reviews/$fakeReleaseId/approve")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+
+        @ParameterizedTest(name = "reject as {0}")
+        @MethodSource("io.plugwerk.server.e2e.auth.ReviewsEndpointAuthzTest#approveRejectDeniedMatrix")
+        fun `reject review denied for unauthorized actors`(case: NsActorExpectation) {
+            val fakeReleaseId = UUID.randomUUID()
+            mockMvc.perform(
+                post("/api/v1/namespaces/${case.namespace}/reviews/$fakeReleaseId/reject")
+                    .actAs(case.actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            )
+                .andExpect(status().`is`(case.expectedStatus))
+        }
+    }
+
+    companion object {
+
+        // listPendingReviews requires MEMBER
+        @JvmStatic
+        fun listPendingMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+            // NS2
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS2, 403),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 403),
+        )
+
+        // approve/reject requires ADMIN
+        @JvmStatic
+        fun approveRejectDeniedMatrix(): Stream<NsActorExpectation> = Stream.of(
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 401),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 403),
+            NsActorExpectation(Actor.NS1_MEMBER_NS2_RO, NS1, 403),
+            NsActorExpectation(Actor.NS2_ADMIN, NS1, 403),
+            NsActorExpectation(Actor.UNRELATED, NS1, 403),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/UpdateCheckEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/UpdateCheckEndpointAuthzTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+/**
+ * Tests update check endpoint. This endpoint is `permitAll()` in SecurityConfig —
+ * no authentication or authorization required.
+ */
+class UpdateCheckEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "POST /updates/check on {0}")
+    @MethodSource("updateCheckMatrix")
+    fun `update check authorization`(case: NsActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/namespaces/${case.namespace}/updates/check")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("plugins" to emptyList<Any>()))),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    companion object {
+        @JvmStatic
+        fun updateCheckMatrix(): Stream<NsActorExpectation> = Stream.of(
+            // NS1 (public) — permitAll
+            NsActorExpectation(Actor.ANONYMOUS, NS1, 200),
+            NsActorExpectation(Actor.SUPERADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_ADMIN, NS1, 200),
+            NsActorExpectation(Actor.NS1_READ_ONLY, NS1, 200),
+            NsActorExpectation(Actor.API_KEY_NS1, NS1, 200),
+            // NS2 (private) — still permitAll in SecurityConfig (no auth check in controller)
+            NsActorExpectation(Actor.ANONYMOUS, NS2, 200),
+            NsActorExpectation(Actor.SUPERADMIN, NS2, 200),
+            NsActorExpectation(Actor.NS2_ADMIN, NS2, 200),
+            NsActorExpectation(Actor.API_KEY_NS2, NS2, 200),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.repository.DownloadEventRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -33,12 +34,14 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayInputStream
 
@@ -53,9 +56,10 @@ import java.io.ByteArrayInputStream
     DownloadEventServiceIntegrationTest.MockConfig::class,
 )
 @Tag("integration")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 class DownloadEventServiceIntegrationTest {
 
-    @Configuration
+    @TestConfiguration
     class MockConfig {
         @Bean
         fun artifactStorageService(): ArtifactStorageService = mock(ArtifactStorageService::class.java).also {
@@ -97,6 +101,14 @@ class DownloadEventServiceIntegrationTest {
     @BeforeEach
     fun setUp() {
         testNamespace = namespaceService.create("dl-event-ns", "DL Event Org")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            namespaceService.delete("dl-event-ns")
+        } catch (_: Exception) {
+        }
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
@@ -39,8 +39,9 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -57,7 +58,7 @@ import kotlin.test.assertFailsWith
 @Tag("integration")
 class NamespaceServiceIntegrationTest {
 
-    @Configuration
+    @TestConfiguration
     class MockConfig {
         @Bean
         fun artifactStorageService(): ArtifactStorageService = mock(ArtifactStorageService::class.java)
@@ -93,6 +94,9 @@ class NamespaceServiceIntegrationTest {
 
     @Autowired
     lateinit var storageService: ArtifactStorageService
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
 
     @Test
     fun `create persists namespace and findBySlug retrieves it`() {
@@ -191,6 +195,8 @@ class NamespaceServiceIntegrationTest {
         )
 
         namespaceService.delete("cascade-ns")
+        entityManager.flush()
+        entityManager.clear()
 
         assertThat(namespaceRepository.existsBySlug("cascade-ns")).isFalse()
         assertThat(pluginRepository.findById(plugin1.id!!)).isEmpty

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
@@ -33,8 +33,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -56,7 +56,7 @@ import kotlin.test.assertFailsWith
 @Tag("integration")
 class PluginReleaseServiceIntegrationTest {
 
-    @Configuration
+    @TestConfiguration
     class MockConfig {
         @Bean
         fun artifactStorageService(): ArtifactStorageService = mock(ArtifactStorageService::class.java).also {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceIntegrationTest.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.service
 
 import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
 import io.plugwerk.spi.model.PluginStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import kotlin.test.assertFailsWith
 
 @DataJpaTest
@@ -50,6 +52,9 @@ class PluginServiceIntegrationTest {
             registry.add("spring.datasource.password") { SharedPostgresContainer.instance.password }
         }
     }
+
+    @MockitoBean
+    lateinit var artifactStorageService: ArtifactStorageService
 
     @Autowired
     lateinit var pluginService: PluginService

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -13,3 +13,6 @@ plugwerk:
       root: ${java.io.tmpdir}/plugwerk-smoke-test
   auth:
     admin-password: smoke-test-password
+    rate-limit:
+      max-attempts: 1000
+      window-seconds: 3600


### PR DESCRIPTION
## Summary

Closes #178

- Add **316 parameterized integration tests** covering authentication and authorization for all REST API endpoints
- 10 actors (anonymous, superadmin, 5 namespace roles, API key NS1/NS2, unrelated user) × 2 namespaces (public/private)
- 14 new test files under `e2e/auth/` with shared Testcontainers infrastructure

## Changes

### New files (14)
| File | Coverage |
|---|---|
| `Actor.kt` | Enum for 10 actors with JWT/API-key/anonymous auth modes |
| `AbstractAuthorizationTest.kt` | Base class: Testcontainers PostgreSQL, test data seeding, token caching, ephemeral entity helpers |
| `CatalogEndpointAuthzTest.kt` | Plugin/release visibility, tags, download, plugins.json (~120 tests) |
| `ManagementEndpointAuthzTest.kt` | Upload, update plugin/release, delete (~60 tests) |
| `NamespaceMemberEndpointAuthzTest.kt` | me, list, add, update, remove members (~35 tests) |
| `NamespaceEndpointAuthzTest.kt` | list, create, update, delete namespaces (~30 tests) |
| `AdminUserEndpointAuthzTest.kt` | Superadmin-only user CRUD (~25 tests) |
| `ReviewsEndpointAuthzTest.kt` | Pending/approve/reject (~20 tests) |
| `AccessKeyEndpointAuthzTest.kt` | Namespace-scoped key management (~20 tests) |
| `OidcProviderEndpointAuthzTest.kt` | Superadmin-only OIDC CRUD (~20 tests) |
| `AuthEndpointAuthzTest.kt` | Login, logout, change-password (~10 tests) |
| `UpdateCheckEndpointAuthzTest.kt` | permitAll verification (~9 tests) |
| `ConfigEndpointAuthzTest.kt` | Public endpoint (~6 tests) |
| `ApiKeyEdgeCaseTest.kt` | Revoked, expired, cross-namespace, write denial (~8 tests) |

### Modified files (2)
- `SmokeTest.kt` — now shares singleton PostgreSQL container with auth tests
- `application-integration.yml` — increased login rate-limit for test profile

## Findings during implementation

The tests validated actual backend behavior and uncovered several differences from the initial issue spec:
- `POST /auth/logout` returns **204** (not 200)
- Authenticated users **without namespace membership** get **PUBLIC** catalog visibility (not AUTHENTICATED)
- API keys see **all releases** via `listReleases()` (no visibility filter applied)
- Private namespaces return **401** (not 403) for anonymous requests
- `POST /updates/check` is fully **permitAll** — no namespace access check

## Test plan

- [x] `./gradlew spotlessApply` — clean
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — all unit tests pass
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — 316 new auth tests pass (17 pre-existing failures in `*ServiceIntegrationTest` classes are unrelated)