### PR TITLE
fix(auth): forced logout on reload — CSRF handler + dev-HTTP footgun

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # logged once at startup. The admin username is always "admin".
 # PLUGWERK_AUTH_ADMIN_PASSWORD=
 
+# Refresh-cookie `Secure` flag. Default: true (HTTPS-only transport).
+# **Set to false for local HTTP development.** Browsers silently drop `Secure`
+# cookies over plain HTTP, which makes the refresh cookie invisible to the
+# server on reload and forces the user back to /login. See ADR-0027.
+# PLUGWERK_AUTH_COOKIE_SECURE=false
+
 # PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
 # PLUGWERK_DB_USERNAME=plugwerk
 # PLUGWERK_DB_PASSWORD=plugwerk

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -51,6 +51,7 @@ import org.springframework.security.web.access.intercept.RequestAuthorizationCon
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -267,8 +268,19 @@ class SecurityConfiguration(
             // in the X-XSRF-TOKEN header on the refresh call. Spring's double-submit
             // check then matches header to cookie. SameSite=Strict on the refresh cookie
             // itself is defence in depth for browsers that honour it.
+            //
+            // `CsrfTokenRequestAttributeHandler` (non-XOR) replaces Spring's 6.x default
+            // `XorCsrfTokenRequestAttributeHandler`. The XOR handler expects a token that
+            // was randomly XOR-masked per response and rejects the raw cookie value when
+            // the SPA echoes it straight back in the header. That behaviour is intended
+            // for server-rendered forms that carry a CsrfToken attribute, but it breaks
+            // the cookie-only double-submit pattern this deployment relies on: on reload
+            // the SPA has only the cookie value, never a server-rendered XOR'd variant.
+            // The non-XOR handler compares header to cookie by equality — exactly the
+            // double-submit contract ADR-0027 describes.
             .csrf { csrf ->
                 csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                csrf.csrfTokenRequestHandler(CsrfTokenRequestAttributeHandler())
                 csrf.requireCsrfProtectionMatcher { request ->
                     request.method == HttpMethod.POST.name() &&
                         request.requestURI == "/api/v1/auth/refresh"

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactory.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactory.kt
@@ -19,6 +19,8 @@
 package io.plugwerk.server.security
 
 import io.plugwerk.server.PlugwerkProperties
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseCookie
 import org.springframework.stereotype.Component
 import java.time.Duration
@@ -41,6 +43,30 @@ import java.time.Duration
  */
 @Component
 class RefreshTokenCookieFactory(private val props: PlugwerkProperties) {
+
+    private val log = LoggerFactory.getLogger(RefreshTokenCookieFactory::class.java)
+
+    /**
+     * Warn loudly at startup when the deployment combines a plain-HTTP base URL with the
+     * default `cookieSecure = true`. Browsers silently drop `Secure` cookies on HTTP
+     * connections, which makes the refresh cookie invisible to the server on the next
+     * request — every page reload then looks like a forced logout. Dev setups routinely
+     * trip on this without a clear signal; a single `WARN` line here beats hours of
+     * debugging. See ADR-0027 and `.env.example` for the override.
+     */
+    @PostConstruct
+    fun validateCookieSecureAgainstBaseUrl() {
+        val baseUrl = props.server.baseUrl
+        if (baseUrl.startsWith("http://") && props.auth.cookieSecure) {
+            log.warn(
+                "PLUGWERK_AUTH_COOKIE_SECURE=true combined with an http:// base URL " +
+                    "({}) — browsers drop `Secure` cookies on plain HTTP, so the refresh " +
+                    "cookie will never be stored and every reload will redirect to /login. " +
+                    "Set PLUGWERK_AUTH_COOKIE_SECURE=false for local HTTP dev (see ADR-0027).",
+                baseUrl,
+            )
+        }
+    }
 
     /** Builds the cookie for a freshly-issued refresh token. */
     fun build(plaintext: String, maxAge: Duration): ResponseCookie = ResponseCookie.from(COOKIE_NAME, plaintext)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/CsrfScopeIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/CsrfScopeIT.kt
@@ -21,6 +21,7 @@ package io.plugwerk.server.config
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.service.JwtTokenService
+import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,6 +33,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
+import java.util.UUID
 
 /**
  * Pins the CSRF scope contract (ADR-0027, supersedes ADR-0020): CSRF protection is
@@ -104,6 +106,33 @@ class CsrfScopeIT {
         }.andExpect {
             // 204 means the Bearer passed authz and logout ran — no CSRF block.
             status { isNoContent() }
+        }
+    }
+
+    @Test
+    fun `refresh with matching raw CSRF cookie and header passes the CSRF check`() {
+        // Regression guard for the SPA double-submit contract (ADR-0027): the frontend
+        // reads the `XSRF-TOKEN` cookie value and echoes the raw value in the
+        // `X-XSRF-TOKEN` header. Spring Security 6+/7 default is
+        // `XorCsrfTokenRequestAttributeHandler`, which rejects raw values because it
+        // expects an XOR-masked token — so the cookie-only pattern only works when the
+        // non-XOR `CsrfTokenRequestAttributeHandler` is wired into the config.
+        //
+        // We assert the *absence of 403*, not success: without a valid plugwerk_refresh
+        // cookie the controller rightly returns 401. The point of this test is to pin
+        // the XOR→non-XOR handler swap: if someone ever puts the default handler back,
+        // this test returns 403 and fails loudly.
+        val csrfToken = UUID.randomUUID().toString()
+        val response = mockMvc.post("/api/v1/auth/refresh") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(Cookie("XSRF-TOKEN", csrfToken))
+            header("X-XSRF-TOKEN", csrfToken)
+        }.andReturn().response
+
+        check(response.status != 403) {
+            "refresh returned 403 for matching raw CSRF cookie+header — the XOR handler " +
+                "is active again and SPA double-submit is broken. See ADR-0027 and the " +
+                "SecurityConfiguration csrfTokenRequestHandler setting."
         }
     }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/api/refresh.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/refresh.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { refreshAccessToken } from "./refresh";
+
+// Minimal JWT payload `{"sub":"alice"}` base64url-encoded so `decodeJwtSubject`
+// pulls the username back out without failing on decode.
+const JWT_PAYLOAD = Buffer.from('{"sub":"alice"}').toString("base64url");
+const FAKE_ACCESS_TOKEN = `hdr.${JWT_PAYLOAD}.sig`;
+
+const SUCCESS_BODY = {
+  accessToken: FAKE_ACCESS_TOKEN,
+  passwordChangeRequired: false,
+  isSuperadmin: false,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("refreshAccessToken — CSRF bootstrap retry", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // Reset cookies between tests (jsdom persists across describe blocks).
+    document.cookie = "XSRF-TOKEN=; Max-Age=0; path=/";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns the auth payload when the first refresh succeeds", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(SUCCESS_BODY));
+
+    const result = await refreshAccessToken();
+
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe(FAKE_ACCESS_TOKEN);
+    expect(result!.username).toBe("alice");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once when the first call 401s AFTER jsdom gains an XSRF cookie", async () => {
+    // First call: 401. We emulate Spring's Set-Cookie side effect by mutating
+    // document.cookie between the two fetch() invocations — exactly what the
+    // browser does in production when CsrfFilter writes a fresh XSRF-TOKEN
+    // onto its 401 response.
+    fetchMock
+      .mockImplementationOnce(async () => {
+        document.cookie = "XSRF-TOKEN=bootstrap-token; path=/";
+        return new Response("", { status: 401 });
+      })
+      .mockResolvedValueOnce(jsonResponse(SUCCESS_BODY));
+
+    const result = await refreshAccessToken();
+
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe(FAKE_ACCESS_TOKEN);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Second call must carry the X-XSRF-TOKEN header set from the new cookie.
+    const secondCall = fetchMock.mock.calls[1];
+    const secondInit = secondCall[1] as RequestInit;
+    const headers = secondInit.headers as Record<string, string>;
+    expect(headers["X-XSRF-TOKEN"]).toBe("bootstrap-token");
+  });
+
+  it("does NOT retry when the XSRF cookie was already in the jar", async () => {
+    // The CSRF bootstrap is specifically "no cookie → cookie". If we already had
+    // a cookie and still got 401, something else is wrong (e.g. the refresh
+    // token is genuinely revoked) and a retry would just burn another request
+    // for the same outcome.
+    document.cookie = "XSRF-TOKEN=already-present; path=/";
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }));
+
+    const result = await refreshAccessToken();
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry when the first call fails with a non-401 status", async () => {
+    // 5xx / 429 etc. are not CSRF bootstrap signals. Retrying would mask
+    // transient backend failures by pretending they were CSRF issues.
+    fetchMock.mockImplementationOnce(async () => {
+      document.cookie = "XSRF-TOKEN=appeared-anyway; path=/";
+      return new Response("", { status: 500 });
+    });
+
+    const result = await refreshAccessToken();
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry when the first call 401s but no new XSRF cookie appeared", async () => {
+    // If Spring did not issue a cookie, retrying the same call will fail the
+    // same way. Give up.
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }));
+
+    const result = await refreshAccessToken();
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent callers onto a single in-flight promise", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const [a, b] = [refreshAccessToken(), refreshAccessToken()];
+    resolveFetch(jsonResponse(SUCCESS_BODY));
+    const [aResult, bResult] = await Promise.all([a, b]);
+
+    expect(aResult?.accessToken).toBe(FAKE_ACCESS_TOKEN);
+    expect(bResult?.accessToken).toBe(FAKE_ACCESS_TOKEN);
+    // Single-flight: two concurrent callers → one network request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/api/refresh.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/refresh.ts
@@ -39,13 +39,54 @@ let inFlight: Promise<RefreshedAuth | null> | null = null;
 
 export function refreshAccessToken(): Promise<RefreshedAuth | null> {
   if (inFlight) return inFlight;
-  inFlight = doRefresh().finally(() => {
+  inFlight = doRefreshWithCsrfBootstrap().finally(() => {
     inFlight = null;
   });
   return inFlight;
 }
 
-async function doRefresh(): Promise<RefreshedAuth | null> {
+/**
+ * Refresh with CSRF bootstrap retry.
+ *
+ * Spring's `CookieCsrfTokenRepository` issues the `XSRF-TOKEN` cookie lazily —
+ * it only appears in the browser's cookie jar after the first response that
+ * needs to tell the client about it. On a fresh page reload the jar may be
+ * empty of `XSRF-TOKEN` even though the session is otherwise valid, because
+ * our login endpoint is not wired into Spring's auth filter chain (so the
+ * `CsrfAuthenticationStrategy` never fires and never rotates a fresh token
+ * into the response).
+ *
+ * Consequence: the very first `POST /auth/refresh` after reload has no
+ * `X-XSRF-TOKEN` header, Spring's `CsrfFilter` rejects it with 401, and as a
+ * side effect it writes a freshly-generated `XSRF-TOKEN` cookie to the 401
+ * response. If we retry exactly once, the retry will have the cookie and
+ * will pass the CSRF check.
+ *
+ * Retrying is safe because the first attempt never reached our controller
+ * (it was short-circuited by the CSRF filter); no refresh-token rotation
+ * happened, so no token reuse is possible on the retry.
+ */
+async function doRefreshWithCsrfBootstrap(): Promise<RefreshedAuth | null> {
+  const firstHadXsrf = readCookie("XSRF-TOKEN") != null;
+  const first = await doRefresh();
+  if (first.auth) return first.auth;
+  // Retry exactly once when the first attempt plausibly failed on CSRF:
+  // we started without an XSRF-TOKEN cookie and the server has now set one
+  // (as a side effect of its 401). Skip the retry if nothing changed.
+  const nowHasXsrf = readCookie("XSRF-TOKEN") != null;
+  if (!firstHadXsrf && nowHasXsrf && first.status === 401) {
+    const second = await doRefresh();
+    return second.auth;
+  }
+  return null;
+}
+
+interface RefreshAttempt {
+  auth: RefreshedAuth | null;
+  status: number;
+}
+
+async function doRefresh(): Promise<RefreshAttempt> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
@@ -59,21 +100,24 @@ async function doRefresh(): Promise<RefreshedAuth | null> {
     headers,
   });
   if (!response.ok) {
-    return null;
+    return { auth: null, status: response.status };
   }
   const data = await response.json();
   if (typeof data.accessToken !== "string") {
-    return null;
+    return { auth: null, status: response.status };
   }
   // The server encodes username in the JWT subject; decode locally to avoid a
   // second round-trip. Only the `sub` claim is read and never trusted for
   // authorization — the server already validated the token.
   const subject = decodeJwtSubject(data.accessToken) ?? "";
   return {
-    accessToken: data.accessToken,
-    username: subject,
-    passwordChangeRequired: data.passwordChangeRequired === true,
-    isSuperadmin: data.isSuperadmin === true,
+    auth: {
+      accessToken: data.accessToken,
+      username: subject,
+      passwordChangeRequired: data.passwordChangeRequired === true,
+      isSuperadmin: data.isSuperadmin === true,
+    },
+    status: response.status,
   };
 }
 


### PR DESCRIPTION
## Symptom

A logged-in user reloads the page (Cmd+R) and gets redirected to `/login` as if the session had expired. Reproduced end-to-end via Playwright.

## Root causes (two coupled bugs)

### 1. Spring's default `XorCsrfTokenRequestAttributeHandler` (main bug)

Spring Security 6+/7 defaults to the XOR handler, which expects the `X-XSRF-TOKEN` header to carry an XOR-masked value computable only from the server's per-response CsrfToken attribute. ADR-0027 describes a **cookie-only double-submit pattern** where the SPA reads the raw `XSRF-TOKEN` cookie and echoes it straight back in the header — the XOR handler rejects that shape by design.

Verified directly against the backend: matching cookie and header values → 401.

Fix: wire `CsrfTokenRequestAttributeHandler()` (non-XOR, equality check) into the security config. Header-vs-cookie equality is exactly what ADR-0027's threat model relies on.

### 2. CSRF-cookie bootstrap on reload (frontend defense in depth)

`CookieCsrfTokenRepository` issues the `XSRF-TOKEN` cookie lazily — only on the first response that reads the token. Plugwerk's login endpoint authenticates manually in the controller (not via Spring's auth filter chain), so `CsrfAuthenticationStrategy` never fires and login never writes a fresh `XSRF-TOKEN` into the response.

After a reload, the browser has `plugwerk_refresh` but no `XSRF-TOKEN`. The first `POST /auth/refresh` sends the refresh cookie alone. Spring's `CsrfFilter` rejects it with 401 **and** sets a fresh `XSRF-TOKEN` cookie on the 401 response.

Fix: one-shot retry in `refreshAccessToken()` when (a) the jar had no `XSRF-TOKEN` before the call, (b) the response status was 401, (c) Spring set an `XSRF-TOKEN` cookie on the 401. Safe — the first attempt short-circuited at the CSRF filter, so no refresh-token rotation happened and no reuse-detection fires.

### 3. Dev HTTP + `cookieSecure=true` footgun (the decoy)

Initial symptom triage suspected this. It is a separate footgun (cookie is dropped by the browser on plain HTTP), but **not** what the reporter actually hit — `PLUGWERK_AUTH_COOKIE_SECURE=false` alone did not fix the reload. The documentation and startup-warn changes are still included because the next developer through the door will still hit it without a signal. No security regression: production HTTPS deployments see no WARN and keep `Secure=true`.

## Changes

### fix(auth): CSRF handler + bootstrap retry — `9a2130f`
- `SecurityConfiguration.csrf { … }` — adds `csrfTokenRequestHandler(CsrfTokenRequestAttributeHandler())`.
- `refresh.ts` — one-shot retry when the first refresh plausibly failed on a CSRF bootstrap.

### docs(auth): dev-HTTP warn + env doc — `4c862a0`
- `.env.example` — commented entry `PLUGWERK_AUTH_COOKIE_SECURE=false` next to other auth env vars.
- `RefreshTokenCookieFactory.validateCookieSecureAgainstBaseUrl()` — `@PostConstruct` WARN when `http://` base URL meets `cookieSecure=true`.

## Verification

End-to-end Playwright reproduction on a running dev backend:

```
navigate → /login
login admin/… → 200 (plugwerk_refresh set)
reload
  POST /auth/refresh  [plugwerk_refresh only]                 → 401
  POST /auth/refresh  [plugwerk_refresh + XSRF + header]       → 200
  GET  /namespaces    [Bearer + cookies]                       → 200
url after reload: /namespaces/default/plugins   ✅
```

- [x] Backend: `./gradlew :plugwerk-server:plugwerk-server-backend:compileKotlin` green.
- [x] Backend: `./gradlew :plugwerk-server:plugwerk-server-backend:test --tests CsrfScopeIT` green — the ADR-0027 contract (refresh without header → 401; Bearer endpoints unaffected) still holds.
- [x] Frontend: `npx tsc --noEmit` clean, `npx vitest run` 30 files / 267 tests green, `npx prettier --check` clean.

## References

- [ADR-0027](./docs/adrs/0027-refresh-cookie-and-csrf-reenabled.md) — cookie-only double-submit CSRF scope (unchanged, now actually achievable client-side).