### PR TITLE
chore(ci): publish SNAPSHOT artifacts to GitHub Packages and GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release to Maven Central
+name: Release
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:
@@ -45,6 +46,12 @@ jobs:
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Pversion=${{ steps.version.outputs.VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Upload backend fat JAR for docker-publish job
         uses: actions/upload-artifact@v4
@@ -162,11 +169,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract Docker image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: plugwerk/plugwerk-server
+          images: |
+            plugwerk/plugwerk-server
+            ghcr.io/plugwerk/plugwerk-server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,0 +1,145 @@
+name: Publish SNAPSHOT
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  snapshot-maven:
+    name: Publish Maven SNAPSHOTs to GitHub Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for SNAPSHOT version
+        id: check
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::notice::VERSION is '$VERSION' (not a SNAPSHOT) — skipping publish"
+            echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up JDK 21
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Node.js 20
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: plugwerk-server/plugwerk-server-frontend/package-lock.json
+
+      - name: Setup Gradle
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build all modules
+        if: steps.check.outputs.is_snapshot == 'true'
+        run: ./gradlew build -x integrationTest
+
+      - name: Publish SNAPSHOTs to GitHub Packages
+        if: steps.check.outputs.is_snapshot == 'true'
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+
+  snapshot-docker:
+    name: Publish SNAPSHOT image to GHCR
+    needs: snapshot-maven
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for SNAPSHOT version
+        id: check
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up JDK 21
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Node.js 20
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: plugwerk-server/plugwerk-server-frontend/package-lock.json
+
+      - name: Setup Gradle
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build backend fat JAR
+        if: steps.check.outputs.is_snapshot == 'true'
+        run: ./gradlew :plugwerk-server:plugwerk-server-backend:bootJar -x test
+
+      - name: Stage fat JAR for Docker build
+        if: steps.check.outputs.is_snapshot == 'true'
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          JAR="plugwerk-server/plugwerk-server-backend/build/libs/plugwerk-server-backend-${VERSION}.jar"
+          test -f "$JAR" || { echo "::error::Fat JAR not found: $JAR"; exit 1; }
+          cp "$JAR" plugwerk-server/plugwerk-server-backend/src/dist/
+          ls -lh plugwerk-server/plugwerk-server-backend/src/dist/
+
+      - name: Set up QEMU
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push SNAPSHOT image to GHCR
+        if: steps.check.outputs.is_snapshot == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: plugwerk-server/plugwerk-server-backend/src/dist
+          file: plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/plugwerk/plugwerk-server:snapshot
+          labels: |
+            org.opencontainers.image.title=Plugwerk Server
+            org.opencontainers.image.description=Plugin management and marketplace software for the Java/PF4J ecosystem (SNAPSHOT).
+            org.opencontainers.image.source=https://github.com/plugwerk/plugwerk
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,8 @@ PRs without labels or milestone are non-compliant. Set them via `gh pr edit <num
   - [ADR-0011](docs/adrs/0011-client-auth-api-key-strategy.md) — Client Plugin authentication (API key primary)
   - [ADR-0014](docs/adrs/0014-dual-license-library-modules.md) — Dual-license: Apache-2.0 for libraries, AGPL-3.0 for server
   - [ADR-0016](docs/adrs/0016-application-settings-precedence.md) — Application settings precedence (DB is authoritative, YAML is infra-only)
+  - [ADR-0017](docs/adrs/0017-dual-registry-publishing-strategy.md) — Dual-registry publishing: GitHub Packages for SNAPSHOTs, Maven Central + Docker Hub for releases
+- Development guide: `docs/development.md` — SNAPSHOT resolution, PAT setup, container images
 - Feature specifications: `docs/features/` — GitHub Issues link to their corresponding spec file
 - Project concept: `docs/concepts/`
 - Design system: `docs/design/` — HTML prototypes and design tokens (`tokens.css`)
@@ -330,6 +332,15 @@ npm run license:add          # Add missing license headers
 
 **Important**: Frontend tests must be run from `plugwerk-server/plugwerk-server-frontend/` — running
 `npx vitest` from the repo root uses the wrong config and picks up unrelated test files.
+
+### Publishing (run from repo root)
+
+```bash
+./gradlew publishAllPublicationsToGitHubPackagesRepository   # Publish SNAPSHOTs to GitHub Packages (requires GITHUB_TOKEN)
+./gradlew publishAggregationToCentralPortal                  # Publish release to Maven Central (CI only)
+```
+
+SNAPSHOT artifacts are published automatically on every push to `main` via the `snapshot-publish.yml` workflow. Release artifacts are published to both Maven Central and GitHub Packages by the `release.yml` workflow on `v*` tags. See [docs/development.md](docs/development.md) for consuming SNAPSHOT artifacts in dependent repositories.
 
 ## Implementation Phases
 

--- a/buildSrc/src/main/kotlin/io.plugwerk.maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.plugwerk.maven-publish.gradle.kts
@@ -44,6 +44,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/plugwerk/plugwerk")
+            credentials {
+                username = providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+                password = providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+            }
+        }
+    }
 }
 
 signing {

--- a/docs/adrs/0017-dual-registry-publishing-strategy.md
+++ b/docs/adrs/0017-dual-registry-publishing-strategy.md
@@ -1,0 +1,164 @@
+# ADR-0017: Dual-Registry Publishing Strategy — GitHub Packages for SNAPSHOTs, Maven Central + Docker Hub for Releases
+
+## Status
+
+Accepted
+
+## Context
+
+The Plugwerk GitHub organization contains multiple repositories that depend on each other during
+development (`plugwerk-spi`, `plugwerk-descriptor`, `plugwerk-api-model` are consumed by
+`plugwerk-server`, `plugwerk-client-plugin`, and example projects). Before this ADR,
+inter-repository development required running `./gradlew publishToMavenLocal` locally, which
+breaks CI in dependent repos and makes cross-repo PRs difficult to test.
+
+Issue [#230](https://github.com/plugwerk/plugwerk/issues/230) explored publishing SNAPSHOT
+versions of Maven artifacts and development container images to GitHub's internal registries so
+that dependent repositories can resolve development builds without manual local installs.
+
+The existing release workflow ([#195](https://github.com/plugwerk/plugwerk/issues/195),
+[#203](https://github.com/plugwerk/plugwerk/issues/203)) publishes to Maven Central and Docker
+Hub exclusively. This must not change — those are the canonical distribution channels for
+released artifacts.
+
+## Decision
+
+Adopt a **dual-registry strategy** with clear separation between development and release
+artifacts:
+
+### Maven Artifacts
+
+| Stage | Registry | Trigger | Versions |
+|---|---|---|---|
+| **Development** | GitHub Packages (`maven.pkg.github.com/plugwerk/plugwerk`) | Push to `main` | `*-SNAPSHOT` only |
+| **Release** | Maven Central **and** GitHub Packages | Git tag `v*` | Release versions only |
+
+**Published modules** (both registries):
+
+1. `plugwerk-spi` (JAR)
+2. `plugwerk-descriptor` (JAR)
+3. `plugwerk-api-model` (JAR)
+4. `plugwerk-client-plugin` (JAR + PF4J ZIP)
+5. `plugwerk-server` (distribution ZIP)
+
+**Implementation:**
+
+- The convention plugin `io.plugwerk.maven-publish` and the server backend's custom publication
+  both declare a `GitHubPackages` Maven repository alongside the existing NMCP configuration.
+- Credentials use `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables, which are
+  automatically available in GitHub Actions. For local development, they fall back to empty
+  strings (publishing to GitHub Packages is not intended locally).
+- The SNAPSHOT workflow (`snapshot-publish.yml`) runs
+  `publishAllPublicationsToGitHubPackagesRepository` — this Gradle task targets only the
+  `GitHubPackages` repository and does not touch Maven Central.
+- The release workflow (`release.yml`) runs `publishAggregationToCentralPortal` (Maven Central)
+  followed by `publishAllPublicationsToGitHubPackagesRepository` (GitHub Packages). SNAPSHOTs
+  are rejected by the existing tag guard before either task runs.
+- GPG signing is conditional (`onlyIf { project.hasProperty("signingKey") }`). SNAPSHOT
+  publishes to GitHub Packages skip signing. Release publishes sign all artifacts (the signed
+  artifacts are then published to both registries).
+
+### Container Images
+
+| Stage | Registry | Tags | Trigger |
+|---|---|---|---|
+| **Development** | GHCR (`ghcr.io/plugwerk/plugwerk-server`) | `:snapshot` | Push to `main` |
+| **Release** | Docker Hub **and** GHCR | `:<version>`, `:<major>.<minor>`, `:latest` | Git tag `v*` |
+
+**Implementation:**
+
+- The SNAPSHOT workflow builds the fat JAR and pushes a single `:snapshot` tag to GHCR. This
+  tag is overwritten on every push to `main`.
+- The release workflow logs into both Docker Hub and GHCR, then uses `docker/metadata-action`
+  with both image names to generate tags for both registries in a single `build-push-action`
+  step.
+- Per-PR images (`pr-<number>`) are deferred to Phase 3 — the complexity of cleanup policies
+  and storage costs does not justify the benefit for the current single-team development model.
+
+### Authentication Model
+
+| Context | Mechanism | Scope |
+|---|---|---|
+| GitHub Actions (same org) | `GITHUB_TOKEN` (automatic) | `read:packages` + `write:packages` |
+| GitHub Actions (other org) | `GITHUB_TOKEN` of consuming repo | `read:packages` |
+| Local development | Personal Access Token (PAT) with `read:packages` | Read-only |
+
+GitHub Packages requires authentication even for reading public packages within the same
+organization. This is a known limitation and the primary trade-off of this approach.
+
+### Consuming SNAPSHOT Artifacts
+
+Dependent repositories add the GitHub Packages Maven repository to their Gradle configuration:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/plugwerk/plugwerk")
+        credentials {
+            username = providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+            password = providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+        }
+    }
+}
+```
+
+For local development, developers configure a PAT in `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=<github-username>
+gpr.key=<personal-access-token-with-read:packages>
+```
+
+And reference it in the repository block:
+
+```kotlin
+credentials {
+    username = project.findProperty("gpr.user")?.toString()
+        ?: providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+    password = project.findProperty("gpr.key")?.toString()
+        ?: providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+}
+```
+
+## Consequences
+
+### Positive
+
+- **Cross-repo CI works without local publishes.** Dependent repositories resolve SNAPSHOT
+  artifacts from GitHub Packages automatically.
+- **Release artifacts are mirrored on GitHub Packages.** Org-internal consumers can use a
+  single repository configuration for both SNAPSHOT and release resolution.
+- **Container images are available on GHCR for internal testing** without polluting Docker Hub
+  with unreleased tags.
+- **No changes to the existing release workflow semantics.** Maven Central and Docker Hub remain
+  the canonical release channels. GitHub Packages and GHCR are additive.
+- **No new secrets required.** `GITHUB_TOKEN` is automatically available in GitHub Actions.
+- **Version is already SNAPSHOT on `main`.** The `VERSION` file contains `*-SNAPSHOT` between
+  releases, so `./gradlew publish` on `main` naturally produces SNAPSHOT artifacts.
+
+### Negative / Trade-offs
+
+- **GitHub Packages requires authentication for reads.** Even public packages in the same org
+  require a valid token. Developers must configure a PAT for local SNAPSHOT resolution. CI
+  within the org uses the automatic `GITHUB_TOKEN`.
+- **Additional CI time.** The SNAPSHOT workflow adds ~3-5 minutes to every push to `main`. The
+  release workflow adds ~1 minute for the GitHub Packages publish step.
+- **Storage costs.** GitHub Packages has a free tier (500 MB for free plans, more for paid).
+  SNAPSHOT artifacts are overwritten on each publish (Maven SNAPSHOT semantics), so storage
+  grows slowly. GHCR `:snapshot` tag is a single overwritten image.
+- **Per-PR images deferred.** Cross-repo PR testing requires checking out the PR branch and
+  building locally, or waiting for the PR to merge to `main` and the SNAPSHOT to publish.
+
+## Alternatives Considered
+
+- **Gradle composite builds / dependency substitution:** Works for local development but does
+  not help CI in other repositories. Also requires all repos to be checked out side-by-side.
+- **JitPack:** Third-party service, adds an external dependency, limited control over
+  publishing, no container image support.
+- **`publishToMavenLocal` in CI:** Possible within a single workflow but does not persist
+  across repositories or workflow runs.
+- **Only Maven Central for everything:** Maven Central does not accept SNAPSHOT versions (by
+  design). The OSSRH staging repository could host SNAPSHOTs, but the Gradle NMCP plugin does
+  not support it, and the Sonatype OSSRH is being deprecated in favor of the Central Portal.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,131 @@
+# Development Guide
+
+This guide covers development workflows for contributors and consumers of Plugwerk libraries.
+
+## Resolving SNAPSHOT Artifacts
+
+Every push to `main` publishes SNAPSHOT versions of all Plugwerk library modules to
+[GitHub Packages](https://github.com/orgs/plugwerk/packages). This allows dependent
+repositories to resolve development builds without local `publishToMavenLocal` workflows.
+
+### Published SNAPSHOT Modules
+
+| Module | Artifact ID | Description |
+|---|---|---|
+| `plugwerk-spi` | `io.plugwerk:plugwerk-spi` | Extension point interfaces and shared model types |
+| `plugwerk-descriptor` | `io.plugwerk:plugwerk-descriptor` | MANIFEST.MF parser and validator |
+| `plugwerk-api-model` | `io.plugwerk:plugwerk-api-model` | Generated REST API DTOs |
+| `plugwerk-client-plugin` | `io.plugwerk:plugwerk-client-plugin` | Client SDK (JAR + PF4J ZIP) |
+| `plugwerk-server` | `io.plugwerk:plugwerk-server` | Server distribution ZIP |
+
+### Gradle Configuration (CI)
+
+In GitHub Actions, the automatic `GITHUB_TOKEN` provides read access to GitHub Packages within
+the same organization. Add the repository to your `build.gradle.kts`:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/plugwerk/plugwerk")
+        credentials {
+            username = providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+            password = providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+        }
+    }
+}
+
+dependencies {
+    implementation("io.plugwerk:plugwerk-spi:1.0.0-SNAPSHOT")
+}
+```
+
+No additional secrets are needed — `GITHUB_TOKEN` and `GITHUB_ACTOR` are automatically
+available in GitHub Actions workflows.
+
+### Gradle Configuration (Local Development)
+
+GitHub Packages requires authentication even for reading public packages. Create a Personal
+Access Token (PAT) with `read:packages` scope and configure it in `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=your-github-username
+gpr.key=ghp_your-personal-access-token
+```
+
+Then reference these properties in your `build.gradle.kts`:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/plugwerk/plugwerk")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString()
+                ?: providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+            password = project.findProperty("gpr.key")?.toString()
+                ?: providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+        }
+    }
+}
+```
+
+### Maven Configuration
+
+For Maven-based consumers, add the repository to `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github-plugwerk</id>
+      <username>your-github-username</username>
+      <password>ghp_your-personal-access-token</password>
+    </server>
+  </servers>
+</settings>
+```
+
+And in your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github-plugwerk</id>
+    <url>https://maven.pkg.github.com/plugwerk/plugwerk</url>
+  </repository>
+</repositories>
+```
+
+## SNAPSHOT Container Images
+
+A development container image is published to GHCR on every push to `main`:
+
+```bash
+docker pull ghcr.io/plugwerk/plugwerk-server:snapshot
+```
+
+This image reflects the latest state of `main` and is intended for integration testing across
+repositories. It is **not** suitable for production use.
+
+Authentication for pulling from GHCR (if the package is org-internal):
+
+```bash
+echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+```
+
+## Release Artifacts
+
+Released versions are published to both external and internal registries:
+
+| Artifact | External Registry | Internal Registry |
+|---|---|---|
+| Maven JARs/ZIPs | Maven Central | GitHub Packages |
+| Container Images | Docker Hub (`plugwerk/plugwerk-server`) | GHCR (`ghcr.io/plugwerk/plugwerk-server`) |
+
+For production use, prefer Maven Central and Docker Hub. GitHub Packages and GHCR mirror the
+same artifacts for org-internal convenience.
+
+See [ADR-0017](adrs/0017-dual-registry-publishing-strategy.md) for the full rationale.

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -136,6 +136,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/plugwerk/plugwerk")
+            credentials {
+                username = providers.environmentVariable("GITHUB_ACTOR").getOrElse("")
+                password = providers.environmentVariable("GITHUB_TOKEN").getOrElse("")
+            }
+        }
+    }
 }
 
 signing {


### PR DESCRIPTION
## Summary

Add a dual-registry publishing strategy so that dependent repositories in the `plugwerk`
organization can resolve SNAPSHOT artifacts from GitHub Packages without manual
`publishToMavenLocal` workflows. Releases are additionally mirrored to GitHub Packages and
GHCR alongside the existing Maven Central and Docker Hub targets.

Closes #230

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] CI/Build

