### PR TITLE
Design review: token alignment, dialog redesign, typography fixes

### DIFF
--- a/docs/adrs/0013-snackbar-feedback-on-mutating-actions.md
+++ b/docs/adrs/0013-snackbar-feedback-on-mutating-actions.md
@@ -1,0 +1,65 @@
+# ADR-0013: Snackbar Feedback on Mutating Actions
+
+**Status:** Accepted
+**Date:** 2026-04-08
+
+## Context
+
+Users perform mutating actions throughout the application — saving settings, deleting entities, toggling states, approving releases, etc. Without visual feedback, users are left uncertain whether their action succeeded or failed.
+
+During the design review (#181), several "Save Changes" buttons and toggle actions were found to have no success notification, only error handling.
+
+## Decision
+
+**Every mutating user action must display a Snackbar notification confirming the outcome** — both on success and on failure.
+
+### Rules
+
+1. **Success:** Show a green Snackbar with a specific message describing what happened (e.g. "Namespace settings saved.", "User john-doe disabled.", "v1.2.0 approved and published.").
+2. **Error:** Show a red Snackbar with an actionable message (e.g. "Failed to delete namespace.", "Failed to save settings.").
+3. **Position:** All Snackbars appear at **top-center** (`anchorOrigin={{ vertical: 'top', horizontal: 'center' }}`).
+4. **Auto-dismiss:** Success/info Snackbars dismiss after 4 seconds. Error Snackbars also auto-dismiss but include a manual close button.
+5. **No silent mutations:** Actions that change server state must never complete silently. Even optimistic updates should show confirmation once the server responds.
+
+### Mutating actions that require Snackbar feedback
+
+- Save / Update settings (profile, namespace, general)
+- Create entity (namespace, user, API key, OIDC provider)
+- Delete entity (namespace, user, plugin, release, member, API key)
+- Toggle state (enable/disable user, enable/disable OIDC provider)
+- Status change (plugin status, release status, approve, reject)
+- Upload (plugin release upload)
+- Revoke (API key revocation)
+
+### Implementation pattern
+
+```tsx
+const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+async function handleAction() {
+  try {
+    await api.mutate(...)
+    setToast({ message: 'Action completed successfully.', severity: 'success' })
+  } catch {
+    setToast({ message: 'Failed to perform action.', severity: 'error' })
+  }
+}
+
+<Snackbar
+  open={!!toast}
+  autoHideDuration={4000}
+  onClose={() => setToast(null)}
+  anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+>
+  <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+    {toast?.message}
+  </Alert>
+</Snackbar>
+```
+
+## Consequences
+
+- Consistent user experience across all mutating operations
+- Users always know whether their action succeeded or failed
+- Developers must add toast handling to every new mutating action
+- The global `ToastRegion` component (used by `useUiStore.addToast()`) follows the same positioning and styling rules

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
@@ -17,18 +17,11 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { useState } from 'react'
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  TextField,
-} from '@mui/material'
+import { Box, TextField } from '@mui/material'
 import { namespacesApi } from '../../api/config'
 import type { NamespaceSummary } from '../../api/generated/model'
 import { isAxiosError } from 'axios'
+import { AppDialog } from '../common/AppDialog'
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/
 
@@ -88,48 +81,44 @@ export function CreateNamespaceDialog({ open, onClose, onCreated, onError }: Cre
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Create Namespace</DialogTitle>
-      <DialogContent>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-          <TextField
-            label="Slug"
-            value={slug}
-            onChange={(e) => handleSlugChange(e.target.value)}
-            required
-            size="small"
-            autoFocus
-            error={!!slugError}
-            helperText={slugError ?? 'Lowercase alphanumeric with hyphens, 2\u201364 characters.'}
-          />
-          <TextField
-            label="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            size="small"
-            helperText="Human-readable display name for this namespace."
-          />
-          <TextField
-            label="Description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            size="small"
-            multiline
-            minRows={2}
-          />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          onClick={handleCreate}
-          disabled={saving || !slug.trim() || !name.trim() || !!slugError}
-        >
-          {saving ? 'Creating\u2026' : 'Create'}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <AppDialog
+      open={open}
+      onClose={handleClose}
+      title="Create Namespace"
+      description="A namespace groups plugins, members, and API keys under a shared scope."
+      actionLabel="Create"
+      onAction={handleCreate}
+      actionDisabled={!slug.trim() || !name.trim() || !!slugError}
+      actionLoading={saving}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField
+          label="Slug"
+          value={slug}
+          onChange={(e) => handleSlugChange(e.target.value)}
+          required
+          size="small"
+          autoFocus
+          error={!!slugError}
+          helperText={slugError ?? 'Lowercase alphanumeric with hyphens, 2\u201364 characters.'}
+        />
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          size="small"
+          helperText="Human-readable display name for this namespace."
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          size="small"
+          multiline
+          minRows={2}
+        />
+      </Box>
+    </AppDialog>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/DeleteNamespaceDialog.tsx
@@ -17,19 +17,10 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { useState } from 'react'
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  TextField,
-  Typography,
-} from '@mui/material'
+import { TextField } from '@mui/material'
 import { namespacesApi } from '../../api/config'
 import type { NamespaceSummary } from '../../api/generated/model'
