### PR TITLE
feat: add SearchCriteria.Builder for ergonomic Java API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ docker-compose.override.yml
 /examples/plugwerk-java-cli-example/plugins/
 /plugwerk-server/plugwerk-server-backend/storage/
 !/examples/plugwerk-java-cli-example/plugins/plugwerk-client-plugin-0.1.0-SNAPSHOT/plugwerk-client-plugin-0.1.0-SNAPSHOT.zip
+
+.playwright-mcp
+.kotlin

--- a/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/command/SearchCommand.java
+++ b/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/command/SearchCommand.java
@@ -64,7 +64,11 @@ public class SearchCommand implements Runnable {
 
   @Override
   public void run() {
-    SearchCriteria criteria = new SearchCriteria(query, tag, compatibleWith);
+    SearchCriteria.Builder builder = new SearchCriteria.Builder();
+    if (query != null) builder.query(query);
+    if (tag != null) builder.tag(tag);
+    if (compatibleWith != null) builder.compatibleWith(compatibleWith);
+    SearchCriteria criteria = builder.build();
     List<PluginInfo> results = parent.getMarketplace().catalog().searchPlugins(criteria);
 
     if (results.isEmpty()) {

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
@@ -38,7 +38,8 @@ import org.pf4j.ExtensionPoint
  * Java:
  * ```java
  * PlugwerkCatalog catalog = pluginManager.getExtensions(PlugwerkCatalog.class).get(0);
- * List<PluginInfo> plugins = catalog.searchPlugins(new SearchCriteria(null, "analytics", null, null));
+ * List<PluginInfo> plugins = catalog.searchPlugins(
+ *     new SearchCriteria.Builder().tag("analytics").build());
  * ```
  *
  * @see PlugwerkMarketplace for a unified facade that also exposes [PlugwerkInstaller] and

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/SearchCriteria.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/SearchCriteria.kt
@@ -33,7 +33,10 @@ package io.plugwerk.spi.model
  *
  * Java:
  * ```java
- * SearchCriteria criteria = new SearchCriteria(null, "experimental", "3.1.0");
+ * SearchCriteria criteria = new SearchCriteria.Builder()
+ *     .tag("experimental")
+ *     .compatibleWith("3.1.0")
+ *     .build();
  * List<PluginInfo> results = catalog.searchPlugins(criteria);
  * ```
  *
@@ -45,4 +48,31 @@ package io.plugwerk.spi.model
  *   whose `requiresSystemVersion` range includes this version are returned;
  *   `null` disables compatibility filtering
  */
-data class SearchCriteria(val query: String? = null, val tag: String? = null, val compatibleWith: String? = null)
+data class SearchCriteria(val query: String? = null, val tag: String? = null, val compatibleWith: String? = null) {
+
+    /**
+     * Fluent builder for [SearchCriteria], primarily intended for Java callers.
+     *
+     * Kotlin callers should prefer the data-class constructor with named arguments.
+     *
+     * ```java
+     * SearchCriteria criteria = new SearchCriteria.Builder()
+     *     .query("crm")
+     *     .tag("salesforce")
+     *     .build();
+     * ```
+     */
+    class Builder {
+        private var query: String? = null
+        private var tag: String? = null
+        private var compatibleWith: String? = null
+
+        fun query(query: String): Builder = apply { this.query = query }
+
+        fun tag(tag: String): Builder = apply { this.tag = tag }
+
+        fun compatibleWith(version: String): Builder = apply { this.compatibleWith = version }
+
+        fun build(): SearchCriteria = SearchCriteria(query, tag, compatibleWith)
+    }
+}

--- a/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/model/SearchCriteriaTest.kt
+++ b/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/model/SearchCriteriaTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.spi.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SearchCriteriaTest {
+
+    @Test
+    fun `builder creates criteria with all fields set`() {
+        val criteria =
+            SearchCriteria.Builder()
+                .query("crm")
+                .tag("salesforce")
+                .compatibleWith("3.1.0")
+                .build()
+
+        assertEquals("crm", criteria.query)
+        assertEquals("salesforce", criteria.tag)
+        assertEquals("3.1.0", criteria.compatibleWith)
+    }
+
+    @Test
+    fun `builder creates empty criteria when no fields set`() {
+        val criteria = SearchCriteria.Builder().build()
+
+        assertNull(criteria.query)
+        assertNull(criteria.tag)
+        assertNull(criteria.compatibleWith)
+    }
+
+    @Test
+    fun `builder creates criteria with single field`() {
+        val criteria = SearchCriteria.Builder().query("analytics").build()
+
+        assertEquals("analytics", criteria.query)
+        assertNull(criteria.tag)
+        assertNull(criteria.compatibleWith)
+    }
+
+    @Test
+    fun `builder produces independent instances`() {
+        val builder = SearchCriteria.Builder().query("shared")
+        val first = builder.build()
+        val second = builder.tag("extra").build()
+
+        assertNotSame(first, second)
+        assertNull(first.tag)
+        assertEquals("extra", second.tag)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a fluent `SearchCriteria.Builder` nested class in `plugwerk-spi` so Java callers can construct criteria without positional `null` arguments
- Update all KDoc Java examples (SearchCriteria, PlugwerkCatalog) to use the Builder pattern
- Migrate the Java CLI example (`SearchCommand`) to use Builder
- Add unit tests for the Builder (all fields, empty, single field, reusability)

Kotlin callers are **unaffected** — named arguments continue to work as before.

**Website docs:** Tracked separately in plugwerk/website#4

Closes #219

## Test plan

- [x] `./gradlew :plugwerk-spi:test` — new `SearchCriteriaTest` passes
- [x] `./gradlew build` — full build green (all modules + examples)
- [x] `./gradlew spotlessCheck` — formatting verified