### PR TITLE
fix(docker): create and persist /var/plugwerk/artifacts in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 
-RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk
+RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk \
+    && mkdir -p /var/plugwerk/artifacts \
+    && chown -R plugwerk:plugwerk /var/plugwerk
 USER plugwerk
 
 COPY --from=build --chown=plugwerk:plugwerk /app/plugwerk-server/plugwerk-server-backend/build/libs/*.jar app.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,14 @@ services:
       PLUGWERK_DB_URL: jdbc:postgresql://postgres:5432/plugwerk
       PLUGWERK_DB_USERNAME: plugwerk
       PLUGWERK_DB_PASSWORD: plugwerk
-      PLUGWERK_STORAGE_ROOT: /tmp/plugwerk-artifacts
       PLUGWERK_JWT_SECRET: "${PLUGWERK_JWT_SECRET:?Set PLUGWERK_JWT_SECRET (min 32 chars)}"
       PLUGWERK_ENCRYPTION_KEY: "${PLUGWERK_ENCRYPTION_KEY:?Set PLUGWERK_ENCRYPTION_KEY (exactly 16 chars)}"
       PLUGWERK_AUTH_ADMIN_PASSWORD: ${PLUGWERK_AUTH_ADMIN_PASSWORD:-}
+    volumes:
+      - plugwerk-artifacts:/var/plugwerk/artifacts
     ports:
       - "8080:8080"
 
 volumes:
   postgres-data:
+  plugwerk-artifacts:

--- a/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/Dockerfile
@@ -2,7 +2,12 @@ FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 
-RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk
+# Create the plugwerk user and the artifact storage directory with correct ownership
+# so the non-root user can write uploads. Matches the default PLUGWERK_STORAGE_ROOT
+# in application.yml (/var/plugwerk/artifacts).
+RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk \
+    && mkdir -p /var/plugwerk/artifacts \
+    && chown -R plugwerk:plugwerk /var/plugwerk
 USER plugwerk
 
 COPY plugwerk-server-backend-*.jar app.jar

--- a/plugwerk-server/plugwerk-server-backend/src/dist/docker-compose.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/dist/docker-compose.yml
@@ -24,12 +24,14 @@ services:
       PLUGWERK_DB_URL: jdbc:postgresql://postgres:5432/plugwerk
       PLUGWERK_DB_USERNAME: plugwerk
       PLUGWERK_DB_PASSWORD: plugwerk
-      PLUGWERK_STORAGE_ROOT: /tmp/plugwerk-artifacts
       PLUGWERK_JWT_SECRET: "${PLUGWERK_JWT_SECRET:?Set PLUGWERK_JWT_SECRET (min 32 chars)}"
       PLUGWERK_ENCRYPTION_KEY: "${PLUGWERK_ENCRYPTION_KEY:?Set PLUGWERK_ENCRYPTION_KEY (exactly 16 chars)}"
       PLUGWERK_AUTH_ADMIN_PASSWORD: ${PLUGWERK_AUTH_ADMIN_PASSWORD:-}
+    volumes:
+      - plugwerk-artifacts:/var/plugwerk/artifacts
     ports:
       - "8080:8080"
 
 volumes:
   postgres-data:
+  plugwerk-artifacts:


### PR DESCRIPTION
## Summary

Uploading a plugin via the running Docker image failed with `AccessDeniedException: /var/plugwerk`. The non-root `plugwerk` user in the container had no write permission because the directory was never created or chown'd in the Dockerfile.

The previous workaround in `docker-compose.yml` overrode `PLUGWERK_STORAGE_ROOT=/tmp/plugwerk-artifacts`, which made uploads ephemeral (lost on container restart) and masked the underlying Dockerfile bug.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Root Cause

```
io.plugwerk.server.service.ArtifactStorageException: Failed to store artifact
  at FilesystemArtifactStorageService.store(FilesystemArtifactStorageService.kt:44)
Caused by: java.nio.file.AccessDeniedException: /var/plugwerk
  at Files.createDirectories(...)
```

The Dockerfile created the `plugwerk` user before copying the JAR but never created `/var/plugwerk` nor set ownership.

## Changes

### `plugwerk-server-backend/src/dist/Dockerfile`
```diff
-RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk
+RUN addgroup -S plugwerk && adduser -S plugwerk -G plugwerk \
+    && mkdir -p /var/plugwerk/artifacts \
+    && chown -R plugwerk:plugwerk /var/plugwerk
 USER plugwerk
```

### `docker-compose.yml` (root + `src/dist/`)
- Drop the `PLUGWERK_STORAGE_ROOT=/tmp/...` override — default (`/var/plugwerk/artifacts`) now works
- Mount a named `plugwerk-artifacts` volume at `/var/plugwerk/artifacts` for persistence across restarts

## Follow-up

A matching change is needed in the `plugwerk/examples` repository's `docker-compose.yml` (separate PR) to add the same volume mount for consumers using the GHCR SNAPSHOT image.

## Verification

- `./gradlew :plugwerk-server:plugwerk-server-backend:bootJar` passes.
- After rebuild the next SNAPSHOT image will have `/var/plugwerk/artifacts` writable by the container user.

## Checklist

- [x] Local build passes
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent
- [x] This PR was co-authored by human + AI agent (Claude Code)