### PR TITLE
Automated release workflow with version bump and multi-repo dispatch (#203)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,181 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g., 1.0.0 or 1.0.0-alpha.1)'
+        required: true
+      next_version:
+        description: 'Next development version (e.g., 1.0.1-SNAPSHOT)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release permissions
+        run: |
+          ROLE=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq .permission)
+          if [[ "$ROLE" != "admin" && "$ROLE" != "maintain" ]]; then
+            echo "::error::User ${{ github.actor }} has role '$ROLE' — admin or maintain required for releases"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate inputs
+        run: |
+          RELEASE_VERSION="${{ inputs.release_version }}"
+          NEXT_VERSION="${{ inputs.next_version }}"
+
+          # Release version must not contain -SNAPSHOT
+          if [[ "$RELEASE_VERSION" == *-SNAPSHOT ]]; then
+            echo "::error::Release version must not contain -SNAPSHOT: $RELEASE_VERSION"
+            exit 1
+          fi
+
+          # Next version must end with -SNAPSHOT
+          if [[ "$NEXT_VERSION" != *-SNAPSHOT ]]; then
+            echo "::error::Next version must end with -SNAPSHOT: $NEXT_VERSION"
+            exit 1
+          fi
+
+          # Release version must match semver (with optional pre-release)
+          if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Release version must match semver pattern: $RELEASE_VERSION"
+            exit 1
+          fi
+
+          # Must be on main branch
+          BRANCH="${GITHUB_REF_NAME}"
+          if [[ "$BRANCH" != "main" ]]; then
+            echo "::error::Releases can only be prepared from main branch, currently on: $BRANCH"
+            exit 1
+          fi
+
+          # Tag must not already exist
+          if git rev-parse "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${RELEASE_VERSION} already exists"
+            exit 1
+          fi
+
+          # Current version must be a SNAPSHOT
+          CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [[ "$CURRENT_VERSION" != *-SNAPSHOT ]]; then
+            echo "::error::Current version is not a SNAPSHOT ($CURRENT_VERSION) — already in release state?"
+            exit 1
+          fi
+
+          echo "✅ All validations passed"
+          echo "  Current:  $CURRENT_VERSION"
+          echo "  Release:  $RELEASE_VERSION"
+          echo "  Next:     $NEXT_VERSION"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump to release version
+        run: |
+          echo "${{ inputs.release_version }}" > VERSION
+          git add VERSION
+          git commit -m "release: prepare ${{ inputs.release_version }}"
+
+      - name: Create release tag
+        run: git tag "v${{ inputs.release_version }}"
+
+      - name: Bump to next development version
+        run: |
+          echo "${{ inputs.next_version }}" > VERSION
+          git add VERSION
+          git commit -m "chore: prepare next development cycle ${{ inputs.next_version }}"
+
+      - name: Push commits and tag
+        run: git push origin main "v${{ inputs.release_version }}"
+
+      - name: Wait for release workflow
+        run: |
+          echo "⏳ Waiting for release.yml to be triggered by tag v${{ inputs.release_version }}..."
+
+          # Wait for the workflow run to appear (may take a few seconds)
+          for i in $(seq 1 30); do
+            RUN_ID=$(gh run list \
+              --workflow=release.yml \
+              --json databaseId,headBranch,status \
+              --jq ".[] | select(.headBranch == \"v${{ inputs.release_version }}\") | .databaseId" \
+              | head -1)
+            if [[ -n "$RUN_ID" ]]; then
+              break
+            fi
+            echo "  Waiting for workflow run to appear... ($i/30)"
+            sleep 10
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::error::release.yml was not triggered within 5 minutes"
+            exit 1
+          fi
+
+          echo "📦 Found release workflow run: $RUN_ID"
+          echo "   https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
+
+          # Wait for completion
+          gh run watch "$RUN_ID" --exit-status
+
+          echo "✅ Release workflow completed successfully"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "v${{ inputs.release_version }}" \
+            --title "v${{ inputs.release_version }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify downstream repositories
+        if: success()
+        run: |
+          # Add downstream repository names here when they exist, e.g.:
+          # DOWNSTREAM_REPOS="plugwerk-docs plugwerk-examples"
+          DOWNSTREAM_REPOS=""
+
+          if [[ -z "$DOWNSTREAM_REPOS" ]]; then
+            echo "ℹ️  No downstream repositories configured — skipping dispatch"
+            exit 0
+          fi
+
+          for REPO in $DOWNSTREAM_REPOS; do
+            echo "📤 Dispatching release event to plugwerk/${REPO}..."
+            gh api "repos/plugwerk/${REPO}/dispatches" \
+              -f event_type=release \
+              -f "client_payload[version]=${{ inputs.release_version }}" \
+              -f "client_payload[tag]=v${{ inputs.release_version }}" || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## 🚀 Release ${{ inputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Step | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version bump to \`${{ inputs.release_version }}\` | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tag \`v${{ inputs.release_version }}\` created | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Next snapshot \`${{ inputs.next_version }}\` | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Maven Central publish | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GitHub Release created | ✅ |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add `prepare-release.yml` workflow triggered via `workflow_dispatch` with inputs `release_version` and `next_version`
- Automates: version bump in `VERSION` file → commit → tag → next snapshot bump → commit → push
- Waits for `release.yml` to complete (Maven Central publish) and reports status
- Creates GitHub Release with auto-generated release notes
- Prepares multi-repo dispatch mechanism for future downstream repos (currently empty list)
- Safeguards: input validation, branch check, duplicate tag check, permission check (admin/maintain only)

## Multi-Repo Strategy

Uses `repository_dispatch` to notify downstream repos after successful release. The repo list is currently empty — repos like `plugwerk-docs` or `plugwerk-examples` can be added later by editing the `DOWNSTREAM_REPOS` variable.

## Test plan

- [ ] Trigger workflow on main with valid inputs (e.g., `1.0.0-alpha.1` / `1.0.0-SNAPSHOT`)
- [ ] Verify two commits created (release + next snapshot)
- [ ] Verify tag `v1.0.0-alpha.1` created and pushed
- [ ] Verify `release.yml` triggered by tag
- [ ] Verify GitHub Release created with notes
- [ ] Test safeguards: SNAPSHOT release version, missing -SNAPSHOT on next version, duplicate tag, non-main branch

Closes #203