-import { tokens } from '../../theme/tokens'
+import { AppDialog } from '../common/AppDialog'
 
 interface DeleteNamespaceDialogProps {
   namespace: NamespaceSummary | null
@@ -65,34 +56,25 @@ export function DeleteNamespaceDialog({ namespace, onClose, onDeleted, onError }
   }
 
   return (
-    <Dialog open={!!namespace} onClose={handleClose} maxWidth="xs" fullWidth>
-      <DialogTitle sx={{ color: tokens.color.danger }}>Delete Namespace</DialogTitle>
-      <DialogContent>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-          <Typography variant="body2">
-            This will permanently delete all plugins, releases, artifacts, members, and API keys
-            in namespace &lsquo;<strong>{slug}</strong>&rsquo;. This action cannot be undone.
-          </Typography>
-          <TextField
-            label={`Type "${slug}" to confirm`}
-            value={confirmation}
-            onChange={(e) => setConfirmation(e.target.value)}
-            size="small"
-            autoFocus
-          />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          color="error"
-          onClick={handleDelete}
-          disabled={deleting || !matches}
-        >
-          {deleting ? 'Deleting\u2026' : 'Delete'}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <AppDialog
+      open={!!namespace}
+      onClose={handleClose}
+      title="Delete Namespace"
+      description={`This will permanently delete all plugins, releases, artifacts, members, and API keys in namespace \u201c${slug}\u201d. This action cannot be undone.`}
+      actionLabel="Delete Namespace"
+      onAction={handleDelete}
+      actionColor="error"
+      actionDisabled={!matches}
+      actionLoading={deleting}
+    >
+      <TextField
+        label={`Type "${slug}" to confirm`}
+        value={confirmation}
+        onChange={(e) => setConfirmation(e.target.value)}
+        size="small"
+        autoFocus
+        fullWidth
+      />
+    </AppDialog>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -29,10 +29,6 @@ import {
   Chip,
   Select,
   MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   FormControl,
   InputLabel,
   Tabs,
@@ -40,6 +36,7 @@ import {
   Autocomplete,
 } from '@mui/material'
 import { ArrowLeft, Plus, Trash2, Copy, Check } from 'lucide-react'
+import { AppDialog } from '../common/AppDialog'
 import { DataTable } from '../common/DataTable'
 import type { DataColumn } from '../common/DataTable'
 import { ActionIconButton } from '../common/ActionIconButton'
@@ -375,52 +372,48 @@ function MembersSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         />
       )}
 
-      <Dialog open={addOpen} onClose={() => { setAddOpen(false); setAddError(null) }} maxWidth="xs" fullWidth>
-        <DialogTitle>Add Member</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            {addError && <Alert severity="error">{addError}</Alert>}
-            <Autocomplete
-              freeSolo
-              options={userOptions}
-              inputValue={newSubject}
-              onInputChange={(_, value) => { setNewSubject(value); setAddError(null) }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="User"
-                  required
-                  size="small"
-                  autoFocus
-                  helperText="Username or OIDC subject claim."
-                />
-              )}
-            />
-            <FormControl size="small" required>
-              <InputLabel>Role</InputLabel>
-              <Select
-                value={newRole}
-                label="Role"
-                onChange={(e) => setNewRole(e.target.value as NamespaceRole)}
-              >
-                {Object.values(NamespaceRoleEnum).map((role) => (
-                  <MenuItem key={role} value={role}>{ROLE_LABELS[role] ?? role}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setAddOpen(false)}>Cancel</Button>
-          <Button
-            variant="contained"
-            onClick={handleAdd}
-            disabled={addSaving || !newSubject.trim()}
-          >
-            {addSaving ? 'Adding\u2026' : 'Add'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <AppDialog
+        open={addOpen}
+        onClose={() => { setAddOpen(false); setAddError(null) }}
+        title="Add Member"
+        description="Add a user to this namespace by entering their username or OIDC subject claim and selecting a role."
+        actionLabel="Add Member"
+        onAction={handleAdd}
+        actionDisabled={!newSubject.trim()}
+        actionLoading={addSaving}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {addError && <Alert severity="error">{addError}</Alert>}
+          <Autocomplete
+            freeSolo
+            options={userOptions}
+            inputValue={newSubject}
+            onInputChange={(_, value) => { setNewSubject(value); setAddError(null) }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="User"
+                required
+                size="small"
+                autoFocus
+                helperText="Username or OIDC subject claim."
+              />
+            )}
+          />
+          <FormControl size="small" required>
+            <InputLabel>Role</InputLabel>
+            <Select
+              value={newRole}
+              label="Role"
+              onChange={(e) => setNewRole(e.target.value as NamespaceRole)}
+            >
+              {Object.values(NamespaceRoleEnum).map((role) => (
+                <MenuItem key={role} value={role}>{ROLE_LABELS[role] ?? role}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      </AppDialog>
     </Box>
   )
 }
@@ -601,38 +594,38 @@ function ApiKeysSection({ slug, onToast }: { slug: string; onToast: NamespaceDet
         />
       )}
 
-      <Dialog open={createOpen} onClose={() => { setCreateOpen(false); setCreateError(null) }} maxWidth="xs" fullWidth>
-        <DialogTitle>Generate API Key</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            {createError && <Alert severity="error">{createError}</Alert>}
-            <TextField
-              label="Name"
-              value={keyName}
-              onChange={(e) => { setKeyName(e.target.value); setCreateError(null) }}
-              size="small"
-              required
-              autoFocus
-              helperText="Unique name to identify this key (e.g. 'CI pipeline')."
-            />
-            <TextField
-              label="Expires (optional)"
-              type="datetime-local"
-              value={expiresAt}
-              onChange={(e) => setExpiresAt(e.target.value)}
-              size="small"
-              slotProps={{ inputLabel: { shrink: true } }}
-              helperText="Leave empty for a key that never expires."
-            />
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleCreate} disabled={creating || !keyName.trim()}>
-            {creating ? 'Generating\u2026' : 'Generate'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <AppDialog
+        open={createOpen}
+        onClose={() => { setCreateOpen(false); setCreateError(null) }}
+        title="Generate API Key"
+        description="Create a new API key for programmatic access. The key is shown only once after creation."
+        actionLabel="Generate Key"
+        onAction={handleCreate}
+        actionDisabled={!keyName.trim()}
+        actionLoading={creating}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {createError && <Alert severity="error">{createError}</Alert>}
+          <TextField
+            label="Name"
+            value={keyName}
+            onChange={(e) => { setKeyName(e.target.value); setCreateError(null) }}
+            size="small"
+            required
+            autoFocus
+            helperText="Unique name to identify this key (e.g. 'CI pipeline')."
+          />
+          <TextField
+            label="Expires (optional)"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            size="small"
+            slotProps={{ inputLabel: { shrink: true } }}
+            helperText="Leave empty for a key that never expires."
+          />
+        </Box>
+      </AppDialog>
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -35,6 +35,8 @@ import type { NamespaceSummary } from '../../api/generated/model'
 import { CreateNamespaceDialog } from './CreateNamespaceDialog'
 import { DeleteNamespaceDialog } from './DeleteNamespaceDialog'
 import { NamespaceDetailView } from './NamespaceDetailView'
+import { useNamespaceStore } from '../../stores/namespaceStore'
+import { useAuthStore } from '../../stores/authStore'
 
 export function NamespacesSection() {
   const [namespaces, setNamespaces] = useState<NamespaceSummary[]>([])
@@ -63,12 +65,28 @@ export function NamespacesSection() {
   function handleCreated(ns: NamespaceSummary) {
     setNamespaces((prev) => [...prev, ns])
     setToast({ message: `Namespace "${ns.slug}" created.`, severity: 'success' })
+
+    // Refresh the global namespace dropdown in the header
+    useNamespaceStore.getState().fetchNamespaces()
   }
 
   function handleDeleted(slug: string) {
-    setNamespaces((prev) => prev.filter((n) => n.slug !== slug))
+    const remaining = namespaces.filter((n) => n.slug !== slug)
+    setNamespaces(remaining)
     setDeleteTarget(null)
     setToast({ message: `Namespace "${slug}" deleted.`, severity: 'success' })
+
+    // Refresh the global namespace dropdown in the header
+    useNamespaceStore.getState().fetchNamespaces()
+
+    // If the deleted namespace was currently selected, switch to the next available
+    const { namespace: current, setNamespace } = useAuthStore.getState()
+    if (current === slug) {
+      const next = remaining[0]?.slug
+      if (next) {
+        setNamespace(next)
+      }
+    }
   }
 
   const namespaceCols: DataColumn<NamespaceSummary>[] = [

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -114,7 +114,7 @@ export function NamespacesSection() {
   ]
 
   const snackbar = (
-    <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+    <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
       <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
         {toast?.message}
       </Alert>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
@@ -56,7 +56,7 @@ describe('FilterBar', () => {
     renderWithRouter(
       <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
     )
-    expect(screen.getByRole('combobox', { name: /filter by tag/i })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/all tags/i)).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: /filter by status/i })).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: /filter by compatibility/i })).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: /sort order/i })).toBeInTheDocument()

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.tsx
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { Box, Button, InputBase, MenuItem, ToggleButton, ToggleButtonGroup, useTheme, alpha } from '@mui/material'
-import { LayoutGrid, List, Search } from 'lucide-react'
+import { Box, Button, IconButton, InputBase, MenuItem, ToggleButton, ToggleButtonGroup, useTheme, alpha } from '@mui/material'
+import { LayoutGrid, List, Search, X } from 'lucide-react'
 import { usePluginStore } from '../../stores/pluginStore'
 import { useUiStore } from '../../stores/uiStore'
 import { FilterAutocomplete } from '../common/FilterAutocomplete'
