### PR TITLE
fix: serve frontend static resources and SPA routes correctly

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
@@ -54,7 +54,7 @@ configurations.create("staticResources") {
 }
 
 artifacts {
-    add("staticResources", file("${layout.buildDirectory.get()}/resources/main/static")) {
+    add("staticResources", file("${layout.buildDirectory.get()}/resources/main")) {
         builtBy(copyFrontend)
     }
 }


### PR DESCRIPTION
## Summary

Two related bugs prevented the Plugwerk web UI from working in the fat JAR / Docker image:

1. **`GET /` returned 500** because the frontend assets (`index.html`, `assets/*`) were merged into the fat JAR at the classpath root instead of under `classpath:/static/`.
2. **Browser reload on any SPA route** (e.g. `/admin/namespaces/acme`, `/profile`, `/login?from=...`) returned 401 / "This page isn't working" because both the SecurityConfig allowlist and the hand-maintained `SpaController` route list were incomplete.

Both are fixed in this PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Changes

### Fix 1 — Frontend static resources classpath location (`42d3af2`)

`plugwerk-server-frontend/build.gradle.kts`: the `staticResources` artifact was rooted at `build/resources/main/static`, which placed files directly at the classpath root when consumed by the backend. Spring Boot's default `ResourceHandler` serves from `classpath:/static/`, so nothing was found.

Changed the artifact root to `build/resources/main` so the `static/` prefix is preserved.

**Before:**
```
BOOT-INF/classes/index.html          ← wrong
BOOT-INF/classes/assets/...          ← wrong
```

**After:**
```
BOOT-INF/classes/static/index.html   ← correct
BOOT-INF/classes/static/assets/...   ← correct
```

### Fix 2 — SPA reload + deep-link fallback (`f199183`)

Replace the hand-maintained `SpaController` with a `WebMvcConfigurer` + `PathResourceResolver` that automatically forwards any non-matching URL to `index.html`. New frontend routes no longer require a backend change.

Extend `SecurityConfiguration` to `permitAll` for all GET requests targeting SPA routes (`/admin/**`, `/profile`, `/change-password`, `/onboarding`, `/namespaces/*/plugins/**`, login/register/reset/error pages). These requests only serve `index.html` or static bundles; real authorization happens in the frontend via API calls.

Query strings (`/login?from=...`) work correctly — matching ignores the query.

## Verification

- Local `./gradlew bootJar` produces a JAR where `index.html` and `assets/` are under `BOOT-INF/classes/static/`.
- `./gradlew compileKotlin` passes.
- `SecurityConfiguration` allowlist now covers all routes defined in `src/router/index.tsx`.

## Checklist

- [x] Local build passes
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent
- [x] This PR was co-authored by human + AI agent (Claude Code)