### PR TITLE
Fix pending review banner count and broken link

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -410,8 +410,9 @@ paths:
         Plugins that have only draft releases are marked with `hasDraftOnly: true` in the response.
 
         For authenticated users with namespace access, the response includes
-        `pendingReviewPluginCount` — the number of active plugins that have draft releases
-        but no published release yet.
+        `pendingReviewPluginCount` — the number of active plugins that have at least one
+        draft release pending review — and `pendingReviewReleaseCount` — the total number
+        of draft releases pending review across all plugins.
 
         This endpoint is publicly accessible unless the namespace has access control enabled.
       operationId: listPlugins
@@ -2242,8 +2243,16 @@ components:
           format: int64
           nullable: true
           description: |
-            Number of active plugins that have draft releases pending review but no
-            published release yet (i.e. plugins not shown in the catalog).
+            Number of active plugins that have at least one draft release pending review.
+            Only populated for authenticated users with namespace access; `null` for
+            anonymous requests.
+        pendingReviewReleaseCount:
+          type: integer
+          format: int64
+          nullable: true
+          description: |
+            Total number of draft releases pending review across all plugins in the
+            namespace. This reflects the actual size of the review queue.
             Only populated for authenticated users with namespace access; `null` for
             anonymous requests.
       required:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -100,7 +100,7 @@ class CatalogController(
                 .associate { (it[0] as UUID) to (it[1] as Long) }
         }
 
