### PR TITLE
feat(settings): persist admin-managed settings in DB (backend, #208)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ PRs without labels or milestone are non-compliant. Set them via `gh pr edit <num
   - [ADR-0004](docs/adrs/0004-frontend-conventions.md) — Frontend conventions (React + TypeScript + MUI + Zustand)
   - [ADR-0011](docs/adrs/0011-client-auth-api-key-strategy.md) — Client Plugin authentication (API key primary)
   - [ADR-0014](docs/adrs/0014-dual-license-library-modules.md) — Dual-license: Apache-2.0 for libraries, AGPL-3.0 for server
+  - [ADR-0016](docs/adrs/0016-application-settings-precedence.md) — Application settings precedence (DB is authoritative, YAML is infra-only)
 - Feature specifications: `docs/features/` — GitHub Issues link to their corresponding spec file
 - Project concept: `docs/concepts/`
 - Design system: `docs/design/` — HTML prototypes and design tokens (`tokens.css`)

--- a/docs/adrs/0016-application-settings-precedence.md
+++ b/docs/adrs/0016-application-settings-precedence.md
@@ -1,0 +1,159 @@
+# ADR-0016: Application Settings Precedence — Database Is Authoritative for Admin-Manageable Settings
+
+## Status
+
+Accepted
+
+## Context
+
+Before this ADR, global application settings lived in two uncoordinated places:
+
+1. **`application.yml`** — admin-manageable values such as `plugwerk.upload.max-file-size-mb` and
+   `plugwerk.tracking.*` were exposed as environment variables but could only be changed by
+   editing the file and restarting the server.
+2. **Admin Settings UI** (`GeneralSection.tsx`) — displayed "Default language" and "Max upload
+   size" form fields that were not persisted anywhere. Changes were lost on page reload.
+
+Issue [#208](https://github.com/plugwerk/plugwerk/issues/208) enumerated three options for a
+unified settings strategy:
+
+- **A** — DB overrides YAML (YAML is fallback).
+- **B** — Infra settings stay in YAML, app-level settings live in DB.
+- **C** — DB is the single source of truth, YAML only for bootstrap.
+
+Option A preserves the dual-source problem. Option B still forces us to pick a side per setting
+and maintain two read paths. Option C is the cleanest, but bare C does not account for settings
+that genuinely require a YAML value at boot (security/infra secrets, Spring multipart limits).
+
+## Decision
+
+Adopt a refined **Option C** — **"DB is authoritative, YAML is infra-only"**:
+
+1. **Admin-manageable settings live exclusively in the `application_setting` database table.**
+   There is no YAML fallback for them. Liquibase seeds defaults on first installation via a
+   dedicated `insert` change set in migration `0005_application_settings.yaml`. Subsequent
+   migrations modify the defaults only for brand-new installations; existing values are
+   preserved.
+
+2. **`application.yml` contains only infra/security/bootstrap settings** — the values the JVM
+   or Spring framework must know before the `ApplicationContext` is fully initialized, or that
+   are security-critical and must not be writable at runtime:
+
+   | Stays in YAML | Reason |
+   |---|---|
+   | `spring.datasource.*` | Needed before Liquibase runs |
+   | `plugwerk.storage.*` | Filesystem root, resolved at startup |
+   | `plugwerk.auth.jwt-secret` | Security-critical, must not be DB-writable |
+   | `plugwerk.auth.encryption-key` | Security-critical, must not be DB-writable |
+   | `plugwerk.auth.token-validity-hours` | Affects JWT signing, low-frequency change |
+   | `plugwerk.auth.rate-limit.*` | Hot-path, loaded once at startup |
+   | `plugwerk.server.base-url` | Used to construct absolute URLs at boot |
+   | `server.port` | Servlet container init |
+
+3. **Removed from YAML entirely** (migrated to `application_setting`):
+
+   | Key | Old YAML path | Value type |
+   |---|---|---|
+   | `general.default_language` | *(never in YAML, new)* | `ENUM(en,de)` |
+   | `general.site_name` | *(never in YAML, new)* | `STRING` |
+   | `upload.max_file_size_mb` | `plugwerk.upload.max-file-size-mb` | `INTEGER` |
+   | `tracking.enabled` | `plugwerk.tracking.enabled` | `BOOLEAN` |
+   | `tracking.capture_ip` | `plugwerk.tracking.capture-ip` | `BOOLEAN` |
+   | `tracking.anonymize_ip` | `plugwerk.tracking.anonymize-ip` | `BOOLEAN` |
+   | `tracking.capture_user_agent` | `plugwerk.tracking.capture-user-agent` | `BOOLEAN` |
+
+   The `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` and `PLUGWERK_TRACKING_*` environment variables are
+   **removed**. This is a breaking change for existing deployments — see the release notes.
+
+4. **`SettingKey` enum is the single registry.** Every supported key lists its type, its
+   hard-coded default (used only for the Liquibase seed and as a last-resort fallback when the
+   row is missing), a `requiresRestart` flag, and an optional validator.
+
+5. **The `MultipartConfigElement` bean** reads the `upload.max_file_size_mb` value from
+   `GeneralSettingsService` at bean-construction time (which runs after Liquibase but before
+   the servlet container is fully wired). This means the filesystem upload ceiling is set from
+   the DB value on startup. Changing the value at runtime still requires a server restart for
+   the multipart filter to take effect — see issue [TBD: follow-up] for a runtime-override
+   design. The Admin UI displays a restart notice whenever `upload.max_file_size_mb` has been
+   changed since boot.
+
+6. **A hard-coded safety ceiling** (`MAX_ALLOWED_UPLOAD_MB = 1024`) in `SettingKey` bounds the
+   allowed DB value for `upload.max_file_size_mb`. The `PATCH` endpoint rejects values above
+   the ceiling with HTTP 400.
+
+### Read path
+
+```
+Service code  ─▶  GeneralSettingsService.get<T>(SettingKey)
+                      │
+                      ├─▶ in-memory cache (AtomicReference<Map<String,Any>>)
+                      │        │
+                      │        └─▶ hit   ─▶ return typed value
+                      │
+                      └─▶ miss ─▶ ApplicationSettingRepository.findBySettingKey()
+                                       │
+                                       ├─▶ row present ─▶ parse + cache + return
+                                       │
+                                       └─▶ row missing ─▶ return SettingKey.default
+```
+
+### Write path
+
+```
+PATCH /api/v1/admin/settings  (superadmin only)
+        │
+        ▼
+Validate against SettingKey.validator
+        │
+        ▼
+Upsert into application_setting
+        │
+        ▼
+Refresh in-memory cache (atomic swap)
+        │
+        ▼
+Return updated snapshot with `source` + `restartPending` per key
+```
+
+## Consequences
+
+### Positive
+
+- **Single source of truth** for every admin-manageable value — no more split-brain between
+  YAML and DB.
+- **Admin UI becomes functional** — changes persist across restarts.
+- **`application.yml` shrinks and its purpose becomes clear**: bootstrap-only, security-only.
+- **No more dual env-variable / UI confusion** for `max-file-size-mb` and `tracking.*`.
+- **Fewer `@ConfigurationProperties` classes** to maintain (`UploadProperties` and
+  `TrackingProperties` are deleted).
+- **Adding a new admin setting** is a one-line addition to `SettingKey` plus one Liquibase
+  seed row — no `application.yml` edit, no new env variable, no new `@ConfigurationProperties`
+  field.
+
+### Negative / Trade-offs
+
+- **Breaking change:** `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` and `PLUGWERK_TRACKING_*` environment
+  variables are ignored from this version onward. Operators must configure these values via
+  the Admin UI after the first startup (Liquibase seeds them with the previous defaults, so no
+  action is required unless the deployment had overrides).
+- **`upload.max_file_size_mb` still requires a restart** for the multipart filter to pick up a
+  new value. The UI warns about this. A follow-up issue tracks a runtime-override
+  implementation (e.g. custom `MultipartResolver`).
+- **In-memory cache is per-instance.** Multi-node deployments would need a cache-invalidation
+  channel, but Phase 1/2 targets single-node self-hosted deployments and this is acceptable.
+- **No per-setting audit log** in this ADR — only the `updated_at` and `updated_by` columns on
+  the row. A full audit trail is out of scope.
+
+## Alternatives Considered
+
+- **Option A (DB overrides YAML):** rejected because every read site has to check both
+  sources, every setting has two possible states, and the "correct" value is ambiguous when
+  env variables exist.
+- **Option B (split YAML/DB by infra vs app):** rejected because the split is subjective and
+  requires ongoing case-by-case decisions. `max_file_size_mb` does not fit neatly into either
+  category.
+- **Reload multipart config at runtime instead of requiring restart:** deferred to a follow-up
+  issue — the implementation touches Tomcat's `MultipartConfigElement` wiring and is large
+  enough to warrant its own change.
+- **Spring Cloud Config / external config server:** disproportionate for a single-binary
+  self-hosted server.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -310,7 +310,13 @@ sudo journalctl -u plugwerk -f    # view logs
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PLUGWERK_BASE_URL` | `http://localhost:8080` | Public base URL (used in download links) |
-| `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` | `100` | Max upload file size in MB |
+
+> **Breaking change in 1.0.0-alpha.2 (#208, ADR-0016):** `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`
+> is no longer read. Upload size is now stored in the `application_setting` database table
+> and managed via the Admin → Settings UI or `PATCH /api/v1/admin/settings`. On first upgrade
+> the value is seeded to `100` MB. Changing it at runtime still requires a server restart for
+> the multipart filter to pick up the new limit — the Admin UI displays a restart-pending
+> notice when applicable.
 
 ### Authentication
 
@@ -322,12 +328,13 @@ sudo journalctl -u plugwerk -f    # view logs
 
 ### Tracking
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PLUGWERK_TRACKING_ENABLED` | `true` | Enable download event tracking |
-| `PLUGWERK_TRACKING_CAPTURE_IP` | `true` | Record client IP |
-| `PLUGWERK_TRACKING_ANONYMIZE_IP` | `true` | Anonymize IPs to /24 (IPv4) or /48 (IPv6) |
-| `PLUGWERK_TRACKING_CAPTURE_USER_AGENT` | `true` | Record User-Agent header |
+> **Breaking change in 1.0.0-alpha.2 (#208, ADR-0016):** The `PLUGWERK_TRACKING_*`
+> environment variables have been removed. Download-tracking flags are now stored in the
+> `application_setting` database table and managed via the Admin → Settings UI or
+> `PATCH /api/v1/admin/settings`. Existing deployments that relied on the env variables
+> must set the equivalent rows in the Admin UI after the first upgrade. The Liquibase seed
+> applies the previous defaults (`enabled=true`, `capture_ip=true`, `anonymize_ip=true`,
+> `capture_user_agent=true`), so no action is required unless your deployment had overrides.
 
 ### JVM
 

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1510,6 +1510,61 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /admin/settings:
+    get:
+      tags:
+        - AdminSettings
+      summary: List all application settings
+      description: |
+        Returns a snapshot of every admin-manageable application setting along with its
+        effective value, source (DATABASE or DEFAULT), and a `restartPending` flag for
+        keys that require a server restart and whose DB value has changed since boot.
+        Requires superadmin privileges. See ADR-0016.
+      operationId: listApplicationSettings
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: All settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationSettingsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    patch:
+      tags:
+        - AdminSettings
+      summary: Update one or more application settings
+      description: |
+        Writes a partial set of `key -> value` pairs to the `application_setting` table.
+        Each value is validated against its SettingKey's validator; invalid values are
+        rejected with HTTP 400 and no partial write occurs. Requires superadmin privileges.
+      operationId: updateApplicationSettings
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationSettingsUpdateRequest'
+      responses:
+        '200':
+          description: Updated snapshot of all settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationSettingsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
 components:
   parameters:
     NamespaceSlug:
@@ -2617,6 +2672,80 @@ components:
         - key
         - name
         - createdAt
+
+    ApplicationSettingDto:
+      type: object
+      description: |
+        One admin-manageable application setting (ADR-0016).
+      properties:
+        key:
+          type: string
+          description: Stable dotted identifier, e.g. `upload.max_file_size_mb`
+        value:
+          type: string
+          description: Raw string value (parsed according to `valueType` on the client)
+        valueType:
+          type: string
+          enum: [STRING, INTEGER, BOOLEAN, ENUM]
+          description: Discriminator for client-side parsing
+        source:
+          type: string
+          enum: [DATABASE, DEFAULT]
+          description: Where the effective value came from
+        requiresRestart:
+          type: boolean
+          description: True if changing this setting requires a server restart to take effect
+        restartPending:
+          type: boolean
+          description: |
+            True if `requiresRestart` is true AND the database value has changed since the
+            JVM started. UI hint only — the running server still uses the boot-time value.
+        allowedValues:
+          type: array
+          description: For ENUM settings, the full set of accepted values. Null otherwise.
+          items:
+            type: string
+        minInt:
+          type: integer
+          description: For INTEGER settings, the inclusive minimum. Null otherwise.
+        maxInt:
+          type: integer
+          description: For INTEGER settings, the inclusive maximum. Null otherwise.
+      required:
+        - key
+        - value
+        - valueType
+        - source
+        - requiresRestart
+        - restartPending
+
+    ApplicationSettingsResponse:
+      type: object
+      description: Full snapshot of every known setting.
+      properties:
+        settings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationSettingDto'
+      required:
+        - settings
+
+    ApplicationSettingsUpdateRequest:
+      type: object
+      description: |
+        Partial write — only the keys present in `settings` are updated. Unknown keys are
+        rejected with HTTP 400.
+      properties:
+        settings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Map of `setting_key` to raw string value
+          example:
+            upload.max_file_size_mb: "200"
+            tracking.enabled: "false"
+      required:
+        - settings
 
   responses:
     BadRequest:

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2684,6 +2684,13 @@ components:
         value:
           type: string
           description: Raw string value (parsed according to `valueType` on the client)
+        description:
+          type: string
+          nullable: true
+          description: |
+            Human-readable description of the setting, persisted in the
+            `application_setting.setting_desc` column. Intended for display as inline help
+            in the Admin UI. May be `null` for legacy rows or keys that have no description.
         valueType:
           type: string
           enum: [STRING, INTEGER, BOOLEAN, ENUM]

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -27,12 +27,16 @@ import org.springframework.validation.annotation.Validated
 /**
  * Central configuration properties for the Plugwerk server, bound to the `plugwerk` prefix.
  *
- * All Plugwerk-specific settings are grouped here. Each logical sub-section is represented
- * by a nested data class so that consumers can depend on only the slice they need.
- * Registered via `@EnableConfigurationProperties` on [PlugwerkApplication].
+ * All infra/security/bootstrap Plugwerk settings are grouped here. Admin-manageable values
+ * (default language, site name, upload size, tracking flags) are **not** here — they live
+ * in the `application_setting` database table and are accessed via
+ * `GeneralSettingsService`. See [ADR-0016](../../../../../../../../docs/adrs/0016-application-settings-precedence.md).
  *
- * Configuration is supplied through `application.yml` and can be overridden per environment
- * using environment variables (see each property for the corresponding variable name).
+ * Each logical sub-section is represented by a nested data class so that consumers can
+ * depend on only the slice they need. Registered via `@EnableConfigurationProperties` on
+ * [PlugwerkApplication]. Configuration is supplied through `application.yml` and can be
+ * overridden per environment using environment variables (see each property for the
+ * corresponding variable name).
  *
  * @property storage Artifact storage configuration — selects the backend and provides
  *   backend-specific settings. See [StorageProperties].
@@ -44,8 +48,6 @@ data class PlugwerkProperties(
     val storage: StorageProperties = StorageProperties(),
     val server: ServerProperties = ServerProperties(),
     @field:Valid val auth: AuthProperties = AuthProperties(),
-    val upload: UploadProperties = UploadProperties(),
-    val tracking: TrackingProperties = TrackingProperties(),
 ) {
     /**
      * Artifact storage configuration (`plugwerk.storage.*`).
@@ -209,57 +211,4 @@ data class PlugwerkProperties(
          */
         data class RateLimitProperties(val maxAttempts: Int = 10, val windowSeconds: Long = 60)
     }
-
-    /**
-     * Upload configuration (`plugwerk.upload.*`).
-     *
-     * Controls the maximum allowed size for plugin artifact uploads.
-     *
-     * @property maxFileSizeMb Maximum artifact file size in megabytes. Files exceeding this
-     *   limit are rejected with HTTP 413 (Payload Too Large). This limit is enforced both
-     *   at the Spring multipart layer and in the application service layer.
-     *
-     *   Environment variable: `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`
-     *
-     *   ```yaml
-     *   plugwerk.upload.max-file-size-mb: 100
-     *   ```
-     */
-    data class UploadProperties(val maxFileSizeMb: Int = 100)
-
-    /**
-     * Download tracking configuration (`plugwerk.tracking.*`).
-     *
-     * Controls whether and how download events are recorded in the `download_event` audit
-     * log table. All options are privacy-oriented: IP anonymisation is enabled by default,
-     * and individual data fields can be suppressed entirely.
-     *
-     * @property enabled Master switch for download event recording. When `false`, no rows
-     *   are written to `download_event` (the atomic `download_count` counter on
-     *   `plugin_release` is still incremented regardless).
-     *
-     *   Environment variable: `PLUGWERK_TRACKING_ENABLED`
-     *
-     * @property captureIp Whether to store the client IP address. When `false`, the
-     *   `client_ip` column is always set to `null`.
-     *
-     *   Environment variable: `PLUGWERK_TRACKING_CAPTURE_IP`
-     *
-     * @property anonymizeIp Whether to anonymize the client IP before storage. When `true`
-     *   (default), IPv4 addresses are truncated to /24 (last octet zeroed) and IPv6
-     *   addresses are truncated to /48 (last 80 bits zeroed).
-     *
-     *   Environment variable: `PLUGWERK_TRACKING_ANONYMIZE_IP`
-     *
-     * @property captureUserAgent Whether to store the HTTP User-Agent header. When `false`,
-     *   the `user_agent` column is always set to `null`.
-     *
-     *   Environment variable: `PLUGWERK_TRACKING_CAPTURE_USER_AGENT`
-     */
-    data class TrackingProperties(
-        val enabled: Boolean = true,
-        val captureIp: Boolean = true,
-        val anonymizeIp: Boolean = true,
-        val captureUserAgent: Boolean = true,
-    )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/MultipartConfig.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/MultipartConfig.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import io.plugwerk.server.service.settings.GeneralSettingsService
+import io.plugwerk.server.service.settings.MAX_ALLOWED_UPLOAD_MB
+import jakarta.servlet.MultipartConfigElement
+import org.slf4j.LoggerFactory
+import org.springframework.boot.servlet.MultipartConfigFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.util.unit.DataSize
+
+/**
+ * Wires Spring's [MultipartConfigElement] from the DB-backed setting
+ * `upload.max_file_size_mb` (ADR-0016).
+ *
+ * The bean is built at context refresh time — **after** Liquibase has run and
+ * `GeneralSettingsService.@PostConstruct` has populated its cache — but **before** Tomcat
+ * registers the multipart filter. Spring Boot then uses this element to configure the
+ * servlet container's max file size and max request size.
+ *
+ * **Runtime changes require a restart.** The `MultipartConfigElement` is read once when
+ * the servlet is registered; changing the DB value afterwards updates the in-memory cache
+ * but does not reconfigure the servlet. The Admin UI displays a "restart pending" notice
+ * whenever the DB value has diverged from the boot value (see
+ * [GeneralSettingsService.listAll] and `SettingSnapshot.restartPending`). A follow-up
+ * issue tracks runtime reconfiguration.
+ *
+ * A hard safety ceiling of [MAX_ALLOWED_UPLOAD_MB] MB is always applied on top
+ * of the DB value — if someone writes a larger number directly, the multipart filter still
+ * caps at the ceiling.
+ */
+@Configuration
+class MultipartConfig {
+
+    private val log = LoggerFactory.getLogger(MultipartConfig::class.java)
+
+    @Bean
+    fun multipartConfigElement(settingsService: GeneralSettingsService): MultipartConfigElement {
+        val dbValue = settingsService.maxUploadSizeMb()
+        val effective = dbValue.coerceAtMost(MAX_ALLOWED_UPLOAD_MB)
+        if (effective != dbValue) {
+            log.warn(
+                "upload.max_file_size_mb={} exceeds hard ceiling {}; capping",
+                dbValue,
+                MAX_ALLOWED_UPLOAD_MB,
+            )
+        }
+        log.info("Configuring Servlet multipart limits to {} MB (from application_setting)", effective)
+        val factory = MultipartConfigFactory()
+        factory.setMaxFileSize(DataSize.ofMegabytes(effective.toLong()))
+        factory.setMaxRequestSize(DataSize.ofMegabytes(effective.toLong()))
+        return factory.createMultipartConfig()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
@@ -88,6 +88,7 @@ class AdminSettingsController(
         },
         requiresRestart = key.requiresRestart,
         restartPending = restartPending,
+        description = description,
         allowedValues = key.allowedValues?.toList(),
         minInt = key.minInt,
         maxInt = key.maxInt,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AdminSettingsApi
+import io.plugwerk.api.model.ApplicationSettingDto
+import io.plugwerk.api.model.ApplicationSettingsResponse
+import io.plugwerk.api.model.ApplicationSettingsUpdateRequest
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.service.settings.GeneralSettingsService
+import io.plugwerk.server.service.settings.SettingKey
+import io.plugwerk.server.service.settings.SettingSnapshot
+import io.plugwerk.server.service.settings.SettingSource
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * REST controller for admin-managed application settings (ADR-0016).
+ *
+ * All endpoints require superadmin privileges. Regular namespace admins do not have access
+ * because these settings are process-wide, not namespace-scoped.
+ *
+ * The controller delegates the entire read/write/validate pipeline to
+ * [GeneralSettingsService]; its job is translation between the OpenAPI-generated DTOs and
+ * the service's internal [SettingSnapshot] type.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AdminSettingsController(
+    private val settingsService: GeneralSettingsService,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AdminSettingsApi {
+
+    override fun listApplicationSettings(): ResponseEntity<ApplicationSettingsResponse> {
+        requireSuperadmin()
+        return ResponseEntity.ok(buildResponse())
+    }
+
+    override fun updateApplicationSettings(
+        applicationSettingsUpdateRequest: ApplicationSettingsUpdateRequest,
+    ): ResponseEntity<ApplicationSettingsResponse> {
+        val principal = requireSuperadmin()
+        val updates = applicationSettingsUpdateRequest.settings
+        for ((rawKey, rawValue) in updates) {
+            val key = SettingKey.byKey(rawKey)
+                ?: throw IllegalArgumentException("Unknown setting key: '$rawKey'")
+            settingsService.update(key, rawValue, updatedBy = principal)
+        }
+        return ResponseEntity.ok(buildResponse())
+    }
+
+    private fun requireSuperadmin(): String {
+        val auth = SecurityContextHolder.getContext().authentication
+            ?: throw UnauthorizedException("Not authenticated")
+        namespaceAuthorizationService.requireSuperadmin(auth)
+        return auth.name
+    }
+
+    private fun buildResponse(): ApplicationSettingsResponse =
+        ApplicationSettingsResponse(settings = settingsService.listAll().map { it.toDto() })
+
+    private fun SettingSnapshot.toDto(): ApplicationSettingDto = ApplicationSettingDto(
+        key = key.key,
+        value = value,
+        valueType = ApplicationSettingDto.ValueType.valueOf(key.valueType.name),
+        source = when (source) {
+            SettingSource.DATABASE -> ApplicationSettingDto.Source.DATABASE
+            SettingSource.DEFAULT -> ApplicationSettingDto.Source.DEFAULT
+        },
+        requiresRestart = key.requiresRestart,
+        restartPending = restartPending,
+        allowedValues = key.allowedValues?.toList(),
+        minInt = key.minInt,
+        maxInt = key.maxInt,
+    )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -18,8 +18,8 @@
  */
 package io.plugwerk.server.controller
 
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.service.VersionProvider
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,14 +27,17 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1")
-class ConfigController(private val properties: PlugwerkProperties, private val versionProvider: VersionProvider) {
+class ConfigController(
+    private val settingsService: GeneralSettingsService,
+    private val versionProvider: VersionProvider,
+) {
 
     @GetMapping("/config")
     fun getServerConfig(): ResponseEntity<ServerConfigResponse> = ResponseEntity.ok(
         ServerConfigResponse(
             version = versionProvider.getVersion(),
             upload = ServerConfigResponse.UploadConfig(
-                maxFileSizeMb = properties.upload.maxFileSizeMb,
+                maxFileSizeMb = settingsService.maxUploadSizeMb(),
             ),
         ),
     )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Scalar value type stored in [ApplicationSettingEntity.valueType].
+ *
+ * Determines how [ApplicationSettingEntity.settingValue] (stored as `text`) is parsed back
+ * into a typed runtime value. See `SettingKey` in the service layer for the per-key mapping.
+ */
+enum class SettingValueType {
+    STRING,
+    INTEGER,
+    BOOLEAN,
+    ENUM,
+}
+
+/**
+ * JPA entity that persists a single global application setting (ADR-0016).
+ *
+ * Every admin-manageable setting is stored as one row in the `application_setting` table.
+ * The table is the single source of truth for admin-manageable values — there is no
+ * `application.yml` fallback for settings managed through this entity.
+ *
+ * Defaults are seeded by Liquibase migration `0005_application_settings.yaml` on first
+ * installation. Subsequent installations keep the existing row values.
+ *
+ * @property id Primary key, UUIDv7 (chronologically ordered — see ADR-0003).
+ * @property settingKey Stable dotted identifier, e.g. `upload.max_file_size_mb`. Unique.
+ * @property settingValue Stringified value. `null` means "unset — fall back to the key's
+ *   hard-coded default in `SettingKey`". Parsing is driven by [valueType].
+ * @property valueType Discriminator used by the service layer to parse [settingValue].
+ * @property updatedAt Last-write timestamp (set automatically on insert and every update).
+ * @property updatedBy Principal name of the user who last wrote this row. `null` for rows
+ *   that were seeded by Liquibase or have never been modified through the admin API.
+ */
+@Entity
+@Table(name = "application_setting")
+class ApplicationSettingEntity(
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "id", updatable = false)
+    var id: UUID? = null,
+
+    @Column(name = "setting_key", nullable = false, unique = true, length = 128, updatable = false)
+    var settingKey: String,
+
+    @Column(name = "setting_value", nullable = true, columnDefinition = "text")
+    var settingValue: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "value_type", nullable = false, length = 16)
+    var valueType: SettingValueType,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+
+    @Column(name = "updated_by", nullable = true, length = 255)
+    var updatedBy: String? = null,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
@@ -56,6 +56,9 @@ enum class SettingValueType {
  * @property settingKey Stable dotted identifier, e.g. `upload.max_file_size_mb`. Unique.
  * @property settingValue Stringified value. `null` means "unset — fall back to the key's
  *   hard-coded default in `SettingKey`". Parsing is driven by [valueType].
+ * @property settingDesc Human-readable description of the setting. Seeded by Liquibase with
+ *   a sensible default for every known key and displayed in the Admin UI as inline help.
+ *   Nullable because a row may exist for an unknown/legacy key without a description.
  * @property valueType Discriminator used by the service layer to parse [settingValue].
  * @property updatedAt Last-write timestamp (set automatically on insert and every update).
  * @property updatedBy Principal name of the user who last wrote this row. `null` for rows
@@ -74,6 +77,9 @@ class ApplicationSettingEntity(
 
     @Column(name = "setting_value", nullable = true, columnDefinition = "text")
     var settingValue: String? = null,
+
+    @Column(name = "setting_desc", nullable = true, columnDefinition = "text")
+    var settingDesc: String? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "value_type", nullable = false, length = 16)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/ApplicationSettingRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/ApplicationSettingRepository.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import io.plugwerk.server.domain.ApplicationSettingEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * Spring Data JPA repository for [ApplicationSettingEntity].
+ *
+ * One row per admin-manageable setting, keyed by the stable dotted identifier in
+ * [ApplicationSettingEntity.settingKey]. The key column has a unique constraint, so
+ * [findBySettingKey] returns at most one result.
+ */
+@Repository
+interface ApplicationSettingRepository : JpaRepository<ApplicationSettingEntity, UUID> {
+
+    /**
+     * Looks up a single setting row by its dotted key.
+     *
+     * @param settingKey e.g. `upload.max_file_size_mb` or `tracking.enabled`.
+     * @return the row if present, otherwise [Optional.empty]. An empty result means the
+     *   setting has never been seeded — callers must fall back to the hard-coded default
+     *   defined in `SettingKey`.
+     */
+    fun findBySettingKey(settingKey: String): Optional<ApplicationSettingEntity>
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/DownloadEventService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/DownloadEventService.kt
@@ -18,10 +18,10 @@
  */
 package io.plugwerk.server.service
 
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.DownloadEventEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.DownloadEventRepository
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -32,28 +32,30 @@ import java.net.InetAddress
  * Records download events in the audit log table.
  *
  * Runs in its own transaction ([Propagation.REQUIRES_NEW]) so that a failure to record
- * an event never rolls back the actual artifact download. The service respects the
- * `plugwerk.tracking.*` configuration for privacy-aware data capture.
+ * an event never rolls back the actual artifact download. The service reads its
+ * privacy-relevant flags from [GeneralSettingsService], which is backed by the
+ * `application_setting` table (ADR-0016). Changes apply to the next download without a
+ * server restart.
  */
 @Service
 class DownloadEventService(
     private val downloadEventRepository: DownloadEventRepository,
-    private val properties: PlugwerkProperties,
+    private val settingsService: GeneralSettingsService,
 ) {
 
     private val log = LoggerFactory.getLogger(DownloadEventService::class.java)
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun record(release: PluginReleaseEntity, clientIp: String?, userAgent: String?) {
-        if (!properties.tracking.enabled) return
+        if (!settingsService.trackingEnabled()) return
 
         val ip = when {
-            !properties.tracking.captureIp || clientIp == null -> null
-            properties.tracking.anonymizeIp -> anonymizeIpAddress(clientIp)
+            !settingsService.trackingCaptureIp() || clientIp == null -> null
+            settingsService.trackingAnonymizeIp() -> anonymizeIpAddress(clientIp)
             else -> clientIp
         }
 
-        val agent = if (properties.tracking.captureUserAgent) userAgent else null
+        val agent = if (settingsService.trackingCaptureUserAgent()) userAgent else null
 
         downloadEventRepository.save(
             DownloadEventEntity(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -20,7 +20,6 @@ package io.plugwerk.server.service
 
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
@@ -28,6 +27,7 @@ import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.data.domain.Page
@@ -49,7 +49,7 @@ class PluginReleaseService(
     private val storageService: ArtifactStorageService,
     private val descriptorResolver: DescriptorResolver,
     private val objectMapper: ObjectMapper,
-    private val properties: PlugwerkProperties,
+    private val settingsService: GeneralSettingsService,
     private val downloadEventService: DownloadEventService,
 ) {
 
@@ -121,15 +121,16 @@ class PluginReleaseService(
         contentLength: Long,
         originalFilename: String? = null,
     ): PluginReleaseEntity {
-        val maxBytes = properties.upload.maxFileSizeMb.toLong() * 1_048_576L
+        val maxFileSizeMb = settingsService.maxUploadSizeMb()
+        val maxBytes = maxFileSizeMb.toLong() * 1_048_576L
 
         if (contentLength > 0 && contentLength > maxBytes) {
-            throw FileTooLargeException(contentLength, properties.upload.maxFileSizeMb)
+            throw FileTooLargeException(contentLength, maxFileSizeMb)
         }
 
         val bytes = content.readNBytes(maxBytes.toInt() + 1)
         if (bytes.size > maxBytes) {
-            throw FileTooLargeException(bytes.size.toLong(), properties.upload.maxFileSizeMb)
+            throw FileTooLargeException(bytes.size.toLong(), maxFileSizeMb)
         }
         if (bytes.size < 4 || bytes[0] != 0x50.toByte() || bytes[1] != 0x4B.toByte()) {
             throw InvalidArtifactException("Uploaded file is not a valid JAR/ZIP archive")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/GeneralSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/GeneralSettingsService.kt
@@ -47,15 +47,15 @@ class GeneralSettingsService(private val repository: ApplicationSettingRepositor
 
     private val log = LoggerFactory.getLogger(GeneralSettingsService::class.java)
 
-    /** Live snapshot of `setting_key -> raw string value`. Updated atomically on writes. */
-    private val cache = AtomicReference<Map<String, String>>(emptyMap())
+    /** Live snapshot of `setting_key -> stored row data`. Updated atomically on writes. */
+    private val cache = AtomicReference<Map<String, StoredSetting>>(emptyMap())
 
     /**
      * Snapshot of the values as they were at JVM startup. Immutable for the lifetime of the
      * process. Used to compute [SettingSnapshot.restartPending] — a UI hint, not a hard
      * enforcement mechanism.
      */
-    private lateinit var bootSnapshot: Map<String, String>
+    private lateinit var bootSnapshot: Map<String, StoredSetting>
 
     @PostConstruct
     fun initialize() {
@@ -71,7 +71,12 @@ class GeneralSettingsService(private val repository: ApplicationSettingRepositor
      */
     private fun refreshCache() {
         val rows = repository.findAll()
-        val snapshot = rows.associate { it.settingKey to (it.settingValue ?: "") }
+        val snapshot = rows.associate {
+            it.settingKey to StoredSetting(
+                rawValue = it.settingValue ?: "",
+                description = it.settingDesc,
+            )
+        }
         cache.set(snapshot)
     }
 
@@ -80,7 +85,7 @@ class GeneralSettingsService(private val repository: ApplicationSettingRepositor
      * the row is missing or the stored value is an empty string.
      */
     fun getRaw(key: SettingKey): String {
-        val stored = cache.get()[key.key]
+        val stored = cache.get()[key.key]?.rawValue
         return if (stored.isNullOrEmpty()) key.defaultValue else stored
     }
 
@@ -108,22 +113,32 @@ class GeneralSettingsService(private val repository: ApplicationSettingRepositor
     fun siteName(): String = getRaw(SettingKey.GENERAL_SITE_NAME)
 
     /**
-     * Returns a complete snapshot of every key, including its effective value, its source
-     * (`DATABASE` if a row exists, `DEFAULT` otherwise), and a `restartPending` flag for
-     * keys whose DB value has changed since the JVM started.
+     * Returns a complete snapshot of every key, including its effective value, description,
+     * source (`DATABASE` if a row exists, `DEFAULT` otherwise), and a `restartPending` flag
+     * for keys whose DB value has changed since the JVM started.
      */
     fun listAll(): List<SettingSnapshot> {
         val current = cache.get()
         val boot = if (::bootSnapshot.isInitialized) bootSnapshot else current
         return SettingKey.entries.map { key ->
-            val raw = current[key.key]
-            val effective = if (raw.isNullOrEmpty()) key.defaultValue else raw
-            val source = if (raw == null) SettingSource.DEFAULT else SettingSource.DATABASE
-            val bootValue = boot[key.key] ?: key.defaultValue
+            val stored = current[key.key]
+            val effective = when {
+                stored == null -> key.defaultValue
+                stored.rawValue.isEmpty() -> key.defaultValue
+                else -> stored.rawValue
+            }
+            val source = if (stored == null) SettingSource.DEFAULT else SettingSource.DATABASE
+            val bootStored = boot[key.key]
+            val bootValue = when {
+                bootStored == null -> key.defaultValue
+                bootStored.rawValue.isEmpty() -> key.defaultValue
+                else -> bootStored.rawValue
+            }
             val restartPending = key.requiresRestart && bootValue != effective
             SettingSnapshot(
                 key = key,
                 value = effective,
+                description = stored?.description,
                 source = source,
                 restartPending = restartPending,
             )
@@ -166,10 +181,17 @@ enum class SettingSource {
 }
 
 /**
+ * Internal cache row — holds the raw stored value plus the DB-persisted description.
+ */
+internal data class StoredSetting(val rawValue: String, val description: String?)
+
+/**
  * A point-in-time view of one setting.
  *
  * @property key the [SettingKey] entry.
  * @property value the effective raw string value (either from DB or the hard-coded default).
+ * @property description human-readable description from the DB row, or `null` if the row
+ *   is missing or has no description persisted.
  * @property source where [value] came from.
  * @property restartPending `true` if [SettingKey.requiresRestart] and the DB value has
  *   diverged from the value the JVM loaded at boot. UI hint only.
@@ -177,6 +199,7 @@ enum class SettingSource {
 data class SettingSnapshot(
     val key: SettingKey,
     val value: String,
+    val description: String?,
     val source: SettingSource,
     val restartPending: Boolean,
 )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/GeneralSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/GeneralSettingsService.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.settings
+
+import io.plugwerk.server.domain.ApplicationSettingEntity
+import io.plugwerk.server.repository.ApplicationSettingRepository
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Single source of truth for admin-manageable application settings (ADR-0016).
+ *
+ * Reads the `application_setting` table into an in-memory snapshot at startup and after
+ * every successful write. The snapshot is held in an [AtomicReference] so reads are
+ * lock-free and consistent with the most recent write.
+ *
+ * The service exposes typed accessors for common reads (e.g. [maxUploadSizeMb]) and a
+ * generic [getRaw] fallback. Writes go through [update], which validates against
+ * [SettingKey.validate] before persisting.
+ *
+ * A per-key **boot snapshot** is captured once at startup so the Admin UI can flag keys
+ * whose current DB value differs from the value the running JVM loaded at boot
+ * (e.g. `upload.max_file_size_mb`, which the multipart filter only picks up on restart —
+ * see [SettingKey.requiresRestart]).
+ */
+@Service
+class GeneralSettingsService(private val repository: ApplicationSettingRepository) {
+
+    private val log = LoggerFactory.getLogger(GeneralSettingsService::class.java)
+
+    /** Live snapshot of `setting_key -> raw string value`. Updated atomically on writes. */
+    private val cache = AtomicReference<Map<String, String>>(emptyMap())
+
+    /**
+     * Snapshot of the values as they were at JVM startup. Immutable for the lifetime of the
+     * process. Used to compute [SettingSnapshot.restartPending] — a UI hint, not a hard
+     * enforcement mechanism.
+     */
+    private lateinit var bootSnapshot: Map<String, String>
+
+    @PostConstruct
+    fun initialize() {
+        refreshCache()
+        bootSnapshot = cache.get()
+        log.info("GeneralSettingsService initialized with {} setting(s)", bootSnapshot.size)
+    }
+
+    /**
+     * Reloads the entire snapshot from the database. Called on startup and after every
+     * successful write. The atomic swap guarantees readers see either the old snapshot or
+     * the new snapshot in full — never a partially-updated view.
+     */
+    private fun refreshCache() {
+        val rows = repository.findAll()
+        val snapshot = rows.associate { it.settingKey to (it.settingValue ?: "") }
+        cache.set(snapshot)
+    }
+
+    /**
+     * Returns the raw string value for [key], falling back to [SettingKey.defaultValue] if
+     * the row is missing or the stored value is an empty string.
+     */
+    fun getRaw(key: SettingKey): String {
+        val stored = cache.get()[key.key]
+        return if (stored.isNullOrEmpty()) key.defaultValue else stored
+    }
+
+    /** Typed accessor: `upload.max_file_size_mb` as an Int, clamped to the hard ceiling. */
+    fun maxUploadSizeMb(): Int = getRaw(SettingKey.UPLOAD_MAX_FILE_SIZE_MB).toIntOrNull()
+        ?.coerceIn(1, MAX_ALLOWED_UPLOAD_MB)
+        ?: SettingKey.UPLOAD_MAX_FILE_SIZE_MB.defaultValue.toInt()
+
+    /** Typed accessor: `tracking.enabled`. */
+    fun trackingEnabled(): Boolean = getRaw(SettingKey.TRACKING_ENABLED).toBooleanStrict()
+
+    /** Typed accessor: `tracking.capture_ip`. */
+    fun trackingCaptureIp(): Boolean = getRaw(SettingKey.TRACKING_CAPTURE_IP).toBooleanStrict()
+
+    /** Typed accessor: `tracking.anonymize_ip`. */
+    fun trackingAnonymizeIp(): Boolean = getRaw(SettingKey.TRACKING_ANONYMIZE_IP).toBooleanStrict()
+
+    /** Typed accessor: `tracking.capture_user_agent`. */
+    fun trackingCaptureUserAgent(): Boolean = getRaw(SettingKey.TRACKING_CAPTURE_USER_AGENT).toBooleanStrict()
+
+    /** Typed accessor: `general.default_language`. */
+    fun defaultLanguage(): String = getRaw(SettingKey.GENERAL_DEFAULT_LANGUAGE)
+
+    /** Typed accessor: `general.site_name`. */
+    fun siteName(): String = getRaw(SettingKey.GENERAL_SITE_NAME)
+
+    /**
+     * Returns a complete snapshot of every key, including its effective value, its source
+     * (`DATABASE` if a row exists, `DEFAULT` otherwise), and a `restartPending` flag for
+     * keys whose DB value has changed since the JVM started.
+     */
+    fun listAll(): List<SettingSnapshot> {
+        val current = cache.get()
+        val boot = if (::bootSnapshot.isInitialized) bootSnapshot else current
+        return SettingKey.entries.map { key ->
+            val raw = current[key.key]
+            val effective = if (raw.isNullOrEmpty()) key.defaultValue else raw
+            val source = if (raw == null) SettingSource.DEFAULT else SettingSource.DATABASE
+            val bootValue = boot[key.key] ?: key.defaultValue
+            val restartPending = key.requiresRestart && bootValue != effective
+            SettingSnapshot(
+                key = key,
+                value = effective,
+                source = source,
+                restartPending = restartPending,
+            )
+        }
+    }
+
+    /**
+     * Persists a new value for [key] and refreshes the cache.
+     *
+     * @throws IllegalArgumentException if [rawValue] fails [SettingKey.validate].
+     */
+    @Transactional
+    fun update(key: SettingKey, rawValue: String, updatedBy: String?): SettingSnapshot {
+        key.validate(rawValue)?.let { error ->
+            throw IllegalArgumentException("Invalid value for setting '${key.key}': $error")
+        }
+        val existing = repository.findBySettingKey(key.key).orElse(null)
+        val entity = existing?.apply {
+            settingValue = rawValue
+            this.updatedBy = updatedBy
+        } ?: ApplicationSettingEntity(
+            settingKey = key.key,
+            settingValue = rawValue,
+            valueType = key.valueType,
+            updatedBy = updatedBy,
+        )
+        repository.save(entity)
+        refreshCache()
+        return listAll().first { it.key == key }
+    }
+}
+
+/** Origin of the effective value returned by [GeneralSettingsService.listAll]. */
+enum class SettingSource {
+    /** Value is backed by a row in `application_setting`. */
+    DATABASE,
+
+    /** No row exists — the value is the hard-coded default in [SettingKey]. */
+    DEFAULT,
+}
+
+/**
+ * A point-in-time view of one setting.
+ *
+ * @property key the [SettingKey] entry.
+ * @property value the effective raw string value (either from DB or the hard-coded default).
+ * @property source where [value] came from.
+ * @property restartPending `true` if [SettingKey.requiresRestart] and the DB value has
+ *   diverged from the value the JVM loaded at boot. UI hint only.
+ */
+data class SettingSnapshot(
+    val key: SettingKey,
+    val value: String,
+    val source: SettingSource,
+    val restartPending: Boolean,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/SettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/SettingKey.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.settings
+
+import io.plugwerk.server.domain.SettingValueType
+
+/** Hard safety ceiling in MB for [SettingKey.UPLOAD_MAX_FILE_SIZE_MB]. */
+const val MAX_ALLOWED_UPLOAD_MB: Int = 1024
+
+/**
+ * Central registry of every admin-manageable application setting (ADR-0016).
+ *
+ * Each entry declares its dotted key, its typed default (used as a last-resort fallback if
+ * the row is missing — under normal operation the Liquibase seed in
+ * `0005_application_settings.yaml` ensures every key has a row), its value type, a
+ * `requiresRestart` flag for UX hints in the Admin UI, and an optional validator that the
+ * write endpoint runs before persisting a new value.
+ *
+ * Adding a new setting:
+ *  1. Add an entry here.
+ *  2. Add a Liquibase insert changeset for it in a new migration (do not edit `0005`).
+ *  3. Expose it via `GeneralSettingsService` accessors as needed by the consumers.
+ */
+enum class SettingKey(
+    val key: String,
+    val valueType: SettingValueType,
+    val defaultValue: String,
+    val requiresRestart: Boolean = false,
+    val allowedValues: Set<String>? = null,
+    val minInt: Int? = null,
+    val maxInt: Int? = null,
+) {
+    GENERAL_DEFAULT_LANGUAGE(
+        key = "general.default_language",
+        valueType = SettingValueType.ENUM,
+        defaultValue = "en",
+        allowedValues = setOf("en", "de"),
+    ),
+    GENERAL_SITE_NAME(
+        key = "general.site_name",
+        valueType = SettingValueType.STRING,
+        defaultValue = "Plugwerk",
+    ),
+    UPLOAD_MAX_FILE_SIZE_MB(
+        key = "upload.max_file_size_mb",
+        valueType = SettingValueType.INTEGER,
+        defaultValue = "100",
+        requiresRestart = true,
+        minInt = 1,
+        maxInt = 1024,
+    ),
+    TRACKING_ENABLED(
+        key = "tracking.enabled",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "true",
+    ),
+    TRACKING_CAPTURE_IP(
+        key = "tracking.capture_ip",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "true",
+    ),
+    TRACKING_ANONYMIZE_IP(
+        key = "tracking.anonymize_ip",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "true",
+    ),
+    TRACKING_CAPTURE_USER_AGENT(
+        key = "tracking.capture_user_agent",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "true",
+    ),
+    ;
+
+    /**
+     * Validates a proposed new raw value for this key.
+     *
+     * @return `null` if the value is acceptable, or a human-readable error message otherwise.
+     */
+    fun validate(rawValue: String): String? {
+        return when (valueType) {
+            SettingValueType.STRING -> if (rawValue.isBlank()) "value must not be blank" else null
+
+            SettingValueType.INTEGER -> {
+                val parsed = rawValue.toIntOrNull()
+                    ?: return "value must be an integer, got '$rawValue'"
+                val lo = minInt
+                val hi = maxInt
+                when {
+                    lo != null && parsed < lo -> "value must be >= $lo"
+                    hi != null && parsed > hi -> "value must be <= $hi"
+                    else -> null
+                }
+            }
+
+            SettingValueType.BOOLEAN -> if (rawValue !in BOOLEAN_LITERALS) {
+                "value must be 'true' or 'false', got '$rawValue'"
+            } else {
+                null
+            }
+
+            SettingValueType.ENUM -> {
+                val allowed = allowedValues
+                when {
+                    allowed == null -> "ENUM key '$key' has no allowedValues declared"
+                    rawValue !in allowed -> "value must be one of $allowed, got '$rawValue'"
+                    else -> null
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val BOOLEAN_LITERALS = setOf("true", "false")
+
+        private val BY_KEY: Map<String, SettingKey> = entries.associateBy { it.key }
+
+        /** Looks up a [SettingKey] by its dotted identifier. */
+        fun byKey(key: String): SettingKey? = BY_KEY[key]
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -19,10 +19,10 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 
-  servlet:
-    multipart:
-      max-file-size: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}MB
-      max-request-size: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}MB
+  # Spring's servlet multipart limits are set programmatically at bean-creation time from
+  # the `upload.max_file_size_mb` setting in `application_setting` (see MultipartConfig.kt).
+  # A hard safety ceiling of 1 GB is applied by the MultipartConfig bean regardless of the
+  # DB value — see SettingKey.MAX_ALLOWED_UPLOAD_MB and ADR-0016.
 
   jackson:
     deserialization:
@@ -66,28 +66,11 @@ plugwerk:
       # Env: PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS
       window-seconds: ${PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS:60}
 
-  # Maximum allowed plugin artifact file size in MB.
-  # Files exceeding this limit are rejected with HTTP 413 (Payload Too Large).
-  # Env: PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB
-  upload:
-    max-file-size-mb: ${PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB:100}
-
-  # Download event tracking (audit log).
-  # Records individual download events in the download_event table.
-  # The atomic download_count counter on plugin_release is always incremented regardless.
-  tracking:
-    # Master switch — set to false to disable event recording entirely.
-    # Env: PLUGWERK_TRACKING_ENABLED
-    enabled: ${PLUGWERK_TRACKING_ENABLED:true}
-    # Whether to capture the client IP address. Default: true.
-    # Env: PLUGWERK_TRACKING_CAPTURE_IP
-    capture-ip: ${PLUGWERK_TRACKING_CAPTURE_IP:true}
-    # Anonymize IPs to /24 (IPv4) or /48 (IPv6) before storage. Default: true.
-    # Env: PLUGWERK_TRACKING_ANONYMIZE_IP
-    anonymize-ip: ${PLUGWERK_TRACKING_ANONYMIZE_IP:true}
-    # Whether to capture the HTTP User-Agent header. Default: true.
-    # Env: PLUGWERK_TRACKING_CAPTURE_USER_AGENT
-    capture-user-agent: ${PLUGWERK_TRACKING_CAPTURE_USER_AGENT:true}
+  # Upload and download-tracking settings were moved to the `application_setting` database
+  # table in 1.0.0-alpha.2 (ADR-0016). The environment variables PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB,
+  # PLUGWERK_TRACKING_ENABLED, PLUGWERK_TRACKING_CAPTURE_IP, PLUGWERK_TRACKING_ANONYMIZE_IP and
+  # PLUGWERK_TRACKING_CAPTURE_USER_AGENT are no longer read. Manage these values via the
+  # Admin UI or the `PATCH /api/v1/admin/settings` endpoint.
 
 server:
   port: 8080

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0003_download_event.yaml
   - include:
       file: db/changelog/migrations/0004_token_revocation.yaml
+  - include:
+      file: db/changelog/migrations/0005_application_settings.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
@@ -1,0 +1,102 @@
+# Persistent global application settings (ADR-0016).
+# Stores admin-manageable values such as default language, site name, max upload size, and
+# download-tracking flags. Supersedes the `plugwerk.upload.*` and `plugwerk.tracking.*`
+# YAML properties, which are removed from application.yml in the same change.
+databaseChangeLog:
+  - changeSet:
+      id: 0005-create-application-setting
+      author: plugwerk
+      changes:
+        - createTable:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: setting_key
+                  type: varchar(128)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_application_setting_key
+              - column:
+                  name: setting_value
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
+                  name: value_type
+                  type: varchar(16)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamptz
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 0005-seed-default-settings
+      author: plugwerk
+      changes:
+        # General application settings
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "general.default_language" }
+              - column: { name: setting_value, value: "en" }
+              - column: { name: value_type, value: "ENUM" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "general.site_name" }
+              - column: { name: setting_value, value: "Plugwerk" }
+              - column: { name: value_type, value: "STRING" }
+        # Upload settings (previously plugwerk.upload.*)
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "upload.max_file_size_mb" }
+              - column: { name: setting_value, value: "100" }
+              - column: { name: value_type, value: "INTEGER" }
+        # Download tracking settings (previously plugwerk.tracking.*)
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "tracking.enabled" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "tracking.capture_ip" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "tracking.anonymize_ip" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: id, valueComputed: "gen_random_uuid()" }
+              - column: { name: setting_key, value: "tracking.capture_user_agent" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: value_type, value: "BOOLEAN" }

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
@@ -29,6 +29,11 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
+                  name: setting_desc
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
                   name: value_type
                   type: varchar(16)
                   constraints:
@@ -56,6 +61,9 @@ databaseChangeLog:
               - column: { name: setting_key, value: "general.default_language" }
               - column: { name: setting_value, value: "en" }
               - column: { name: value_type, value: "ENUM" }
+              - column:
+                  name: setting_desc
+                  value: "Default UI language shown to users who have no explicit language preference. Accepted values: en, de."
         - insert:
             tableName: application_setting
             columns:
@@ -63,7 +71,10 @@ databaseChangeLog:
               - column: { name: setting_key, value: "general.site_name" }
               - column: { name: setting_value, value: "Plugwerk" }
               - column: { name: value_type, value: "STRING" }
-        # Upload settings (previously plugwerk.upload.*)
+              - column:
+                  name: setting_desc
+                  value: "Display name of this Plugwerk instance. Shown in the top bar, page titles, and email notifications."
+        # Upload settings
         - insert:
             tableName: application_setting
             columns:
@@ -71,7 +82,10 @@ databaseChangeLog:
               - column: { name: setting_key, value: "upload.max_file_size_mb" }
               - column: { name: setting_value, value: "100" }
               - column: { name: value_type, value: "INTEGER" }
-        # Download tracking settings (previously plugwerk.tracking.*)
+              - column:
+                  name: setting_desc
+                  value: "Maximum plugin artifact size accepted on upload, in megabytes. Files exceeding this limit are rejected with HTTP 413. Changes require a server restart to take effect on the Servlet multipart filter (a hard safety ceiling of 1024 MB always applies)."
+        # Download tracking settings
         - insert:
             tableName: application_setting
             columns:
@@ -79,6 +93,9 @@ databaseChangeLog:
               - column: { name: setting_key, value: "tracking.enabled" }
               - column: { name: setting_value, value: "true" }
               - column: { name: value_type, value: "BOOLEAN" }
+              - column:
+                  name: setting_desc
+                  value: "Master switch for recording individual download events in the download_event audit log. When disabled, only the atomic download counter on plugin_release is incremented."
         - insert:
             tableName: application_setting
             columns:
@@ -86,6 +103,9 @@ databaseChangeLog:
               - column: { name: setting_key, value: "tracking.capture_ip" }
               - column: { name: setting_value, value: "true" }
               - column: { name: value_type, value: "BOOLEAN" }
+              - column:
+                  name: setting_desc
+                  value: "Whether to store the client IP address on download events. When disabled, the client_ip column is written as NULL regardless of the anonymize setting."
         - insert:
             tableName: application_setting
             columns:
@@ -93,6 +113,9 @@ databaseChangeLog:
               - column: { name: setting_key, value: "tracking.anonymize_ip" }
               - column: { name: setting_value, value: "true" }
               - column: { name: value_type, value: "BOOLEAN" }
+              - column:
+                  name: setting_desc
+                  value: "Whether to anonymise captured IPs before storage. IPv4 addresses are truncated to /24 and IPv6 addresses to /48. Has no effect when tracking.capture_ip is disabled."
         - insert:
             tableName: application_setting
             columns:
@@ -100,3 +123,6 @@ databaseChangeLog:
               - column: { name: setting_key, value: "tracking.capture_user_agent" }
               - column: { name: setting_value, value: "true" }
               - column: { name: value_type, value: "BOOLEAN" }
+              - column:
+                  name: setting_desc
+                  value: "Whether to store the HTTP User-Agent header on download events. When disabled, the user_agent column is written as NULL."

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -18,12 +18,12 @@
  */
 package io.plugwerk.server.controller
 
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.service.VersionProvider
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -51,7 +51,7 @@ class ConfigControllerTest {
 
     @MockitoBean lateinit var jwtDecoder: JwtDecoder
 
-    @MockitoBean lateinit var plugwerkProperties: PlugwerkProperties
+    @MockitoBean lateinit var settingsService: GeneralSettingsService
 
     @MockitoBean lateinit var versionProvider: VersionProvider
 
@@ -59,9 +59,7 @@ class ConfigControllerTest {
 
     @Test
     fun `GET config returns upload limits and version`() {
-        whenever(plugwerkProperties.upload).thenReturn(
-            PlugwerkProperties.UploadProperties(maxFileSizeMb = 200),
-        )
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(200)
         whenever(versionProvider.getVersion()).thenReturn("1.2.3")
 
         mockMvc.get("/api/v1/config")
@@ -74,9 +72,7 @@ class ConfigControllerTest {
 
     @Test
     fun `GET config returns unknown when version is not available`() {
-        whenever(plugwerkProperties.upload).thenReturn(
-            PlugwerkProperties.UploadProperties(maxFileSizeMb = 100),
-        )
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
         whenever(versionProvider.getVersion()).thenReturn("unknown")
 
         mockMvc.get("/api/v1/config")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
@@ -53,6 +53,7 @@ import java.io.ByteArrayInputStream
     PluginReleaseService::class,
     PluginService::class,
     NamespaceService::class,
+    io.plugwerk.server.service.settings.GeneralSettingsService::class,
     DownloadEventServiceIntegrationTest.MockConfig::class,
 )
 @Tag("integration")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceTest.kt
@@ -18,29 +18,31 @@
  */
 package io.plugwerk.server.service
 
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.DownloadEventEntity
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.DownloadEventRepository
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DownloadEventServiceTest {
 
-    @Mock lateinit var downloadEventRepository: DownloadEventRepository
-
+    private lateinit var downloadEventRepository: DownloadEventRepository
     private lateinit var service: DownloadEventService
 
     private val namespace = NamespaceEntity(slug = "acme", name = "ACME Corp")
@@ -52,27 +54,24 @@ class DownloadEventServiceTest {
         artifactKey = "acme:my-plugin:1.0.0:jar",
     )
 
-    private fun buildProperties(
+    private fun buildSettings(
         enabled: Boolean = true,
         captureIp: Boolean = true,
         anonymizeIp: Boolean = true,
         captureUserAgent: Boolean = true,
-    ) = PlugwerkProperties(
-        auth = PlugwerkProperties.AuthProperties(
-            jwtSecret = "test-only-secret-not-for-production-32ch",
-            encryptionKey = "test-encrypt16c!",
-        ),
-        tracking = PlugwerkProperties.TrackingProperties(
-            enabled = enabled,
-            captureIp = captureIp,
-            anonymizeIp = anonymizeIp,
-            captureUserAgent = captureUserAgent,
-        ),
-    )
+    ): GeneralSettingsService {
+        val settings = mock<GeneralSettingsService>()
+        whenever(settings.trackingEnabled()).thenReturn(enabled)
+        whenever(settings.trackingCaptureIp()).thenReturn(captureIp)
+        whenever(settings.trackingAnonymizeIp()).thenReturn(anonymizeIp)
+        whenever(settings.trackingCaptureUserAgent()).thenReturn(captureUserAgent)
+        return settings
+    }
 
     @BeforeEach
     fun setUp() {
-        service = DownloadEventService(downloadEventRepository, buildProperties())
+        downloadEventRepository = mock()
+        service = DownloadEventService(downloadEventRepository, buildSettings())
     }
 
     @Test
@@ -90,7 +89,7 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record does nothing when tracking is disabled`() {
-        service = DownloadEventService(downloadEventRepository, buildProperties(enabled = false))
+        service = DownloadEventService(downloadEventRepository, buildSettings(enabled = false))
 
         service.record(release, "192.168.1.42", "Mozilla/5.0")
 
@@ -121,7 +120,7 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record stores raw IP when anonymization is disabled`() {
-        service = DownloadEventService(downloadEventRepository, buildProperties(anonymizeIp = false))
+        service = DownloadEventService(downloadEventRepository, buildSettings(anonymizeIp = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
         service.record(release, "192.168.1.42", null)
@@ -133,7 +132,7 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record nullifies IP when captureIp is false`() {
-        service = DownloadEventService(downloadEventRepository, buildProperties(captureIp = false))
+        service = DownloadEventService(downloadEventRepository, buildSettings(captureIp = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
         service.record(release, "192.168.1.42", "Mozilla/5.0")
@@ -145,7 +144,7 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record nullifies user agent when captureUserAgent is false`() {
-        service = DownloadEventService(downloadEventRepository, buildProperties(captureUserAgent = false))
+        service = DownloadEventService(downloadEventRepository, buildSettings(captureUserAgent = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
         service.record(release, null, "Mozilla/5.0")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
@@ -51,6 +51,7 @@ import kotlin.test.assertFailsWith
     PluginService::class,
     NamespaceService::class,
     DownloadEventService::class,
+    io.plugwerk.server.service.settings.GeneralSettingsService::class,
     PluginReleaseServiceIntegrationTest.MockConfig::class,
 )
 @Tag("integration")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -20,7 +20,6 @@ package io.plugwerk.server.service
 
 import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
-import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.FileFormat
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
@@ -28,6 +27,7 @@ import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
+import io.plugwerk.server.service.settings.GeneralSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
@@ -38,6 +38,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -77,13 +78,9 @@ class PluginReleaseServiceTest {
     private val autoApprovePlugin =
         PluginEntity(namespace = autoApproveNamespace, pluginId = "auto-plugin", name = "Auto Plugin")
 
-    private val properties = PlugwerkProperties(
-        auth = PlugwerkProperties.AuthProperties(
-            jwtSecret = "test-only-secret-not-for-production-32ch",
-            encryptionKey = "test-encrypt16c!",
-        ),
-        upload = PlugwerkProperties.UploadProperties(maxFileSizeMb = 1),
-    )
+    private val settingsService: GeneralSettingsService = mock<GeneralSettingsService>().also {
+        whenever(it.maxUploadSizeMb()).thenReturn(1)
+    }
 
     @BeforeEach
     fun setUp() {
@@ -94,7 +91,7 @@ class PluginReleaseServiceTest {
             storageService,
             descriptorResolver,
             ObjectMapper(),
-            properties,
+            settingsService,
             downloadEventService,
         )
     }


### PR DESCRIPTION
Refs #208 (partial — backend only).

## Summary

Moves admin-manageable global settings (default language, site name, max upload size,
download-tracking flags) out of `application.yml` into a new `application_setting` database
table. Establishes a single source of truth for these values and wires the server side up
end-to-end. Adopts **ADR-0016** ("DB is authoritative, YAML is infra-only") — see
`docs/adrs/0016-application-settings-precedence.md`.

## What's in this PR

### ADR & schema
- **ADR-0016** records the precedence strategy, the read/write flow, the breaking change
  around `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` / `PLUGWERK_TRACKING_*`, and the hard 1 GB
  safety ceiling for upload size.
- **Liquibase `0005_application_settings.yaml`** creates
  `application_setting(id, setting_key, setting_value, setting_desc, value_type,
  updated_at, updated_by)` and seeds seven rows (general, upload, tracking) with sensible
  defaults **and** per-key descriptions used as inline help in the Admin UI.

### Domain + service layer
- `ApplicationSettingEntity` + `SettingValueType` enum — UUIDv7 / `@UpdateTimestamp`
  conventions per ADR-0003.
- `ApplicationSettingRepository` — `findBySettingKey(String)`.
- `SettingKey` enum is the registry: key, `valueType`, hardcoded fallback, `requiresRestart`,
  optional `allowedValues` / `minInt` / `maxInt`, and a per-entry validator.
- `GeneralSettingsService` holds an atomically-swapped in-memory snapshot
  (`AtomicReference<Map<String, StoredSetting>>`) populated at startup and refreshed on
  every write. Captures a `bootSnapshot` so the UI can flag `restartPending` when a
  `requiresRestart` value has diverged since the JVM started. Typed accessors
  (`maxUploadSizeMb()`, `trackingEnabled()`, …) and `listAll()` returning
  `SettingSnapshot(key, value, description, source, restartPending)`.

### REST API
- **New endpoints** (superadmin-only):
  - `GET  /api/v1/admin/settings` — full snapshot with per-key `source` + `restartPending`.
  - `PATCH /api/v1/admin/settings` — partial write, validator-backed, upserts into DB and
    refreshes cache atomically.
- `ApplicationSettingDto`, `ApplicationSettingsResponse`, `ApplicationSettingsUpdateRequest`
  added to `plugwerk-api.yaml`. Backend DTOs regenerated via `./gradlew ...openApiGenerate`.

### Infra wiring
- **`MultipartConfig`** bean builds `MultipartConfigElement` from the DB value at context
  refresh time (after Liquibase, before Tomcat registers the multipart filter). Caps at
  `MAX_ALLOWED_UPLOAD_MB = 1024` as a hard safety ceiling regardless of the DB value.
  Runtime changes still require a restart — tracked as a separate follow-up issue.
- **Call-site migrations**: `DownloadEventService`, `PluginReleaseService`,
  `ConfigController` now read from `GeneralSettingsService` instead of
  `PlugwerkProperties.tracking` / `PlugwerkProperties.upload`.
- **Deleted**: `PlugwerkProperties.UploadProperties`, `PlugwerkProperties.TrackingProperties`,
  `plugwerk.upload.*` / `plugwerk.tracking.*` / `spring.servlet.multipart.*` blocks from
  `application.yml`.

### ⚠️ Breaking change for operators

The environment variables `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB`, `PLUGWERK_TRACKING_ENABLED`,
`PLUGWERK_TRACKING_CAPTURE_IP`, `PLUGWERK_TRACKING_ANONYMIZE_IP`, and
`PLUGWERK_TRACKING_CAPTURE_USER_AGENT` are **no longer read**. Liquibase seeds the previous
defaults, so upgrades are transparent unless the deployment had overrides — in which case
the operator must set the equivalent rows via the Admin UI after upgrade. `docs/deployment.md`
documents the migration path.

## What's intentionally NOT in this PR

- **Frontend wiring** of `GeneralSection.tsx` → `adminSettingsApi` → `settingsStore`, and
  the `restartPending` alert. This is the remaining acceptance criterion for #208 and will
  be submitted as a follow-up PR on `feature/208_admin-settings-frontend`.
- **Dedicated unit tests** for `GeneralSettingsService` and `AdminSettingsController`. The
  existing 257-test suite still passes and covers the migrated call sites, but the new
  service/controller have no dedicated tests yet — a follow-up PR on
  `feature/208_settings-tests` will add them.
- **Runtime reload** of `upload.max_file_size_mb` without a restart. The UI will warn about
  pending restart via the `restartPending` flag already returned by the API. A separate
  issue will be created to track the multipart-filter reload implementation.

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:compileKotlin` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:compileTestKotlin` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — **257 / 257 passing**
- [x] OpenAPI regeneration via
  `./gradlew :plugwerk-api:plugwerk-api-model:openApiGenerate :plugwerk-api:plugwerk-api-endpoint:openApiGenerate`

Manual post-merge smoke test checklist for the reviewer:
- [ ] Start `docker compose up -d postgres` and boot the server — Liquibase applies 0005
      cleanly, `application_setting` has 7 rows.
- [ ] `GET /api/v1/admin/settings` as superadmin returns the snapshot with `setting_desc`
      populated for every key.
- [ ] `PATCH /api/v1/admin/settings` with `{"settings": {"tracking.enabled": "false"}}`
      disables download-event writes for the next download (verify via `download_event`
      table).
- [ ] `PATCH /api/v1/admin/settings` with `{"settings": {"upload.max_file_size_mb": "50"}}`
      returns `restartPending: true` in the response and the existing multipart filter
      still accepts 100 MB uploads until restart.
- [ ] Restart the server — the multipart filter now caps uploads at 50 MB.

Refs #208