### PR TITLE
Fix: use RELEASE_TOKEN PAT to bypass branch protection (#203)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Verify release permissions
         run: |


### PR DESCRIPTION
## Summary

- Use `secrets.RELEASE_TOKEN` (fine-grained PAT) in the checkout step of `prepare-release.yml`
- This allows the workflow to push release commits directly to `main`, bypassing branch protection rules
- The previous run failed because `GITHUB_TOKEN` cannot bypass the "changes must be made through a pull request" rule

## Setup required

1. Create a fine-grained PAT with **Contents: Read and Write** + **Bypass branch protections** for `plugwerk/plugwerk`
2. Add it as repository secret `RELEASE_TOKEN`
3. Clean up the orphaned tag from the failed run: `git push origin --delete v1.0.0-alpha.1`

## Test plan

- [ ] `RELEASE_TOKEN` secret configured
- [ ] Orphaned tag `v1.0.0-alpha.1` deleted
- [ ] Re-trigger `prepare-release.yml` — push to main should succeed

Relates to #203