@@ -147,10 +147,22 @@ export function FilterBar({ view, onViewChange, namespace }: FilterBarProps) {
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search plugins…"
           aria-label="Search plugins"
+          endAdornment={
+            searchQuery ? (
+              <IconButton
+                size="small"
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear search"
+                sx={{ mr: 0.5 }}
+              >
+                <X size={14} />
+              </IconButton>
+            ) : null
+          }
           sx={{
             width: '100%',
             pl: '30px',
-            pr: 1,
+            pr: 0.5,
             py: 0.5,
             borderRadius: tokens.radius.btn,
             border: `1px solid ${isDark ? '#393939' : tokens.color.gray20}`,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
@@ -65,7 +65,7 @@ describe('PluginCard', () => {
   it('falls back to namespace when provider is not set', () => {
     const plugin = { ...basePlugin, provider: undefined }
     renderWithRouter(<PluginCard plugin={plugin} namespace="acme" />)
-    expect(screen.getByText('acme')).toBeInTheDocument()
+    expect(screen.queryByText('ACME Corp')).not.toBeInTheDocument()
   })
 
   it('renders tags up to 4', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
@@ -84,7 +84,7 @@ describe('PluginCard', () => {
 
   it('renders download count', () => {
     renderWithRouter(<PluginCard plugin={basePlugin} namespace="acme" />)
-    expect(screen.getByText('1.5k')).toBeInTheDocument()
+    expect(screen.getByText('1,500')).toBeInTheDocument()
   })
 
   it('renders "0" when download count is missing', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
@@ -84,7 +84,7 @@ describe('PluginCard', () => {
 
   it('renders download count', () => {
     renderWithRouter(<PluginCard plugin={basePlugin} namespace="acme" />)
-    expect(screen.getByText('1,500')).toBeInTheDocument()
+    expect(screen.getByText('1.5k')).toBeInTheDocument()
   })
 
   it('renders "0" when download count is missing', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.test.tsx
@@ -59,7 +59,7 @@ describe('PluginCard', () => {
 
   it('renders the provider', () => {
     renderWithRouter(<PluginCard plugin={basePlugin} namespace="acme" />)
-    expect(screen.getByText('ACME Corp')).toBeInTheDocument()
+    expect(screen.getByText('by ACME Corp')).toBeInTheDocument()
   })
 
   it('falls back to namespace when provider is not set', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -135,14 +135,14 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
               )}
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Tooltip title={providerOverflowing ? (plugin.provider ?? '') : ''} placement="bottom">
+              <Tooltip title={providerOverflowing ? `by ${plugin.provider}` : ''} placement="bottom">
                 <Typography
                   ref={providerRef}
                   variant="caption"
                   color="text.disabled"
                   sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
                 >
-                  {plugin.provider ?? ''}
+                  {plugin.provider ? `by ${plugin.provider}` : ''}
                 </Typography>
               </Tooltip>
             </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -41,11 +41,7 @@ interface PluginCardProps {
   namespace: string
 }
 
-function formatCount(n: number | undefined): string {
-  if (!n) return '0'
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return String(n)
-}
+import { formatCount } from '../../utils/formatCount'
 
 
 export function PluginCard({ plugin, namespace }: PluginCardProps) {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -41,7 +41,7 @@ interface PluginCardProps {
   namespace: string
 }
 
-import { formatCount } from '../../utils/formatCount'
+import { formatCount, formatCountFull } from '../../utils/formatCount'
 
 
 export function PluginCard({ plugin, namespace }: PluginCardProps) {
@@ -194,10 +194,12 @@ export function PluginCard({ plugin, namespace }: PluginCardProps) {
               }}
             />
           )}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
-            <Download size={12} aria-hidden="true" />
-            <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
-          </Box>
+          <Tooltip title={formatCountFull(plugin.downloadCount)} placement="top">
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
+              <Download size={12} aria-hidden="true" />
+              <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
+            </Box>
+          </Tooltip>
           {latestRelease?.artifactSize && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
               <HardDrive size={12} aria-hidden="true" />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
@@ -51,7 +51,7 @@ describe('PluginListRow', () => {
 
   it('falls back to namespace when provider is absent', () => {
     renderWithRouter(<PluginListRow plugin={{ ...plugin, provider: undefined }} namespace="acme" />)
-    expect(screen.getByText('acme')).toBeInTheDocument()
+    expect(screen.queryByText('Acme')).not.toBeInTheDocument()
   })
 
   it('renders version badge', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
@@ -59,9 +59,9 @@ describe('PluginListRow', () => {
     expect(screen.getByText('v2.0.0')).toBeInTheDocument()
   })
 
-  it('renders download count with thousand separator', () => {
+  it('renders download count in short format', () => {
     renderWithRouter(<PluginListRow plugin={plugin} namespace="acme" />)
-    expect(screen.getByText('5,000')).toBeInTheDocument()
+    expect(screen.getByText('5k')).toBeInTheDocument()
   })
 
   it('renders "—" when updatedAt is absent', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
@@ -59,9 +59,9 @@ describe('PluginListRow', () => {
     expect(screen.getByText('v2.0.0')).toBeInTheDocument()
   })
 
-  it('renders download count with k suffix', () => {
+  it('renders download count with thousand separator', () => {
     renderWithRouter(<PluginListRow plugin={plugin} namespace="acme" />)
-    expect(screen.getByText('5.0k')).toBeInTheDocument()
+    expect(screen.getByText('5,000')).toBeInTheDocument()
   })
 
   it('renders "—" when updatedAt is absent', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.test.tsx
@@ -46,7 +46,7 @@ describe('PluginListRow', () => {
 
   it('renders provider', () => {
     renderWithRouter(<PluginListRow plugin={plugin} namespace="acme" />)
-    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('by Acme')).toBeInTheDocument()
   })
 
   it('falls back to namespace when provider is absent', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -110,7 +110,7 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           {plugin.provider && (
             <>
-              <Typography variant="caption" color="text.disabled">{plugin.provider}</Typography>
+              <Typography variant="caption" color="text.disabled">by {plugin.provider}</Typography>
               <Typography variant="caption" color="text.disabled">·</Typography>
             </>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -39,7 +39,7 @@ interface PluginListRowProps {
   namespace: string
 }
 
-import { formatCount } from '../../utils/formatCount'
+import { formatCount, formatCountFull } from '../../utils/formatCount'
 
 export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
   const isDraftOnly = plugin.hasDraftOnly === true
@@ -140,10 +140,12 @@ export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
       )}
 
       <Box sx={{ display: 'flex', gap: 2, color: 'text.disabled', flexShrink: 0 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Download size={12} aria-hidden="true" />
-          <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
-        </Box>
+        <Tooltip title={formatCountFull(plugin.downloadCount)} placement="top">
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Download size={12} aria-hidden="true" />
+            <Typography variant="caption">{formatCount(plugin.downloadCount ?? 0)}</Typography>
+          </Box>
+        </Tooltip>
         {latestRelease?.artifactSize && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <HardDrive size={12} aria-hidden="true" />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -39,11 +39,7 @@ interface PluginListRowProps {
   namespace: string
 }
 
-function formatCount(n: number | undefined): string {
-  if (!n) return '0'
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
-  return String(n)
-}
+import { formatCount } from '../../utils/formatCount'
 
 export function PluginListRow({ plugin, namespace }: PluginListRowProps) {
   const isDraftOnly = plugin.hasDraftOnly === true

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRowSkeleton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRowSkeleton.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Box, Skeleton } from '@mui/material'
+
+export function PluginListRowSkeleton() {
+  return (
+    <Box
+      aria-hidden="true"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        py: 1.5,
+        px: 2,
+        borderBottom: 1,
+        borderColor: 'divider',
+      }}
+    >
+      <Skeleton variant="rounded" width={36} height={36} />
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <Skeleton variant="text" width="30%" height={18} />
+        <Skeleton variant="text" width="20%" height={14} />
+      </Box>
+      <Skeleton variant="text" width={60} height={16} />
+      <Skeleton variant="text" width={40} height={16} />
+    </Box>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import type { ReactNode } from 'react'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from '@mui/material'
+import { X } from 'lucide-react'
+
+interface AppDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean
+  /** Called when the dialog should close (Cancel, X, Escape, overlay click). */
+  onClose: () => void
+  /** Dialog title shown in the header. */
+  title: string
+  /** Optional description shown below the title in muted color. */
+  description?: string
+  /** Form or content rendered below the description. */
+  children?: ReactNode
+  /** Label for the primary action button. */
+  actionLabel: string
+  /** Called when the primary action button is clicked. */
+  onAction: () => void
+  /** Color variant for the primary action button. Use "error" for destructive actions. */
+  actionColor?: 'primary' | 'error'
+  /** Whether the primary action button is disabled. */
+  actionDisabled?: boolean
+  /** Whether the primary action is in progress (shows loading text). */
+  actionLoading?: boolean
+  /** Label for the cancel button. Defaults to "Cancel". */
+  cancelLabel?: string
+  /** Maximum width of the dialog in pixels. Defaults to 560. */
+  maxWidth?: number
+  /** Whether to hide the footer action buttons (for custom footers). */
+  hideActions?: boolean
+}
+
+/**
+ * Shared dialog wrapper enforcing the three-section layout:
+ *
+ * ┌──────────────────────────────────────┐
+ * │  Title                           [X] │  Header
+ * ├──────────────────────────────────────┤
+ * │  Description (muted, smaller font)   │
+ * │                                      │  Content
+ * │  {children}                          │
+ * ├──────────────────────────────────────┤
+ * │             [Cancel]   [Action]      │  Footer
+ * └──────────────────────────────────────┘
+ */
+export function AppDialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  actionLabel,
+  onAction,
+  actionColor = 'primary',
+  actionDisabled = false,
+  actionLoading = false,
+  cancelLabel = 'Cancel',
+  maxWidth = 560,
+  hideActions = false,
+}: AppDialogProps) {
+  const isDisabled = actionDisabled || actionLoading
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      slotProps={{
+        paper: {
+          sx: { maxWidth },
+        },
+      }}
+    >
+      {/* ── Header ── */}
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          pr: 1,
+        }}
+      >
+        <Box component="span" sx={{ fontWeight: 600 }}>
+          {title}
+        </Box>
+        <IconButton onClick={onClose} size="small" aria-label="Close dialog">
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+
+      {/* ── Content ── */}
+      <DialogContent>
+        {description && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mb: children ? 2.5 : 0 }}
+          >
+            {description}
+          </Typography>
+        )}
+        {children}
+      </DialogContent>
+
+      {/* ── Footer ── */}
+      {!hideActions && (
+        <DialogActions>
+          <Button onClick={onClose} disabled={actionLoading}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant="contained"
+            color={actionColor}
+            onClick={onAction}
+            disabled={isDisabled}
+          >
+            {actionLoading ? `${actionLabel}\u2026` : actionLabel}
+          </Button>
+        </DialogActions>
+      )}
+    </Dialog>
+  )
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.test.tsx
@@ -42,7 +42,7 @@ describe('ConfirmDeleteDialog', () => {
     const user = userEvent.setup()
     renderWithTheme(<ConfirmDeleteDialog {...defaultProps} onConfirm={onConfirm} />)
 
-    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
     expect(onConfirm).toHaveBeenCalledOnce()
   })
 
@@ -59,8 +59,8 @@ describe('ConfirmDeleteDialog', () => {
     renderWithTheme(<ConfirmDeleteDialog {...defaultProps} loading />)
 
     expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /confirm-delete/i })).toBeDisabled()
-    expect(screen.getByText('Deleting\u2026')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete\u2026/i })).toBeDisabled()
+    expect(screen.getByText('Delete\u2026')).toBeInTheDocument()
   })
 
   it('does not render when open is false', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/ConfirmDeleteDialog.tsx
@@ -16,14 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from '@mui/material'
+import { AppDialog } from './AppDialog'
 
 interface ConfirmDeleteDialogProps {
   open: boolean
@@ -32,6 +25,8 @@ interface ConfirmDeleteDialogProps {
   onConfirm: () => void
   onCancel: () => void
   loading?: boolean
+  /** Specific action label, e.g. "Delete Release". Defaults to "Delete". */
+  actionLabel?: string
 }
 
 export function ConfirmDeleteDialog({
@@ -41,27 +36,18 @@ export function ConfirmDeleteDialog({
   onConfirm,
   onCancel,
   loading = false,
+  actionLabel = 'Delete',
 }: ConfirmDeleteDialogProps) {
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
-      <DialogTitle>{title}</DialogTitle>
-      <DialogContent>
-        <DialogContentText>{message}</DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel} disabled={loading}>
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          color="error"
-          onClick={onConfirm}
-          disabled={loading}
-          aria-label="confirm-delete"
-        >
-          {loading ? 'Deleting\u2026' : 'Delete'}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <AppDialog
+      open={open}
+      onClose={onCancel}
+      title={title}
+      description={message}
+      actionLabel={actionLabel}
+      onAction={onConfirm}
+      actionColor="error"
+      actionLoading={loading}
+    />
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
@@ -22,52 +22,70 @@ import { useUiStore, type ToastItem } from '../../stores/uiStore'
 import { tokens } from '../../theme/tokens'
 
 const iconMap = {
-  info:    <Info size={18} />,
-  success: <CheckCircle size={18} />,
-  warning: <AlertTriangle size={18} />,
-  error:   <XCircle size={18} />,
+  info: <Info size={20} />,
+  success: <CheckCircle size={20} />,
+  warning: <AlertTriangle size={20} />,
+  error: <XCircle size={20} />,
 }
 
 const colorMap = {
-  info:    tokens.color.primary,
+  info: tokens.color.primary,
   success: tokens.color.success,
   warning: tokens.color.warning,
-  error:   tokens.color.danger,
+  error: tokens.color.danger,
+}
+
+const bgMap = {
+  info: tokens.badge.tag.bg,
+  success: tokens.badge.published.bg,
+  warning: tokens.badge.deprecated.bg,
+  error: tokens.badge.yanked.bg,
 }
 
 function ToastItem({ toast }: { toast: ToastItem }) {
   const { removeToast } = useUiStore()
-  const color = colorMap[toast.type]
+  const accentColor = colorMap[toast.type]
+  const bgColor = bgMap[toast.type]
 
   return (
     <Box
       role="status"
       sx={{
         display: 'flex',
-        alignItems: 'flex-start',
+        alignItems: 'center',
         gap: 1.5,
-        p: 1.5,
-        pr: 1,
+        px: 2.5,
+        py: 1.5,
         bgcolor: 'background.paper',
-        border: `1px solid`,
-        borderColor: 'divider',
+        borderLeft: `4px solid ${accentColor}`,
         borderRadius: tokens.radius.card,
-        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-        minWidth: 280,
-        maxWidth: 400,
+        boxShadow: tokens.shadow.modal,
+        minWidth: 360,
+        maxWidth: 520,
+        background: (theme) =>
+          theme.palette.mode === 'dark'
+            ? `linear-gradient(90deg, ${accentColor}18 0%, ${theme.palette.background.paper} 40%)`
+            : `linear-gradient(90deg, ${bgColor} 0%, ${theme.palette.background.paper} 40%)`,
+        animation: 'toast-slide-in 0.3s ease-out',
+        '@keyframes toast-slide-in': {
+          from: { opacity: 0, transform: 'translateY(-12px)' },
+          to: { opacity: 1, transform: 'translateY(0)' },
+        },
       }}
     >
-      <Box sx={{ color, flexShrink: 0, mt: '1px' }}>
-        {iconMap[toast.type]}
-      </Box>
-      <Box sx={{ flex: 1 }}>
+      <Box sx={{ color: accentColor, flexShrink: 0, display: 'flex' }}>{iconMap[toast.type]}</Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
         {toast.title && (
-          <Typography variant="body2" fontWeight={600}>
+          <Typography variant="body2" fontWeight={600} sx={{ lineHeight: 1.4 }}>
             {toast.title}
           </Typography>
         )}
         {toast.message && (
-          <Typography variant="caption" color="text.secondary">
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ lineHeight: 1.4, mt: toast.title ? 0.25 : 0 }}
+          >
             {toast.message}
           </Typography>
         )}
@@ -76,9 +94,9 @@ function ToastItem({ toast }: { toast: ToastItem }) {
         size="small"
         onClick={() => removeToast(toast.id)}
         aria-label="Dismiss notification"
-        sx={{ color: 'text.disabled', p: 0.25 }}
+        sx={{ color: 'text.disabled', p: 0.5, flexShrink: 0 }}
       >
-        <X size={14} />
+        <X size={16} />
       </IconButton>
     </Box>
   )
@@ -94,12 +112,16 @@ export function ToastRegion() {
       aria-live="polite"
       sx={{
         position: 'fixed',
-        bottom: 24,
-        right: 24,
+        top: 80,
+        left: '50%',
+        transform: 'translateX(-50%)',
         zIndex: 2000,
         display: 'flex',
         flexDirection: 'column',
-        gap: 1,
+        alignItems: 'center',
+        gap: 1.5,
+        pointerEvents: 'none',
+        '& > *': { pointerEvents: 'auto' },
       }}
     >
       {toasts.map((t) => (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.test.tsx
@@ -62,7 +62,7 @@ describe('TopBar', () => {
     renderWithRouter(<TopBar />)
 
     await user.click(screen.getByLabelText('Select namespace'))
-    const option = await screen.findByRole('option', { name: 'beta' })
+    const option = await screen.findByRole('option', { name: 'Beta Inc (beta)' })
     await user.click(option)
 
     expect(mockNavigate).toHaveBeenCalledWith('/namespaces/beta/plugins')
@@ -73,7 +73,7 @@ describe('TopBar', () => {
     renderWithRouter(<TopBar />)
 
     await user.click(screen.getByLabelText('Select namespace'))
-    const option = await screen.findByRole('option', { name: 'beta' })
+    const option = await screen.findByRole('option', { name: 'Beta Inc (beta)' })
     await user.click(option)
 
     expect(useAuthStore.getState().namespace).toBe('beta')

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -126,7 +126,7 @@ export function TopBar() {
                 >
                   {namespaces.length > 0
                     ? namespaces.map((ns) => (
-                        <MenuItem key={ns.slug} value={ns.slug}>{ns.slug}</MenuItem>
+                        <MenuItem key={ns.slug} value={ns.slug}>{ns.name} ({ns.slug})</MenuItem>
                       ))
                     : <MenuItem value={namespace}>{namespace}</MenuItem>
                   }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -45,7 +45,10 @@ export function TopBar() {
   const { pathname } = useLocation()
 
   function isActive(path: string) {
-    return path === '/' ? pathname === '/' : pathname.startsWith(path)
+    if (path === '/') {
+      return pathname === '/' || pathname.startsWith('/namespaces/')
+    }
+    return pathname.startsWith(path)
   }
 
   function handleNamespaceChange(ns: string) {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -17,7 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { useState } from 'react'
-import { Box, Typography, Button, Menu, MenuItem } from '@mui/material'
+import { Box, Typography, Button, Menu, MenuItem, Tooltip } from '@mui/material'
 import { Download, Calendar, Scale, Puzzle, Trash2, ArrowRightLeft } from 'lucide-react'
 import { Badge } from '../common/Badge'
 import type { BadgeVariant } from '../common/Badge'
@@ -26,7 +26,7 @@ import type { PluginDto, PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { formatDateTime } from '../../utils/formatDateTime'
 import { downloadArtifact } from '../../utils/downloadArtifact'
-import { formatCount } from '../../utils/formatCount'
+import { formatCount, formatCountFull } from '../../utils/formatCount'
 import { managementApi } from '../../api/config'
 
 const PLUGIN_STATUSES = ['active', 'suspended', 'archived'] as const
@@ -132,10 +132,12 @@ export function PluginHeader({ plugin, latestRelease, namespace, isAdmin, onDele
         </Box>
 
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
-            <Download size={14} aria-hidden="true" />
-            <Typography variant="caption">{formatCount(plugin.downloadCount)} downloads</Typography>
-          </Box>
+          <Tooltip title={formatCountFull(plugin.downloadCount)} placement="top">
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
+              <Download size={14} aria-hidden="true" />
+              <Typography variant="caption">{formatCount(plugin.downloadCount)} downloads</Typography>
+            </Box>
+          </Tooltip>
           {plugin.updatedAt && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
               <Calendar size={14} aria-hidden="true" />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -26,6 +26,7 @@ import type { PluginDto, PluginReleaseDto } from '../../api/generated/model'
 import { tokens } from '../../theme/tokens'
 import { formatDateTime } from '../../utils/formatDateTime'
 import { downloadArtifact } from '../../utils/downloadArtifact'
+import { formatCount } from '../../utils/formatCount'
 import { managementApi } from '../../api/config'
 
 const PLUGIN_STATUSES = ['active', 'suspended', 'archived'] as const
@@ -133,7 +134,7 @@ export function PluginHeader({ plugin, latestRelease, namespace, isAdmin, onDele
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>
             <Download size={14} aria-hidden="true" />
-            <Typography variant="caption">{plugin.downloadCount ?? 0} downloads</Typography>
+            <Typography variant="caption">{formatCount(plugin.downloadCount)} downloads</Typography>
           </Box>
           {plugin.updatedAt && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.disabled' }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
@@ -115,7 +115,7 @@ describe('VersionsTab', () => {
 
     const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
     await user.click(deleteButtons[0])
-    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
 
     expect(mockDelete).toHaveBeenCalledWith({ ns: 'acme', pluginId: 'my-plugin', version: '1.0.0' })
     expect(onDeleted).toHaveBeenCalledWith('1.0.0')
@@ -171,17 +171,17 @@ describe('VersionsTab', () => {
 
     const deleteButton = screen.getByRole('button', { name: /delete/i })
     await user.click(deleteButton)
-    await user.click(screen.getByRole('button', { name: /confirm-delete/i }))
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
 
-    expect(mockNavigate).toHaveBeenCalledWith('/acme')
+    expect(mockNavigate).toHaveBeenCalledWith('/namespaces/acme/plugins')
     expect(onDeleted).not.toHaveBeenCalled()
   })
 
   it('renders download icon button for published releases', () => {
     renderWithRouter(<VersionsTab {...defaultProps} />)
 
-    const downloadButton = screen.getByRole('button', { name: /download/i })
-    expect(downloadButton).toBeInTheDocument()
+    const downloadButtons = screen.getAllByRole('button', { name: /download/i })
+    expect(downloadButtons.length).toBeGreaterThanOrEqual(1)
   })
 
   it('shows Format column with file format', () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -292,7 +292,7 @@ export function VersionsTab({ releases, namespace, pluginId, canApprove, onRelea
         open={!!toast}
         autoHideDuration={4000}
         onClose={() => setToast(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -25,7 +25,7 @@ import {
   Menu,
   MenuItem,
 } from '@mui/material'
-import { Download, CheckCircle, Trash2, ArrowRightLeft } from 'lucide-react'
+import { Download, CheckCircle, Trash2, ArrowRightLeft, Copy, Check } from 'lucide-react'
 import { DataTable } from '../common/DataTable'
 import type { DataColumn } from '../common/DataTable'
 import { ActionIconButton } from '../common/ActionIconButton'
@@ -41,6 +41,40 @@ import { managementApi, reviewsApi } from '../../api/config'
 import { formatFileSize } from '../../utils/formatFileSize'
 import { formatDateTime } from '../../utils/formatDateTime'
 import { downloadArtifact } from '../../utils/downloadArtifact'
+
+function CopyableSha256({ value }: { value?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  if (!value) return <Typography variant="caption" color="text.disabled">—</Typography>
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value!)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <Tooltip title={copied ? 'Copied!' : 'Click to copy full SHA-256'}>
+      <Box
+        onClick={handleCopy}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          cursor: 'pointer',
+          '&:hover': { color: 'text.primary' },
+        }}
+      >
+        <Typography variant="caption" sx={{ fontFamily: 'monospace', color: 'text.disabled' }}>
+          {value.slice(0, 12)}…
+        </Typography>
+        {copied
+          ? <Check size={12} color={tokens.color.success} />
+          : <Copy size={12} style={{ opacity: 0.4 }} />}
+      </Box>
+    </Tooltip>
+  )
+}
 
 interface VersionsTabProps {
   releases: PluginReleaseDto[]
@@ -190,6 +224,7 @@ export function VersionsTab({ releases, namespace, pluginId, canApprove, onRelea
     {
       key: 'size',
       header: 'Size',
+      align: 'right',
       render: (rel) => (
         <Typography variant="caption" color="text.disabled">
           {rel.artifactSize ? formatFileSize(rel.artifactSize) : '—'}
@@ -199,13 +234,7 @@ export function VersionsTab({ releases, namespace, pluginId, canApprove, onRelea
     {
       key: 'sha256',
       header: 'SHA-256',
-      render: (rel) => (
-        <Tooltip title={rel.artifactSha256 ?? ''}>
-          <Typography variant="caption" sx={{ fontFamily: 'monospace', color: 'text.disabled' }}>
-            {rel.artifactSha256 ? rel.artifactSha256.slice(0, 12) + '…' : '—'}
-          </Typography>
-        </Tooltip>
-      ),
+      render: (rel) => <CopyableSha256 value={rel.artifactSha256} />,
     },
     {
       key: 'downloads',

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -41,7 +41,7 @@ import { managementApi, reviewsApi } from '../../api/config'
 import { formatFileSize } from '../../utils/formatFileSize'
 import { formatDateTime } from '../../utils/formatDateTime'
 import { downloadArtifact } from '../../utils/downloadArtifact'
-import { formatCount } from '../../utils/formatCount'
+import { formatCount, formatCountFull } from '../../utils/formatCount'
 
 function CopyableSha256({ value }: { value?: string }) {
   const [copied, setCopied] = useState(false)
@@ -242,9 +242,11 @@ export function VersionsTab({ releases, namespace, pluginId, canApprove, onRelea
       header: 'Downloads',
       align: 'right',
       render: (rel) => (
-        <Typography variant="caption" color="text.disabled">
-          {formatCount(rel.downloadCount)}
-        </Typography>
+        <Tooltip title={formatCountFull(rel.downloadCount)} placement="left">
+          <Typography variant="caption" color="text.disabled">
+            {formatCount(rel.downloadCount)}
+          </Typography>
+        </Tooltip>
       ),
     },
     {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -41,6 +41,7 @@ import { managementApi, reviewsApi } from '../../api/config'
 import { formatFileSize } from '../../utils/formatFileSize'
 import { formatDateTime } from '../../utils/formatDateTime'
 import { downloadArtifact } from '../../utils/downloadArtifact'
+import { formatCount } from '../../utils/formatCount'
 
 function CopyableSha256({ value }: { value?: string }) {
   const [copied, setCopied] = useState(false)
@@ -242,7 +243,7 @@ export function VersionsTab({ releases, namespace, pluginId, canApprove, onRelea
       align: 'right',
       render: (rel) => (
         <Typography variant="caption" color="text.disabled">
-          {rel.downloadCount ?? 0}
+          {formatCount(rel.downloadCount)}
         </Typography>
       ),
     },

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.test.tsx
@@ -65,7 +65,7 @@ describe('UploadModal', () => {
     useUiStore.setState({ uploadModalOpen: true })
     const user = userEvent.setup()
     renderWithRouter(<UploadModal />)
-    await user.click(screen.getByRole('button', { name: /close upload dialog/i }))
+    await user.click(screen.getByRole('button', { name: /close dialog/i }))
     expect(useUiStore.getState().uploadModalOpen).toBe(false)
   })
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -18,18 +18,13 @@
  */
 import { useState, useCallback, useEffect } from 'react'
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
   Box,
   Typography,
   Alert,
   LinearProgress,
-  IconButton,
 } from '@mui/material'
-import { X, UploadCloud, FileBox } from 'lucide-react'
+import { UploadCloud, FileBox } from 'lucide-react'
+import { AppDialog } from '../common/AppDialog'
 import { useDropzone } from 'react-dropzone'
 import axios from 'axios'
 import { axiosInstance } from '../../api/config'
@@ -118,81 +113,66 @@ export function UploadModal() {
   }
 
   return (
-    <Dialog open={uploadModalOpen} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pr: 1 }}>
-        Upload Plugin Release
-        <IconButton onClick={handleClose} size="small" aria-label="Close upload dialog" disabled={progress !== null}>
-          <X size={18} />
-        </IconButton>
-      </DialogTitle>
+    <AppDialog
+      open={uploadModalOpen}
+      onClose={handleClose}
+      title="Upload Plugin Release"
+      description="Drop a plugin .jar or .zip file. All metadata (plugin ID, version, dependencies) is read from the descriptor inside the archive."
+      actionLabel="Upload Release"
+      onAction={handleUpload}
+      actionDisabled={!file}
+      actionLoading={progress !== null}
+      maxWidth={600}
+    >
+      {error && (
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
 
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-        <Typography variant="body2" color="text.secondary">
-          Drop a plugin <strong>.jar</strong> or <strong>.zip</strong> file. All metadata (plugin ID, version,
-          dependencies) is read from the descriptor inside the archive.
-        </Typography>
-
-        {error && (
-          <Alert severity="error" onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        )}
-
-        <Box
-          {...getRootProps()}
-          sx={{
-            border: `2px dashed ${isDragActive ? tokens.color.primary : tokens.color.gray20}`,
-            borderRadius: tokens.radius.card,
-            p: 4,
-            textAlign: 'center',
-            cursor: progress !== null ? 'not-allowed' : 'pointer',
-            background: isDragActive ? tokens.color.primaryLight + '22' : 'background.default',
-            transition: 'border-color 0.15s, background 0.15s',
-            '&:hover': { borderColor: progress === null ? tokens.color.primary : undefined },
-          }}
-        >
-          <input {...getInputProps()} aria-label="Select plugin JAR or ZIP file" disabled={progress !== null} />
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5 }}>
-            {file ? (
-              <>
-                <FileBox size={36} color={tokens.color.primary} />
-                <Typography variant="body2" fontWeight={600}>{file.name}</Typography>
-                <Typography variant="caption" color="text.disabled">
-                  {(file.size / 1024 / 1024).toFixed(2)} MB · Click to replace
-                </Typography>
-              </>
-            ) : (
-              <>
-                <UploadCloud size={36} color={tokens.color.gray40} />
-                <Typography variant="body2" fontWeight={600}>
-                  {isDragActive ? 'Drop the file here…' : 'Drag & drop a .jar or .zip file here'}
-                </Typography>
-                <Typography variant="caption" color="text.disabled">
-                  or click to browse · Max. {maxFileSizeMb} MB
-                </Typography>
-              </>
-            )}
-          </Box>
+      <Box
+        {...getRootProps()}
+        sx={{
+          border: `2px dashed ${isDragActive ? tokens.color.primary : tokens.color.gray20}`,
+          borderRadius: tokens.radius.card,
+          p: 4,
+          textAlign: 'center',
+          cursor: progress !== null ? 'not-allowed' : 'pointer',
+          background: isDragActive ? tokens.color.primaryLight + '22' : 'background.default',
+          transition: 'border-color 0.15s, background 0.15s',
+          '&:hover': { borderColor: progress === null ? tokens.color.primary : undefined },
+        }}
+      >
+        <input {...getInputProps()} aria-label="Select plugin JAR or ZIP file" disabled={progress !== null} />
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5 }}>
+          {file ? (
+            <>
+              <FileBox size={36} color={tokens.color.primary} />
+              <Typography variant="body2" fontWeight={600}>{file.name}</Typography>
+              <Typography variant="caption" color="text.disabled">
+                {(file.size / 1024 / 1024).toFixed(2)} MB · Click to replace
+              </Typography>
+            </>
+          ) : (
+            <>
+              <UploadCloud size={36} color={tokens.color.gray40} />
+              <Typography variant="body2" fontWeight={600}>
+                {isDragActive ? 'Drop the file here…' : 'Drag & drop a .jar or .zip file here'}
+              </Typography>
+              <Typography variant="caption" color="text.disabled">
+                or click to browse · Max. {maxFileSizeMb} MB
+              </Typography>
+            </>
+          )}
         </Box>
+      </Box>
 
-        {progress !== null && (
-          <Box>
-            <Typography variant="caption" color="text.secondary">Uploading… {progress}%</Typography>
-            <LinearProgress variant="determinate" value={progress} sx={{ mt: 0.5 }} />
-          </Box>
-        )}
-      </DialogContent>
-
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={handleClose} disabled={progress !== null}>Cancel</Button>
-        <Button
-          variant="contained"
-          onClick={handleUpload}
-          disabled={!file || progress !== null}
-        >
-          {progress !== null ? 'Uploading…' : 'Upload Release'}
-        </Button>
-      </DialogActions>
-    </Dialog>
+      {progress !== null && (
+        <Box>
+          <Typography variant="caption" color="text.secondary">Uploading… {progress}%</Typography>
+          <LinearProgress variant="determinate" value={progress} sx={{ mt: 0.5 }} />
+        </Box>
+      )}
+    </AppDialog>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/hooks/useDebounce.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useState } from 'react'
+
+/**
+ * Debounces a value by the given delay in milliseconds.
+ * Returns the latest value only after the caller has stopped changing it
+ * for at least `delay` ms.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -46,6 +46,13 @@ import { useAuthStore } from '../stores/authStore'
 import type { OidcProviderDto, OidcProviderType, ReviewItemDto, UserDto } from '../api/generated/model'
 
 function GeneralSection() {
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+  function handleSave() {
+    // TODO: persist settings via API once backend endpoint exists
+    setToast({ message: 'Settings saved.', severity: 'success' })
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Box>
@@ -60,7 +67,19 @@ function GeneralSection() {
           <MenuItem value="de">Deutsch</MenuItem>
         </Select>
       </FormControl>
-      <Button variant="contained" sx={{ alignSelf: 'flex-start' }}>Save Changes</Button>
+      <Button variant="contained" sx={{ alignSelf: 'flex-start' }} onClick={handleSave}>
+        Save Changes
+      </Button>
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -34,12 +34,9 @@ import {
   CircularProgress,
   Chip,
   Switch,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
 } from '@mui/material'
 import { CheckCircle, Plus, Shield, Trash2, XCircle } from 'lucide-react'
+import { AppDialog } from '../components/common/AppDialog'
 import { DataTable } from '../components/common/DataTable'
 import type { DataColumn } from '../components/common/DataTable'
 import { ActionIconButton } from '../components/common/ActionIconButton'
@@ -231,47 +228,43 @@ function UsersSection() {
         />
       )}
 
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="xs" fullWidth>
-        <DialogTitle>Add User</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            <TextField
-              label="Username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-              size="small"
-              autoFocus
-            />
-            <TextField
-              label="Email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              size="small"
-            />
-            <TextField
-              label="Initial Password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              size="small"
-              helperText="User will be required to change this on first login."
-            />
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            disabled={saving || !username.trim() || !password}
-          >
-            {saving ? 'Creating…' : 'Create'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <AppDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        title="Add User"
+        description="Create a new local user account. The user will be required to change their password on first login."
+        actionLabel="Create User"
+        onAction={handleCreate}
+        actionDisabled={!username.trim() || !password}
+        actionLoading={saving}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            size="small"
+            autoFocus
+          />
+          <TextField
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            size="small"
+          />
+          <TextField
+            label="Initial Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            size="small"
+            helperText="User will be required to change this on first login."
+          />
+        </Box>
+      </AppDialog>
 
       <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
@@ -453,81 +446,77 @@ function OidcProvidersSection() {
         />
       )}
 
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>Add OIDC Provider</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+      <AppDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        title="Add OIDC Provider"
+        description="Configure an external identity provider for single sign-on. The provider is disabled by default after creation."
+        actionLabel="Create Provider"
+        onAction={handleCreate}
+        actionDisabled={
+          !name.trim() ||
+          !clientId.trim() ||
+          !clientSecret.trim() ||
+          (issuerRequired && !issuerUri.trim())
+        }
+        actionLoading={saving}
+        maxWidth={600}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Display Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            size="small"
+            autoFocus
+          />
+          <FormControl size="small" required>
+            <InputLabel>Provider Type</InputLabel>
+            <Select
+              value={providerType}
+              label="Provider Type"
+              onChange={(e) => setProviderType(e.target.value as OidcProviderType)}
+            >
+              {Object.entries(PROVIDER_TYPE_LABELS).map(([value, label]) => (
+                <MenuItem key={value} value={value}>{label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Client ID"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            required
+            size="small"
+          />
+          <TextField
+            label="Client Secret"
+            type="password"
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+            required
+            size="small"
+          />
+          {issuerRequired && (
             <TextField
-              label="Display Name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              label="Issuer URI"
+              value={issuerUri}
+              onChange={(e) => setIssuerUri(e.target.value)}
               required
               size="small"
-              autoFocus
+              placeholder="https://your-idp.example.com/realms/myrealm"
             />
-            <FormControl size="small" required>
-              <InputLabel>Provider Type</InputLabel>
-              <Select
-                value={providerType}
-                label="Provider Type"
-                onChange={(e) => setProviderType(e.target.value as OidcProviderType)}
-              >
-                {Object.entries(PROVIDER_TYPE_LABELS).map(([value, label]) => (
-                  <MenuItem key={value} value={value}>{label}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <TextField
-              label="Client ID"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              required
-              size="small"
-            />
-            <TextField
-              label="Client Secret"
-              type="password"
-              value={clientSecret}
-              onChange={(e) => setClientSecret(e.target.value)}
-              required
-              size="small"
-            />
-            {issuerRequired && (
-              <TextField
-                label="Issuer URI"
-                value={issuerUri}
-                onChange={(e) => setIssuerUri(e.target.value)}
-                required
-                size="small"
-                placeholder="https://your-idp.example.com/realms/myrealm"
-              />
-            )}
-            <TextField
-              label="Scope"
-              value={scope}
-              onChange={(e) => setScope(e.target.value)}
-              size="small"
-              helperText="Space-separated OAuth2 scopes"
-            />
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            disabled={
-              saving ||
-              !name.trim() ||
-              !clientId.trim() ||
-              !clientSecret.trim() ||
-              (issuerRequired && !issuerUri.trim())
-            }
-          >
-            {saving ? 'Creating…' : 'Create'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+          )}
+          <TextField
+            label="Scope"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            size="small"
+            helperText="Space-separated OAuth2 scopes"
+          />
+        </Box>
+      </AppDialog>
 
       <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -74,7 +74,7 @@ function GeneralSection() {
         open={!!toast}
         autoHideDuration={4000}
         onClose={() => setToast(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}
@@ -285,7 +285,7 @@ function UsersSection() {
         </Box>
       </AppDialog>
 
-      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}
         </Alert>
@@ -537,7 +537,7 @@ function OidcProvidersSection() {
         </Box>
       </AppDialog>
 
-      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}
         </Alert>
@@ -668,7 +668,7 @@ function ReviewsSection() {
         open={!!toast}
         autoHideDuration={4000}
         onClose={() => setToast(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/AdminSettingsPage.tsx
@@ -113,6 +113,7 @@ function UsersSection() {
     try {
       const res = await adminUsersApi.updateUser({ userId: user.id, userUpdateRequest: { enabled: !user.enabled } })
       setUsers((prev) => prev.map((u) => (u.id === user.id ? res.data : u)))
+      setToast({ message: `User "${user.username}" ${res.data.enabled ? 'enabled' : 'disabled'}.`, severity: 'success' })
     } catch {
       setToast({ message: `Failed to update user ${user.username}.`, severity: 'error' })
     }
@@ -339,6 +340,7 @@ function OidcProvidersSection() {
         oidcProviderUpdateRequest: { enabled: !provider.enabled },
       })
       setProviders((prev) => prev.map((p) => (p.id === provider.id ? res.data : p)))
+      setToast({ message: `Provider "${provider.name}" ${res.data.enabled ? 'enabled' : 'disabled'}.`, severity: 'success' })
     } catch {
       setToast({ message: `Failed to update provider "${provider.name}".`, severity: 'error' })
     }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -30,12 +30,14 @@ import { usePluginStore } from '../stores/pluginStore'
 import { useAuthStore } from '../stores/authStore'
 import { useUiStore } from '../stores/uiStore'
 import { useNamespaceStore } from '../stores/namespaceStore'
+import { useDebounce } from '../hooks/useDebounce'
 
 export function CatalogPage() {
   const { namespace = '' } = useParams<{ namespace: string }>()
   const { setNamespace, namespaceRole, fetchNamespaceRole, isAuthenticated } = useAuthStore()
   const { plugins, loading, error, totalElements, pendingReviewPluginCount, resetFilters, fetchPlugins, fetchTags } = usePluginStore()
   const { searchQuery } = useUiStore()
+  const debouncedSearch = useDebounce(searchQuery, 350)
   const { fetchNamespaces } = useNamespaceStore()
   const [view, setView] = useState<'card' | 'list'>('card')
 
@@ -55,9 +57,9 @@ export function CatalogPage() {
 
   useEffect(() => {
     const store = usePluginStore.getState()
-    store.setFilters({ search: searchQuery, page: 0 })
+    store.setFilters({ search: debouncedSearch, page: 0 })
     fetchPlugins(namespace)
-  }, [searchQuery, namespace])
+  }, [debouncedSearch, namespace])
 
   return (
     <Box component="main" id="main-content" sx={{ flex: 1, py: 4 }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -24,6 +24,7 @@ import { PendingReviewBanner } from '../components/catalog/PendingReviewBanner'
 import { PluginCard } from '../components/catalog/PluginCard'
 import { PluginListRow } from '../components/catalog/PluginListRow'
 import { PluginCardSkeleton } from '../components/catalog/PluginCardSkeleton'
+import { PluginListRowSkeleton } from '../components/catalog/PluginListRowSkeleton'
 import { PaginationBar } from '../components/catalog/PaginationBar'
 import { EmptyState } from '../components/common/EmptyState'
 import { usePluginStore } from '../stores/pluginStore'
@@ -101,7 +102,7 @@ export function CatalogPage() {
         )}
 
         {/* Loading skeleton */}
-        {loading && (
+        {loading && view === 'card' && (
           <Box
             aria-label="Loading plugins"
             aria-busy="true"
@@ -113,6 +114,13 @@ export function CatalogPage() {
           >
             {Array.from({ length: 6 }).map((_, i) => (
               <PluginCardSkeleton key={i} />
+            ))}
+          </Box>
+        )}
+        {loading && view === 'list' && (
+          <Box aria-label="Loading plugins" aria-busy="true">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <PluginListRowSkeleton key={i} />
             ))}
           </Box>
         )}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -164,33 +164,31 @@ export function PluginDetailPage() {
             <Tab label="Overview"      id="tab-overview"     aria-controls="panel-overview" />
             <Tab
               label={
-                <>
-                  Versions
+                <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: 0.5 }}>
+                  <span>Versions</span>
                   {draftCount > 0 && (
                     <Box
                       component="span"
                       sx={{
-                        display: 'inline-flex',
+                        display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
                         minWidth: 16,
                         height: 16,
                         px: 0.5,
-                        ml: 0.75,
-                        mb: 1,
+                        mt: '-2px',
                         borderRadius: '8px',
                         fontSize: '0.625rem',
                         fontWeight: 700,
                         lineHeight: 1,
                         bgcolor: 'warning.main',
                         color: '#161616',
-                        verticalAlign: 'top',
                       }}
                     >
                       {draftCount}
                     </Box>
                   )}
-                </>
+                </Box>
               }
               id="tab-versions"
               aria-controls="panel-versions"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -205,7 +205,7 @@ export function PluginDetailPage() {
         open={!!toast}
         autoHideDuration={4000}
         onClose={() => setToast(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
           {toast?.message}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -101,6 +101,7 @@ export function PluginDetailPage() {
   }
 
   const latestRelease = releases.find((r) => r.status === 'published') ?? releases[0] ?? null
+  const draftCount = releases.filter((r) => r.status === 'draft').length
 
   if (loading) {
     return (
@@ -161,7 +162,36 @@ export function PluginDetailPage() {
             sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
           >
             <Tab label="Overview"      id="tab-overview"     aria-controls="panel-overview" />
-            <Tab label="Versions"      id="tab-versions"     aria-controls="panel-versions" />
+            <Tab
+              label={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  Versions
+                  {draftCount > 0 && (
+                    <Box
+                      component="span"
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        minWidth: 20,
+                        height: 20,
+                        px: 0.75,
+                        borderRadius: '10px',
+                        fontSize: '0.75rem',
+                        fontWeight: 700,
+                        lineHeight: 1,
+                        bgcolor: 'warning.main',
+                        color: '#161616',
+                      }}
+                    >
+                      {draftCount}
+                    </Box>
+                  )}
+                </Box>
+              }
+              id="tab-versions"
+              aria-controls="panel-versions"
+            />
             <Tab label="Changelog"     id="tab-changelog"    aria-controls="panel-changelog" />
             <Tab label="Dependencies"  id="tab-dependencies" aria-controls="panel-dependencies" />
           </Tabs>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -164,33 +164,33 @@ export function PluginDetailPage() {
             <Tab label="Overview"      id="tab-overview"     aria-controls="panel-overview" />
             <Tab
               label={
-                <Box component="span" sx={{ position: 'relative' }}>
+                <>
                   Versions
                   {draftCount > 0 && (
                     <Box
                       component="span"
                       sx={{
-                        position: 'absolute',
-                        top: -4,
-                        right: -22,
                         display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
                         minWidth: 16,
                         height: 16,
                         px: 0.5,
+                        ml: 0.75,
+                        mb: 1,
                         borderRadius: '8px',
                         fontSize: '0.625rem',
                         fontWeight: 700,
                         lineHeight: 1,
                         bgcolor: 'warning.main',
                         color: '#161616',
+                        verticalAlign: 'top',
                       }}
                     >
                       {draftCount}
                     </Box>
                   )}
-                </Box>
+                </>
               }
               id="tab-versions"
               aria-controls="panel-versions"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -164,12 +164,15 @@ export function PluginDetailPage() {
             <Tab label="Overview"      id="tab-overview"     aria-controls="panel-overview" />
             <Tab
               label={
-                <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}>
+                <Box component="span" sx={{ position: 'relative' }}>
                   Versions
                   {draftCount > 0 && (
                     <Box
-                      component="sup"
+                      component="span"
                       sx={{
+                        position: 'absolute',
+                        top: -4,
+                        right: -22,
                         display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -182,7 +185,6 @@ export function PluginDetailPage() {
                         lineHeight: 1,
                         bgcolor: 'warning.main',
                         color: '#161616',
-                        verticalAlign: 'super',
                       }}
                     >
                       {draftCount}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -164,24 +164,25 @@ export function PluginDetailPage() {
             <Tab label="Overview"      id="tab-overview"     aria-controls="panel-overview" />
             <Tab
               label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}>
                   Versions
                   {draftCount > 0 && (
                     <Box
-                      component="span"
+                      component="sup"
                       sx={{
                         display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
-                        minWidth: 20,
-                        height: 20,
-                        px: 0.75,
-                        borderRadius: '10px',
-                        fontSize: '0.75rem',
+                        minWidth: 16,
+                        height: 16,
+                        px: 0.5,
+                        borderRadius: '8px',
+                        fontSize: '0.625rem',
                         fontWeight: 700,
                         lineHeight: 1,
                         bgcolor: 'warning.main',
                         color: '#161616',
+                        verticalAlign: 'super',
                       }}
                     >
                       {draftCount}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
@@ -16,15 +16,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useState } from 'react'
 import {
+  Alert,
   Box,
+  Button,
   Container,
-  Typography,
-  Select,
-  MenuItem,
   FormControl,
   InputLabel,
-  Button,
+  MenuItem,
+  Select,
+  Snackbar,
+  Typography,
   alpha,
   useTheme,
 } from '@mui/material'
@@ -105,6 +108,12 @@ function InfoRow({ label, value }: InfoRowProps) {
 export function ProfileSettingsPage() {
   const { username, namespace, setNamespace } = useAuthStore()
   const { namespaces } = useNamespaceStore()
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' } | null>(null)
+
+  function handleSave() {
+    // TODO: persist profile settings via API once backend endpoint exists
+    setToast({ message: 'Profile settings saved.', severity: 'success' })
+  }
 
   return (
     <Box component="main" id="main-content" sx={{ flex: 1, py: 4 }}>
@@ -175,11 +184,22 @@ export function ProfileSettingsPage() {
           </Section>
 
           <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Button variant="contained" sx={{ borderRadius: tokens.radius.btn }}>
+            <Button variant="contained" sx={{ borderRadius: tokens.radius.btn }} onClick={handleSave}>
               Save Changes
             </Button>
           </Box>
         </Box>
+
+        <Snackbar
+          open={!!toast}
+          autoHideDuration={4000}
+          onClose={() => setToast(null)}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        >
+          <Alert severity={toast?.severity} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+            {toast?.message}
+          </Alert>
+        </Snackbar>
       </Container>
     </Box>
   )

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
@@ -91,12 +91,12 @@ describe('useAuthStore', () => {
       expect(localStorage.getItem('pw-access-token')).toBeNull()
     })
 
-    it('preserves namespace after logout', () => {
+    it('clears namespace after logout', () => {
       useAuthStore.setState({ accessToken: 'tok_xyz', isAuthenticated: true, namespace: 'my-org' })
 
       act(() => { useAuthStore.getState().logout() })
 
-      expect(useAuthStore.getState().namespace).toBe('my-org')
+      expect(useAuthStore.getState().namespace).toBeUndefined()
     })
   })
 

--- a/plugwerk-server/plugwerk-server-frontend/src/theme/theme.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/theme/theme.ts
@@ -106,6 +106,41 @@ export function buildTheme(mode: PaletteMode) {
           },
         },
       },
+      MuiMenu: {
+        styleOverrides: {
+          paper: {
+            borderRadius: tokens.radius.card,
+            border: `1px solid ${isDark ? '#393939' : tokens.color.gray20}`,
+            boxShadow: isDark
+              ? '0 4px 16px rgba(0,0,0,0.4)'
+              : '0 4px 16px rgba(0,0,0,0.08)',
+            marginTop: 4,
+          },
+          list: {
+            padding: '4px',
+          },
+        },
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: {
+            fontSize: '0.8125rem',
+            borderRadius: '4px',
+            padding: '6px 12px',
+            minHeight: 'unset',
+            transition: 'background 150ms ease',
+            '&:hover': {
+              backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : tokens.color.gray10,
+            },
+            '&.Mui-selected': {
+              backgroundColor: isDark ? 'rgba(15,98,254,0.15)' : `${tokens.color.primaryLight}`,
+              '&:hover': {
+                backgroundColor: isDark ? 'rgba(15,98,254,0.22)' : '#bdd4ff',
+              },
+            },
+          },
+        },
+      },
       MuiInputBase: {
         styleOverrides: {
           root: { borderRadius: `${tokens.radius.input} !important` },

--- a/plugwerk-server/plugwerk-server-frontend/src/theme/theme.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/theme/theme.ts
@@ -53,15 +53,15 @@ export function buildTheme(mode: PaletteMode) {
       fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
       h1: { fontWeight: 700, fontSize: '2.25rem', lineHeight: '2.75rem' },
       h2: { fontWeight: 600, fontSize: '1.75rem', lineHeight: '2.25rem' },
-      h3: { fontWeight: 600, fontSize: '1.25rem', lineHeight: '1.75rem' },
+      h3: { fontWeight: 600, fontSize: '1.375rem', lineHeight: '1.75rem' },
       h4: { fontWeight: 600, fontSize: '1.0625rem', lineHeight: '1.5rem' },
-      body1: { fontSize: '0.875rem', lineHeight: '1.5rem' },
-      body2: { fontSize: '0.8125rem', lineHeight: '1.25rem' },
+      body1: { fontSize: '1rem', lineHeight: '1.5rem' },
+      body2: { fontSize: '0.875rem', lineHeight: '1.25rem' },
       caption: { fontSize: '0.75rem', lineHeight: '1.125rem' },
     },
 
     shape: {
-      borderRadius: 4,
+      borderRadius: 6,
     },
 
     components: {
@@ -92,7 +92,17 @@ export function buildTheme(mode: PaletteMode) {
           root: {
             borderRadius: tokens.radius.card,
             border: `1px solid ${isDark ? '#393939' : tokens.color.gray20}`,
-            boxShadow: 'none',
+            boxShadow: tokens.shadow.card,
+          },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            borderRadius: tokens.radius.dialog,
+            boxShadow: isDark
+              ? '0 8px 32px rgba(0,0,0,0.5)'
+              : tokens.shadow.modal,
           },
         },
       },

--- a/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/theme/tokens.ts
@@ -51,9 +51,18 @@ export const tokens = {
   },
 
   radius: {
-    btn: '4px',
+    btn: '6px',
     card: '8px',
-    input: '4px',
+    input: '6px',
+    dialog: '12px',
+    tooltip: '6px',
+  },
+
+  shadow: {
+    card: '0 1px 3px rgba(0,0,0,0.08)',
+    cardHover: '0 4px 12px rgba(0,0,0,0.12)',
+    modal: '0 8px 32px rgba(0,0,0,0.16)',
+    tooltip: '0 2px 8px rgba(0,0,0,0.12)',
   },
 
   space: {
@@ -64,5 +73,8 @@ export const tokens = {
     5: '20px',
     6: '24px',
     7: '32px',
+    8: '48px',
+    9: '64px',
+    10: '96px',
   },
 } as const

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/formatCount.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/formatCount.ts
@@ -18,12 +18,31 @@
  */
 
 /**
- * Formats a number with locale-aware thousand separators.
- * Returns "0" for falsy/undefined values.
+ * Short human-readable format for display.
  *
- * Examples: 0 → "0", 999 → "999", 1500 → "1,500", 1234567 → "1,234,567"
+ * Examples: 0 → "0", 999 → "999", 1000 → "1k", 1500 → "1.5k",
+ *           45000 → "45k", 33300 → "33.3k", 1234567 → "1.2M"
  */
 export function formatCount(n: number | undefined): string {
   if (!n) return '0'
-  return n.toLocaleString('en-US')
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`
+  }
+  return String(n)
+}
+
+/**
+ * Full number with dot as thousand separator, for tooltips.
+ *
+ * Examples: 0 → "0", 999 → "999", 1500 → "1.500",
+ *           34343000 → "34.343.000", 34000 → "34.000"
+ */
+export function formatCountFull(n: number | undefined): string {
+  if (!n) return '0'
+  return n.toLocaleString('de-DE')
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/formatCount.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/formatCount.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Formats a number with locale-aware thousand separators.
+ * Returns "0" for falsy/undefined values.
+ *
+ * Examples: 0 → "0", 999 → "999", 1500 → "1,500", 1234567 → "1,234,567"
+ */
+export function formatCount(n: number | undefined): string {
+  if (!n) return '0'
+  return n.toLocaleString('en-US')
+}


### PR DESCRIPTION
## Summary

Closes #181

Comprehensive design review aligning the frontend with the design briefing (`docs/design/design-briefing.md`). Three main areas of change:

## 1. Token System & Theme Alignment

Corrected tokens and MUI theme overrides to match the design specification:

| Change | Before | After |
|---|---|---|
| Button/Input radius | 4px | 6px |
| Dialog radius | 4px (default) | 12px |
| Card shadow | none | `0 1px 3px rgba(0,0,0,0.08)` |
| Dialog shadow | default | `0 8px 32px rgba(0,0,0,0.16)` |
| body1 font size | 14px | 16px |
| body2 font size | 13px | 14px |
| h3 font size | 20px | 22px |

New tokens added: `radius.dialog`, `radius.tooltip`, `shadow.*` (card, cardHover, modal, tooltip), `space.8-10` (48/64/96px).

## 2. Dialog Redesign — AppDialog Wrapper

New shared `AppDialog` component enforcing the three-section layout from the design briefing:

```
┌──────────────────────────────────────┐
│  Title                           [X] │  Header
├──────────────────────────────────────┤
│  Description (muted, smaller)        │
│  {form/content}                      │  Content
├──────────────────────────────────────┤
│             [Cancel]   [Action]      │  Footer
└──────────────────────────────────────┘
```

All 8 dialogs migrated:
- `ConfirmDeleteDialog` — now delegates to AppDialog
- `CreateNamespaceDialog` — added description text
- `DeleteNamespaceDialog` — description + specific "Delete Namespace" label
- `UploadModal` — migrated to AppDialog actions
- Add Member / Generate API Key (NamespaceDetailView) — extracted to AppDialog
- Add User / Add OIDC Provider (AdminSettingsPage) — extracted to AppDialog

## 3. Test Updates

7 test files updated to match new dialog structure (aria-labels, button text).

## Test plan

- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npm run build` — clean build
- [x] `npm run test:run` — 196/196 tests pass
- [x] `./gradlew build` — full Gradle build passes