### PR TITLE
chore: set up Maven Central publishing for library modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release to Maven Central
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Reject SNAPSHOT tags
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "::error::SNAPSHOT versions must not be published to Maven Central: $VERSION"
+            exit 1
+          fi
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishAggregationToCentralPortal -Pversion=${{ steps.version.outputs.VERSION }}
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
 
 COPY gradle/ gradle/
+COPY buildSrc/ buildSrc/
 COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties* ./
 COPY plugwerk-api/ plugwerk-api/
 COPY plugwerk-spi/ plugwerk-spi/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io.plugwerk.maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.plugwerk.maven-publish.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    java
+    `maven-publish`
+    signing
+}
+
+// Sources JAR
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+
+            pom {
+                name.set(project.name)
+                description.set(provider { project.description ?: project.name })
+                url.set("https://github.com/plugwerk/plugwerk")
+
+                licenses {
+                    license {
+                        name.set("Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("devtank42")
+                        name.set("devtank42 GmbH")
+                        url.set("https://github.com/plugwerk")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:https://github.com/plugwerk/plugwerk.git")
+                    developerConnection.set("scm:git:ssh://git@github.com:plugwerk/plugwerk.git")
+                    url.set("https://github.com/plugwerk/plugwerk")
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["mavenJava"])
+}
+
+// Skip signing on local builds that lack GPG keys
+tasks.withType<Sign>().configureEach {
+    onlyIf { project.hasProperty("signingKey") }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ yasson = "3.0.4"
 bucket4j = "8.17.0"
 caffeine = "3.2.3"
 spotless = "7.0.4"
-nmcp = "1.4.4"
 
 [libraries]
 # Kotlin
@@ -102,4 +101,3 @@ spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-nmcp-settings = { id = "com.gradleup.nmcp.settings", version.ref = "nmcp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ yasson = "3.0.4"
 bucket4j = "8.17.0"
 caffeine = "3.2.3"
 spotless = "7.0.4"
+nmcp = "1.4.4"
 
 [libraries]
 # Kotlin
@@ -101,3 +102,4 @@ spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+nmcp-settings = { id = "com.gradleup.nmcp.settings", version.ref = "nmcp" }

--- a/plugwerk-api/plugwerk-api-model/build.gradle.kts
+++ b/plugwerk-api/plugwerk-api-model/build.gradle.kts
@@ -1,7 +1,10 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.openapi.generator)
+    id("io.plugwerk.maven-publish")
 }
+
+description = "Plugwerk API Model — generated REST API data transfer objects for Plugwerk server communication"
 
 kotlin {
     jvmToolchain(21)
@@ -9,13 +12,13 @@ kotlin {
 
 tasks.compileKotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 
 tasks.compileJava {
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
 }
 
 dependencies {

--- a/plugwerk-api/plugwerk-api-model/build.gradle.kts
+++ b/plugwerk-api/plugwerk-api-model/build.gradle.kts
@@ -71,3 +71,7 @@ sourceSets {
 tasks.compileKotlin {
     dependsOn(tasks.openApiGenerate)
 }
+
+tasks.named("sourcesJar") {
+    dependsOn(tasks.openApiGenerate)
+}

--- a/plugwerk-client-plugin/build.gradle.kts
+++ b/plugwerk-client-plugin/build.gradle.kts
@@ -1,15 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    `maven-publish`
+    id("io.plugwerk.maven-publish")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
-}
+description = "Plugwerk Client SDK — catalog, install, and update lifecycle for PF4J host applications"
 
 kotlin {
     jvmToolchain(21)
@@ -17,13 +11,13 @@ kotlin {
 
 tasks.compileKotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 
 tasks.compileJava {
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
 }
 
 // PF4J plugin metadata — embedded in MANIFEST.MF so the SDK JAR is loadable as a PF4J plugin

--- a/plugwerk-descriptor/build.gradle.kts
+++ b/plugwerk-descriptor/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    id("io.plugwerk.maven-publish")
 }
+
+description = "Plugwerk Descriptor — MANIFEST.MF parser and validator for PF4J plugin metadata"
 
 kotlin {
     jvmToolchain(21)

--- a/plugwerk-spi/build.gradle.kts
+++ b/plugwerk-spi/build.gradle.kts
@@ -1,15 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    `maven-publish`
+    id("io.plugwerk.maven-publish")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
-}
+description = "Plugwerk SPI — extension point interfaces and shared model types for the PF4J plugin ecosystem"
 
 kotlin {
     jvmToolchain(21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,22 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("com.gradleup.nmcp.settings").version("1.4.4")
+}
+
+nmcpSettings {
+    centralPortal {
+        username = providers.environmentVariable("MAVEN_CENTRAL_USERNAME").orNull
+        password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD").orNull
+        publishingType = "USER_MANAGED"
+    }
+}
+
 rootProject.name = "plugwerk"
 
 include("plugwerk-api:plugwerk-api-model")


### PR DESCRIPTION
## Summary

Set up Maven Central publishing infrastructure for the 4 library modules using a shared Gradle convention plugin, NMCP for the new Maven Central Portal, and a tag-triggered GitHub Actions release workflow.

### Published artifacts

| Module | Artifact | JVM Target |
|--------|----------|------------|
| `plugwerk-spi` | `io.plugwerk:plugwerk-spi` | 11 |
| `plugwerk-descriptor` | `io.plugwerk:plugwerk-descriptor` | 11 |
| `plugwerk-client-plugin` | `io.plugwerk:plugwerk-client-plugin` | 11 |
| `plugwerk-api-model` | `io.plugwerk:plugwerk-api-model` | 11 |

Each artifact includes: main JAR, sources JAR, javadoc JAR, POM with full metadata (Apache-2.0 license, SCM, developers).

### Changes

**New files:**
- `buildSrc/` — convention plugin `io.plugwerk.maven-publish` (POM metadata, signing, sources + javadoc JARs)
- `.github/workflows/release.yml` — triggered on `v*` tags, publishes to Maven Central Portal

**Modified files:**
- `settings.gradle.kts` — NMCP settings plugin + pluginManagement
- `libs.versions.toml` — NMCP 1.4.4
- 4 module `build.gradle.kts` — apply convention, remove stubs, unify JVM target to 11

### JVM target changes
- `plugwerk-client-plugin`: 17 → **11** (only uses JVM 11 APIs)
- `plugwerk-api-model`: 17 → **11** (generated DTOs, no JVM 17 APIs)

### Manual prerequisites before first release
1. Register at [Maven Central Portal](https://central.sonatype.com) and claim `io.plugwerk` namespace
2. Generate GPG key and publish public key to keyserver
3. Add 4 GitHub secrets: `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `GPG_SIGNING_KEY`, `GPG_SIGNING_PASSWORD`

## Test plan

- [x] `./gradlew spotlessCheck` passes
- [x] `./gradlew build -x openApiGenerate` passes (OpenAPI issue is pre-existing)
- [x] `publishToMavenLocal` produces JAR + sources JAR + javadoc JAR + POM for all modules
- [x] POM contains correct Apache-2.0 license, SCM, developers metadata
- [x] Signing skipped gracefully without GPG key (no build failure)
- [x] `plugwerk-client-plugin` pluginZip still produces PF4J ZIP
- [ ] Tag `v0.1.0` triggers release workflow (after secrets are configured)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)