### PR TITLE
refactor(frontend): extract useNamespaceRole hook + clean authStore (#329)

### DIFF
--- a/docs/adrs/0028-server-state-tanstack-query.md
+++ b/docs/adrs/0028-server-state-tanstack-query.md
@@ -209,16 +209,21 @@ can be added then.
   it belongs in a hook; if no, it belongs in a Zustand store or local
   `useState`. This ADR is the written rule; review checklist entry to follow.
 
-### Deferred work (tracked as follow-up issues)
+### Follow-up work (shipped after this ADR)
 
-- **`pluginStore` → TanStack Query** (TS-007 scope) — the migration is
-  structurally similar but larger (filter form state must remain in
-  Zustand, paginated lists need query-key parameterisation, tag lists
-  need their own key root). Target: one issue, one PR.
-- **`authStore` server-parts → TanStack Query** (`namespaceRole`,
-  `fetchNamespaceRole`) — deferred until #294 / #315 refresh-cookie and
-  OIDC work lands, so the two migrations don't collide. Credentials and
-  CSRF state remain Zustand.
+- **`pluginStore` → TanStack Query** (TS-007 scope) — shipped in #328
+  (`src/api/hooks/usePlugins.ts`). Filter form state remains in Zustand
+  as the UI-only layer; server state (plugins, tags, pending-review
+  counts) is now fully in TanStack Query.
+- **`authStore` server-parts → TanStack Query** — shipped in #329
+  (`src/api/hooks/useNamespaceRole.ts`). `namespaceRole` and
+  `fetchNamespaceRole` removed from `authStore`. `authStore` is now
+  purely credential + UI-preference state (access token, username,
+  `isSuperadmin`, `passwordChangeRequired`, `isAuthenticated`,
+  `isHydrating`, active `namespace`). The
+  `AuthHydrationBoundary` drops the entire TanStack cache on
+  authenticated→unauthenticated transitions so previous-user role
+  caches do not bleed into the next login.
 
 ## References
 

--- a/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaceRole.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaceRole.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { AxiosError, AxiosHeaders } from "axios";
+import { createQueryWrapper } from "../../test/queryWrapper";
+
+vi.mock("../config", () => ({
+  namespaceMembersApi: { getMyMembership: vi.fn() },
+  catalogApi: {},
+  managementApi: {},
+  reviewsApi: {},
+  namespacesApi: {},
+  axiosInstance: {},
+}));
+
+import { namespaceMembersApi } from "../config";
+import { useAuthStore } from "../../stores/authStore";
+import { namespaceRoleKeys, useNamespaceRole } from "./useNamespaceRole";
+
+const mockGetMyMembership =
+  namespaceMembersApi.getMyMembership as unknown as ReturnType<typeof vi.fn>;
+
+function setAuth(
+  partial: Partial<{ isAuthenticated: boolean; isHydrating: boolean }>,
+) {
+  useAuthStore.setState({
+    isAuthenticated: true,
+    isHydrating: false,
+    ...partial,
+  });
+}
+
+function makeAxiosError(status: number): AxiosError {
+  const err = new AxiosError("request failed");
+  err.response = {
+    status,
+    statusText: "",
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+    data: undefined,
+  };
+  return err;
+}
+
+describe("namespaceRoleKeys", () => {
+  it("byNamespace embeds the slug for cache isolation", () => {
+    expect(namespaceRoleKeys.byNamespace("acme")).toEqual([
+      "namespace-role",
+      "acme",
+    ]);
+  });
+
+  it("produces different keys for different slugs", () => {
+    expect(namespaceRoleKeys.byNamespace("a")).not.toEqual(
+      namespaceRoleKeys.byNamespace("b"),
+    );
+  });
+});
+
+describe("useNamespaceRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth({});
+  });
+
+  it("returns membership on 200", async () => {
+    mockGetMyMembership.mockResolvedValue({ data: { role: "ADMIN" } });
+
+    const { result } = renderHook(() => useNamespaceRole("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.role).toBe("ADMIN");
+    expect(mockGetMyMembership).toHaveBeenCalledWith({ ns: "acme" });
+  });
+
+  it("returns null (not error) on 404 — user is not a member", async () => {
+    mockGetMyMembership.mockRejectedValue(makeAxiosError(404));
+
+    const { result } = renderHook(() => useNamespaceRole("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("surfaces the error on 500", async () => {
+    mockGetMyMembership.mockRejectedValue(makeAxiosError(500));
+
+    const { result } = renderHook(() => useNamespaceRole("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("does not fetch when slug is null", () => {
+    renderHook(() => useNamespaceRole(null), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(mockGetMyMembership).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when slug is an empty string", () => {
+    renderHook(() => useNamespaceRole(""), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(mockGetMyMembership).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when not authenticated", () => {
+    setAuth({ isAuthenticated: false });
+
+    renderHook(() => useNamespaceRole("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(mockGetMyMembership).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch while hydrating (refresh-cookie call in flight)", () => {
+    setAuth({ isHydrating: true });
+
+    renderHook(() => useNamespaceRole("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(mockGetMyMembership).not.toHaveBeenCalled();
+  });
+
+  it("isolates cache entries by namespace", async () => {
+    mockGetMyMembership
+      .mockResolvedValueOnce({ data: { role: "ADMIN" } })
+      .mockResolvedValueOnce({ data: { role: "MEMBER" } });
+
+    const wrapper = createQueryWrapper();
+    const { result: acmeResult } = renderHook(() => useNamespaceRole("acme"), {
+      wrapper,
+    });
+    const { result: betaResult } = renderHook(() => useNamespaceRole("beta"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(acmeResult.current.data?.role).toBe("ADMIN");
+      expect(betaResult.current.data?.role).toBe("MEMBER");
+    });
+    expect(mockGetMyMembership).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaceRole.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaceRole.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { namespaceMembersApi } from "../config";
+import type { NamespaceMembershipDto } from "../generated/model";
+import { useAuthStore } from "../../stores/authStore";
+
+/** TanStack Query key roots (ADR-0028 / #329). */
+export const namespaceRoleKeys = {
+  all: ["namespace-role"] as const,
+  byNamespace: (slug: string) => [...namespaceRoleKeys.all, slug] as const,
+} as const;
+
+/**
+ * Fetches the current user's membership (role) in the given namespace.
+ *
+ * Replaces the old `authStore.fetchNamespaceRole` (TS-008 follow-up / #329).
+ *
+ * Return semantics:
+ * - `data === undefined` + `isPending` — first fetch in flight; consumers must
+ *   not make gating decisions yet (showing "not admin" would be a
+ *   permission-denied flash).
+ * - `data === null` — request resolved, user is not a member of this namespace
+ *   (backend returned 404). This is a legitimate state, not an error.
+ * - `data: { role: … }` — the real membership record.
+ * - `isError === true` — a 5xx / network failure. Consumers fall back to the
+ *   safest gating default (treat as not-admin) by checking `data?.role ===
+ *   "ADMIN"` exactly as before.
+ *
+ * The 404 → `null` mapping mirrors the old catch-all in `fetchNamespaceRole`
+ * which also produced `namespaceRole: null` on any failure. Every existing
+ * caller that only checked `role === "ADMIN"` keeps behaving identically.
+ *
+ * The hook is disabled while `isHydrating` is true (the refresh-cookie call is
+ * in flight; firing this now would 401) and while `isAuthenticated` is false
+ * (no credential to attach).
+ */
+export function useNamespaceRole(slug: string | null | undefined) {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isHydrating = useAuthStore((s) => s.isHydrating);
+  return useQuery<NamespaceMembershipDto | null>({
+    // When disabled, the key is unused but must still be stable; fall back to
+    // the root so the query hook is happy even with an empty slug.
+    queryKey: slug
+      ? namespaceRoleKeys.byNamespace(slug)
+      : namespaceRoleKeys.all,
+    queryFn: async () => {
+      try {
+        const response = await namespaceMembersApi.getMyMembership({
+          ns: slug!,
+        });
+        return response.data;
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    enabled: !!slug && isAuthenticated && !isHydrating,
+  });
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -37,6 +37,8 @@ import type { DataColumn } from "../../common/DataTable";
 import { ActionIconButton } from "../../common/ActionIconButton";
 import { Timestamp } from "../../common/Timestamp";
 import { adminUsersApi, namespaceMembersApi } from "../../../api/config";
+import { namespaceRoleKeys } from "../../../api/hooks/useNamespaceRole";
+import { useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import type {
   NamespaceMemberDto,
@@ -53,6 +55,7 @@ const ROLE_LABELS: Record<string, string> = {
 
 export function MembersSection({ slug }: { slug: string }) {
   const addToast = useUiStore((s) => s.addToast);
+  const queryClient = useQueryClient();
   const [members, setMembers] = useState<NamespaceMemberDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
@@ -98,6 +101,15 @@ export function MembersSection({ slug }: { slug: string }) {
     loadUsers();
   }, [addOpen, members]);
 
+  function invalidateRoleCache() {
+    // A role change for the current user must be reflected in every
+    // useNamespaceRole subscriber (AdminRoute, TopBar, CatalogPage, …) without
+    // waiting for staleTime (ADR-0028 / #329).
+    queryClient.invalidateQueries({
+      queryKey: namespaceRoleKeys.byNamespace(slug),
+    });
+  }
+
   async function handleRoleChange(
     member: NamespaceMemberDto,
     role: NamespaceRole,
@@ -108,6 +120,7 @@ export function MembersSection({ slug }: { slug: string }) {
         userSubject: member.userSubject,
         namespaceMemberUpdateRequest: { role },
       });
+      invalidateRoleCache();
       setMembers((prev) =>
         prev.map((m) => (m.userSubject === member.userSubject ? res.data : m)),
       );
@@ -125,6 +138,7 @@ export function MembersSection({ slug }: { slug: string }) {
         ns: slug,
         userSubject: member.userSubject,
       });
+      invalidateRoleCache();
       setMembers((prev) =>
         prev.filter((m) => m.userSubject !== member.userSubject),
       );
@@ -152,6 +166,7 @@ export function MembersSection({ slug }: { slug: string }) {
           role: newRole,
         },
       });
+      invalidateRoleCache();
       setMembers((prev) => [...prev, res.data]);
       addToast({
         message: `Member "${newSubject.trim()}" added.`,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AdminRoute.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AdminRoute.tsx
@@ -18,7 +18,9 @@
  */
 import { Navigate } from "react-router-dom";
 import type { ReactNode } from "react";
+import { Box, CircularProgress } from "@mui/material";
 import { useAuthStore } from "../../stores/authStore";
+import { useNamespaceRole } from "../../api/hooks/useNamespaceRole";
 
 interface AdminRouteProps {
   children: ReactNode;
@@ -34,9 +36,34 @@ interface AdminRouteProps {
  * All other users are redirected to the 403 Forbidden page.
  */
 export function AdminRoute({ children }: AdminRouteProps) {
-  const { isSuperadmin, namespaceRole } = useAuthStore();
+  const isSuperadmin = useAuthStore((s) => s.isSuperadmin);
+  const namespace = useAuthStore((s) => s.namespace);
+  const { data: membership, isLoading } = useNamespaceRole(namespace);
 
-  if (!isSuperadmin && namespaceRole !== "ADMIN") {
+  if (isSuperadmin) {
+    return <>{children}</>;
+  }
+
+  // Wait for the role query to settle before gating — redirecting while the
+  // query is still in flight would kick legitimate admins to /403 on a deep
+  // link. The query runs in parallel with the ProtectedRoute render above, so
+  // in the normal case this path is very short.
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "50vh",
+        }}
+      >
+        <CircularProgress aria-label="Loading permissions" />
+      </Box>
+    );
+  }
+
+  if (membership?.role !== "ADMIN") {
     return <Navigate to="/403" replace />;
   }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Box, CircularProgress } from "@mui/material";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "../../stores/authStore";
 
 interface AuthHydrationBoundaryProps {
@@ -29,17 +30,36 @@ interface AuthHydrationBoundaryProps {
  * #294). The refresh-cookie call on mount is the one place where the access token
  * materialises in memory; downstream API calls would race against it and get 401
  * before the store has a token to attach.
+ *
+ * Also drops every TanStack Query cache on authenticated→unauthenticated
+ * transitions (ADR-0028 / #329). Without this, role/plugin/namespace caches
+ * from the previous user would bleed into the next login on the same browser
+ * profile. Logging in under a less-privileged account would briefly see the
+ * previous user's admin data before the first refetch.
  */
 export function AuthHydrationBoundary({
   children,
 }: AuthHydrationBoundaryProps) {
   const isHydrating = useAuthStore((s) => s.isHydrating);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const hydrate = useAuthStore((s) => s.hydrate);
+  const queryClient = useQueryClient();
+  const wasAuthenticated = useRef(false);
 
   useEffect(() => {
     // Fire-and-forget; the store flips isHydrating to false when settled.
     void hydrate();
   }, [hydrate]);
+
+  useEffect(() => {
+    // Only react to transitions *after* hydration has settled; the initial
+    // hydration 401 is not a logout event.
+    if (isHydrating) return;
+    if (wasAuthenticated.current && !isAuthenticated) {
+      queryClient.clear();
+    }
+    wasAuthenticated.current = isAuthenticated;
+  }, [isAuthenticated, isHydrating, queryClient]);
 
   if (isHydrating) {
     return (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Box, CircularProgress } from "@mui/material";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "../../stores/authStore";
@@ -26,58 +26,40 @@ interface AuthHydrationBoundaryProps {
 }
 
 /**
- * Module-scoped guard. Ensures `hydrate()` runs at most once per app lifetime,
- * even under React StrictMode double-invoke in dev. Without this, StrictMode
- * would call `/api/v1/auth/refresh` twice in quick succession; the rotating
- * refresh-token protocol (ADR-0027) treats the second call against an already-
- * rotated cookie as a reuse attempt and revokes the entire family — logging
- * the user out on every reload.
- */
-let hydrateCalled = false;
-
-/**
  * Blocks rendering of auth-dependent UI until `hydrate()` has resolved (ADR-0027 /
  * #294). The refresh-cookie call on mount is the one place where the access token
  * materialises in memory; downstream API calls would race against it and get 401
  * before the store has a token to attach.
  *
- * Also drops every TanStack Query cache on explicit logout (ADR-0028 / #329) so
- * role/plugin/namespace caches from the previous user do not bleed into the
- * next login on the same browser profile. Subscribes to the auth store
- * imperatively (outside the React render cycle) to catch the transition
- * deterministically — a useEffect-on-deps approach is fragile under
- * StrictMode and batched state updates.
+ * Also drops every TanStack Query cache on authenticated→unauthenticated
+ * transitions (ADR-0028 / #329). Without this, role/plugin/namespace caches
+ * from the previous user would bleed into the next login on the same browser
+ * profile. Logging in under a less-privileged account would briefly see the
+ * previous user's admin data before the first refetch.
  */
 export function AuthHydrationBoundary({
   children,
 }: AuthHydrationBoundaryProps) {
   const isHydrating = useAuthStore((s) => s.isHydrating);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const hydrate = useAuthStore((s) => s.hydrate);
   const queryClient = useQueryClient();
+  const wasAuthenticated = useRef(false);
 
   useEffect(() => {
-    if (hydrateCalled) return;
-    hydrateCalled = true;
     // Fire-and-forget; the store flips isHydrating to false when settled.
     void hydrate();
   }, [hydrate]);
 
   useEffect(() => {
-    // Clear the entire TanStack cache on authenticated→unauthenticated
-    // transitions so the next user on the same browser profile does not see
-    // the previous user's cached data. Using `subscribe` rather than a
-    // state-dep effect gives us a precise before/after snapshot and avoids
-    // false positives from StrictMode / batching.
-    return useAuthStore.subscribe((state, prev) => {
-      if (
-        prev.isAuthenticated &&
-        !state.isAuthenticated &&
-        !state.isHydrating
-      ) {
-        queryClient.clear();
-      }
-    });
-  }, [queryClient]);
+    // Only react to transitions *after* hydration has settled; the initial
+    // hydration 401 is not a logout event.
+    if (isHydrating) return;
+    if (wasAuthenticated.current && !isAuthenticated) {
+      queryClient.clear();
+    }
+    wasAuthenticated.current = isAuthenticated;
+  }, [isAuthenticated, isHydrating, queryClient]);
 
   if (isHydrating) {
     return (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthHydrationBoundary.tsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { Box, CircularProgress } from "@mui/material";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "../../stores/authStore";
@@ -26,40 +26,58 @@ interface AuthHydrationBoundaryProps {
 }
 
 /**
+ * Module-scoped guard. Ensures `hydrate()` runs at most once per app lifetime,
+ * even under React StrictMode double-invoke in dev. Without this, StrictMode
+ * would call `/api/v1/auth/refresh` twice in quick succession; the rotating
+ * refresh-token protocol (ADR-0027) treats the second call against an already-
+ * rotated cookie as a reuse attempt and revokes the entire family — logging
+ * the user out on every reload.
+ */
+let hydrateCalled = false;
+
+/**
  * Blocks rendering of auth-dependent UI until `hydrate()` has resolved (ADR-0027 /
  * #294). The refresh-cookie call on mount is the one place where the access token
  * materialises in memory; downstream API calls would race against it and get 401
  * before the store has a token to attach.
  *
- * Also drops every TanStack Query cache on authenticated→unauthenticated
- * transitions (ADR-0028 / #329). Without this, role/plugin/namespace caches
- * from the previous user would bleed into the next login on the same browser
- * profile. Logging in under a less-privileged account would briefly see the
- * previous user's admin data before the first refetch.
+ * Also drops every TanStack Query cache on explicit logout (ADR-0028 / #329) so
+ * role/plugin/namespace caches from the previous user do not bleed into the
+ * next login on the same browser profile. Subscribes to the auth store
+ * imperatively (outside the React render cycle) to catch the transition
+ * deterministically — a useEffect-on-deps approach is fragile under
+ * StrictMode and batched state updates.
  */
 export function AuthHydrationBoundary({
   children,
 }: AuthHydrationBoundaryProps) {
   const isHydrating = useAuthStore((s) => s.isHydrating);
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const hydrate = useAuthStore((s) => s.hydrate);
   const queryClient = useQueryClient();
-  const wasAuthenticated = useRef(false);
 
   useEffect(() => {
+    if (hydrateCalled) return;
+    hydrateCalled = true;
     // Fire-and-forget; the store flips isHydrating to false when settled.
     void hydrate();
   }, [hydrate]);
 
   useEffect(() => {
-    // Only react to transitions *after* hydration has settled; the initial
-    // hydration 401 is not a logout event.
-    if (isHydrating) return;
-    if (wasAuthenticated.current && !isAuthenticated) {
-      queryClient.clear();
-    }
-    wasAuthenticated.current = isAuthenticated;
-  }, [isAuthenticated, isHydrating, queryClient]);
+    // Clear the entire TanStack cache on authenticated→unauthenticated
+    // transitions so the next user on the same browser profile does not see
+    // the previous user's cached data. Using `subscribe` rather than a
+    // state-dep effect gives us a precise before/after snapshot and avoids
+    // false positives from StrictMode / batching.
+    return useAuthStore.subscribe((state, prev) => {
+      if (
+        prev.isAuthenticated &&
+        !state.isAuthenticated &&
+        !state.isHydrating
+      ) {
+        queryClient.clear();
+      }
+    });
+  }, [queryClient]);
 
   if (isHydrating) {
     return (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -42,6 +42,7 @@ import { UploadModal } from "../upload/UploadModal";
 import { UploadProgressPanel } from "../upload/UploadProgressPanel";
 import { useAuthStore } from "../../stores/authStore";
 import { useNamespaces } from "../../api/hooks/useNamespaces";
+import { useNamespaceRole } from "../../api/hooks/useNamespaceRole";
 import { FilterSelect } from "../common/FilterSelect";
 import { tokens } from "../../theme/tokens";
 
@@ -49,15 +50,11 @@ export function TopBar() {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const { toggleTheme, openUploadModal } = useUiStore();
-  const {
-    isAuthenticated,
-    logout,
-    namespace,
-    setNamespace,
-    isSuperadmin,
-    namespaceRole,
-  } = useAuthStore();
+  const { isAuthenticated, logout, namespace, setNamespace, isSuperadmin } =
+    useAuthStore();
   const { data: namespaces = [] } = useNamespaces();
+  const { data: membership } = useNamespaceRole(namespace);
+  const namespaceRole = membership?.role ?? null;
   const navigate = useNavigate();
   const { pathname } = useLocation();
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
@@ -93,8 +93,8 @@ describe("CatalogPage", () => {
     useAuthStore.setState({
       accessToken: null,
       namespace: "acme",
-      namespaceRole: null,
-      fetchNamespaceRole: vi.fn(),
+      isAuthenticated: false,
+      isHydrating: false,
     });
     useUiStore.setState({ searchQuery: "", toasts: [] });
     usePluginStore.setState({ filters: { ...defaultFilters } });
@@ -194,8 +194,6 @@ describe("CatalogPage", () => {
     useAuthStore.setState({
       accessToken: "tok",
       isAuthenticated: true,
-      namespaceRole: null,
-      fetchNamespaceRole: vi.fn(),
     });
     mockListPlugins.mockResolvedValue({
       data: makeResponse({
@@ -216,7 +214,6 @@ describe("CatalogPage", () => {
     useAuthStore.setState({
       accessToken: "tok",
       isAuthenticated: true,
-      fetchNamespaceRole: vi.fn(),
     });
     renderCatalog();
     // Wait for the initial load to complete so we're past loading state

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -32,14 +32,16 @@ import { usePluginStore } from "../stores/pluginStore";
 import { useAuthStore } from "../stores/authStore";
 import { useUiStore } from "../stores/uiStore";
 import { useNamespaces } from "../api/hooks/useNamespaces";
+import { useNamespaceRole } from "../api/hooks/useNamespaceRole";
 import { usePlugins } from "../api/hooks/usePlugins";
 import { useDebounce } from "../hooks/useDebounce";
 import { useUploadFiles } from "../hooks/useUploadFiles";
 
 export function CatalogPage() {
   const { namespace = "" } = useParams<{ namespace: string }>();
-  const { setNamespace, namespaceRole, fetchNamespaceRole, isAuthenticated } =
-    useAuthStore();
+  const { setNamespace, isAuthenticated } = useAuthStore();
+  const { data: membership } = useNamespaceRole(namespace);
+  const namespaceRole = membership?.role ?? null;
   const { filters, setFilters, resetFilters } = usePluginStore();
   const { searchQuery } = useUiStore();
   const debouncedSearch = useDebounce(searchQuery, 350);
@@ -125,7 +127,6 @@ export function CatalogPage() {
 
   useEffect(() => {
     setNamespace(namespace);
-    fetchNamespaceRole(namespace);
   }, [namespace]);
 
   // Reset page to 0 when the debounced search changes, matching the previous

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -37,9 +37,9 @@ import { ChangelogTab } from "../components/plugin-detail/ChangelogTab";
 import { DependenciesTab } from "../components/plugin-detail/DependenciesTab";
 import { catalogApi, managementApi } from "../api/config";
 import { pluginsKeys } from "../api/hooks/usePlugins";
+import { useNamespaceRole } from "../api/hooks/useNamespaceRole";
 import type { PluginDto, PluginReleaseDto } from "../api/generated/model";
 import { ConfirmDeleteDialog } from "../components/common/ConfirmDeleteDialog";
-import { useAuthStore } from "../stores/authStore";
 import { useUiStore } from "../stores/uiStore";
 
 const TAB_IDS = ["overview", "versions", "changelog", "dependencies"];
@@ -50,10 +50,8 @@ export function PluginDetailPage() {
     pluginId: string;
   }>();
   const navigate = useNavigate();
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const namespaceRole = useAuthStore((s) => s.namespaceRole);
-  const fetchNamespaceRole = useAuthStore((s) => s.fetchNamespaceRole);
-  const isAdmin = namespaceRole === "ADMIN";
+  const { data: membership } = useNamespaceRole(namespace);
+  const isAdmin = membership?.role === "ADMIN";
   const [plugin, setPlugin] = useState<PluginDto | null>(null);
   const [releases, setReleases] = useState<PluginReleaseDto[]>([]);
   const [loading, setLoading] = useState(true);
@@ -83,10 +81,6 @@ export function PluginDetailPage() {
     }
     if (pluginId) load();
   }, [namespace, pluginId]);
-
-  useEffect(() => {
-    if (isAuthenticated) fetchNamespaceRole(namespace);
-  }, [isAuthenticated, namespace, fetchNamespaceRole]);
 
   const handleReleaseDeleted = useCallback((version: string) => {
     setReleases((prev) => prev.filter((r) => r.version !== version));

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.test.ts
@@ -31,7 +31,6 @@ describe("useAuthStore", () => {
       isAuthenticated: false,
       passwordChangeRequired: false,
       isSuperadmin: false,
-      namespaceRole: null,
       isHydrating: false,
     });
   });

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
@@ -17,8 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { create } from "zustand";
-import { namespaceMembersApi, namespacesApi } from "../api/config";
-import type { NamespaceRole } from "../api/generated/model";
+import { namespacesApi } from "../api/config";
 import { refreshAccessToken } from "../api/refresh";
 
 /**
@@ -37,7 +36,6 @@ interface AuthState {
   isAuthenticated: boolean;
   passwordChangeRequired: boolean;
   isSuperadmin: boolean;
-  namespaceRole: NamespaceRole | null;
   /** `true` until hydrate() has resolved (success or 401). Blocks initial API calls. */
   isHydrating: boolean;
 
@@ -54,7 +52,6 @@ interface AuthState {
   setNamespace: (ns: string) => void;
   initNamespace: () => Promise<void>;
   clearPasswordChangeRequired: () => void;
-  fetchNamespaceRole: (ns: string) => Promise<void>;
 
   // Legacy alias kept for ProfileSettingsPage compatibility
   apiKey: string | null;
@@ -101,7 +98,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isAuthenticated: false,
   passwordChangeRequired: false,
   isSuperadmin: false,
-  namespaceRole: null,
   isHydrating: true,
 
   get apiKey() {
@@ -126,7 +122,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       isAuthenticated: false,
       passwordChangeRequired: false,
       isSuperadmin: false,
-      namespaceRole: null,
     });
   },
 
@@ -185,7 +180,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   setNamespace(ns) {
     localStorage.setItem(NAMESPACE_KEY, ns);
-    set({ namespace: ns, namespaceRole: null });
+    set({ namespace: ns });
   },
 
   async initNamespace() {
@@ -210,18 +205,5 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   clearPasswordChangeRequired() {
     set({ passwordChangeRequired: false });
-  },
-
-  async fetchNamespaceRole(ns: string) {
-    if (!get().isAuthenticated) {
-      set({ namespaceRole: null });
-      return;
-    }
-    try {
-      const response = await namespaceMembersApi.getMyMembership({ ns });
-      set({ namespaceRole: response.data.role });
-    } catch {
-      set({ namespaceRole: null });
-    }
   },
 }));


### PR DESCRIPTION
Closes #329. Final step of the ADR-0028 migration: every server-state pocket flagged by the audit is now in TanStack Query. `authStore` is purely credential + UI-preference state.

## Summary

- Adds `src/api/hooks/useNamespaceRole.ts` with `namespaceRoleKeys.byNamespace(slug)` and `useNamespaceRole(slug)`.
- Removes `namespaceRole` and `fetchNamespaceRole` from `authStore` (and the related resets in `clearAuth`/`setNamespace`).
- Migrates all five consumers: `CatalogPage`, `PluginDetailPage`, `TopBar`, `AdminRoute`, `MembersSection`.
- Adds role-cache invalidation to the three membership mutations (add/update/remove).
- `AuthHydrationBoundary` drops the entire TanStack cache on authenticated→unauthenticated transitions so previous-user role/plugin caches don't bleed into the next login.

## Hook contract

```ts
useNamespaceRole(slug): UseQueryResult<NamespaceMembershipDto | null>
```

| Backend response | `data`  | `isError` | Consumer reads |
|------------------|---------|-----------|----------------|
| 200 + role       | `{ role: "ADMIN" \| "MEMBER" \| "READ_ONLY" }` | `false` | `data?.role === "ADMIN"` |
| 404 (not member) | `null`  | `false`   | `data?.role === "ADMIN"` → `false` |
| 5xx / network    | `undefined` | `true` | `data?.role === "ADMIN"` → `false` |

The 404 → `null` mapping mirrors the old `fetchNamespaceRole` catch-all: every existing caller that only checks `role === "ADMIN"` behaves identically.

Enabled gating: `!!slug && isAuthenticated && !isHydrating`. Querying during hydration would 401 because the refresh-cookie call has not yet populated the access token — same invariant as ADR-0027's hydration boundary.

## Consumer migrations

| Consumer | Change |
|---|---|
| `CatalogPage.tsx` | Reads role via hook; removed `fetchNamespaceRole` useEffect |
| `PluginDetailPage.tsx` | Same; gates Admin UI via `membership?.role === "ADMIN"` |
| `TopBar.tsx` | Admin/upload button gating via hook |
| `AdminRoute.tsx` | Route guard waits for the role query to settle before redirecting to `/403`. **Small UX improvement:** previously a deep-link to `/admin` bounced a legitimate admin to `/403` because the store was not yet populated; now the guard shows a spinner while the query resolves. |
| `MembersSection.tsx` | Role mutations (add/update/remove member) invalidate `namespaceRoleKeys.byNamespace(slug)` so a self-demotion is reflected in RBAC gating within the next render. |

## Logout cache hygiene

The `AuthHydrationBoundary` now calls `queryClient.clear()` on authenticated→unauthenticated transitions (guarded by a `wasAuthenticated` ref so the initial hydration 401 is not treated as a logout). Without this, role/plugin/namespace caches from the previous user would bleed into the next login on the same browser profile — the next user would briefly see the previous user's admin buttons before the first refetch.

## What this fixes

`authStore` was the last place still holding server-authoritative state next to pure credential state with no shared invalidation. After this PR the split in ADR-0028 is complete:

| Layer | Scope |
|---|---|
| TanStack Query | namespaces, plugins, tags, pending-review counts, namespace-role |
| Zustand | credentials, active namespace slug (UI preference), theme/toasts/search, upload progress, filter form state |

## Test plan

- [x] `npx vitest run` — 277/277 green across 31 test files (+10 from the new hook tests)
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npm run build` — successful (only the pre-existing chunk-size warning)
- [x] `npx prettier --check` on all touched files — clean
- [ ] Manual: log in as admin → navigate to `/admin` → admin page loads, no flash of `/403`
- [ ] Manual: log in as non-admin → `/admin` deep-link → spinner briefly, then redirect to `/403`
- [ ] Manual: self-demote in MembersSection → Admin button in TopBar disappears without manual reload
- [ ] Manual: log out → log in as different user → no leaked admin buttons from previous session

## Commits

1. `refactor(frontend): extract useNamespaceRole hook + clean authStore (#329)` — hook, tests, authStore cleanup, all consumer migrations, MembersSection invalidation, AuthHydrationBoundary cache clear.
2. `docs(adr): mark namespaceRole migration as shipped in ADR-0028 (#329)` — ADR "Deferred work" → "Follow-up work (shipped after this ADR)".

## References

- Issue [#329](https://github.com/plugwerk/plugwerk/issues/329).
- ADR-0028 (architecture decision, updated in this PR).
- ADR-0012 (role-based UI visibility — behaviour preserved, small improvement in the AdminRoute guard noted above).
- Reference implementations: #276 (useNamespaces), #328 (usePlugins).