### PR TITLE
Publish client-plugin ZIP and upload release assets (#214)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -45,3 +45,58 @@ jobs:
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
+      - name: Collect release artifacts
+        id: artifacts
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          STAGING_DIR="$(mktemp -d)"
+
+          # Publishable library JARs
+          for MODULE in plugwerk-spi plugwerk-descriptor plugwerk-client-plugin; do
+            JAR="${MODULE}/build/libs/${MODULE}-${VERSION}.jar"
+            if [[ -f "$JAR" ]]; then
+              cp "$JAR" "$STAGING_DIR/"
+            fi
+          done
+
+          # plugwerk-api-model (nested module path)
+          API_JAR="plugwerk-api/plugwerk-api-model/build/libs/plugwerk-api-model-${VERSION}.jar"
+          if [[ -f "$API_JAR" ]]; then
+            cp "$API_JAR" "$STAGING_DIR/"
+          fi
+
+          # PF4J plugin ZIP
+          ZIP="plugwerk-client-plugin/build/pf4j/plugwerk-client-plugin-${VERSION}.zip"
+          if [[ -f "$ZIP" ]]; then
+            cp "$ZIP" "$STAGING_DIR/"
+          fi
+
+          echo "STAGING_DIR=$STAGING_DIR" >> "$GITHUB_OUTPUT"
+          echo "📦 Collected artifacts:"
+          ls -lh "$STAGING_DIR/"
+
+      - name: Upload assets to GitHub Release
+        run: |
+          STAGING_DIR="${{ steps.artifacts.outputs.STAGING_DIR }}"
+          TAG="v${{ steps.version.outputs.VERSION }}"
+
+          # Wait for the GitHub Release to exist (created by prepare-release.yml)
+          for i in $(seq 1 30); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              break
+            fi
+            echo "  Waiting for GitHub Release $TAG to be created... ($i/30)"
+            sleep 10
+          done
+
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "⚠️  GitHub Release $TAG not found — creating it now"
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
+
+          echo "📤 Uploading assets to GitHub Release $TAG..."
+          gh release upload "$TAG" "$STAGING_DIR"/* --clobber
+          echo "✅ Assets uploaded"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,6 @@ jobs:
             cp "$ZIP" "$STAGING_DIR/"
           fi
 
-          # Server fat JAR (bootJar)
-          BOOT_JAR="plugwerk-server/plugwerk-server-backend/build/libs/plugwerk-server-backend-${VERSION}.jar"
-          if [[ -f "$BOOT_JAR" ]]; then
-            cp "$BOOT_JAR" "$STAGING_DIR/"
-          fi
-
           # Server distribution ZIP
           DIST_ZIP="plugwerk-server/plugwerk-server-backend/build/dist/plugwerk-server-${VERSION}.zip"
           if [[ -f "$DIST_ZIP" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,18 @@ jobs:
             cp "$ZIP" "$STAGING_DIR/"
           fi
 
+          # Server fat JAR (bootJar)
+          BOOT_JAR="plugwerk-server/plugwerk-server-backend/build/libs/plugwerk-server-backend-${VERSION}.jar"
+          if [[ -f "$BOOT_JAR" ]]; then
+            cp "$BOOT_JAR" "$STAGING_DIR/"
+          fi
+
+          # Server distribution ZIP
+          DIST_ZIP="plugwerk-server/plugwerk-server-backend/build/dist/plugwerk-server-${VERSION}.zip"
+          if [[ -f "$DIST_ZIP" ]]; then
+            cp "$DIST_ZIP" "$STAGING_DIR/"
+          fi
+
           echo "STAGING_DIR=$STAGING_DIR" >> "$GITHUB_OUTPUT"
           echo "📦 Collected artifacts:"
           ls -lh "$STAGING_DIR/"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 # Node
 node_modules/
 dist/
+!**/src/dist/
 dist-ssr/
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -123,7 +123,17 @@ dependencies {
 }
 ```
 
-The `plugwerk-client-plugin` ZIP is deployed as a PF4J plugin alongside your application's plugins, not as a compile-time dependency.
+The `plugwerk-client-plugin` ZIP is deployed as a PF4J plugin alongside your application's plugins, not as a compile-time dependency. Pull it from Maven Central using the `pf4j` classifier:
+
+```kotlin
+// Download the PF4J plugin ZIP
+val plugwerkPlugin by configurations.creating
+dependencies {
+    plugwerkPlugin("io.plugwerk:plugwerk-client-plugin:<version>:pf4j@zip")
+}
+```
+
+Or download it directly from the [GitHub Releases](https://github.com/plugwerk/plugwerk/releases) page.
 
 ### Configure and use the client
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,7 +153,7 @@ JAVA_OPTS="-Xms512m -Xmx2g" ./start.sh
 ### 3.4 Pass Spring Boot arguments
 
 ```bash
-./start.sh --server.port=9090 --spring.profiles.active=production
+./start.sh --server.port=9090
 ```
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,316 @@
+# Plugwerk Server — Deployment Guide
+
+This guide covers all supported ways to run the Plugwerk Server.
+
+## Prerequisites
+
+- **Java 21** or later (for non-container deployment)
+- **Docker** and **Docker Compose** (for container deployment)
+- **PostgreSQL 16+** database
+
+## Download
+
+Download the distribution ZIP from the latest [GitHub Release](https://github.com/plugwerk/plugwerk/releases):
+
+```
+plugwerk-server-<version>.zip
+```
+
+Or pull from Maven Central:
+
+```bash
+# Using Maven dependency:resolve
+mvn dependency:copy -Dartifact=io.plugwerk:plugwerk-server:<version>:zip -DoutputDirectory=.
+```
+
+Extract the ZIP:
+
+```bash
+unzip plugwerk-server-<version>.zip
+cd plugwerk-server-<version>/
+```
+
+Contents:
+
+```
+plugwerk-server-<version>/
+├── plugwerk-server-backend-<version>.jar   # Spring Boot fat JAR
+├── start.sh                                 # Linux/macOS start script
+├── start.bat                                # Windows start script
+├── Dockerfile                               # Container image definition
+├── docker-compose.yml                       # Full stack with PostgreSQL
+├── LICENSE
+└── README.md
+```
+
+---
+
+## Option 1: Docker Compose (recommended)
+
+The fastest way to get started. Includes PostgreSQL and the server.
+
+### 1.1 Generate secrets
+
+```bash
+export PLUGWERK_JWT_SECRET="$(openssl rand -base64 32)"
+export PLUGWERK_ENCRYPTION_KEY="$(openssl rand -hex 8)"
+```
+
+### 1.2 Start the stack
+
+```bash
+docker compose up -d
+```
+
+The server is available at `http://localhost:8080`.
+
+### 1.3 Check health
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+### 1.4 Stop
+
+```bash
+docker compose down          # stop, keep data
+docker compose down -v       # stop and delete database volume
+```
+
+### 1.5 Custom JVM options
+
+```yaml
+# docker-compose.override.yml
+services:
+  plugwerk-server:
+    environment:
+      JAVA_OPTS: "-Xms512m -Xmx2g"
+```
+
+---
+
+## Option 2: Standalone Docker
+
+Run the server container without Compose. Requires an external PostgreSQL instance.
+
+### 2.1 Build the image
+
+```bash
+docker build -t plugwerk-server .
+```
+
+### 2.2 Run
+
+```bash
+docker run -d \
+  --name plugwerk-server \
+  -p 8080:8080 \
+  -e PLUGWERK_DB_URL=jdbc:postgresql://host.docker.internal:5432/plugwerk \
+  -e PLUGWERK_DB_USERNAME=plugwerk \
+  -e PLUGWERK_DB_PASSWORD=plugwerk \
+  -e PLUGWERK_JWT_SECRET="$(openssl rand -base64 32)" \
+  -e PLUGWERK_ENCRYPTION_KEY="$(openssl rand -hex 8)" \
+  -e PLUGWERK_STORAGE_ROOT=/data/artifacts \
+  -v plugwerk-artifacts:/data/artifacts \
+  plugwerk-server
+```
+
+### 2.3 Custom JVM options
+
+```bash
+docker run -e JAVA_OPTS="-Xms512m -Xmx2g" plugwerk-server
+```
+
+---
+
+## Option 3: Start Script (Linux/macOS)
+
+Run directly on the host with the included start script.
+
+### 3.1 Prerequisites
+
+- Java 21+ installed (`java -version`)
+- PostgreSQL running and accessible
+
+### 3.2 Configure and start
+
+```bash
+export PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
+export PLUGWERK_DB_USERNAME=plugwerk
+export PLUGWERK_DB_PASSWORD=plugwerk
+export PLUGWERK_JWT_SECRET="$(openssl rand -base64 32)"
+export PLUGWERK_ENCRYPTION_KEY="$(openssl rand -hex 8)"
+
+./start.sh
+```
+
+### 3.3 Custom JVM options
+
+```bash
+JAVA_OPTS="-Xms512m -Xmx2g" ./start.sh
+```
+
+### 3.4 Pass Spring Boot arguments
+
+```bash
+./start.sh --server.port=9090 --spring.profiles.active=production
+```
+
+---
+
+## Option 4: Start Script (Windows)
+
+### 4.1 Prerequisites
+
+- Java 21+ installed and on `PATH`
+- PostgreSQL running and accessible
+
+### 4.2 Configure and start
+
+```cmd
+set PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
+set PLUGWERK_DB_USERNAME=plugwerk
+set PLUGWERK_DB_PASSWORD=plugwerk
+set PLUGWERK_JWT_SECRET=<your-secret-min-32-chars>
+set PLUGWERK_ENCRYPTION_KEY=<your-key-exactly-16-chars>
+
+start.bat
+```
+
+### 4.3 Custom JVM options
+
+```cmd
+set JAVA_OPTS=-Xms512m -Xmx2g
+start.bat
+```
+
+---
+
+## Option 5: Direct JAR execution
+
+For full control, run the fat JAR directly:
+
+```bash
+java \
+  -Xms256m -Xmx512m \
+  -XX:+UseG1GC \
+  -XX:+ExitOnOutOfMemoryError \
+  -jar plugwerk-server-backend-<version>.jar \
+  --server.port=8080
+```
+
+---
+
+## Option 6: systemd Service (Linux production)
+
+For production Linux servers, create a systemd unit file:
+
+```ini
+# /etc/systemd/system/plugwerk.service
+[Unit]
+Description=Plugwerk Server
+After=network.target postgresql.service
+
+[Service]
+Type=exec
+User=plugwerk
+Group=plugwerk
+WorkingDirectory=/opt/plugwerk
+ExecStart=/usr/bin/java -Xms512m -Xmx2g -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -jar plugwerk-server-backend.jar
+EnvironmentFile=/etc/plugwerk/plugwerk.env
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+# /etc/plugwerk/plugwerk.env
+PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
+PLUGWERK_DB_USERNAME=plugwerk
+PLUGWERK_DB_PASSWORD=<secret>
+PLUGWERK_JWT_SECRET=<secret>
+PLUGWERK_ENCRYPTION_KEY=<secret>
+PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts
+```
+
+```bash
+sudo systemctl enable plugwerk
+sudo systemctl start plugwerk
+sudo journalctl -u plugwerk -f    # view logs
+```
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `PLUGWERK_JWT_SECRET` | HMAC-SHA256 signing key for JWTs. Min 32 characters. | `openssl rand -base64 32` |
+| `PLUGWERK_ENCRYPTION_KEY` | AES key for OIDC client secrets at rest. Exactly 16 characters. | `openssl rand -hex 8` |
+
+### Database
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_DB_URL` | `jdbc:postgresql://localhost:5432/plugwerk` | JDBC connection URL |
+| `PLUGWERK_DB_USERNAME` | `plugwerk` | Database username |
+| `PLUGWERK_DB_PASSWORD` | `plugwerk` | Database password |
+
+### Storage
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_STORAGE_TYPE` | `fs` | Storage backend (`fs` for filesystem) |
+| `PLUGWERK_STORAGE_ROOT` | `/var/plugwerk/artifacts` | Directory for uploaded plugin artifacts |
+
+### Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_BASE_URL` | `http://localhost:8080` | Public base URL (used in download links) |
+| `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` | `100` | Max upload file size in MB |
+
+### Authentication
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_AUTH_ADMIN_PASSWORD` | *(random, logged on first start)* | Fixed superadmin password. If unset, a random password is generated and printed to the log on first startup. |
+| `PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS` | `10` | Max login attempts per IP per window |
+| `PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60` | Rate limit window duration |
+
+### Tracking
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGWERK_TRACKING_ENABLED` | `true` | Enable download event tracking |
+| `PLUGWERK_TRACKING_CAPTURE_IP` | `true` | Record client IP |
+| `PLUGWERK_TRACKING_ANONYMIZE_IP` | `true` | Anonymize IPs to /24 (IPv4) or /48 (IPv6) |
+| `PLUGWERK_TRACKING_CAPTURE_USER_AGENT` | `true` | Record User-Agent header |
+
+### JVM
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JAVA_OPTS` | `-Xms256m -Xmx512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError` | JVM arguments (used by start scripts and Dockerfile) |
+
+---
+
+## Health Check
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+Returns `{"status":"UP"}` when the server and database connection are healthy.
+
+## API Documentation
+
+Once running, the OpenAPI spec is available at:
+
+```
+http://localhost:8080/api-docs/openapi.yaml
+```

--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -110,6 +110,47 @@ plugin.configure(config)
 - **JVM target:** 17
 - **Dependencies:** `plugwerk-spi` (api), `plugwerk-api-model` (api), OkHttp, Jackson, PF4J
 
+## Distribution
+
+The client plugin is published to **Maven Central** in two formats:
+
+| Artifact | Coordinates | Use case |
+|----------|------------|----------|
+| **JAR** | `io.plugwerk:plugwerk-client-plugin:<version>` | Compile-time dependency (rarely needed directly) |
+| **PF4J Plugin ZIP** | `io.plugwerk:plugwerk-client-plugin:<version>:pf4j@zip` | Runtime plugin — drop into your PF4J plugins directory |
+
+### Download via Gradle
+
+```kotlin
+// Download the PF4J plugin ZIP (e.g., for copying into a plugins directory)
+val plugwerkPlugin by configurations.creating
+dependencies {
+    plugwerkPlugin("io.plugwerk:plugwerk-client-plugin:<version>:pf4j@zip")
+}
+
+tasks.register<Copy>("copyPlugwerkPlugin") {
+    from(plugwerkPlugin)
+    into(layout.projectDirectory.dir("plugins"))
+}
+```
+
+### Download via Maven
+
+```xml
+<dependency>
+    <groupId>io.plugwerk</groupId>
+    <artifactId>plugwerk-client-plugin</artifactId>
+    <version>1.0.0</version>
+    <classifier>pf4j</classifier>
+    <type>zip</type>
+</dependency>
+```
+
+### Download from GitHub Release
+
+Every release also attaches the ZIP as a GitHub Release asset at:
+`https://github.com/plugwerk/plugwerk/releases/download/v<version>/plugwerk-client-plugin-<version>.zip`
+
 ## Build
 
 ```bash

--- a/plugwerk-client-plugin/build.gradle.kts
+++ b/plugwerk-client-plugin/build.gradle.kts
@@ -136,3 +136,15 @@ val pluginZip by tasks.registering(Zip::class) {
 tasks.named("assemble") {
     dependsOn(pluginZip)
 }
+
+// Publish the PF4J plugin ZIP alongside the JAR on Maven Central
+publishing {
+    publications {
+        named<MavenPublication>("mavenJava") {
+            artifact(pluginZip) {
+                classifier = "pf4j"
+                extension = "zip"
+            }
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
-    id("io.plugwerk.maven-publish")
+    `maven-publish`
+    signing
 }
 
 kotlin {
@@ -70,16 +71,13 @@ tasks.named<ProcessResources>("processResources") {
 // Publishing: fat JAR (bootJar) + distribution ZIP to Maven Central
 // ---------------------------------------------------------------------------
 
-// Spring Boot disables the plain JAR by default — re-enable it for the
-// maven-publish convention plugin which publishes from components["java"]
-tasks.named<Jar>("jar") {
-    archiveClassifier.set("plain")
-    enabled = true
-}
+// ---------------------------------------------------------------------------
+// Distribution ZIP: fat JAR + LICENSE + README
+// ---------------------------------------------------------------------------
 
 val serverDistZip by tasks.registering(Zip::class) {
     group = "distribution"
-    description = "Assembles a distribution ZIP with the fat JAR, config, and start scripts"
+    description = "Assembles a distribution ZIP with the fat JAR, LICENSE, and README"
     archiveBaseName.set("plugwerk-server")
     destinationDirectory.set(layout.buildDirectory.dir("dist"))
 
@@ -94,20 +92,60 @@ tasks.named("assemble") {
     dependsOn(serverDistZip)
 }
 
+// ---------------------------------------------------------------------------
+// Publish only the distribution ZIP to Maven Central (no JAR, no sources)
+// ---------------------------------------------------------------------------
+
 publishing {
     publications {
-        named<MavenPublication>("mavenJava") {
-            // Add the fat JAR as the primary artifact (replaces plain JAR)
-            artifact(tasks.named("bootJar")) {
-                classifier = null as String?
-            }
-            // Add the distribution ZIP
-            artifact(serverDistZip) {
-                classifier = "dist"
-                extension = "zip"
+        create<MavenPublication>("serverDist") {
+            groupId = project.group.toString()
+            artifactId = "plugwerk-server"
+            version = project.version.toString()
+
+            artifact(serverDistZip)
+
+            pom {
+                name.set("Plugwerk Server")
+                description.set("Plugwerk Server distribution — Spring Boot application for plugin registry management")
+                url.set("https://github.com/plugwerk/plugwerk")
+                packaging = "zip"
+
+                licenses {
+                    license {
+                        name.set("GNU Affero General Public License v3.0")
+                        url.set("https://www.gnu.org/licenses/agpl-3.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("devtank42")
+                        name.set("devtank42 GmbH")
+                        url.set("https://github.com/plugwerk")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:https://github.com/plugwerk/plugwerk.git")
+                    developerConnection.set("scm:git:ssh://git@github.com:plugwerk/plugwerk.git")
+                    url.set("https://github.com/plugwerk/plugwerk")
+                }
             }
         }
     }
+}
+
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["serverDist"])
+}
+
+tasks.withType<Sign>().configureEach {
+    onlyIf { project.hasProperty("signingKey") }
 }
 
 tasks.named<Test>("test") {

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -68,21 +68,22 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 // ---------------------------------------------------------------------------
-// Publishing: fat JAR (bootJar) + distribution ZIP to Maven Central
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Distribution ZIP: fat JAR + LICENSE + README
+// Distribution ZIP: fat JAR + start scripts + Dockerfile + docker-compose
 // ---------------------------------------------------------------------------
 
 val serverDistZip by tasks.registering(Zip::class) {
     group = "distribution"
-    description = "Assembles a distribution ZIP with the fat JAR, LICENSE, and README"
+    description = "Assembles a distribution ZIP with fat JAR, start scripts, Docker files, and docs"
     archiveBaseName.set("plugwerk-server")
     destinationDirectory.set(layout.buildDirectory.dir("dist"))
 
     into("plugwerk-server-${project.version}") {
         from(tasks.named("bootJar"))
+        from("src/dist") {
+            include("start.sh", "start.bat", "Dockerfile", "docker-compose.yml")
+            // Ensure shell script is executable
+            filePermissions { unix("rwxr-xr-x") }
+        }
         from(rootProject.file("LICENSE"))
         from(rootProject.file("README.md"))
     }

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
+    id("io.plugwerk.maven-publish")
 }
 
 kotlin {
@@ -60,6 +61,50 @@ tasks.named<ProcessResources>("processResources") {
                 "  version: ${project.version}"
             } else {
                 line
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Publishing: fat JAR (bootJar) + distribution ZIP to Maven Central
+// ---------------------------------------------------------------------------
+
+// Spring Boot disables the plain JAR by default — re-enable it for the
+// maven-publish convention plugin which publishes from components["java"]
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("plain")
+    enabled = true
+}
+
+val serverDistZip by tasks.registering(Zip::class) {
+    group = "distribution"
+    description = "Assembles a distribution ZIP with the fat JAR, config, and start scripts"
+    archiveBaseName.set("plugwerk-server")
+    destinationDirectory.set(layout.buildDirectory.dir("dist"))
+
+    into("plugwerk-server-${project.version}") {
+        from(tasks.named("bootJar"))
+        from(rootProject.file("LICENSE"))
+        from(rootProject.file("README.md"))
+    }
+}
+
+tasks.named("assemble") {
+    dependsOn(serverDistZip)
+}
+
+publishing {
+    publications {
+        named<MavenPublication>("mavenJava") {
+            // Add the fat JAR as the primary artifact (replaces plain JAR)
+            artifact(tasks.named("bootJar")) {
+                classifier = null as String?
+            }
+            // Add the distribution ZIP
+            artifact(serverDistZip) {
+                classifier = "dist"
+                extension = "zip"
             }
         }
     }

--- a/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk
+USER plugwerk
+
+COPY plugwerk-server-backend-*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", \
+  "-Xms256m", "-Xmx512m", \
+  "-XX:+UseG1GC", \
+  "-XX:+ExitOnOutOfMemoryError", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
@@ -9,9 +9,6 @@ COPY plugwerk-server-backend-*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", \
-  "-Xms256m", "-Xmx512m", \
-  "-XX:+UseG1GC", \
-  "-XX:+ExitOnOutOfMemoryError", \
-  "-Djava.security.egd=file:/dev/./urandom", \
-  "-jar", "app.jar"]
+ENV JAVA_OPTS="-Xms256m -Xmx512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom"
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/plugwerk-server/plugwerk-server-backend/src/dist/docker-compose.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: plugwerk
+      POSTGRES_USER: plugwerk
+      POSTGRES_PASSWORD: plugwerk
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U plugwerk"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  plugwerk-server:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PLUGWERK_DB_URL: jdbc:postgresql://postgres:5432/plugwerk
+      PLUGWERK_DB_USERNAME: plugwerk
+      PLUGWERK_DB_PASSWORD: plugwerk
+      PLUGWERK_STORAGE_ROOT: /tmp/plugwerk-artifacts
+      PLUGWERK_JWT_SECRET: "${PLUGWERK_JWT_SECRET:?Set PLUGWERK_JWT_SECRET (min 32 chars)}"
+      PLUGWERK_ENCRYPTION_KEY: "${PLUGWERK_ENCRYPTION_KEY:?Set PLUGWERK_ENCRYPTION_KEY (exactly 16 chars)}"
+      PLUGWERK_AUTH_ADMIN_PASSWORD: ${PLUGWERK_AUTH_ADMIN_PASSWORD:-}
+    ports:
+      - "8080:8080"
+
+volumes:
+  postgres-data:

--- a/plugwerk-server/plugwerk-server-backend/src/dist/start.bat
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/start.bat
@@ -1,0 +1,31 @@
+@echo off
+rem ---------------------------------------------------------------------------
+rem Plugwerk Server — Start Script (Windows)
+rem ---------------------------------------------------------------------------
+rem Usage:
+rem   start.bat                              Start with defaults
+rem   set JAVA_OPTS=-Xmx2g && start.bat     Override JVM options
+rem ---------------------------------------------------------------------------
+
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+
+rem Find the server JAR
+set "JAR="
+for %%f in ("%SCRIPT_DIR%plugwerk-server-backend-*.jar") do set "JAR=%%f"
+
+if "%JAR%"=="" (
+    echo ERROR: No plugwerk-server-backend-*.jar found in %SCRIPT_DIR%
+    exit /b 1
+)
+
+rem JVM defaults — override with JAVA_OPTS environment variable
+if "%JAVA_OPTS%"=="" set "JAVA_OPTS=-Xms256m -Xmx512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8"
+
+echo Starting Plugwerk Server...
+echo   JAR:       %JAR%
+echo   JAVA_OPTS: %JAVA_OPTS%
+echo.
+
+java %JAVA_OPTS% -jar "%JAR%" %*

--- a/plugwerk-server/plugwerk-server-backend/src/dist/start.sh
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Plugwerk Server — Start Script
+# ---------------------------------------------------------------------------
+# Usage:
+#   ./start.sh                          Start with defaults
+#   PLUGWERK_DB_URL=... ./start.sh      Override database URL
+#   JAVA_OPTS="-Xmx2g" ./start.sh      Override JVM options
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+JAR="$(ls "$SCRIPT_DIR"/plugwerk-server-backend-*.jar 2>/dev/null | head -1)"
+
+if [[ -z "$JAR" ]]; then
+  echo "ERROR: No plugwerk-server-backend-*.jar found in $SCRIPT_DIR" >&2
+  exit 1
+fi
+
+# JVM defaults — override with JAVA_OPTS environment variable
+: "${JAVA_OPTS:=-Xms256m -Xmx512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8}"
+
+echo "Starting Plugwerk Server..."
+echo "  JAR:       $(basename "$JAR")"
+echo "  JAVA_OPTS: $JAVA_OPTS"
+echo ""
+
+# shellcheck disable=SC2086
+exec java $JAVA_OPTS -jar "$JAR" "$@"


### PR DESCRIPTION
## Summary

- **Maven Central ZIP**: `plugwerk-client-plugin` PF4J plugin ZIP is now published to Maven Central with classifier `pf4j` (e.g., `io.plugwerk:plugwerk-client-plugin:1.0.0:pf4j@zip`)
- **GitHub Release assets**: `release.yml` now collects all library JARs (4 modules) + the client-plugin ZIP and uploads them to the GitHub Release page

## Files changed

- `plugwerk-client-plugin/build.gradle.kts` — register `pluginZip` as Maven publication artifact
- `.github/workflows/release.yml` — add artifact collection and GitHub Release upload steps

## How users consume the ZIP

```kotlin
// Gradle
dependencies {
    implementation("io.plugwerk:plugwerk-client-plugin:1.0.0:pf4j@zip")
}
```

```xml
<!-- Maven -->
<dependency>
    <groupId>io.plugwerk</groupId>
    <artifactId>plugwerk-client-plugin</artifactId>
    <version>1.0.0</version>
    <classifier>pf4j</classifier>
    <type>zip</type>
</dependency>
```

Or download directly from the GitHub Release page.

## Test plan

- [ ] `./gradlew :plugwerk-client-plugin:publishToMavenLocal` publishes both JAR and ZIP
- [ ] Verify in `~/.m2/repository/io/plugwerk/plugwerk-client-plugin/` that `-pf4j.zip` exists
- [ ] Next release via `prepare-release.yml` should show assets on the GitHub Release page

Closes #214