-        val pendingCount = resolvePendingReviewCount(ns)
+        val (pendingPluginCount, pendingReleaseCount) = resolvePendingReviewCounts(ns)
 
         val response = PluginPagedResponse(
             content = resultPage.content.map {
@@ -116,7 +116,8 @@ class CatalogController(
             page = resultPage.number,
             propertySize = resultPage.size,
             totalPages = resultPage.totalPages,
-            pendingReviewPluginCount = pendingCount,
+            pendingReviewPluginCount = pendingPluginCount,
+            pendingReviewReleaseCount = pendingReleaseCount,
         )
         return ResponseEntity.ok(response)
     }
@@ -180,14 +181,20 @@ class CatalogController(
         ResponseEntity.ok(pf4jService.buildPluginsJson(ns))
 
     /**
-     * Returns the number of active plugins pending review (draft-only) for authenticated users.
-     * Returns `null` for anonymous requests — no sensitive information is leaked.
+     * Returns pending review counts for authenticated users:
+     * - plugin count: active plugins with at least one draft release
+     * - release count: total draft releases across all plugins in the namespace
+     *
+     * Returns `(null, null)` for anonymous requests — no sensitive information is leaked.
      */
-    private fun resolvePendingReviewCount(ns: String): Long? {
-        val auth = SecurityContextHolder.getContext().authentication ?: return null
-        if (!auth.isAuthenticated) return null
-        val namespace = namespaceRepository.findBySlug(ns).orElse(null) ?: return null
-        return releaseRepository.countPluginsWithOnlyDraftReleases(namespace.id!!)
+    private fun resolvePendingReviewCounts(ns: String): Pair<Long?, Long?> {
+        val auth = SecurityContextHolder.getContext().authentication ?: return null to null
+        if (!auth.isAuthenticated) return null to null
+        val namespace = namespaceRepository.findBySlug(ns).orElse(null) ?: return null to null
+        val namespaceId = namespace.id!!
+        val pluginCount = releaseRepository.countPluginsWithDraftReleases(namespaceId)
+        val releaseCount = releaseRepository.countDraftReleasesByNamespace(namespaceId)
+        return pluginCount to releaseCount
     }
 
     private fun parsePluginStatus(value: String): PluginStatus = when (value.lowercase()) {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -100,8 +100,8 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
     ): List<PluginReleaseEntity>
 
     /**
-     * Counts the number of active plugins in a namespace that have at least one draft release
-     * but no published release. Used for the "pending review" banner on the catalog page.
+     * Counts the number of active plugins in a namespace that have at least one draft release.
+     * Used for the "pending review" banner on the catalog page.
      */
     @Query(
         """
@@ -111,15 +111,9 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         WHERE p.namespace.id = :namespaceId
           AND p.status = io.plugwerk.spi.model.PluginStatus.ACTIVE
           AND r.status = io.plugwerk.spi.model.ReleaseStatus.DRAFT
-          AND NOT EXISTS (
-            SELECT 1
-            FROM PluginReleaseEntity r2
-            WHERE r2.plugin = p
-              AND r2.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
-          )
         """,
     )
-    fun countPluginsWithOnlyDraftReleases(@Param("namespaceId") namespaceId: UUID): Long
+    fun countPluginsWithDraftReleases(@Param("namespaceId") namespaceId: UUID): Long
 
     /**
      * Returns the IDs of active plugins in a namespace that have at least one draft release
@@ -142,4 +136,18 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
         """,
     )
     fun findPluginIdsWithOnlyDraftReleases(@Param("namespaceId") namespaceId: UUID): Set<UUID>
+
+    /**
+     * Counts the total number of draft releases across all plugins in the namespace.
+     * This reflects the actual size of the review queue.
+     */
+    @Query(
+        """
+        SELECT COUNT(r)
+        FROM PluginReleaseEntity r
+        WHERE r.plugin.namespace.id = :namespaceId
+          AND r.status = io.plugwerk.spi.model.ReleaseStatus.DRAFT
+        """,
+    )
+    fun countDraftReleasesByNamespace(@Param("namespaceId") namespaceId: UUID): Long
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -120,6 +120,8 @@ class CatalogControllerTest {
                 content { contentType(MediaType.APPLICATION_JSON) }
                 jsonPath("$.content") { isArray() }
                 jsonPath("$.totalElements") { value(1) }
+                jsonPath("$.pendingReviewPluginCount") { doesNotExist() }
+                jsonPath("$.pendingReviewReleaseCount") { doesNotExist() }
             }
     }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PendingReviewBanner.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PendingReviewBanner.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithRouter } from '../../test/renderWithTheme'
+import { PendingReviewBanner } from './PendingReviewBanner'
+
+function renderBanner(props: { pluginCount: number; releaseCount: number | null; isAdmin: boolean }) {
+  return renderWithRouter(<PendingReviewBanner {...props} />)
+}
+
+describe('PendingReviewBanner', () => {
+  it('renders nothing when pluginCount is 0', () => {
+    const { container } = renderBanner({ pluginCount: 0, releaseCount: null, isAdmin: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows singular plugin and release text', () => {
+    renderBanner({ pluginCount: 1, releaseCount: 1, isAdmin: false })
+    expect(screen.getByText(/1 plugin \(1 release\) pending review/)).toBeInTheDocument()
+  })
+
+  it('shows plural plugins and releases text', () => {
+    renderBanner({ pluginCount: 3, releaseCount: 5, isAdmin: false })
+    expect(screen.getByText(/3 plugins \(5 releases\) pending review/)).toBeInTheDocument()
+  })
+
+  it('shows plugin-only text when releaseCount is null', () => {
+    renderBanner({ pluginCount: 2, releaseCount: null, isAdmin: false })
+    expect(screen.getByText(/2 plugins pending review/)).toBeInTheDocument()
+    expect(screen.queryByText(/releases/)).not.toBeInTheDocument()
+  })
+
+  it('shows Review link for admins pointing to /admin/reviews', () => {
+    renderBanner({ pluginCount: 1, releaseCount: 2, isAdmin: true })
+    const link = screen.getByText('Review')
+    expect(link).toBeInTheDocument()
+    expect(link.closest('a')).toHaveAttribute('href', '/admin/reviews')
+  })
+
+  it('does not show Review link for non-admins', () => {
+    renderBanner({ pluginCount: 1, releaseCount: 2, isAdmin: false })
+    expect(screen.queryByText('Review')).not.toBeInTheDocument()
+  })
+})

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PendingReviewBanner.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PendingReviewBanner.tsx
@@ -21,13 +21,16 @@ import { Link } from 'react-router-dom'
 import { tokens } from '../../theme/tokens'
 
 interface PendingReviewBannerProps {
-  count: number
-  namespace: string
+  pluginCount: number
+  releaseCount: number | null
   isAdmin: boolean
 }
 
-export function PendingReviewBanner({ count, namespace, isAdmin }: PendingReviewBannerProps) {
-  if (count <= 0) return null
+export function PendingReviewBanner({ pluginCount, releaseCount, isAdmin }: PendingReviewBannerProps) {
+  if (pluginCount <= 0) return null
+
+  const pluginLabel = pluginCount === 1 ? 'plugin' : 'plugins'
+  const releaseLabel = releaseCount === 1 ? 'release' : 'releases'
 
   return (
     <Alert
@@ -40,12 +43,14 @@ export function PendingReviewBanner({ count, namespace, isAdmin }: PendingReview
       }}
     >
       <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
-        {count} {count === 1 ? 'plugin' : 'plugins'} pending review
+        {pluginCount} {pluginLabel}
+        {releaseCount != null && releaseCount > 0 && ` (${releaseCount} ${releaseLabel})`}
+        {' '}pending review
       </Typography>
       {isAdmin && (
         <Typography
           component={Link}
-          to={`/namespaces/${namespace}/reviews/pending`}
+          to="/admin/reviews"
           variant="body2"
           sx={{
             color: tokens.color.primary,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
@@ -83,6 +83,7 @@ describe('CatalogPage', () => {
       totalElements: 0,
       totalPages: 0,
       pendingReviewPluginCount: null,
+      pendingReviewReleaseCount: null,
       loading: false,
       error: null,
       filters: { ...defaultFilters },
@@ -157,6 +158,27 @@ describe('CatalogPage', () => {
     renderCatalog()
     await user.click(screen.getByRole('button', { name: /list view/i }))
     expect(screen.getByRole('list', { name: /plugin list/i })).toBeInTheDocument()
+  })
+
+  it('shows pending review banner with plugin and release counts', () => {
+    useAuthStore.setState({ accessToken: 'tok', isAuthenticated: true, namespaceRole: null, fetchNamespaceRole: vi.fn() })
+    usePluginStore.setState({
+      plugins: [mockPlugin],
+      totalElements: 1,
+      totalPages: 1,
+      pendingReviewPluginCount: 2,
+      pendingReviewReleaseCount: 5,
+      fetchPlugins: noOpFetch,
+    })
+    renderCatalog()
+    expect(screen.getByText(/2 plugins \(5 releases\) pending review/)).toBeInTheDocument()
+  })
+
+  it('does not show pending review banner when count is null', () => {
+    useAuthStore.setState({ accessToken: 'tok', isAuthenticated: true, fetchNamespaceRole: vi.fn() })
+    usePluginStore.setState({ pendingReviewPluginCount: null, pendingReviewReleaseCount: null, fetchPlugins: noOpFetch })
+    renderCatalog()
+    expect(screen.queryByText(/pending review/)).not.toBeInTheDocument()
   })
 
   it('syncs namespace from URL param into the auth store', async () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -36,7 +36,7 @@ import { useDebounce } from '../hooks/useDebounce'
 export function CatalogPage() {
   const { namespace = '' } = useParams<{ namespace: string }>()
   const { setNamespace, namespaceRole, fetchNamespaceRole, isAuthenticated } = useAuthStore()
-  const { plugins, loading, error, totalElements, pendingReviewPluginCount, resetFilters, fetchPlugins, fetchTags } = usePluginStore()
+  const { plugins, loading, error, totalElements, pendingReviewPluginCount, pendingReviewReleaseCount, resetFilters, fetchPlugins, fetchTags } = usePluginStore()
   const { searchQuery } = useUiStore()
   const debouncedSearch = useDebounce(searchQuery, 350)
   const { fetchNamespaces } = useNamespaceStore()
@@ -78,8 +78,8 @@ export function CatalogPage() {
           <Typography variant="h1">Plugin Catalog</Typography>
           {isAuthenticated && pendingReviewPluginCount != null && pendingReviewPluginCount > 0 && (
             <PendingReviewBanner
-              count={pendingReviewPluginCount}
-              namespace={namespace}
+              pluginCount={pendingReviewPluginCount}
+              releaseCount={pendingReviewReleaseCount}
               isAdmin={namespaceRole === 'ADMIN'}
             />
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/pluginStore.ts
@@ -36,6 +36,7 @@ interface PluginState {
   totalElements: number
   totalPages: number
   pendingReviewPluginCount: number | null
+  pendingReviewReleaseCount: number | null
   availableTags: string[]
   loading: boolean
   error: string | null
@@ -62,6 +63,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   totalElements: 0,
   totalPages: 0,
   pendingReviewPluginCount: null,
+  pendingReviewReleaseCount: null,
   availableTags: [],
   loading: false,
   error: null,
@@ -97,6 +99,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         totalElements: data.totalElements,
         totalPages: data.totalPages,
         pendingReviewPluginCount: data.pendingReviewPluginCount ?? null,
+        pendingReviewReleaseCount: data.pendingReviewReleaseCount ?? null,
         loading: false,
       })
     } catch (err) {


### PR DESCRIPTION
## Summary

- Banner now displays **"X plugins (Y releases) pending review"** with accurate counts
- Fixed plugin count query: counts all plugins with ≥1 draft release (was: only plugins with *exclusively* draft releases)
- Fixed broken "Review" link: `/namespaces/{ns}/reviews/pending` → `/admin/reviews`
- Added `pendingReviewReleaseCount` field to OpenAPI spec and API response

## Changes

### Backend
- **OpenAPI spec**: Added `pendingReviewReleaseCount` to `PluginPagedResponse`
- **PluginReleaseRepository**: Renamed `countPluginsWithOnlyDraftReleases` → `countPluginsWithDraftReleases` (removed `NOT EXISTS` clause), added `countDraftReleasesByNamespace`
- **CatalogController**: `resolvePendingReviewCounts()` returns both plugin and release counts

### Frontend
- **pluginStore**: Added `pendingReviewReleaseCount` state field
- **PendingReviewBanner**: Updated props (`pluginCount`, `releaseCount`), fixed review link to `/admin/reviews`
- **CatalogPage**: Passes release count to banner

### Tests
- `PendingReviewBanner.test.tsx` (NEW): 6 tests for rendering, singular/plural, admin link
- `CatalogPage.test.tsx`: 2 new tests for banner with/without counts
- `CatalogControllerTest.kt`: Asserts both count fields are null for anonymous requests

## Test plan

- [x] Backend build + tests pass (`./gradlew build`)
- [x] Frontend tests pass (204/204 via `vitest run`)
- [ ] Manual: upload plugins with draft releases → verify banner text matches review queue
- [ ] Manual: click "Review" link → navigates to `/admin/reviews`

Closes #184