### PR TITLE
chore: add Renovate dependency updates and Trivy CVE scanning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Europe/Berlin",
+  "automerge": false,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "labels": ["chore"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "description": "Spring Boot starters, BOM, and dependency management plugin",
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "matchPackagePatterns": [
+        "^org\\.springframework\\.boot",
+        "^org\\.springframework\\.security",
+        "^io\\.spring\\.dependency-management"
+      ],
+      "groupName": "Spring Boot",
+      "groupSlug": "spring-boot"
+    },
+    {
+      "description": "Kotlin stdlib, reflect, and compiler plugins",
+      "matchManagers": ["gradle"],
+      "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
+      "groupName": "Kotlin",
+      "groupSlug": "kotlin"
+    },
+    {
+      "description": "JUnit 5, Mockito, and Testcontainers",
+      "matchManagers": ["gradle"],
+      "matchPackagePatterns": [
+        "^org\\.junit",
+        "^org\\.mockito",
+        "^org\\.testcontainers"
+      ],
+      "groupName": "Test dependencies",
+      "groupSlug": "test-deps"
+    },
+    {
+      "description": "Jackson 3.x (tools.jackson) and legacy annotations (com.fasterxml)",
+      "matchManagers": ["gradle"],
+      "matchPackagePatterns": [
+        "^tools\\.jackson",
+        "^com\\.fasterxml\\.jackson"
+      ],
+      "groupName": "Jackson",
+      "groupSlug": "jackson"
+    },
+    {
+      "description": "OkHttp client and MockWebServer",
+      "matchManagers": ["gradle"],
+      "matchPackagePatterns": ["^com\\.squareup\\.okhttp3"],
+      "groupName": "OkHttp",
+      "groupSlug": "okhttp"
+    },
+    {
+      "description": "Gradle wrapper version",
+      "matchManagers": ["gradle-wrapper"],
+      "groupName": "Gradle wrapper",
+      "groupSlug": "gradle-wrapper"
+    },
+    {
+      "description": "GitHub Actions version bumps",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "npm minor and patch updates (grouped)",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm dependencies",
+      "groupSlug": "npm-deps"
+    },
+    {
+      "description": "npm major updates (separate PRs for deliberate review)",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "npm major updates",
+      "groupSlug": "npm-major"
+    }
+  ]
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,76 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    name: Trivy vulnerability scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Gradle — resolve dependencies so Trivy sees the full dependency tree
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Resolve Gradle dependencies
+        run: ./gradlew dependencies --configuration runtimeClasspath > /dev/null 2>&1 || true
+
+      # npm — ensure lock file is present for frontend scanning
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: plugwerk-server/plugwerk-server-frontend/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: plugwerk-server/plugwerk-server-frontend
+        run: npm ci --ignore-scripts
+
+      # Trivy filesystem scan
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: '0'
+          ignore-unfixed: false
+          scanners: vuln,secret
+          skip-dirs: build,.gradle,plugwerk-server/plugwerk-server-frontend/node_modules/.cache,.claude
+
+      # Upload results to GitHub Security tab
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
+
+      # Keep raw report as downloadable artifact
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-sarif-report
+          path: trivy-results.sarif
+          retention-days: 30


### PR DESCRIPTION
## Summary

- Add **Renovate** configuration (`.github/renovate.json`) for automated dependency update PRs across Gradle (Version Catalog), npm, and GitHub Actions
- Add **Trivy** security scanning workflow (`.github/workflows/security.yml`) for CVE detection on JVM and npm dependencies plus secret scanning

### Renovate highlights
- Weekly schedule (Monday mornings, `Europe/Berlin`)
- No automerge — all PRs require manual review
- Grouped updates: Spring Boot, Kotlin, Test deps, Jackson, OkHttp, GitHub Actions, npm (minor/patch vs major)
- Dependency Dashboard issue for overview and manual triggers
- Max 5 concurrent PRs, 2 per hour

### Trivy highlights
- Filesystem scan mode (no container image needed)
- Scanners: `vuln` (CVEs) + `secret` (leaked credentials)
- SARIF upload to GitHub Security tab (Code Scanning Alerts)
- Informational only (`exit-code: 0`) — does not fail builds
- Severity: CRITICAL, HIGH, MEDIUM
- Raw SARIF report saved as artifact (30 days)

## Manual step required after merge

Install the [Renovate GitHub App](https://github.com/apps/renovate) on the repository for Renovate to start creating PRs.

## Test plan

- [ ] Trivy workflow runs successfully on this PR
- [ ] SARIF results appear in GitHub Security → Code scanning tab
- [ ] After merge and Renovate app installation: Renovate creates a Dependency Dashboard issue
- [ ] Renovate creates at least one grouped dependency update PR

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)