### PR TITLE
chore: dual-license library modules under Apache-2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,23 @@ Never skip these checks — even for "small" renames or refactors (longer class 
   - Bugs: `bug_report.md`
   - Features: `feature_request.md`
 
-## License Header (MANDATORY)
+## Licensing (MANDATORY)
 
-Every source file — Kotlin and TypeScript — **must** begin with the same AGPL-3.0 license header.
-The canonical text lives in **`license-header.txt`** at the project root (single source of truth):
+Plugwerk uses a **dual-license model** (see [ADR-0014](docs/adrs/0014-dual-license-library-modules.md)):
+
+| Module | License | Header file |
+|--------|---------|-------------|
+| `plugwerk-server` (backend + frontend) | **AGPL-3.0** | `license-header.txt` |
+| `plugwerk-spi` | **Apache-2.0** | `license-header-apache.txt` |
+| `plugwerk-descriptor` | **Apache-2.0** | `license-header-apache.txt` |
+| `plugwerk-client-plugin` | **Apache-2.0** | `license-header-apache.txt` |
+| `plugwerk-api-model` | **Apache-2.0** | `license-header-apache.txt` |
+
+Every source file — Kotlin and TypeScript — **must** begin with the correct license header for its module. Spotless is configured per-module to enforce the right header automatically.
+
+### AGPL-3.0 header (server modules)
+
+Canonical text in **`license-header.txt`**:
 
 ```
 /*
@@ -76,15 +89,37 @@ The canonical text lives in **`license-header.txt`** at the project root (single
  */
 ```
 
+### Apache-2.0 header (library modules)
+
+Canonical text in **`license-header-apache.txt`**:
+
+```
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+```
+
 ### Enforcement
 
 | Language | Check | Fix | Scope |
 |---|---|---|---|
-| Kotlin (`src/**/*.kt`) | `./gradlew spotlessCheck` | `./gradlew spotlessApply` | Spotless reads `license-header.txt` via `licenseHeaderFile()` |
+| Kotlin (`src/**/*.kt`) | `./gradlew spotlessCheck` | `./gradlew spotlessApply` | Spotless applies per-module header automatically |
 | TypeScript (`src/**/*.ts`, `src/**/*.tsx`) | `npm run license:check` | `npm run license:add` | Shell script in `scripts/license-check.sh` |
 
 - **Never omit** the header from new files — CI enforces both checks.
-- Do **not** modify the header text directly in `build.gradle.kts` — edit `license-header.txt` instead.
+- Do **not** modify headers directly in `build.gradle.kts` — edit the header text files instead.
 - Generated files are excluded: `build/generated/` (Kotlin), `src/api/generated/` and `vite-env.d.ts` (TypeScript).
 
 ## Issue Management
@@ -125,6 +160,7 @@ PRs without labels or milestone are non-compliant. Set them via `gh pr edit <num
   - [ADR-0003](docs/adrs/0003-spring-boot-4-backend-conventions.md) — Spring Boot 4.x backend conventions
   - [ADR-0004](docs/adrs/0004-frontend-conventions.md) — Frontend conventions (React + TypeScript + MUI + Zustand)
   - [ADR-0011](docs/adrs/0011-client-auth-api-key-strategy.md) — Client SDK authentication (API key primary)
+  - [ADR-0014](docs/adrs/0014-dual-license-library-modules.md) — Dual-license: Apache-2.0 for libraries, AGPL-3.0 for server
 - Feature specifications: `docs/features/` — GitHub Issues link to their corresponding spec file
 - Project concept: `docs/concepts/`
 - Design system: `docs/design/` — HTML prototypes and design tokens (`tokens.css`)

--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2025-present devtank42 GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,13 +17,21 @@ allprojects {
     }
 }
 
+val apacheModules = setOf("plugwerk-spi", "plugwerk-descriptor", "plugwerk-client-plugin", "plugwerk-api-model")
+
 subprojects {
     apply(plugin = "com.diffplug.spotless")
+
+    val headerFile = if (project.name in apacheModules) {
+        rootProject.file("license-header-apache.txt")
+    } else {
+        rootProject.file("license-header.txt")
+    }
 
     spotless {
         kotlin {
             target("src/**/*.kt")
-            licenseHeaderFile(rootProject.file("license-header.txt"))
+            licenseHeaderFile(headerFile)
             ktlint("1.8.0")
                 .editorConfigOverride(
                     mapOf(

--- a/docs/adrs/0014-dual-license-library-modules.md
+++ b/docs/adrs/0014-dual-license-library-modules.md
@@ -1,0 +1,65 @@
+# ADR-0014: Dual-License Library Modules under Apache-2.0
+
+## Status
+
+Accepted
+
+## Context
+
+Plugwerk was originally licensed entirely under AGPL-3.0. While AGPL is appropriate for the
+server component (protecting against proprietary forks of the self-hosted server), it creates
+a fundamental adoption barrier for the reusable library modules.
+
+AGPL's copyleft clause requires any software that links against an AGPL library to also be
+released under AGPL — effectively forcing host applications to open-source their entire
+codebase. No enterprise will embed a plugin SDK (plugwerk-spi, plugwerk-client-plugin) under
+these terms, as it would require them to publish their proprietary application source code.
+
+This is the standard problem with copyleft licenses on libraries intended for third-party
+embedding, and it has a well-established industry solution.
+
+## Decision
+
+Adopt a **split-licensing model**: the server remains AGPL-3.0, all client-facing library
+modules are relicensed to Apache-2.0.
+
+| Module | License | Rationale |
+|--------|---------|-----------|
+| `plugwerk-server` (backend + frontend) | AGPL-3.0 | Protects the server; self-hosters must contribute back |
+| `plugwerk-spi` | Apache-2.0 | ExtensionPoint interfaces used by every host application |
+| `plugwerk-descriptor` | Apache-2.0 | MANIFEST.MF parser used by build tools and CI/CD |
+| `plugwerk-client-plugin` | Apache-2.0 | Client SDK embedded in host applications as PF4J plugin |
+| `plugwerk-api-model` | Apache-2.0 | Generated DTOs for REST API consumers |
+
+**Precedent:** GitLab (server AGPL, client libs MIT), Grafana (server AGPL, SDKs Apache-2.0),
+MongoDB (server SSPL, drivers Apache-2.0).
+
+**Why Apache-2.0 over MIT?** Apache-2.0 includes an explicit patent grant, which provides
+stronger legal protection for both the project and its users. It is the standard choice for
+Java/JVM ecosystem libraries.
+
+## Consequences
+
+### Positive
+
+- Host applications can embed `plugwerk-spi` and `plugwerk-client-plugin` in proprietary
+  software without any copyleft obligation.
+- Enterprise adoption is unblocked — the licensing model matches industry expectations.
+- Maven Central publication (issue #195) can proceed with correct license metadata.
+- The server remains protected by AGPL-3.0 — self-hosters must still contribute modifications
+  back.
+
+### Negative
+
+- Two license headers must be maintained (AGPL for server, Apache for libraries). Spotless
+  is configured per-module to enforce the correct header automatically.
+- Contributors must understand which license applies to which module. This is documented in
+  `AGENTS.md` and in per-module `LICENSE` files.
+
+### Implementation
+
+- `LICENSE` (AGPL-3.0) remains at the project root for the server.
+- `LICENSE-APACHE-2.0` added at the project root with the full Apache-2.0 text.
+- Each library module has its own `LICENSE` file pointing to Apache-2.0.
+- `license-header-apache.txt` contains the short Apache-2.0 header for source files.
+- Spotless is configured to apply the correct header per module automatically.

--- a/license-header-apache.txt
+++ b/license-header-apache.txt
@@ -13,22 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.plugwerk.descriptor
-
-data class PlugwerkDescriptor(
-    val id: String,
-    val version: String,
-    val name: String,
-    val description: String? = null,
-    val provider: String? = null,
-    val license: String? = null,
-    val tags: List<String> = emptyList(),
-    val requiresSystemVersion: String? = null,
-    val pluginDependencies: List<PluginDependency> = emptyList(),
-    val icon: String? = null,
-    val screenshots: List<String> = emptyList(),
-    val homepage: String? = null,
-    val repository: String? = null,
-)
-
-data class PluginDependency(val id: String, val version: String)

--- a/plugwerk-api/plugwerk-api-model/LICENSE
+++ b/plugwerk-api/plugwerk-api-model/LICENSE
@@ -1,0 +1,4 @@
+This module is licensed under the Apache License, Version 2.0.
+See the LICENSE-APACHE-2.0 file in the project root for the full license text.
+
+SPDX-License-Identifier: Apache-2.0

--- a/plugwerk-client-plugin/LICENSE
+++ b/plugwerk-client-plugin/LICENSE
@@ -1,0 +1,4 @@
+This module is licensed under the Apache License, Version 2.0.
+See the LICENSE-APACHE-2.0 file in the project root for the full license text.
+
+SPDX-License-Identifier: Apache-2.0

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkClient.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkClient.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkException.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkException.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.catalog
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImpl.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.installer
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/internal/DtoMappers.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/internal/DtoMappers.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.internal
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImpl.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.updater
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkClientTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkClientTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.catalog
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/installer/PlugwerkInstallerImplTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.installer
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImplTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.client.updater
 

--- a/plugwerk-descriptor/LICENSE
+++ b/plugwerk-descriptor/LICENSE
@@ -1,0 +1,4 @@
+This module is licensed under the Apache License, Version 2.0.
+See the LICENSE-APACHE-2.0 file in the project root for the full license text.
+
+SPDX-License-Identifier: Apache-2.0

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorExceptions.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorExceptions.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorResolver.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorResolver.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/DescriptorValidator.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/Pf4jManifestParser.kt
+++ b/plugwerk-descriptor/src/main/kotlin/io/plugwerk/descriptor/Pf4jManifestParser.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorResolverTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/DescriptorValidatorTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/Pf4jManifestParserTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/Pf4jManifestParserTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.descriptor
 

--- a/plugwerk-spi/LICENSE
+++ b/plugwerk-spi/LICENSE
@@ -1,0 +1,4 @@
+This module is licensed under the Apache License, Version 2.0.
+See the LICENSE-APACHE-2.0 file in the project root for the full license text.
+
+SPDX-License-Identifier: Apache-2.0

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkConfig.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkConfig.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkConstants.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkConstants.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.extension
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkInstaller.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkInstaller.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.extension
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.extension
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkUpdateChecker.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkUpdateChecker.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.extension
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstallResult.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstallResult.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginInfo.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginInfo.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginReleaseInfo.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginReleaseInfo.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginStatus.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/PluginStatus.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/ReleaseStatus.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/ReleaseStatus.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/SearchCriteria.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/SearchCriteria.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/UpdateInfo.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/UpdateInfo.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.model
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/version/SemVerExtensions.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/version/SemVerExtensions.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.version
 

--- a/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/PlugwerkConfigTest.kt
+++ b/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/PlugwerkConfigTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi
 

--- a/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/version/SemVerExtensionsTest.kt
+++ b/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/version/SemVerExtensionsTest.kt
@@ -1,20 +1,17 @@
 /*
  * Copyright (c) 2025-present devtank42 GmbH
  *
- * This file is part of Plugwerk.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Plugwerk is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Plugwerk is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.plugwerk.spi.version
 


### PR DESCRIPTION
## Summary

Adopt a **split-licensing model** for Plugwerk: the server stays AGPL-3.0, all client-facing library modules are relicensed to **Apache-2.0**. This unblocks enterprise adoption — host applications can embed the SDK without copyleft obligations.

### Why?

AGPL's copyleft clause requires any software linking against an AGPL library to also be released under AGPL. No enterprise will embed a plugin SDK (`plugwerk-spi`, `plugwerk-client-plugin`) under those terms. This is the standard problem with copyleft on libraries, solved by the same split-licensing approach used by GitLab, Grafana, and MongoDB.

### License mapping

| Module | Before | After |
|--------|--------|-------|
| `plugwerk-server` | AGPL-3.0 | **AGPL-3.0** (unchanged) |
| `plugwerk-spi` | AGPL-3.0 | **Apache-2.0** |
| `plugwerk-descriptor` | AGPL-3.0 | **Apache-2.0** |
| `plugwerk-client-plugin` | AGPL-3.0 | **Apache-2.0** |
| `plugwerk-api-model` | — | **Apache-2.0** |

### Changes

- `LICENSE-APACHE-2.0` — full Apache-2.0 license text at project root
- `license-header-apache.txt` — short Apache-2.0 header for Spotless
- Per-module `LICENSE` files for all 4 library modules
- `build.gradle.kts` — Spotless configured per-module (`apacheModules` set)
- All `.kt` source files in library modules — AGPL header → Apache-2.0 header (41 files)
- `AGENTS.md` — Licensing section rewritten with dual-license table
- `docs/adrs/0014-dual-license-library-modules.md` — ADR documenting the decision

## Test plan

- [x] `./gradlew spotlessCheck` passes — correct headers enforced per module
- [x] `./gradlew build` passes — no regressions
- [ ] Verify: all `.kt` files in `plugwerk-spi/`, `plugwerk-descriptor/`, `plugwerk-client-plugin/` contain "Apache License"
- [ ] Verify: all `.kt` files in `plugwerk-server/` still contain "GNU Affero"
- [ ] Verify: `spotlessApply` does not change any files (already clean)

**Blocks #195** (Maven Central publishing) — license must be correct before first public release.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)