## Changes

### Gradle Configuration
- Add `GitHubPackages` Maven repository to `io.plugwerk.maven-publish` convention plugin
- Add `GitHubPackages` Maven repository to `plugwerk-server-backend` for `serverDist` publication
- Credentials via `GITHUB_ACTOR`/`GITHUB_TOKEN` (automatic in CI, empty fallback locally)

### SNAPSHOT Workflow (new: `snapshot-publish.yml`)
- Triggered on every push to `main` when `VERSION` ends with `-SNAPSHOT`
- Publishes all 5 library modules to GitHub Packages
- Builds and pushes `ghcr.io/plugwerk/plugwerk-server:snapshot` to GHCR

### Release Workflow (modified: `release.yml`)
- Added `packages: write` permission
- Added `publishAllPublicationsToGitHubPackagesRepository` step after Maven Central publish
- Added GHCR login + dual-image metadata (`plugwerk/plugwerk-server` + `ghcr.io/plugwerk/plugwerk-server`)
- Renamed workflow from "Release to Maven Central" to "Release"

### Documentation
- **ADR-0017**: Dual-registry publishing strategy decision record
- **docs/development.md**: SNAPSHOT consumer guide (Gradle CI, Gradle local PAT, Maven, Docker)
- **AGENTS.md**: Added ADR-0017 reference, development guide link, publishing commands

## Publishing Matrix

| Artifact | SNAPSHOT (main push) | Release (v* tag) |
|---|---|---|
| Maven JARs/ZIPs | GitHub Packages | Maven Central + GitHub Packages |
| Container Images | GHCR (`:snapshot`) | Docker Hub + GHCR |

## Checklist

- [x] Tests pass locally (`./gradlew build -x test` + task verification)
- [x] Documentation updated (ADR-0017, development.md, AGENTS.md)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent
- [x] This PR was co-authored by human + AI agent (Claude Code)