### PR TITLE
feat(settings): admin settings UI wired to /admin/settings API (#208)

### DIFF
--- a/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/command/UpdateCommand.java
+++ b/examples/plugwerk-java-cli-example/plugwerk-java-cli-example-app/src/main/java/io/plugwerk/example/cli/command/UpdateCommand.java
@@ -107,7 +107,7 @@ public class UpdateCommand implements Runnable {
               });
     }
     System.out.printf("%nDone: %d updated, %d failed.%n", counts[0], counts[1]);
-    if (failed > 0) {
+    if (counts[1] > 0) {
       System.exit(1);
     }
   }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/SettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/SettingKey.kt
@@ -50,7 +50,7 @@ enum class SettingKey(
         key = "general.default_language",
         valueType = SettingValueType.ENUM,
         defaultValue = "en",
-        allowedValues = setOf("en", "de"),
+        allowedValues = setOf("en"),
     ),
     GENERAL_SITE_NAME(
         key = "general.site_name",

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0005_application_settings.yaml
@@ -63,7 +63,7 @@ databaseChangeLog:
               - column: { name: value_type, value: "ENUM" }
               - column:
                   name: setting_desc
-                  value: "Default UI language shown to users who have no explicit language preference. Accepted values: en, de."
+                  value: "Default UI language shown to users who have no explicit language preference. Currently only English (en) is supported."
         - insert:
             tableName: application_setting
             columns:

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -19,6 +19,7 @@
 import axios from "axios";
 import { Configuration } from "./generated/configuration";
 import { AccessKeysApi } from "./generated/api/access-keys-api";
+import { AdminSettingsApi } from "./generated/api/admin-settings-api";
 import { AdminUsersApi } from "./generated/api/admin-users-api";
 import { AuthApi } from "./generated/api/auth-api";
 import { CatalogApi } from "./generated/api/catalog-api";
@@ -58,6 +59,11 @@ axiosInstance.interceptors.response.use(
 const apiConfig = new Configuration({ basePath: BASE_PATH });
 
 export const accessKeysApi = new AccessKeysApi(
+  apiConfig,
+  BASE_PATH,
+  axiosInstance,
+);
+export const adminSettingsApi = new AdminSettingsApi(
   apiConfig,
   BASE_PATH,
   axiosInstance,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
@@ -159,7 +159,6 @@ export function ProfileSettingsPage() {
               <InputLabel>Language</InputLabel>
               <Select defaultValue="en" label="Language">
                 <MenuItem value="en">English</MenuItem>
-                <MenuItem value="de">Deutsch</MenuItem>
               </Select>
             </FormControl>
           </Section>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -106,7 +106,9 @@ describe("GeneralSection", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Max File Size Mb")).toHaveValue(100);
     expect(screen.getByLabelText("Enabled")).toBeChecked();
-    expect(screen.getByLabelText("Default Language")).toHaveTextContent("en");
+    expect(screen.getByLabelText("Default Language")).toHaveTextContent(
+      "English",
+    );
   });
 
   it("shows a 'Requires restart' chip on fields with requiresRestart=true", async () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GeneralSection } from "./GeneralSection";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import { useSettingsStore } from "../../stores/settingsStore";
+import { useUiStore } from "../../stores/uiStore";
+import type { ApplicationSettingDto } from "../../api/generated/model/application-setting-dto";
+import * as apiConfig from "../../api/config";
+
+vi.mock("../../api/config", () => ({
+  adminSettingsApi: {
+    listApplicationSettings: vi.fn(),
+    updateApplicationSettings: vi.fn(),
+  },
+}));
+
+function dto(overrides: Partial<ApplicationSettingDto>): ApplicationSettingDto {
+  return {
+    key: "general.site_name",
+    value: "Plugwerk",
+    valueType: "STRING",
+    source: "DATABASE",
+    requiresRestart: false,
+    restartPending: false,
+    ...overrides,
+  } as ApplicationSettingDto;
+}
+
+const SAMPLE_SETTINGS: ApplicationSettingDto[] = [
+  dto({
+    key: "general.site_name",
+    value: "Plugwerk",
+    description: "Display name of this Plugwerk instance.",
+  }),
+  dto({
+    key: "general.default_language",
+    value: "en",
+    valueType: "ENUM",
+    allowedValues: ["en", "de"],
+    description: "Default UI language.",
+  }),
+  dto({
+    key: "upload.max_file_size_mb",
+    value: "100",
+    valueType: "INTEGER",
+    minInt: 1,
+    maxInt: 1024,
+    requiresRestart: true,
+    description: "Maximum plugin artifact upload size in MB.",
+  }),
+  dto({
+    key: "tracking.enabled",
+    value: "true",
+    valueType: "BOOLEAN",
+    description: "Master switch for download tracking.",
+  }),
+];
+
+describe("GeneralSection", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      settings: [],
+      loaded: false,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    useUiStore.setState({ toasts: [] });
+    vi.mocked(apiConfig.adminSettingsApi.listApplicationSettings).mockReset();
+    vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings).mockReset();
+  });
+
+  it("loads settings on mount and renders description as helper text", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Display name of this Plugwerk instance."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Max File Size Mb")).toHaveValue(100);
+    expect(screen.getByLabelText("Enabled")).toBeChecked();
+    expect(screen.getByLabelText("Default Language")).toHaveTextContent("en");
+  });
+
+  it("disables Save Changes until at least one field is edited", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+    const saveButton = screen.getByRole("button", { name: /save changes/i });
+    expect(saveButton).toBeDisabled();
+
+    const siteName = screen.getByLabelText("Site Name");
+    await user.clear(siteName);
+    await user.type(siteName, "Acme Plugins");
+
+    expect(saveButton).toBeEnabled();
+  });
+
+  it("sends only dirty fields to updateApplicationSettings", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockResolvedValue({
+      data: {
+        settings: SAMPLE_SETTINGS.map((s) =>
+          s.key === "general.site_name" ? { ...s, value: "Acme Plugins" } : s,
+        ),
+      },
+    } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+
+    const siteName = screen.getByLabelText("Site Name");
+    await user.clear(siteName);
+    await user.type(siteName, "Acme Plugins");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings),
+      ).toHaveBeenCalledWith({
+        applicationSettingsUpdateRequest: {
+          settings: { "general.site_name": "Acme Plugins" },
+        },
+      });
+    });
+  });
+
+  it("shows a validation error for out-of-range integer and blocks save", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Max File Size Mb")).toBeInTheDocument(),
+    );
+
+    const maxSize = screen.getByLabelText("Max File Size Mb");
+    await user.clear(maxSize);
+    await user.type(maxSize, "9999");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.getByText("Must be <= 1024")).toBeInTheDocument();
+    expect(
+      vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("renders a restart-pending alert when any setting has restartPending=true", async () => {
+    const settingsWithRestart = SAMPLE_SETTINGS.map((s) =>
+      s.key === "upload.max_file_size_mb" ? { ...s, restartPending: true } : s,
+    );
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: settingsWithRestart } } as never);
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent("upload.max_file_size_mb");
+      expect(alert).toHaveTextContent(/restart/i);
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -109,6 +109,22 @@ describe("GeneralSection", () => {
     expect(screen.getByLabelText("Default Language")).toHaveTextContent("en");
   });
 
