### PR TITLE
feat(security): enable @PreAuthorize on all mutating endpoints (#257)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/MethodSecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/MethodSecurityConfiguration.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+
+/**
+ * Enables AOP-based method-level authorization (`@PreAuthorize`).
+ *
+ * `prePostEnabled = true` is the default in Spring Security 7, so `@PreAuthorize` and
+ * `@PostAuthorize` evaluation is active without any further configuration.
+ *
+ * Every mutating REST endpoint carries a `@PreAuthorize` that mirrors the programmatic
+ * `requireRole` / `requireSuperadmin` call made inside the method body. The programmatic
+ * calls stay in place as defence-in-depth; this configuration adds the AOP safety net.
+ *
+ * Kept as a standalone configuration (separate from [SecurityConfiguration]) so the
+ * filter-chain bean stays focused and test slices can opt into method-security
+ * independently.
+ */
+@Configuration
+@EnableMethodSecurity
+class MethodSecurityConfiguration

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AccessKeyController.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.domain.NamespaceAccessKeyEntity
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.AccessKeyService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -50,6 +51,7 @@ class AccessKeyController(
         return ResponseEntity.ok(keys)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun createAccessKey(
         ns: String,
         accessKeyCreateRequest: AccessKeyCreateRequest,
@@ -75,6 +77,7 @@ class AccessKeyController(
             .body(response)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun revokeAccessKey(ns: String, keyId: UUID): ResponseEntity<Unit> {
         namespaceAuthorizationService.requireRole(
             ns,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.service.settings.SettingKey
 import io.plugwerk.server.service.settings.SettingSnapshot
 import io.plugwerk.server.service.settings.SettingSource
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -55,6 +56,7 @@ class AdminSettingsController(
         return ResponseEntity.ok(buildResponse())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun updateApplicationSettings(
         applicationSettingsUpdateRequest: ApplicationSettingsUpdateRequest,
     ): ResponseEntity<ApplicationSettingsResponse> {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.UnauthorizedException
 import io.plugwerk.server.service.UserService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -48,6 +49,7 @@ class AdminUserController(
         return ResponseEntity.ok(users.map { it.toDto() })
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun createUser(userCreateRequest: UserCreateRequest): ResponseEntity<UserDto> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")
@@ -60,6 +62,7 @@ class AdminUserController(
         return ResponseEntity.created(URI("/api/v1/admin/users/${user.id}")).body(user.toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun updateUser(userId: UUID, userUpdateRequest: UserUpdateRequest): ResponseEntity<UserDto> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")
@@ -70,6 +73,7 @@ class AdminUserController(
         return ResponseEntity.ok(user.toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteUser(userId: UUID): ResponseEntity<Unit> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -77,6 +79,16 @@ class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenException::class)
     fun handleForbidden(ex: ForbiddenException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.FORBIDDEN, ex.message ?: "Forbidden")
+
+    /**
+     * Maps `@PreAuthorize`-denied requests (Spring Security 7's
+     * [AuthorizationDeniedException] and its parent [AccessDeniedException]) to the
+     * same 403 JSON envelope used for [ForbiddenException]. Without this handler Spring
+     * falls back to a plain 403 response that bypasses the API's error-envelope contract.
+     */
+    @ExceptionHandler(AuthorizationDeniedException::class, AccessDeniedException::class)
+    fun handleAuthorizationDenied(ex: RuntimeException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.FORBIDDEN, "Access denied")
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(ex: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ManagementController.kt
@@ -32,6 +32,7 @@ import io.plugwerk.server.service.PluginService
 import io.plugwerk.spi.model.PluginStatus
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -48,6 +49,7 @@ class ManagementController(
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
 ) : ManagementApi {
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'MEMBER')")
     override fun updatePlugin(
         ns: String,
         pluginId: String,
@@ -80,6 +82,7 @@ class ManagementController(
         return ResponseEntity.ok(pluginMapper.toDto(plugin, ns, latestRelease = null))
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'MEMBER')")
     override fun uploadPluginRelease(ns: String, artifact: MultipartFile): ResponseEntity<PluginReleaseDto> {
         namespaceAuthorizationService.requireRole(
             ns,
@@ -98,6 +101,7 @@ class ManagementController(
         ).body(dto)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun updateReleaseStatus(
         ns: String,
         pluginId: String,
@@ -114,6 +118,7 @@ class ManagementController(
         return ResponseEntity.ok(releaseMapper.toDto(release, pluginId))
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun deletePlugin(ns: String, pluginId: String): ResponseEntity<Unit> {
         namespaceAuthorizationService.requireRole(
             ns,
@@ -124,6 +129,7 @@ class ManagementController(
         return ResponseEntity.noContent().build()
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun deleteRelease(ns: String, pluginId: String, version: String): ResponseEntity<Unit> {
         namespaceAuthorizationService.requireRole(
             ns,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.service.NamespaceAlreadyExistsException
 import io.plugwerk.server.service.NamespaceService
 import io.plugwerk.server.service.UnauthorizedException
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -49,6 +50,7 @@ class NamespaceController(
         return ResponseEntity.ok(namespaces)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun createNamespace(namespaceCreateRequest: NamespaceCreateRequest): ResponseEntity<NamespaceSummary> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")
@@ -67,6 +69,7 @@ class NamespaceController(
         }
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun updateNamespace(
         ns: String,
         namespaceUpdateRequest: NamespaceUpdateRequest,
@@ -84,6 +87,7 @@ class NamespaceController(
         return ResponseEntity.ok(entity.toSummary())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteNamespace(ns: String): ResponseEntity<Unit> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
@@ -33,6 +33,7 @@ import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.RequestMapping
@@ -84,6 +85,7 @@ class NamespaceMemberController(
         return ResponseEntity.ok(members)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun addNamespaceMember(
         ns: String,
         namespaceMemberCreateRequest: NamespaceMemberCreateRequest,
@@ -117,6 +119,7 @@ class NamespaceMemberController(
         return ResponseEntity.created(URI("/api/v1/namespaces/$ns/members/${member.userSubject}")).body(member.toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun updateNamespaceMember(
         ns: String,
         userSubject: String,
@@ -134,6 +137,7 @@ class NamespaceMemberController(
         return ResponseEntity.ok(namespaceMemberRepository.save(member).toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun removeNamespaceMember(ns: String, userSubject: String): ResponseEntity<Unit> {
         namespaceAuthorizationService.requireRole(
             ns,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.OidcProviderService
 import io.plugwerk.server.service.UnauthorizedException
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -49,6 +50,7 @@ class OidcProviderController(
         return ResponseEntity.ok(oidcProviderService.findAll().map { it.toDto() })
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun createOidcProvider(
         oidcProviderCreateRequest: OidcProviderCreateRequest,
     ): ResponseEntity<OidcProviderDto> {
@@ -66,6 +68,7 @@ class OidcProviderController(
         return ResponseEntity.created(URI("/api/v1/admin/oidc-providers/${provider.id}")).body(provider.toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun updateOidcProvider(
         providerId: UUID,
         oidcProviderUpdateRequest: OidcProviderUpdateRequest,
@@ -81,6 +84,7 @@ class OidcProviderController(
         return ResponseEntity.ok(provider.toDto())
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteOidcProvider(providerId: UUID): ResponseEntity<Unit> {
         val auth = SecurityContextHolder.getContext().authentication
             ?: throw UnauthorizedException("Not authenticated")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ReviewsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ReviewsController.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -60,6 +61,7 @@ class ReviewsController(
         return ResponseEntity.ok(pending)
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun approveRelease(
         ns: String,
         releaseId: UUID,
@@ -77,6 +79,7 @@ class ReviewsController(
         return ResponseEntity.ok(releaseMapper.toDto(release, release.plugin.pluginId))
     }
 
+    @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
     override fun rejectRelease(
         ns: String,
         releaseId: UUID,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
@@ -24,6 +24,7 @@ import io.plugwerk.api.model.UserSettingsUpdateRequest
 import io.plugwerk.server.service.UnauthorizedException
 import io.plugwerk.server.service.settings.UserSettingsService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -38,6 +39,7 @@ class UserSettingsController(private val userSettingsService: UserSettingsServic
         return ResponseEntity.ok(UserSettingsResponse(settings = settings))
     }
 
+    @PreAuthorize("isAuthenticated() and !authentication.name.startsWith('key:')")
     override fun updateUserSettings(
         userSettingsUpdateRequest: UserSettingsUpdateRequest,
     ): ResponseEntity<UserSettingsResponse> {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 
 /**
@@ -125,6 +126,41 @@ class NamespaceAuthorizationService(
      */
     fun isSuperadmin(authentication: Authentication): Boolean = !authentication.name.startsWith("key:") &&
         userRepository.findByUsername(authentication.name).map { it.isSuperadmin }.orElse(false)
+
+    /**
+     * SpEL-friendly mirror of [requireRole] for use in `@PreAuthorize` annotations.
+     * Reads the current [Authentication] from [SecurityContextHolder] and returns a boolean
+     * instead of throwing. Unknown namespaces return `false` so the SpEL pass-through
+     * produces a 403; the subsequent service call will re-raise the 404 on the happy path.
+     */
+    fun hasRole(namespaceSlug: String, minimumRole: NamespaceRole): Boolean {
+        val auth = SecurityContextHolder.getContext().authentication ?: return false
+        return try {
+            requireRole(namespaceSlug, auth, minimumRole)
+            true
+        } catch (_: ForbiddenException) {
+            false
+        } catch (_: NamespaceNotFoundException) {
+            false
+        }
+    }
+
+    /**
+     * Overload that accepts the role as a string literal so `@PreAuthorize` SpEL can use
+     * `@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')` without a fully-qualified
+     * enum reference.
+     */
+    fun hasRole(namespaceSlug: String, minimumRole: String): Boolean =
+        hasRole(namespaceSlug, NamespaceRole.valueOf(minimumRole))
+
+    /**
+     * SpEL-friendly mirror of [requireSuperadmin] that reads the current [Authentication]
+     * from [SecurityContextHolder] and returns a boolean.
+     */
+    fun isCurrentUserSuperadmin(): Boolean {
+        val auth = SecurityContextHolder.getContext().authentication ?: return false
+        return isSuperadmin(auth)
+    }
 
     /**
      * Returns the namespaces visible to the authenticated principal:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/NamespaceAuthorizationServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/NamespaceAuthorizationServiceTest.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -37,6 +38,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import java.util.Optional
 import java.util.UUID
 
@@ -214,5 +216,101 @@ class NamespaceAuthorizationServiceTest {
         // Access key principals are never superadmin
         assertThatThrownBy { service.requireSuperadmin(auth("key:acme-production")) }
             .isInstanceOf(ForbiddenException::class.java)
+    }
+
+    // ---------------------------------------------------------------------------------
+    // SpEL-friendly boolean mirrors used by @PreAuthorize (issue #257)
+    // ---------------------------------------------------------------------------------
+
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun withAuth(subject: String) {
+        SecurityContextHolder.getContext().authentication = auth(subject)
+    }
+
+    @Test
+    fun `hasRole returns true when principal holds the minimum role`() {
+        withAuth("alice")
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(userRepository.findByUsername("alice")).thenReturn(Optional.empty())
+        whenever(
+            namespaceMemberRepository.existsByNamespaceIdAndUserSubjectAndRoleIn(
+                eq(nsId),
+                eq("alice"),
+                any(),
+            ),
+        ).thenReturn(true)
+
+        assertThatCode { service.hasRole("acme", NamespaceRole.MEMBER) }.doesNotThrowAnyException()
+        assert(service.hasRole("acme", NamespaceRole.MEMBER))
+    }
+
+    @Test
+    fun `hasRole returns false when principal lacks the role`() {
+        withAuth("alice")
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(userRepository.findByUsername("alice")).thenReturn(Optional.empty())
+        whenever(
+            namespaceMemberRepository.existsByNamespaceIdAndUserSubjectAndRoleIn(
+                eq(nsId),
+                eq("alice"),
+                any(),
+            ),
+        ).thenReturn(false)
+
+        assert(!service.hasRole("acme", NamespaceRole.ADMIN))
+    }
+
+    @Test
+    fun `hasRole returns false when no authentication is present`() {
+        // SecurityContextHolder is clear thanks to @AfterEach
+        assert(!service.hasRole("acme", NamespaceRole.READ_ONLY))
+    }
+
+    @Test
+    fun `hasRole returns false for unknown namespace`() {
+        withAuth("alice")
+        whenever(namespaceRepository.findBySlug("ghost")).thenReturn(Optional.empty())
+        whenever(userRepository.findByUsername("alice")).thenReturn(Optional.empty())
+
+        assert(!service.hasRole("ghost", NamespaceRole.READ_ONLY))
+    }
+
+    @Test
+    fun `hasRole returns false for write role from access key`() {
+        withAuth("key:acme")
+
+        assert(!service.hasRole("acme", NamespaceRole.MEMBER))
+    }
+
+    @Test
+    fun `hasRole string overload delegates to enum-typed hasRole`() {
+        withAuth("key:acme")
+
+        assert(service.hasRole("acme", "READ_ONLY"))
+        assert(!service.hasRole("acme", "ADMIN"))
+    }
+
+    @Test
+    fun `isCurrentUserSuperadmin returns true for superadmin`() {
+        withAuth("superadmin")
+        whenever(userRepository.findByUsername("superadmin")).thenReturn(Optional.of(superadminUser("superadmin")))
+
+        assert(service.isCurrentUserSuperadmin())
+    }
+
+    @Test
+    fun `isCurrentUserSuperadmin returns false without authentication`() {
+        assert(!service.isCurrentUserSuperadmin())
+    }
+
+    @Test
+    fun `isCurrentUserSuperadmin returns false for access key principal`() {
+        withAuth("key:acme")
+
+        assert(!service.isCurrentUserSuperadmin())
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PreAuthorizeCoverageTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PreAuthorizeCoverageTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * Regression guard for audit finding SBS-AUTHZ-001..009 (issue #257).
+ *
+ * Scans every `@RestController` in `io.plugwerk.server.controller` for mutating HTTP
+ * handlers (POST / PUT / PATCH / DELETE). Each handler must carry `@PreAuthorize` either
+ * on the method itself or on the declaring class, or be explicitly allow-listed here.
+ *
+ * Handler HTTP-method metadata lives on the OpenAPI-generated `*Api` interface
+ * (`@RequestMapping(method = [RequestMethod.POST])`), not on the implementation — the
+ * test walks the interface hierarchy when needed.
+ *
+ * This test runs as a plain unit test (no Spring context needed) so it is cheap to
+ * execute on every build.
+ */
+class PreAuthorizeCoverageTest {
+
+    /**
+     * Handlers that intentionally do NOT carry `@PreAuthorize`. Every entry must be
+     * accompanied by a written justification — these are reviewed on every audit.
+     */
+    private val allowList: Set<String> = setOf(
+        // AuthController.login — unauthenticated endpoint by design (credential exchange).
+        "AuthController.login",
+        // AuthController.refresh — unauthenticated endpoint; token-bound via refresh cookie.
+        "AuthController.refresh",
+        // AuthController.logout — authentication enforcement lives in the security filter chain.
+        "AuthController.logout",
+        // AuthController.changePassword — authentication is enforced by the URL-level
+        // requestMatchers(...).authenticated() rule in SecurityConfiguration; the operation
+        // is scoped to the caller's own subject inside the controller body.
+        "AuthController.changePassword",
+        // UpdateCheckController.checkForUpdates — intentionally public: PF4J client plugins
+        // submit their installed-plugin list (no secrets) and the server answers with
+        // available updates. Anonymous callers are allowed by design (see
+        // UpdateCheckEndpointAuthzTest). POST is used only because the batch payload needs
+        // a request body; there is no authorization gate.
+        "UpdateCheckController.checkForUpdates",
+    )
+
+    private val mutatingMethods = setOf(
+        RequestMethod.POST,
+        RequestMethod.PUT,
+        RequestMethod.PATCH,
+        RequestMethod.DELETE,
+    )
+
+    @Test
+    fun `every mutating endpoint has @PreAuthorize or is on the allow-list`() {
+        val scanner = ClassPathScanningCandidateComponentProvider(false).apply {
+            addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+        }
+        val controllers: List<Class<*>> = scanner
+            .findCandidateComponents("io.plugwerk.server.controller")
+            .map { Class.forName(it.beanClassName) }
+
+        val violations = mutableListOf<String>()
+
+        for (controller in controllers) {
+            for (method in controller.declaredMethods) {
+                if (!Modifier.isPublic(method.modifiers)) continue
+                if (method.isSynthetic || method.isBridge) continue
+
+                if (!isMutatingHandler(method)) continue
+
+                val hasPreAuthorize = method.isAnnotationPresent(PreAuthorize::class.java) ||
+                    controller.isAnnotationPresent(PreAuthorize::class.java)
+
+                val key = "${controller.simpleName}.${method.name}"
+                if (!hasPreAuthorize && key !in allowList) {
+                    violations += key
+                }
+            }
+        }
+
+        assertTrue(violations.isEmpty()) {
+            "Mutating endpoints missing @PreAuthorize:\n" + violations.joinToString("\n") { "  - $it" }
+        }
+    }
+
+    /**
+     * True iff [method] handles a mutating HTTP verb. Inspects:
+     *  - the method itself
+     *  - the same-signature method on any interface the declaring class implements
+     *  - the direct superclass chain
+     */
+    private fun isMutatingHandler(method: Method): Boolean {
+        methodsToCheck(method).forEach { candidate ->
+            if (candidate.isAnnotationPresent(PostMapping::class.java) ||
+                candidate.isAnnotationPresent(PutMapping::class.java) ||
+                candidate.isAnnotationPresent(PatchMapping::class.java) ||
+                candidate.isAnnotationPresent(DeleteMapping::class.java)
+            ) {
+                return true
+            }
+            val requestMapping = candidate.getAnnotation(RequestMapping::class.java)
+            if (requestMapping != null && requestMapping.method.toSet().intersect(mutatingMethods).isNotEmpty()) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun methodsToCheck(method: Method): Sequence<Method> = sequence {
+        yield(method)
+        for (iface in method.declaringClass.interfaces) {
+            runCatching { iface.getMethod(method.name, *method.parameterTypes) }
+                .getOrNull()
+                ?.let { yield(it) }
+        }
+        var superClass: Class<*>? = method.declaringClass.superclass
+        while (superClass != null && superClass != Any::class.java) {
+            runCatching { superClass!!.getDeclaredMethod(method.name, *method.parameterTypes) }
+                .getOrNull()
+                ?.let { yield(it) }
+            superClass = superClass.superclass
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #257. Adds AOP-based method-level authorization (`@PreAuthorize`) on top of the existing programmatic `requireRole` / `requireSuperadmin` calls in `NamespaceAuthorizationService`. The programmatic calls stay in place as defence-in-depth; this change adds the AOP safety net that the audit found missing.

Before this PR, a new mutating endpoint that forgot the service call would silently authorize anyone. After this PR, `@EnableMethodSecurity` is enabled globally and every mutating endpoint carries a matching `@PreAuthorize` expression, with a reflection-based test guarding against regressions.

## Changes

### Infrastructure

- **New** `config/MethodSecurityConfiguration.kt` — enables `@EnableMethodSecurity` globally, kept isolated from the filter-chain `SecurityConfiguration`
- `security/NamespaceAuthorizationService.kt` — adds three boolean SpEL-friendly mirrors:
  - `hasRole(namespaceSlug: String, minimumRole: NamespaceRole): Boolean`
  - `hasRole(namespaceSlug: String, minimumRole: String): Boolean` (quoted-string convenience for SpEL)
  - `isCurrentUserSuperadmin(): Boolean`
  - These read the current `Authentication` from `SecurityContextHolder`, return `false` on auth absent / unknown namespace / access-key trying to write, and never throw
- `controller/GlobalExceptionHandler.kt` — maps `AuthorizationDeniedException` (Spring Security 7) and `AccessDeniedException` to the existing `ErrorResponse` JSON envelope at HTTP 403

### `@PreAuthorize` annotations (23 mutating endpoints across 9 controllers)

| Controller | Endpoints | Expression |
|---|---|---|
| `AccessKeyController` | createAccessKey, revokeAccessKey | `hasRole(#ns, 'ADMIN')` |
| `AdminUserController` | createUser, updateUser, deleteUser | `isCurrentUserSuperadmin()` |
| `NamespaceController` | createNamespace, deleteNamespace | `isCurrentUserSuperadmin()` |
| `NamespaceController` | updateNamespace | `hasRole(#ns, 'ADMIN')` |
| `NamespaceMemberController` | add / update / remove | `hasRole(#ns, 'ADMIN')` |
| `OidcProviderController` | create / update / delete | `isCurrentUserSuperadmin()` |
| `ManagementController` | updatePlugin, uploadPluginRelease | `hasRole(#ns, 'MEMBER')` |
| `ManagementController` | updateReleaseStatus, deletePlugin, deleteRelease | `hasRole(#ns, 'ADMIN')` |
| `ReviewsController` | approveRelease, rejectRelease | `hasRole(#ns, 'ADMIN')` |
| `AdminSettingsController` | updateApplicationSettings | `isCurrentUserSuperadmin()` |
| `UserSettingsController` | updateUserSettings | `isAuthenticated() and !authentication.name.startsWith('key:')` |

`ManagementController.updatePlugin` keeps its split-role check inside the method body: the `MEMBER` annotation gates entry; the extra `ADMIN` requirement when `status` is non-null stays in the body so the fine-grained behaviour is preserved.

### Regression test

- **New** `security/PreAuthorizeCoverageTest.kt` — scans every `@RestController` in `io.plugwerk.server.controller`, walks the OpenAPI-generated `*Api` interface hierarchy to find mutating HTTP verbs, and fails if any handler is missing `@PreAuthorize` without an explicit allow-list entry.
- Allow-list:
  - `AuthController.{login, refresh, logout, changePassword}` — credential exchange and URL-level enforcement
  - `UpdateCheckController.checkForUpdates` — intentionally public POST-for-batching read used by PF4J client plugins (pre-existing behaviour, confirmed by `UpdateCheckEndpointAuthzTest`)

### Extended unit tests

- `NamespaceAuthorizationServiceTest` — 9 new cases covering the three new boolean mirrors (matching / missing role, absent authentication, unknown namespace, access-key write rejection, string overload, superadmin detection)

## Verified

- `./gradlew :plugwerk-server:plugwerk-server-backend:build` — unit tests + spotless — **green**
- `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — full E2E authorization matrix (360 tests) across all 9 affected controllers — **green**
- `PreAuthorizeCoverageTest` fails when any mutating endpoint loses its annotation (verified manually by locally removing one).

## Not in this PR

- No behavioural change for authorized clients
- No removal of programmatic `requireRole` / `requireSuperadmin` calls — kept as defence-in-depth
- No new Spring Security filter chain changes
- Other audit findings remain on milestone 1.0.0-beta.1 — each lands as its own PR

## Test plan

- [x] Unit tests green
- [x] Integration tests green (E2E authz matrix)
- [x] Regression test enforces future coverage
- [ ] Reviewer confirms the SpEL bean-reference approach is preferred over a custom `PermissionEvaluator`
- [ ] Reviewer confirms the `UpdateCheckController.checkForUpdates` public-by-design exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)