### PR TITLE
Logo redesign: stacked plugin icons (#210)

### DIFF
--- a/docs/design/plugwerk-logo/plugwerk-logo-full-dark.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logo-full-dark.svg
@@ -1,23 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="white"/>
-      <circle cx="0" cy="0" r="27" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(50, 50)">
-    <g mask="url(#ring)">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="#0F62FE"/>
-    </g>
-    <rect x="-3.5" y="-44" width="7" height="7" rx="1.5" fill="#0F62FE"/>
-    <rect x="31" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(60, 35, -20)"/>
-    <rect x="31" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(120, 35, 20)"/>
-    <rect x="-3.5" y="37" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(180, 0, 40)"/>
-    <rect x="-38.5" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(240, -35, 20)"/>
-    <rect x="-38.5" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(300, -35, -20)"/>
-    <rect x="-10" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="4" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="-3" y="3" width="6" height="11" rx="2" fill="#0F62FE"/>
+  <!-- Plugwerk Full Logo (Dark Background) -->
+
+  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
-  <text x="108" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(20, 40) scale(1.55)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
 </svg>

--- a/docs/design/plugwerk-logo/plugwerk-logo-full-dark.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logo-full-dark.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
   <!-- Plugwerk Full Logo (Dark Background) -->
 
-  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Icon: scale 2.2 (nur Bild groesser, Text bleibt) -->
   <!-- Plugin 3 (hinten) -->
-  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+  <g transform="translate(2, 22) scale(2.2)" opacity="0.3">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 2 (mitte) -->
-  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+  <g transform="translate(8, 28) scale(2.2)" opacity="0.6">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 1 (vorne) -->
-  <g transform="translate(20, 40) scale(1.55)">
+  <g transform="translate(14, 34) scale(2.2)">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 
-  <!-- Wordmark -->
-  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
+  <!-- Wordmark (unveraendert) -->
+  <text x="68" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="42" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
 </svg>

--- a/docs/design/plugwerk-logo/plugwerk-logo-full-light.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logo-full-light.svg
@@ -1,23 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="white"/>
-      <circle cx="0" cy="0" r="27" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(50, 50)">
-    <g mask="url(#ring)">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="#0F62FE"/>
-    </g>
-    <rect x="-3.5" y="-44" width="7" height="7" rx="1.5" fill="#0F62FE"/>
-    <rect x="31" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(60, 35, -20)"/>
-    <rect x="31" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(120, 35, 20)"/>
-    <rect x="-3.5" y="37" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(180, 0, 40)"/>
-    <rect x="-38.5" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(240, -35, 20)"/>
-    <rect x="-38.5" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(300, -35, -20)"/>
-    <rect x="-10" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="4" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="-3" y="3" width="6" height="11" rx="2" fill="#0F62FE"/>
+  <!-- Plugwerk Full Logo (Light Background) -->
+
+  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
-  <text x="108" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(20, 40) scale(1.55)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
 </svg>

--- a/docs/design/plugwerk-logo/plugwerk-logo-full-light.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logo-full-light.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
   <!-- Plugwerk Full Logo (Light Background) -->
 
-  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Icon: scale 2.2 (nur Bild groesser, Text bleibt) -->
   <!-- Plugin 3 (hinten) -->
-  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+  <g transform="translate(2, 22) scale(2.2)" opacity="0.3">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 2 (mitte) -->
-  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+  <g transform="translate(8, 28) scale(2.2)" opacity="0.6">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 1 (vorne) -->
-  <g transform="translate(20, 40) scale(1.55)">
+  <g transform="translate(14, 34) scale(2.2)">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 
-  <!-- Wordmark -->
-  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
+  <!-- Wordmark (unveraendert) -->
+  <text x="68" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="42" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
 </svg>

--- a/docs/design/plugwerk-logo/plugwerk-logomark-brand-transparent.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logomark-brand-transparent.svg
@@ -1,25 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="white"/>
-      <circle cx="0" cy="0" r="48" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(80, 80)">
-    <!-- Hexagon ring with transparent center -->
-    <g mask="url(#ring)">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="#0F62FE"/>
-    </g>
-    <!-- Gear teeth -->
-    <rect x="-6" y="-78" width="12" height="12" rx="2" fill="#0F62FE"/>
-    <rect x="56" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(60, 62, -36)"/>
-    <rect x="56" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(120, 62, 36)"/>
-    <rect x="-6" y="66" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(180, 0, 72)"/>
-    <rect x="-68" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(240, -62, 36)"/>
-    <rect x="-68" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(300, -62, -36)"/>
-    <!-- Plug prongs -->
-    <rect x="-18" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="8" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="-5" y="6" width="10" height="20" rx="3" fill="#0F62FE"/>
+  <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
+
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(33, 32) scale(3.5)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(49, 48) scale(3.5)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(65, 64) scale(3.5)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 </svg>

--- a/docs/design/plugwerk-logo/plugwerk-logomark-brand-transparent.svg
+++ b/docs/design/plugwerk-logo/plugwerk-logomark-brand-transparent.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 26 104 104" width="160" height="160">
   <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
 
   <!-- Plugin 3 (hinten) -->

--- a/plugwerk-server/plugwerk-server-frontend/public/favicon.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/favicon.svg
@@ -1,25 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="white"/>
-      <circle cx="0" cy="0" r="48" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(80, 80)">
-    <!-- Hexagon ring with transparent center -->
-    <g mask="url(#ring)">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="#0F62FE"/>
-    </g>
-    <!-- Gear teeth -->
-    <rect x="-6" y="-78" width="12" height="12" rx="2" fill="#0F62FE"/>
-    <rect x="56" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(60, 62, -36)"/>
-    <rect x="56" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(120, 62, 36)"/>
-    <rect x="-6" y="66" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(180, 0, 72)"/>
-    <rect x="-68" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(240, -62, 36)"/>
-    <rect x="-68" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(300, -62, -36)"/>
-    <!-- Plug prongs -->
-    <rect x="-18" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="8" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="-5" y="6" width="10" height="20" rx="3" fill="#0F62FE"/>
+  <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
+
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(33, 32) scale(3.5)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(49, 48) scale(3.5)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(65, 64) scale(3.5)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/favicon.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 26 104 104" width="160" height="160">
   <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
 
   <!-- Plugin 3 (hinten) -->

--- a/plugwerk-server/plugwerk-server-frontend/public/logo-dark.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logo-dark.svg
@@ -1,23 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="white"/>
-      <circle cx="0" cy="0" r="27" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(50, 50)">
-    <g mask="url(#ring)">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="#0F62FE"/>
-    </g>
-    <rect x="-3.5" y="-44" width="7" height="7" rx="1.5" fill="#0F62FE"/>
-    <rect x="31" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(60, 35, -20)"/>
-    <rect x="31" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(120, 35, 20)"/>
-    <rect x="-3.5" y="37" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(180, 0, 40)"/>
-    <rect x="-38.5" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(240, -35, 20)"/>
-    <rect x="-38.5" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(300, -35, -20)"/>
-    <rect x="-10" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="4" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="-3" y="3" width="6" height="11" rx="2" fill="#0F62FE"/>
+  <!-- Plugwerk Full Logo (Dark Background) -->
+
+  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
-  <text x="108" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(20, 40) scale(1.55)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/logo-dark.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logo-dark.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
   <!-- Plugwerk Full Logo (Dark Background) -->
 
-  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Icon: scale 2.2 (nur Bild groesser, Text bleibt) -->
   <!-- Plugin 3 (hinten) -->
-  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+  <g transform="translate(2, 22) scale(2.2)" opacity="0.3">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 2 (mitte) -->
-  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+  <g transform="translate(8, 28) scale(2.2)" opacity="0.6">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 1 (vorne) -->
-  <g transform="translate(20, 40) scale(1.55)">
+  <g transform="translate(14, 34) scale(2.2)">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 
-  <!-- Wordmark -->
-  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
+  <!-- Wordmark (unveraendert) -->
+  <text x="68" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="42" fill="#FFFFFF" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#5A9CFF">WERK</tspan></text>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/logo-light.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logo-light.svg
@@ -1,23 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="white"/>
-      <circle cx="0" cy="0" r="27" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(50, 50)">
-    <g mask="url(#ring)">
-      <polygon points="0,-40 35,-20 35,20 0,40 -35,20 -35,-20" fill="#0F62FE"/>
-    </g>
-    <rect x="-3.5" y="-44" width="7" height="7" rx="1.5" fill="#0F62FE"/>
-    <rect x="31" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(60, 35, -20)"/>
-    <rect x="31" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(120, 35, 20)"/>
-    <rect x="-3.5" y="37" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(180, 0, 40)"/>
-    <rect x="-38.5" y="16.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(240, -35, 20)"/>
-    <rect x="-38.5" y="-23.5" width="7" height="7" rx="1.5" fill="#0F62FE" transform="rotate(300, -35, -20)"/>
-    <rect x="-10" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="4" y="-16" width="6" height="20" rx="2" fill="#0F62FE"/>
-    <rect x="-3" y="3" width="6" height="11" rx="2" fill="#0F62FE"/>
+  <!-- Plugwerk Full Logo (Light Background) -->
+
+  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
-  <text x="108" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(20, 40) scale(1.55)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/logo-light.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logo-light.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 100" width="520" height="100">
   <!-- Plugwerk Full Logo (Light Background) -->
 
-  <!-- Icon: 3 gestapelte Plugin-Stecker, eng verschachtelt -->
+  <!-- Icon: scale 2.2 (nur Bild groesser, Text bleibt) -->
   <!-- Plugin 3 (hinten) -->
-  <g transform="translate(8, 28) scale(1.55)" opacity="0.3">
+  <g transform="translate(2, 22) scale(2.2)" opacity="0.3">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 2 (mitte) -->
-  <g transform="translate(14, 34) scale(1.55)" opacity="0.6">
+  <g transform="translate(8, 28) scale(2.2)" opacity="0.6">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
   <!-- Plugin 1 (vorne) -->
-  <g transform="translate(20, 40) scale(1.55)">
+  <g transform="translate(14, 34) scale(2.2)">
     <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 
-  <!-- Wordmark -->
-  <text x="56" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="58" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
+  <!-- Wordmark (unveraendert) -->
+  <text x="68" y="50" font-family="Inter, system-ui, sans-serif" font-weight="700" font-size="42" fill="#161616" letter-spacing="-1" dominant-baseline="central">PLUG<tspan fill="#0F62FE">WERK</tspan></text>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/logomark.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logomark.svg
@@ -1,25 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
-  <defs>
-    <mask id="ring">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="white"/>
-      <circle cx="0" cy="0" r="48" fill="black"/>
-    </mask>
-  </defs>
-  <g transform="translate(80, 80)">
-    <!-- Hexagon ring with transparent center -->
-    <g mask="url(#ring)">
-      <polygon points="0,-72 62,-36 62,36 0,72 -62,36 -62,-36" fill="#0F62FE"/>
-    </g>
-    <!-- Gear teeth -->
-    <rect x="-6" y="-78" width="12" height="12" rx="2" fill="#0F62FE"/>
-    <rect x="56" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(60, 62, -36)"/>
-    <rect x="56" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(120, 62, 36)"/>
-    <rect x="-6" y="66" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(180, 0, 72)"/>
-    <rect x="-68" y="30" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(240, -62, 36)"/>
-    <rect x="-68" y="-42" width="12" height="12" rx="2" fill="#0F62FE" transform="rotate(300, -62, -36)"/>
-    <!-- Plug prongs -->
-    <rect x="-18" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="8" y="-28" width="10" height="36" rx="3" fill="#0F62FE"/>
-    <rect x="-5" y="6" width="10" height="20" rx="3" fill="#0F62FE"/>
+  <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
+
+  <!-- Plugin 3 (hinten) -->
+  <g transform="translate(33, 32) scale(3.5)" opacity="0.3">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 2 (mitte) -->
+  <g transform="translate(49, 48) scale(3.5)" opacity="0.6">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
+  </g>
+
+  <!-- Plugin 1 (vorne) -->
+  <g transform="translate(65, 64) scale(3.5)">
+    <path d="M13.11 4.36L9.87 7.6L8 5.73l3.24-3.24c.18-.18.7-.12 1.56.32c.28.28.42.98.31 1.55m-8 1.77l.91-1.12l9.01 9.01l-1.19.84c-.4.4-2.2.9-3.82 1.16H6.14L4.9 17.26c-.3.3-1.3.4-2.12 0a1.1 1.1 0 0 1 0-2.12l1.24-1.24v-3.88c0-.8.25-2.7 1.09-3.89m7.26 3.97l3.24-3.24c.18-.18.7-.12 1.55.31c.28.28.42.98.31 1.55l-3.24 3.25z" fill="#0F62FE"/>
   </g>
 </svg>

--- a/plugwerk-server/plugwerk-server-frontend/public/logomark.svg
+++ b/plugwerk-server/plugwerk-server-frontend/public/logomark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 26 104 104" width="160" height="160">
   <!-- Plugwerk Logomark: 3 gestapelte Plugin-Stecker -->
 
   <!-- Plugin 3 (hinten) -->

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
@@ -58,7 +58,7 @@ export function AuthCard({ title, subtitle, children }: AuthCardProps) {
             component="img"
             src="/logomark.svg"
             alt="Plugwerk"
-            sx={{ height: 56, width: 'auto' }}
+            sx={{ height: 96, width: 'auto' }}
           />
         </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -102,7 +102,7 @@ export function TopBar() {
             component="img"
             src={isDark ? '/logo-dark.svg' : '/logo-light.svg'}
             alt="Plugwerk"
-            sx={{ height: 32, width: 'auto', maxWidth: { xs: 100, sm: 140 }, display: 'block', flexShrink: 0 }}
+            sx={{ height: 40, width: 'auto', maxWidth: { xs: 120, sm: 180 }, display: 'block', flexShrink: 0 }}
           />
         </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -102,7 +102,7 @@ export function TopBar() {
             component="img"
             src={isDark ? '/logo-dark.svg' : '/logo-light.svg'}
             alt="Plugwerk"
-            sx={{ height: 40, width: 'auto', maxWidth: { xs: 120, sm: 180 }, display: 'block', flexShrink: 0 }}
+            sx={{ height: 48, width: 'auto', maxWidth: { xs: 160, sm: 220 }, display: 'block', flexShrink: 0 }}
           />
         </Box>
 


### PR DESCRIPTION
## Summary

- Replace hexagonal gear ring logo with new design: three stacked electrical plug icons with opacity graduation (0.3 / 0.6 / 1.0)
- New logo represents the plugin registry concept — multiple plugins organized/stacked
- All three variants updated: logomark (160x160), full-dark (520x100), full-light (520x100)
- Frontend assets updated (favicon, logomark, logo-dark, logo-light) — no code changes needed

## Files Changed

**Design sources:**
- `docs/design/plugwerk-logo/plugwerk-logomark-brand-transparent.svg`
- `docs/design/plugwerk-logo/plugwerk-logo-full-dark.svg`
- `docs/design/plugwerk-logo/plugwerk-logo-full-light.svg`

**Frontend assets (copied from design):**
- `public/favicon.svg`, `public/logomark.svg`, `public/logo-dark.svg`, `public/logo-light.svg`

## Test plan

- [ ] Verify favicon renders correctly in browser tab
- [ ] Verify logomark displays in AuthCard (login page)
- [ ] Verify full logo in TopBar (light mode)
- [ ] Verify full logo in TopBar (dark mode)
- [ ] Check logo at small sizes (16px, 32px favicon)

Closes #210