### PR TITLE
fix: auto-dismiss upload progress panel after 5s for all completions

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
@@ -132,18 +132,16 @@ export function UploadProgressPanel() {
   const successCount = entries.filter((e) => e.status === 'success').length
   const failedCount = entries.filter((e) => e.status === 'failed').length
   const isComplete = totalCount > 0 && successCount + failedCount === totalCount
-  const allSucceeded = isComplete && failedCount === 0
-
-  // Auto-dismiss after 5 seconds when all uploads succeeded
+  // Auto-dismiss after 5 seconds when all uploads have completed (success or failed)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
-    if (allSucceeded && panelVisible) {
+    if (isComplete && panelVisible) {
       timerRef.current = setTimeout(() => dismissPanel(), AUTO_DISMISS_MS)
     }
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [allSucceeded, panelVisible, dismissPanel])
+  }, [isComplete, panelVisible, dismissPanel])
 
   const headerText = isComplete
     ? `Upload complete — ${successCount} succeeded`


### PR DESCRIPTION
## Summary

- Auto-dismiss the upload progress panel after 5 seconds when **all** uploads have completed, not only when all succeeded
- Previously the panel stayed visible indefinitely when uploads failed, requiring manual dismissal

## Change

One-line fix in `UploadProgressPanel.tsx`: trigger auto-dismiss on `isComplete` instead of `allSucceeded`.

## Test plan

- [ ] Upload a duplicate plugin → panel shows failure → panel auto-dismisses after 5s
- [ ] Upload a valid plugin → panel shows success → panel auto-dismisses after 5s (unchanged)
- [ ] Upload mix of valid + duplicate → panel shows partial failure → panel auto-dismisses after 5s
- [ ] All 8 UploadProgressPanel tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)