### PR TITLE
feat(release): dispatch docker-compose-update to website on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,14 @@ jobs:
           event-type: openapi-update
           client-payload: '{"version": "${{ steps.version.outputs.VERSION }}"}'
 
+      - name: Sync docker-compose.yml to website
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          repository: plugwerk/website
+          event-type: docker-compose-update
+          client-payload: '{"version": "${{ steps.version.outputs.VERSION }}"}'
+
   docker-publish:
     name: Build and push Docker image
     needs: publish


### PR DESCRIPTION
## Summary

Adds a second `peter-evans/repository-dispatch` step to `release.yml`, right after the existing OpenAPI sync. Fires `event-type: docker-compose-update` with the release version so the [website repo](https://github.com/plugwerk/website) picks up the canonical `plugwerk-server/plugwerk-server-backend/src/dist/docker-compose.yml` and updates `public/deploy/docker-compose.yml` via its existing `sync-docker-compose.yml` workflow.

Closes #246

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [x] CI/Build

## Context

The canonical deployer-facing compose file already exists at the path above (uses `image:` not `build:`, required-secret syntax, healthcheck, named volume). The website repo already has:

- `public/deploy/docker-compose.yml` (target)
- `src/lib/deploy.ts` — build-time `readFileSync` import
- `deployment.mdx` — renders via `<Code code={composeYaml} … />`
- `.github/workflows/sync-docker-compose.yml` — listens for `docker-compose-update` dispatches

What was missing: the dispatch from this repo. This PR adds it.

## Scope

This PR introduces **8 added lines** in `release.yml` (one new step, identical pattern to the existing OpenAPI dispatch).

## Follow-up

After merge, trigger the initial sync for the already-released `v1.0.0-alpha.2` manually (it didn't fire a dispatch yet):

```bash
gh workflow run sync-docker-compose.yml \
  --repo plugwerk/website \
  --ref main \
  -f version=1.0.0-alpha.2
```

That opens a sync PR in `plugwerk/website` correcting the minor drift that already exists (missing `ports: "127.0.0.1:5432:5432"` on the postgres service).

## Checklist

- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent
- [x] This PR was co-authored by human + AI agent (Claude Code)