### PR TITLE
chore: stop tracking Thymeleaf example plugin build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ docs/superpowers/
 **/plugwerk-server-frontend/coverage
 **/plugwerk-server-frontend/src/api/generated
 /examples/plugwerk-java-cli-example/plugins/
+/examples/plugwerk-springboot-thymeleaf-example/plugins/
 /plugwerk-server/plugwerk-server-backend/storage/
 !/examples/plugwerk-java-cli-example/plugins/plugwerk-client-plugin-0.1.0-SNAPSHOT/plugwerk-client-plugin-0.1.0-SNAPSHOT.zip
 


### PR DESCRIPTION
## Summary

`examples/plugwerk-springboot-thymeleaf-example/plugins/plugwerk-client-plugin-1.0.0-SNAPSHOT.zip` is a PF4J plugin build output that should never have been committed — binary, regenerated on every build, and stale relative to the current SNAPSHOT version.

## Changes

- `git rm` the file.
- Add `/examples/plugwerk-springboot-thymeleaf-example/plugins/` to `.gitignore`, mirroring the existing rule for `/examples/plugwerk-java-cli-example/plugins/`.
- No whitelist exception needed — unlike the CLI example, the Thymeleaf example does not ship a pre-built demo ZIP.

## Note on history

This PR stops **future** tracking. The file remains in git history (clones before this merge will still have it); removing it from history would need `git filter-repo` + force-push, which is not worth the disruption for a ~280 KB non-sensitive build artifact.

## Test plan

- [x] `git ls-files | grep plugwerk-client-plugin-1.0.0-SNAPSHOT.zip` returns nothing after merge.
- [ ] Anyone cloning fresh and running the Thymeleaf example's build locally sees the ZIP regenerated in place (ignored).