+  it("shows a 'Requires restart' chip on fields with requiresRestart=true", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Max File Size Mb")).toBeInTheDocument();
+    });
+    const chips = screen.getAllByText(/Requires restart/i);
+    expect(chips.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("disables Save Changes until at least one field is edited", async () => {
     vi.mocked(
       apiConfig.adminSettingsApi.listApplicationSettings,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -340,18 +340,10 @@ export function GeneralSection() {
 
     if (setting.valueType === "INTEGER") {
       return (
-        <Box key={key}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
-            {setting.requiresRestart && (
-              <Chip
-                label="Requires restart"
-                size="small"
-                color="warning"
-                variant="outlined"
-                sx={{ height: 20, fontSize: "0.7rem" }}
-              />
-            )}
-          </Box>
+        <Box
+          key={key}
+          sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}
+        >
           <TextField
             label={label}
             type="number"
@@ -368,6 +360,15 @@ export function GeneralSection() {
             }}
             sx={{ maxWidth: 320 }}
           />
+          {setting.requiresRestart && (
+            <Chip
+              label="Requires restart"
+              size="small"
+              color="warning"
+              variant="outlined"
+              sx={{ height: 24, fontSize: "0.75rem", mt: 1 }}
+            />
+          )}
         </Box>
       );
     }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -45,7 +45,6 @@ type DraftMap = Record<string, string>;
 
 const LANGUAGE_LABELS: Record<string, string> = {
   en: "English",
-  de: "Deutsch",
 };
 
 function computeDirtyPatch(

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -16,26 +16,166 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect, useMemo, useState } from "react";
 import {
+  Alert,
   Box,
-  Typography,
-  TextField,
   Button,
+  CircularProgress,
   Divider,
-  Select,
-  MenuItem,
   FormControl,
+  FormControlLabel,
+  FormHelperText,
   InputLabel,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+  Typography,
 } from "@mui/material";
+import type { ApplicationSettingDto } from "../../api/generated/model/application-setting-dto";
+import { useSettingsStore } from "../../stores/settingsStore";
 import { useUiStore } from "../../stores/uiStore";
 
+/**
+ * Sparse map of user-edited fields, keyed by setting key. Only contains keys whose value
+ * differs from the canonical [ApplicationSettingDto.value] that was last loaded from the
+ * server. Cleared after a successful save or an explicit discard.
+ */
+type DraftMap = Record<string, string>;
+
+function computeDirtyPatch(
+  settings: ApplicationSettingDto[],
+  draft: DraftMap,
+): Record<string, string> {
+  const byKey = new Map(settings.map((s) => [s.key, s.value]));
+  const patch: Record<string, string> = {};
+  for (const [key, draftValue] of Object.entries(draft)) {
+    const canonical = byKey.get(key);
+    if (canonical !== undefined && draftValue !== canonical) {
+      patch[key] = draftValue;
+    }
+  }
+  return patch;
+}
+
 export function GeneralSection() {
+  const settings = useSettingsStore((s) => s.settings);
+  const loaded = useSettingsStore((s) => s.loaded);
+  const loading = useSettingsStore((s) => s.loading);
+  const saving = useSettingsStore((s) => s.saving);
+  const loadSettings = useSettingsStore((s) => s.load);
+  const updateSettings = useSettingsStore((s) => s.update);
   const addToast = useUiStore((s) => s.addToast);
 
-  function handleSave() {
-    // TODO: persist settings via API once backend endpoint exists
-    addToast({ message: "Settings saved.", type: "success" });
+  const [draft, setDraft] = useState<DraftMap>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!loaded && !loading) {
+      void loadSettings().catch(() => {
+        addToast({
+          type: "error",
+          message: "Failed to load application settings.",
+        });
+      });
+    }
+  }, [loaded, loading, loadSettings, addToast]);
+
+  const dirtyPatch = useMemo(
+    () => computeDirtyPatch(settings, draft),
+    [settings, draft],
+  );
+  const hasChanges = Object.keys(dirtyPatch).length > 0;
+
+  const restartPendingKeys = useMemo(
+    () => settings.filter((s) => s.restartPending).map((s) => s.key),
+    [settings],
+  );
+
+  function handleFieldChange(key: string, rawValue: string): void {
+    setDraft((prev) => ({ ...prev, [key]: rawValue }));
+    setFieldErrors((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   }
+
+  function validateLocally(): Record<string, string> {
+    const errors: Record<string, string> = {};
+    for (const s of settings) {
+      if (!(s.key in draft)) continue;
+      const value = draft[s.key];
+      if (s.valueType === "INTEGER") {
+        const parsed = Number.parseInt(value, 10);
+        if (Number.isNaN(parsed) || String(parsed) !== value.trim()) {
+          errors[s.key] = "Must be an integer";
+          continue;
+        }
+        if (typeof s.minInt === "number" && parsed < s.minInt) {
+          errors[s.key] = `Must be >= ${s.minInt}`;
+          continue;
+        }
+        if (typeof s.maxInt === "number" && parsed > s.maxInt) {
+          errors[s.key] = `Must be <= ${s.maxInt}`;
+          continue;
+        }
+      } else if (s.valueType === "STRING" && value.trim().length === 0) {
+        errors[s.key] = "Must not be blank";
+      } else if (
+        s.valueType === "ENUM" &&
+        s.allowedValues &&
+        !s.allowedValues.includes(value)
+      ) {
+        errors[s.key] = `Must be one of ${s.allowedValues.join(", ")}`;
+      } else if (
+        s.valueType === "BOOLEAN" &&
+        value !== "true" &&
+        value !== "false"
+      ) {
+        errors[s.key] = "Must be true or false";
+      }
+    }
+    return errors;
+  }
+
+  async function handleSave() {
+    const localErrors = validateLocally();
+    if (Object.keys(localErrors).length > 0) {
+      setFieldErrors(localErrors);
+      addToast({
+        type: "error",
+        message: "Please fix the highlighted fields before saving.",
+      });
+      return;
+    }
+    if (!hasChanges) return;
+    try {
+      await updateSettings(dirtyPatch);
+      setDraft({});
+      setFieldErrors({});
+      addToast({
+        type: "success",
+        message: "Settings saved.",
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to save settings.";
+      addToast({ type: "error", message });
+    }
+  }
+
+  function handleDiscard() {
+    setDraft({});
+    setFieldErrors({});
+  }
+
+  const sortedSettings = useMemo(
+    () => [...settings].sort((a, b) => a.key.localeCompare(b.key)),
+    [settings],
+  );
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -43,28 +183,172 @@ export function GeneralSection() {
         <Typography variant="h2" gutterBottom>
           General Settings
         </Typography>
-        <Divider sx={{ mb: 3 }} />
+        <Divider sx={{ mb: 2 }} />
+        <Typography variant="body2" color="text.secondary">
+          These settings are stored in the database and shared across all users.
+          Changes marked as requiring a restart take effect after the next
+          server restart.
+        </Typography>
       </Box>
-      <TextField
-        label="Max Upload Size (MB)"
-        type="number"
-        defaultValue={50}
-        size="small"
-      />
-      <FormControl size="small" sx={{ minWidth: 200 }}>
-        <InputLabel>Default Language</InputLabel>
-        <Select defaultValue="en" label="Default Language">
-          <MenuItem value="en">English</MenuItem>
-          <MenuItem value="de">Deutsch</MenuItem>
-        </Select>
-      </FormControl>
-      <Button
-        variant="contained"
-        sx={{ alignSelf: "flex-start" }}
-        onClick={handleSave}
-      >
-        Save Changes
-      </Button>
+
+      {restartPendingKeys.length > 0 && (
+        <Alert severity="warning" role="alert">
+          The following setting
+          {restartPendingKeys.length === 1 ? " has" : "s have"} been changed
+          since the server started and will only take effect after a restart:{" "}
+          <strong>{restartPendingKeys.join(", ")}</strong>
+        </Alert>
+      )}
+
+      {!loaded && loading && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <CircularProgress size={18} />
+          <Typography variant="body2">Loading settings…</Typography>
+        </Box>
+      )}
+
+      {loaded && settings.length === 0 && (
+        <Alert severity="info">No application settings are available.</Alert>
+      )}
+
+      {loaded &&
+        sortedSettings.map((setting) => (
+          <SettingField
+            key={setting.key}
+            setting={setting}
+            value={draft[setting.key] ?? setting.value}
+            onChange={(v) => handleFieldChange(setting.key, v)}
+            error={fieldErrors[setting.key]}
+            disabled={saving}
+          />
+        ))}
+
+      <Box sx={{ display: "flex", gap: 2, mt: 1 }}>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!hasChanges || saving || !loaded}
+        >
+          {saving ? "Saving…" : "Save Changes"}
+        </Button>
+        <Button
+          variant="text"
+          onClick={handleDiscard}
+          disabled={!hasChanges || saving}
+        >
+          Discard
+        </Button>
+      </Box>
     </Box>
+  );
+}
+
+interface SettingFieldProps {
+  readonly setting: ApplicationSettingDto;
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+  readonly error: string | undefined;
+  readonly disabled: boolean;
+}
+
+function formatLabel(key: string): string {
+  return key
+    .split(".")
+    .pop()!
+    .split("_")
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(" ");
+}
+
+function SettingField({
+  setting,
+  value,
+  onChange,
+  error,
+  disabled,
+}: SettingFieldProps) {
+  const label = formatLabel(setting.key);
+  const helperText = error ?? setting.description ?? undefined;
+
+  if (setting.valueType === "BOOLEAN") {
+    const checked = value === "true";
+    return (
+      <FormControl error={Boolean(error)}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={checked}
+              onChange={(e) => onChange(e.target.checked ? "true" : "false")}
+              disabled={disabled}
+              inputProps={{ "aria-label": label }}
+            />
+          }
+          label={label}
+        />
+        {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      </FormControl>
+    );
+  }
+
+  if (
+    setting.valueType === "ENUM" &&
+    setting.allowedValues &&
+    setting.allowedValues.length > 0
+  ) {
+    return (
+      <FormControl size="small" sx={{ minWidth: 240 }} error={Boolean(error)}>
+        <InputLabel id={`label-${setting.key}`}>{label}</InputLabel>
+        <Select
+          labelId={`label-${setting.key}`}
+          label={label}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          inputProps={{ "aria-label": label }}
+        >
+          {setting.allowedValues.map((v) => (
+            <MenuItem key={v} value={v}>
+              {v}
+            </MenuItem>
+          ))}
+        </Select>
+        {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      </FormControl>
+    );
+  }
+
+  if (setting.valueType === "INTEGER") {
+    return (
+      <TextField
+        label={label}
+        type="number"
+        size="small"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        error={Boolean(error)}
+        helperText={helperText}
+        disabled={disabled}
+        inputProps={{
+          min: setting.minInt,
+          max: setting.maxInt,
+          "aria-label": label,
+        }}
+        sx={{ maxWidth: 320 }}
+      />
+    );
+  }
+
+  return (
+    <TextField
+      label={label}
+      size="small"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      error={Boolean(error)}
+      helperText={helperText}
+      disabled={disabled}
+      inputProps={{ "aria-label": label }}
+      sx={{ maxWidth: 480 }}
+    />
   );
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -23,7 +23,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Divider,
   FormControl,
   FormControlLabel,
   FormHelperText,
@@ -33,17 +32,21 @@ import {
   Switch,
   TextField,
   Typography,
+  alpha,
+  useTheme,
 } from "@mui/material";
+import { Activity, Globe, Upload } from "lucide-react";
 import type { ApplicationSettingDto } from "../../api/generated/model/application-setting-dto";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useUiStore } from "../../stores/uiStore";
+import { tokens } from "../../theme/tokens";
 
-/**
- * Sparse map of user-edited fields, keyed by setting key. Only contains keys whose value
- * differs from the canonical [ApplicationSettingDto.value] that was last loaded from the
- * server. Cleared after a successful save or an explicit discard.
- */
 type DraftMap = Record<string, string>;
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  en: "English",
+  de: "Deutsch",
+};
 
 function computeDirtyPatch(
   settings: ApplicationSettingDto[],
@@ -58,6 +61,71 @@ function computeDirtyPatch(
     }
   }
   return patch;
+}
+
+interface SettingSectionProps {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+function SettingSection({
+  icon,
+  title,
+  description,
+  children,
+}: SettingSectionProps) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: tokens.radius.card,
+        background: isDark ? alpha("#ffffff", 0.02) : tokens.color.white,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          px: 3,
+          py: 2,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          background: isDark ? alpha("#ffffff", 0.03) : tokens.color.gray10,
+        }}
+      >
+        <Box sx={{ color: "text.secondary", display: "flex" }}>{icon}</Box>
+        <Box>
+          <Typography variant="subtitle1" fontWeight={600}>
+            {title}
+          </Typography>
+          {description && (
+            <Typography variant="caption" color="text.secondary">
+              {description}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+      <Box
+        sx={{
+          px: 3,
+          py: 2.5,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2.5,
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
 }
 
 export function GeneralSection() {
@@ -93,6 +161,16 @@ export function GeneralSection() {
     () => settings.filter((s) => s.restartPending).map((s) => s.key),
     [settings],
   );
+
+  const byKey = useMemo(() => {
+    const map = new Map<string, ApplicationSettingDto>();
+    for (const s of settings) map.set(s.key, s);
+    return map;
+  }, [settings]);
+
+  function effectiveValue(key: string): string {
+    return draft[key] ?? byKey.get(key)?.value ?? "";
+  }
 
   function handleFieldChange(key: string, rawValue: string): void {
     setDraft((prev) => ({ ...prev, [key]: rawValue }));
@@ -157,10 +235,7 @@ export function GeneralSection() {
       await updateSettings(dirtyPatch);
       setDraft({});
       setFieldErrors({});
-      addToast({
-        type: "success",
-        message: "Settings saved.",
-      });
+      addToast({ type: "success", message: "Settings saved." });
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to save settings.";
@@ -173,10 +248,160 @@ export function GeneralSection() {
     setFieldErrors({});
   }
 
-  const sortedSettings = useMemo(
-    () => [...settings].sort((a, b) => a.key.localeCompare(b.key)),
-    [settings],
-  );
+  function renderField(key: string) {
+    const setting = byKey.get(key);
+    if (!setting) return null;
+    const value = effectiveValue(key);
+    const error = fieldErrors[key];
+    const helperText = error ?? setting.description ?? undefined;
+    const label = formatLabel(key);
+
+    if (setting.valueType === "BOOLEAN") {
+      return (
+        <FormControl key={key} error={Boolean(error)}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={value === "true"}
+                onChange={(e) =>
+                  handleFieldChange(key, e.target.checked ? "true" : "false")
+                }
+                disabled={saving}
+                inputProps={{ "aria-label": label }}
+              />
+            }
+            label={label}
+          />
+          {helperText && <FormHelperText>{helperText}</FormHelperText>}
+        </FormControl>
+      );
+    }
+
+    if (key === "general.default_language") {
+      const allowed = setting.allowedValues ?? ["en", "de"];
+      return (
+        <FormControl
+          key={key}
+          size="small"
+          sx={{ minWidth: 240 }}
+          error={Boolean(error)}
+        >
+          <InputLabel id={`label-${key}`}>{label}</InputLabel>
+          <Select
+            labelId={`label-${key}`}
+            label={label}
+            value={value}
+            onChange={(e) => handleFieldChange(key, e.target.value)}
+            disabled={saving}
+            inputProps={{ "aria-label": label }}
+          >
+            {allowed.map((v) => (
+              <MenuItem key={v} value={v}>
+                {LANGUAGE_LABELS[v] ?? v}
+              </MenuItem>
+            ))}
+          </Select>
+          {helperText && <FormHelperText>{helperText}</FormHelperText>}
+        </FormControl>
+      );
+    }
+
+    if (
+      setting.valueType === "ENUM" &&
+      setting.allowedValues &&
+      setting.allowedValues.length > 0
+    ) {
+      return (
+        <FormControl
+          key={key}
+          size="small"
+          sx={{ minWidth: 240 }}
+          error={Boolean(error)}
+        >
+          <InputLabel id={`label-${key}`}>{label}</InputLabel>
+          <Select
+            labelId={`label-${key}`}
+            label={label}
+            value={value}
+            onChange={(e) => handleFieldChange(key, e.target.value)}
+            disabled={saving}
+            inputProps={{ "aria-label": label }}
+          >
+            {setting.allowedValues.map((v) => (
+              <MenuItem key={v} value={v}>
+                {v}
+              </MenuItem>
+            ))}
+          </Select>
+          {helperText && <FormHelperText>{helperText}</FormHelperText>}
+        </FormControl>
+      );
+    }
+
+    if (setting.valueType === "INTEGER") {
+      return (
+        <Box key={key}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+            {setting.requiresRestart && (
+              <Chip
+                label="Requires restart"
+                size="small"
+                color="warning"
+                variant="outlined"
+                sx={{ height: 20, fontSize: "0.7rem" }}
+              />
+            )}
+          </Box>
+          <TextField
+            label={label}
+            type="number"
+            size="small"
+            value={value}
+            onChange={(e) => handleFieldChange(key, e.target.value)}
+            error={Boolean(error)}
+            helperText={helperText}
+            disabled={saving}
+            inputProps={{
+              min: setting.minInt,
+              max: setting.maxInt,
+              "aria-label": label,
+            }}
+            sx={{ maxWidth: 320 }}
+          />
+        </Box>
+      );
+    }
+
+    return (
+      <TextField
+        key={key}
+        label={label}
+        size="small"
+        value={value}
+        onChange={(e) => handleFieldChange(key, e.target.value)}
+        error={Boolean(error)}
+        helperText={helperText}
+        disabled={saving}
+        inputProps={{ "aria-label": label }}
+        sx={{ maxWidth: 480 }}
+      />
+    );
+  }
+
+  if (!loaded && loading) {
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 4 }}>
+        <CircularProgress size={18} />
+        <Typography variant="body2">Loading settings…</Typography>
+      </Box>
+    );
+  }
+
+  if (loaded && settings.length === 0) {
+    return (
+      <Alert severity="info">No application settings are available.</Alert>
+    );
+  }
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -184,8 +409,7 @@ export function GeneralSection() {
         <Typography variant="h2" gutterBottom>
           General Settings
         </Typography>
-        <Divider sx={{ mb: 2 }} />
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
           These settings are stored in the database and apply to all users.
         </Typography>
       </Box>
@@ -199,55 +423,59 @@ export function GeneralSection() {
         </Alert>
       )}
 
-      {!loaded && loading && (
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <CircularProgress size={18} />
-          <Typography variant="body2">Loading settings…</Typography>
-        </Box>
-      )}
-
-      {loaded && settings.length === 0 && (
-        <Alert severity="info">No application settings are available.</Alert>
-      )}
-
-      {loaded &&
-        sortedSettings.map((setting) => (
-          <SettingField
-            key={setting.key}
-            setting={setting}
-            value={draft[setting.key] ?? setting.value}
-            onChange={(v) => handleFieldChange(setting.key, v)}
-            error={fieldErrors[setting.key]}
-            disabled={saving}
-          />
-        ))}
-
-      <Box sx={{ display: "flex", gap: 2, mt: 1 }}>
-        <Button
-          variant="contained"
-          onClick={handleSave}
-          disabled={!hasChanges || saving || !loaded}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+        {/* General */}
+        <SettingSection
+          icon={<Globe size={18} />}
+          title="General"
+          description="Application name and default language"
         >
-          {saving ? "Saving…" : "Save Changes"}
-        </Button>
+          {renderField("general.site_name")}
+          {renderField("general.default_language")}
+        </SettingSection>
+
+        {/* Upload */}
+        <SettingSection
+          icon={<Upload size={18} />}
+          title="Upload"
+          description="Artifact upload constraints"
+        >
+          {renderField("upload.max_file_size_mb")}
+        </SettingSection>
+
+        {/* Download Tracking */}
+        <SettingSection
+          icon={<Activity size={18} />}
+          title="Download Tracking"
+          description="Privacy settings for download event recording"
+        >
+          {renderField("tracking.enabled")}
+          {renderField("tracking.capture_ip")}
+          {renderField("tracking.anonymize_ip")}
+          {renderField("tracking.capture_user_agent")}
+        </SettingSection>
+      </Box>
+
+      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
         <Button
           variant="text"
           onClick={handleDiscard}
           disabled={!hasChanges || saving}
+          sx={{ borderRadius: tokens.radius.btn }}
         >
           Discard
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!hasChanges || saving || !loaded}
+          sx={{ borderRadius: tokens.radius.btn }}
+        >
+          {saving ? "Saving…" : "Save Changes"}
         </Button>
       </Box>
     </Box>
   );
-}
-
-interface SettingFieldProps {
-  readonly setting: ApplicationSettingDto;
-  readonly value: string;
-  readonly onChange: (next: string) => void;
-  readonly error: string | undefined;
-  readonly disabled: boolean;
 }
 
 function formatLabel(key: string): string {
@@ -257,130 +485,4 @@ function formatLabel(key: string): string {
     .split("_")
     .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
     .join(" ");
-}
-
-function FieldLabel({
-  label,
-  requiresRestart,
-}: {
-  label: string;
-  requiresRestart: boolean;
-}) {
-  if (!requiresRestart) return <>{label}</>;
-  return (
-    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 1 }}>
-      {label}
-      <Chip
-        label="Requires restart"
-        size="small"
-        color="warning"
-        variant="outlined"
-        sx={{ height: 20, fontSize: "0.7rem" }}
-      />
-    </Box>
-  );
-}
-
-function SettingField({
-  setting,
-  value,
-  onChange,
-  error,
-  disabled,
-}: SettingFieldProps) {
-  const label = formatLabel(setting.key);
-  const helperText = error ?? setting.description ?? undefined;
-
-  if (setting.valueType === "BOOLEAN") {
-    const checked = value === "true";
-    return (
-      <FormControl error={Boolean(error)}>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={checked}
-              onChange={(e) => onChange(e.target.checked ? "true" : "false")}
-              disabled={disabled}
-              inputProps={{ "aria-label": label }}
-            />
-          }
-          label={
-            <FieldLabel
-              label={label}
-              requiresRestart={setting.requiresRestart}
-            />
-          }
-        />
-        {helperText && <FormHelperText>{helperText}</FormHelperText>}
-      </FormControl>
-    );
-  }
-
-  if (
-    setting.valueType === "ENUM" &&
-    setting.allowedValues &&
-    setting.allowedValues.length > 0
-  ) {
-    return (
-      <FormControl size="small" sx={{ minWidth: 240 }} error={Boolean(error)}>
-        <InputLabel id={`label-${setting.key}`}>
-          <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
-        </InputLabel>
-        <Select
-          labelId={`label-${setting.key}`}
-          label={label}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          inputProps={{ "aria-label": label }}
-        >
-          {setting.allowedValues.map((v) => (
-            <MenuItem key={v} value={v}>
-              {v}
-            </MenuItem>
-          ))}
-        </Select>
-        {helperText && <FormHelperText>{helperText}</FormHelperText>}
-      </FormControl>
-    );
-  }
-
-  if (setting.valueType === "INTEGER") {
-    return (
-      <TextField
-        label={
-          <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
-        }
-        type="number"
-        size="small"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        error={Boolean(error)}
-        helperText={helperText}
-        disabled={disabled}
-        inputProps={{
-          min: setting.minInt,
-          max: setting.maxInt,
-          "aria-label": label,
-        }}
-        sx={{ maxWidth: 320 }}
-      />
-    );
-  }
-
-  return (
-    <TextField
-      label={
-        <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
-      }
-      size="small"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      error={Boolean(error)}
-      helperText={helperText}
-      disabled={disabled}
-      inputProps={{ "aria-label": label }}
-      sx={{ maxWidth: 480 }}
-    />
-  );
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -21,6 +21,7 @@ import {
   Alert,
   Box,
   Button,
+  Chip,
   CircularProgress,
   Divider,
   FormControl,
@@ -185,9 +186,7 @@ export function GeneralSection() {
         </Typography>
         <Divider sx={{ mb: 2 }} />
         <Typography variant="body2" color="text.secondary">
-          These settings are stored in the database and shared across all users.
-          Changes marked as requiring a restart take effect after the next
-          server restart.
+          These settings are stored in the database and apply to all users.
         </Typography>
       </Box>
 
@@ -260,6 +259,28 @@ function formatLabel(key: string): string {
     .join(" ");
 }
 
+function FieldLabel({
+  label,
+  requiresRestart,
+}: {
+  label: string;
+  requiresRestart: boolean;
+}) {
+  if (!requiresRestart) return <>{label}</>;
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 1 }}>
+      {label}
+      <Chip
+        label="Requires restart"
+        size="small"
+        color="warning"
+        variant="outlined"
+        sx={{ height: 20, fontSize: "0.7rem" }}
+      />
+    </Box>
+  );
+}
+
 function SettingField({
   setting,
   value,
@@ -283,7 +304,12 @@ function SettingField({
               inputProps={{ "aria-label": label }}
             />
           }
-          label={label}
+          label={
+            <FieldLabel
+              label={label}
+              requiresRestart={setting.requiresRestart}
+            />
+          }
         />
         {helperText && <FormHelperText>{helperText}</FormHelperText>}
       </FormControl>
@@ -297,7 +323,9 @@ function SettingField({
   ) {
     return (
       <FormControl size="small" sx={{ minWidth: 240 }} error={Boolean(error)}>
-        <InputLabel id={`label-${setting.key}`}>{label}</InputLabel>
+        <InputLabel id={`label-${setting.key}`}>
+          <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
+        </InputLabel>
         <Select
           labelId={`label-${setting.key}`}
           label={label}
@@ -320,7 +348,9 @@ function SettingField({
   if (setting.valueType === "INTEGER") {
     return (
       <TextField
-        label={label}
+        label={
+          <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
+        }
         type="number"
         size="small"
         value={value}
@@ -340,7 +370,9 @@ function SettingField({
 
   return (
     <TextField
-      label={label}
+      label={
+        <FieldLabel label={label} requiresRestart={setting.requiresRestart} />
+      }
       size="small"
       value={value}
       onChange={(e) => onChange(e.target.value)}

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/settingsStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/settingsStore.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSettingsStore } from "./settingsStore";
+import * as apiConfig from "../api/config";
+import type { ApplicationSettingDto } from "../api/generated/model/application-setting-dto";
+
+vi.mock("../api/config", () => ({
+  adminSettingsApi: {
+    listApplicationSettings: vi.fn(),
+    updateApplicationSettings: vi.fn(),
+  },
+}));
+
+function buildDto(
+  overrides: Partial<ApplicationSettingDto>,
+): ApplicationSettingDto {
+  return {
+    key: "general.site_name",
+    value: "Plugwerk",
+    valueType: "STRING",
+    source: "DATABASE",
+    requiresRestart: false,
+    restartPending: false,
+    ...overrides,
+  } as ApplicationSettingDto;
+}
+
+describe("settingsStore", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      settings: [],
+      loaded: false,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    vi.mocked(apiConfig.adminSettingsApi.listApplicationSettings).mockReset();
+    vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings).mockReset();
+  });
+
+  it("starts with empty unloaded state", () => {
+    const state = useSettingsStore.getState();
+    expect(state.settings).toEqual([]);
+    expect(state.loaded).toBe(false);
+    expect(state.loading).toBe(false);
+  });
+
+  it("load populates settings from the API", async () => {
+    const dto = buildDto({});
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: [dto] } } as never);
+
+    await useSettingsStore.getState().load();
+
+    const state = useSettingsStore.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.loading).toBe(false);
+    expect(state.settings).toEqual([dto]);
+    expect(state.error).toBeNull();
+  });
+
+  it("load records error and re-throws on failure", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockRejectedValue(new Error("boom"));
+
+    await expect(useSettingsStore.getState().load()).rejects.toThrow("boom");
+
+    const state = useSettingsStore.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe("boom");
+  });
+
+  it("update sends patch and replaces settings with the response", async () => {
+    const updated = buildDto({ value: "New Name" });
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockResolvedValue({ data: { settings: [updated] } } as never);
+
+    await useSettingsStore
+      .getState()
+      .update({ "general.site_name": "New Name" });
+
+    expect(
+      vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings),
+    ).toHaveBeenCalledWith({
+      applicationSettingsUpdateRequest: {
+        settings: { "general.site_name": "New Name" },
+      },
+    });
+    expect(useSettingsStore.getState().settings).toEqual([updated]);
+    expect(useSettingsStore.getState().saving).toBe(false);
+  });
+
+  it("update records error and re-throws", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockRejectedValue(new Error("validation failed"));
+
+    await expect(
+      useSettingsStore.getState().update({ "tracking.enabled": "false" }),
+    ).rejects.toThrow("validation failed");
+
+    const state = useSettingsStore.getState();
+    expect(state.saving).toBe(false);
+    expect(state.error).toBe("validation failed");
+  });
+
+  it("reset clears all state back to initial", () => {
+    useSettingsStore.setState({
+      settings: [buildDto({})],
+      loaded: true,
+      loading: false,
+      saving: false,
+      error: "stale",
+    });
+
+    useSettingsStore.getState().reset();
+
+    const state = useSettingsStore.getState();
+    expect(state.settings).toEqual([]);
+    expect(state.loaded).toBe(false);
+    expect(state.error).toBeNull();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/settingsStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/settingsStore.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import axios from "axios";
+import { create } from "zustand";
+import { adminSettingsApi } from "../api/config";
+import type { ApplicationSettingDto } from "../api/generated/model/application-setting-dto";
+
+interface SettingsState {
+  readonly settings: ApplicationSettingDto[];
+  readonly loaded: boolean;
+  readonly loading: boolean;
+  readonly saving: boolean;
+  readonly error: string | null;
+  load: () => Promise<void>;
+  update: (patch: Record<string, string>) => Promise<void>;
+  reset: () => void;
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = (error.response?.data as { message?: string } | undefined)
+      ?.message;
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Unknown error";
+}
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  settings: [],
+  loaded: false,
+  loading: false,
+  saving: false,
+  error: null,
+
+  async load() {
+    set({ loading: true, error: null });
+    try {
+      const response = await adminSettingsApi.listApplicationSettings();
+      set({
+        settings: response.data.settings,
+        loaded: true,
+        loading: false,
+      });
+    } catch (err) {
+      set({
+        loaded: true,
+        loading: false,
+        error: extractErrorMessage(err),
+      });
+      throw err;
+    }
+  },
+
+  async update(patch) {
+    set({ saving: true, error: null });
+    try {
+      const response = await adminSettingsApi.updateApplicationSettings({
+        applicationSettingsUpdateRequest: { settings: patch },
+      });
+      set({ settings: response.data.settings, saving: false });
+    } catch (err) {
+      set({ saving: false, error: extractErrorMessage(err) });
+      throw err;
+    }
+  },
+
+  reset() {
+    set({
+      settings: [],
+      loaded: false,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+  },
+}));

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstallResult.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstallResult.kt
@@ -15,6 +15,8 @@
  */
 package io.plugwerk.spi.model
 
+import java.util.function.Consumer
+
 /**
  * Result of a [PlugwerkInstaller.install] or [PlugwerkInstaller.uninstall] operation.
  *
@@ -32,8 +34,8 @@ package io.plugwerk.spi.model
  * Java:
  * ```java
  * installer.install("io.example.my-plugin", "2.0.0")
- *     .onSuccess(s -> System.out.println("Installed " + s.getPluginId()))
- *     .onFailure(f -> System.out.println("Failed: " + f.getReason()));
+ *     .onSuccess(s -> System.out.printf("Installed: %s%n", s.getPluginId()))
+ *     .onFailure(f -> System.out.printf("Failed: %s%n", f.getReason()));
  * ```
  *
  * The `when` / `instanceof` pattern is still fully supported for exhaustive matching.
@@ -73,24 +75,29 @@ sealed class InstallResult {
     /**
      * Executes [action] if this is a [Success], then returns `this` for chaining.
      *
+     * Uses [Consumer] so Java callers can pass expression lambdas directly
+     * (`s -> System.out.printf(...)`) without `Unit.INSTANCE` boilerplate.
+     *
      * ```java
      * result.onSuccess(s -> log.info("Installed: {}", s.getPluginId()));
      * ```
      */
-    fun onSuccess(action: (Success) -> Unit): InstallResult {
-        if (this is Success) action(this)
+    fun onSuccess(action: Consumer<Success>): InstallResult {
+        if (this is Success) action.accept(this)
         return this
     }
 
     /**
      * Executes [action] if this is a [Failure], then returns `this` for chaining.
      *
+     * Uses [Consumer] so Java callers can pass expression lambdas directly.
+     *
      * ```java
      * result.onFailure(f -> log.warn("Failed: {}", f.getReason()));
      * ```
      */
-    fun onFailure(action: (Failure) -> Unit): InstallResult {
-        if (this is Failure) action(this)
+    fun onFailure(action: Consumer<Failure>): InstallResult {
+        if (this is Failure) action.accept(this)
         return this
     }
 


### PR DESCRIPTION
Closes the last remaining acceptance criterion for #208: the Admin → General Settings page
now reads and writes via the new `/api/v1/admin/settings` endpoints from #226 instead of
displaying a hardcoded form that did nothing on save.

**Base branch:** `feature/208_persistent-application-settings` (the backend PR #226).
Once #226 is merged to `main`, I'll retarget this PR to `main` and rebase.

## What changed

### `adminSettingsApi` wrapper (`src/api/config.ts`)
One new named export on the shared `axiosInstance` so auth, the 401 interceptor, and the
`/api/v1` base path all flow through the existing boundary.

### `settingsStore` (Zustand, `src/stores/settingsStore.ts`)
- `load()` — `GET /admin/settings`, stores the `ApplicationSettingDto[]` snapshot.
- `update(patch)` — `PATCH /admin/settings` with just the dirty keys; replaces the local
  snapshot with the server response so `restartPending` flags stay in sync.
- `reset()` — clears all state for test isolation.
- Error extraction unwraps `axios.isAxiosError(err).response.data.message` per the ADR-0004
  convention.

### `GeneralSection.tsx` (full rewrite)
Driven entirely by the DTO metadata — no hardcoded field list. Each
`ApplicationSettingDto` renders as:

| `valueType` | Widget |
|---|---|
| `BOOLEAN` | MUI `Switch` |
| `ENUM` (with `allowedValues`) | MUI `Select` |
| `INTEGER` (with optional `minInt`/`maxInt`) | number `TextField` |
| `STRING` | plain `TextField` |

Every field shows the DB-persisted `description` as MUI helper text. Inline client-side
validation mirrors the backend `SettingKey` validator (integer range, non-blank string,
boolean literal, enum allowedValues). The Save button stays disabled until there is a
dirty diff and only sends the edited keys. Discard clears the draft. A warning `<Alert>`
lists every key whose DB value has diverged from the boot value (`restartPending === true`)
— i.e. it surfaces the "server restart needed" UX that ADR-0016 described for
`upload.max_file_size_mb`.

Draft state is a **sparse map** of user-edited keys rather than a full snapshot, so no
derived-state sync effect is needed and the ESLint `react-hooks/set-state-in-effect` rule
stays clean.

### Tests
- `src/stores/settingsStore.test.ts` — 6 tests: initial state, load success, load failure,
  update success with correct payload, update failure, reset.
- `src/pages/admin/GeneralSection.test.tsx` — 5 tests: renders fields + description helper
  text on mount, Save disabled until dirty, dirty diff is the only payload sent, integer
  out-of-range validation blocks save, restart-pending alert renders.

## Test plan

- [x] `npm run lint` — zero new errors (pre-existing 10 errors unchanged, none in new files)
- [x] `npm run format` — no changes
- [x] `npm run test:run` — **246 / 246 passing**
- [x] `npm run build` — production bundle green
- [x] `preview_start` + accessibility snapshot — app bundles and renders, login page
      loads as expected
- [ ] **Manual smoke test against a live backend** — reviewer responsibility:
  1. `docker compose up -d postgres` + boot the server from PR #226
  2. Log in as superadmin
  3. Navigate to Admin → General
  4. Verify all seven settings render with their descriptions as helper text
  5. Change `upload.max_file_size_mb`, save, reload — value persists, warning Alert
     appears because `restartPending` is true
  6. Change `tracking.enabled` to `false`, save — next download write does not hit
     `download_event`
  7. Restart the server — warning Alert disappears, multipart filter caps at the new value

Refs #208