### PR TITLE
refactor(security): consolidate SecurityContextHolder access via currentAuthentication helpers (#336)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
@@ -23,14 +23,13 @@ import io.plugwerk.api.model.ApplicationSettingDto
 import io.plugwerk.api.model.ApplicationSettingsResponse
 import io.plugwerk.api.model.ApplicationSettingsUpdateRequest
 import io.plugwerk.server.security.NamespaceAuthorizationService
-import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.settings.ApplicationSettingKey
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import io.plugwerk.server.service.settings.SettingSnapshot
 import io.plugwerk.server.service.settings.SettingSource
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -71,8 +70,7 @@ class AdminSettingsController(
     }
 
     private fun requireSuperadmin(): String {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         return auth.name
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -23,11 +23,10 @@ import io.plugwerk.api.model.UserCreateRequest
 import io.plugwerk.api.model.UserDto
 import io.plugwerk.api.model.UserUpdateRequest
 import io.plugwerk.server.security.NamespaceAuthorizationService
-import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -42,8 +41,7 @@ class AdminUserController(
 ) : AdminUsersApi {
 
     override fun listUsers(enabled: Boolean?): ResponseEntity<List<UserDto>> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         val users = if (enabled != null) userService.findAllByEnabled(enabled) else userService.findAll()
         return ResponseEntity.ok(users.map { it.toDto() })
@@ -51,8 +49,7 @@ class AdminUserController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun createUser(userCreateRequest: UserCreateRequest): ResponseEntity<UserDto> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         val user = userService.create(
             username = userCreateRequest.username,
@@ -64,8 +61,7 @@ class AdminUserController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun updateUser(userId: UUID, userUpdateRequest: UserUpdateRequest): ResponseEntity<UserDto> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         var user = userService.findById(userId)
         userUpdateRequest.enabled?.let { user = userService.setEnabled(userId, it) }
@@ -75,8 +71,7 @@ class AdminUserController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteUser(userId: UUID): ResponseEntity<Unit> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         userService.delete(userId)
         return ResponseEntity.noContent().build()

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
@@ -25,6 +25,7 @@ import io.plugwerk.api.model.LoginResponse
 import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.security.RefreshTokenCookieFactory
 import io.plugwerk.server.security.UserCredentialValidator
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.JwtTokenService
 import io.plugwerk.server.service.RefreshTokenService
 import io.plugwerk.server.service.TokenRevocationService
@@ -33,7 +34,6 @@ import io.plugwerk.server.service.UserService
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -116,8 +116,7 @@ class AuthController(
     }
 
     override fun logout(): ResponseEntity<Unit> {
-        val authentication = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Authentication required")
+        val authentication = currentAuthentication()
         val jwt = authentication.credentials as? Jwt
             ?: throw UnauthorizedException("Bearer token required for logout")
         val jti = jwt.id ?: throw UnauthorizedException("Token missing jti claim")
@@ -133,7 +132,7 @@ class AuthController(
     }
 
     override fun changePassword(changePasswordRequest: ChangePasswordRequest): ResponseEntity<Unit> {
-        val username = SecurityContextHolder.getContext().authentication?.name
+        val username = currentAuthentication().name
             ?: throw UnauthorizedException("Authentication required to change password")
         userService.changePassword(username, changePasswordRequest.currentPassword, changePasswordRequest.newPassword)
         tokenRevocationService.revokeAllForUser(username)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -31,6 +31,7 @@ import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthenticationOrNull
 import io.plugwerk.server.security.resolveClientIp
 import io.plugwerk.server.service.Pf4jCompatibilityService
 import io.plugwerk.server.service.PluginReleaseService
@@ -45,7 +46,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -187,7 +187,7 @@ class CatalogController(
      * Returns `(null, null)` for anonymous requests — no sensitive information is leaked.
      */
     private fun resolvePendingReviewCounts(ns: String): Pair<Long?, Long?> {
-        val auth = SecurityContextHolder.getContext().authentication ?: return null to null
+        val auth = currentAuthenticationOrNull() ?: return null to null
         if (!auth.isAuthenticated) return null to null
         val namespace = namespaceRepository.findBySlug(ns).orElse(null) ?: return null to null
         val namespaceId = namespace.id!!
@@ -215,7 +215,7 @@ class CatalogController(
      * authenticated user's own URL.
      */
     private fun resolveVisibility(ns: String): CatalogVisibility {
-        val auth = SecurityContextHolder.getContext().authentication ?: return CatalogVisibility.PUBLIC
+        val auth = currentAuthenticationOrNull() ?: return CatalogVisibility.PUBLIC
         if (!auth.isAuthenticated) return CatalogVisibility.PUBLIC
         // API key callers (name starts with "key:") are treated as PUBLIC visibility
         if (auth.name.startsWith("key:")) return CatalogVisibility.PUBLIC

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceController.kt
@@ -25,11 +25,10 @@ import io.plugwerk.api.model.NamespaceUpdateRequest
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.NamespaceRole
 import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.NamespaceService
-import io.plugwerk.server.service.UnauthorizedException
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -42,8 +41,7 @@ class NamespaceController(
 ) : NamespacesApi {
 
     override fun listNamespaces(): ResponseEntity<List<NamespaceSummary>> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         val namespaces = namespaceAuthorizationService.listVisibleNamespaces(auth)
             .map { it.toSummary() }
         return ResponseEntity.ok(namespaces)
@@ -51,8 +49,7 @@ class NamespaceController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun createNamespace(namespaceCreateRequest: NamespaceCreateRequest): ResponseEntity<NamespaceSummary> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         // NamespaceAlreadyExistsException propagates to GlobalExceptionHandler.handleConflict,
         // which returns 409 with a structured ErrorResponse — matching the contract used by
@@ -72,8 +69,7 @@ class NamespaceController(
         ns: String,
         namespaceUpdateRequest: NamespaceUpdateRequest,
     ): ResponseEntity<NamespaceSummary> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireRole(ns, auth, NamespaceRole.ADMIN)
         val entity = namespaceService.update(
             slug = ns,
@@ -87,8 +83,7 @@ class NamespaceController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteNamespace(ns: String): ResponseEntity<Unit> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         namespaceService.delete(ns)
         return ResponseEntity.noContent().build()

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
@@ -35,7 +35,6 @@ import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -53,8 +52,11 @@ class NamespaceMemberController(
 ) : NamespaceMembersApi {
 
     override fun getMyMembership(ns: String): ResponseEntity<NamespaceMembershipDto> {
-        val authentication = SecurityContextHolder.getContext().authentication
-            ?: return ResponseEntity.status(401).build()
+        // currentAuthentication() throws UnauthorizedException → 401 with the standard
+        // structured error envelope (matches every other endpoint). The previous
+        // raw `ResponseEntity.status(401).build()` returned an empty body and
+        // bypassed the GlobalExceptionHandler envelope contract — see #336.
+        val authentication = currentAuthentication()
         val namespace = namespaceRepository.findBySlug(ns)
             .orElseThrow { NamespaceNotFoundException(ns) }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
@@ -25,11 +25,10 @@ import io.plugwerk.api.model.OidcProviderType
 import io.plugwerk.api.model.OidcProviderUpdateRequest
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.OidcProviderService
-import io.plugwerk.server.service.UnauthorizedException
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -44,8 +43,7 @@ class OidcProviderController(
 ) : OidcProvidersApi {
 
     override fun listOidcProviders(): ResponseEntity<List<OidcProviderDto>> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         return ResponseEntity.ok(oidcProviderService.findAll().map { it.toDto() })
     }
@@ -54,8 +52,7 @@ class OidcProviderController(
     override fun createOidcProvider(
         oidcProviderCreateRequest: OidcProviderCreateRequest,
     ): ResponseEntity<OidcProviderDto> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         val provider = oidcProviderService.create(
             name = oidcProviderCreateRequest.name,
@@ -73,8 +70,7 @@ class OidcProviderController(
         providerId: UUID,
         oidcProviderUpdateRequest: OidcProviderUpdateRequest,
     ): ResponseEntity<OidcProviderDto> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         var provider = oidcProviderService.findById(providerId)
         oidcProviderUpdateRequest.enabled?.let { provider = oidcProviderService.setEnabled(providerId, it) }
@@ -86,8 +82,7 @@ class OidcProviderController(
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
     override fun deleteOidcProvider(providerId: UUID): ResponseEntity<Unit> {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         oidcProviderService.delete(providerId)
         return ResponseEntity.noContent().build()

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
@@ -21,11 +21,11 @@ package io.plugwerk.server.controller
 import io.plugwerk.api.UserSettingsApi
 import io.plugwerk.api.model.UserSettingsResponse
 import io.plugwerk.api.model.UserSettingsUpdateRequest
+import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.UnauthorizedException
 import io.plugwerk.server.service.settings.UserSettingsService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -49,8 +49,7 @@ class UserSettingsController(private val userSettingsService: UserSettingsServic
     }
 
     private fun requireAuthenticatedSubject(): String {
-        val auth = SecurityContextHolder.getContext().authentication
-            ?: throw UnauthorizedException("Not authenticated")
+        val auth = currentAuthentication()
         val name = auth.name
         if (name.isNullOrBlank() || name.startsWith("key:")) {
             throw UnauthorizedException("User settings are not available for API key authentication")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ChangePasswordRateLimitFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ChangePasswordRateLimitFilter.kt
@@ -24,7 +24,6 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.AnonymousAuthenticationToken
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.time.OffsetDateTime
@@ -76,7 +75,7 @@ class ChangePasswordRateLimitFilter(private val rateLimitService: ChangePassword
     }
 
     private fun currentSubject(): String? {
-        val auth = SecurityContextHolder.getContext().authentication ?: return null
+        val auth = currentAuthenticationOrNull() ?: return null
         if (auth is AnonymousAuthenticationToken) return null
         if (!auth.isAuthenticated) return null
         val name = auth.name

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/CurrentAuthentication.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/CurrentAuthentication.kt
@@ -34,6 +34,51 @@ import org.springframework.security.core.context.SecurityContextHolder
  * Previous call sites used `SecurityContextHolder.getContext().authentication!!` in 16
  * places across `ManagementController`, `ReviewsController`, `AccessKeyController`, and
  * `NamespaceMemberController`. Each was a latent NPE with no context.
+ *
+ * @see currentAuthenticationOrNull for code paths that have a legitimate anonymous
+ *   fallback (e.g. catalog visibility downgrade).
+ * @see currentAuthenticationOrElse for single-expression bodies that branch on auth
+ *   presence with a fixed default.
  */
 fun currentAuthentication(): Authentication = SecurityContextHolder.getContext().authentication
     ?: throw UnauthorizedException("Authentication required")
+
+/**
+ * Returns the current [Authentication] from the [SecurityContextHolder], or `null` when
+ * no authentication is present. Use this when an absent authentication is **a legitimate
+ * state** the caller wants to react to — typically by falling back to a typed default
+ * via the elvis operator:
+ *
+ * ```kotlin
+ * fun resolveVisibility(ns: String): CatalogVisibility {
+ *   val auth = currentAuthenticationOrNull() ?: return CatalogVisibility.PUBLIC
+ *   …
+ * }
+ * ```
+ *
+ * Picks up the same call shape as Kotlin's `firstOrNull` / `singleOrNull` family.
+ */
+fun currentAuthenticationOrNull(): Authentication? = SecurityContextHolder.getContext().authentication
+
+/**
+ * Returns [block]`(authentication)` when an [Authentication] is present in the
+ * [SecurityContextHolder], otherwise returns [default]. Designed for single-expression
+ * function bodies that derive a typed value from the (possibly absent) auth:
+ *
+ * ```kotlin
+ * fun hasRole(slug: String, role: NamespaceRole): Boolean =
+ *   currentAuthenticationOrElse(default = false) { auth ->
+ *     try { requireRole(slug, auth, role); true }
+ *     catch (_: ForbiddenException) { false }
+ *     catch (_: NamespaceNotFoundException) { false }
+ *   }
+ * ```
+ *
+ * Generic on `T` via `inline` — the compiler specialises per call site so no `Any` cast
+ * is needed and the return type matches whatever default the caller passes. Prefer
+ * [currentAuthenticationOrNull] when the function body has multiple early returns sharing
+ * the same default — using `OrElse` there would force `return@currentAuthenticationOrElse`
+ * labels and read worse than the elvis pattern.
+ */
+inline fun <T> currentAuthenticationOrElse(default: T, block: (Authentication) -> T): T =
+    SecurityContextHolder.getContext().authentication?.let(block) ?: default

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAuthorizationService.kt
@@ -26,7 +26,6 @@ import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.NamespaceNotFoundException
 import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 
 /**
@@ -133,17 +132,17 @@ class NamespaceAuthorizationService(
      * instead of throwing. Unknown namespaces return `false` so the SpEL pass-through
      * produces a 403; the subsequent service call will re-raise the 404 on the happy path.
      */
-    fun hasRole(namespaceSlug: String, minimumRole: NamespaceRole): Boolean {
-        val auth = SecurityContextHolder.getContext().authentication ?: return false
-        return try {
-            requireRole(namespaceSlug, auth, minimumRole)
-            true
-        } catch (_: ForbiddenException) {
-            false
-        } catch (_: NamespaceNotFoundException) {
-            false
+    fun hasRole(namespaceSlug: String, minimumRole: NamespaceRole): Boolean =
+        currentAuthenticationOrElse(default = false) { auth ->
+            try {
+                requireRole(namespaceSlug, auth, minimumRole)
+                true
+            } catch (_: ForbiddenException) {
+                false
+            } catch (_: NamespaceNotFoundException) {
+                false
+            }
         }
-    }
 
     /**
      * Overload that accepts the role as a string literal so `@PreAuthorize` SpEL can use
@@ -157,10 +156,7 @@ class NamespaceAuthorizationService(
      * SpEL-friendly mirror of [requireSuperadmin] that reads the current [Authentication]
      * from [SecurityContextHolder] and returns a boolean.
      */
-    fun isCurrentUserSuperadmin(): Boolean {
-        val auth = SecurityContextHolder.getContext().authentication ?: return false
-        return isSuperadmin(auth)
-    }
+    fun isCurrentUserSuperadmin(): Boolean = currentAuthenticationOrElse(default = false) { auth -> isSuperadmin(auth) }
 
     /**
      * Returns the namespaces visible to the authenticated principal:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/CurrentAuthenticationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/CurrentAuthenticationTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.service.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+class CurrentAuthenticationTest {
+
+    @AfterEach
+    fun clear() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun setAuth(name: String) {
+        SecurityContextHolder.getContext().authentication =
+            TestingAuthenticationToken(name, "n/a", "ROLE_USER").apply { isAuthenticated = true }
+    }
+
+    // --- currentAuthentication() ----------------------------------------------------
+
+    @Test
+    fun `currentAuthentication returns the authentication when present`() {
+        setAuth("alice")
+
+        val auth = currentAuthentication()
+
+        assertThat(auth.name).isEqualTo("alice")
+    }
+
+    @Test
+    fun `currentAuthentication throws UnauthorizedException when absent`() {
+        // SecurityContextHolder cleared by @AfterEach; here we start with no auth.
+        assertThatThrownBy { currentAuthentication() }
+            .isInstanceOf(UnauthorizedException::class.java)
+            .hasMessage("Authentication required")
+    }
+
+    // --- currentAuthenticationOrNull() ----------------------------------------------
+
+    @Test
+    fun `currentAuthenticationOrNull returns the authentication when present`() {
+        setAuth("alice")
+
+        assertThat(currentAuthenticationOrNull()?.name).isEqualTo("alice")
+    }
+
+    @Test
+    fun `currentAuthenticationOrNull returns null when absent`() {
+        assertThat(currentAuthenticationOrNull()).isNull()
+    }
+
+    // --- currentAuthenticationOrElse(default, block) --------------------------------
+
+    @Test
+    fun `currentAuthenticationOrElse runs the block with the authentication when present`() {
+        setAuth("alice")
+
+        val result = currentAuthenticationOrElse(default = "anon") { auth -> auth.name }
+
+        assertThat(result).isEqualTo("alice")
+    }
+
+    @Test
+    fun `currentAuthenticationOrElse returns the default when no authentication is present`() {
+        val result = currentAuthenticationOrElse(default = "anon") { auth -> auth.name }
+
+        assertThat(result).isEqualTo("anon")
+    }
+
+    @Test
+    fun `currentAuthenticationOrElse infers the result type from the default — Boolean`() {
+        // No auth → false (the bare default). The `block` is never called, so the
+        // inference site is the `default = false` argument.
+        val result: Boolean = currentAuthenticationOrElse(default = false) { _ -> true }
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `currentAuthenticationOrElse infers the result type from the default — nullable Pair`() {
+        val result: Pair<String?, Boolean?> =
+            currentAuthenticationOrElse(default = null to null) { auth -> auth.name to true }
+
+        assertThat(result).isEqualTo(null to null)
+    }
+
+    @Test
+    fun `currentAuthenticationOrElse propagates exceptions from the block`() {
+        setAuth("alice")
+
+        assertThatThrownBy {
+            currentAuthenticationOrElse(default = false) { _ ->
+                throw IllegalStateException("boom")
+            }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("boom")
+    }
+}


### PR DESCRIPTION
Closes #336.

## Summary

Adds two new helpers next to the existing `currentAuthentication()` and migrates **21 call sites across 9 files** from open-coded `SecurityContextHolder.getContext().authentication` to the appropriate helper.

```kotlin
fun currentAuthentication(): Authentication                                  // already existed — throws → 401
fun currentAuthenticationOrNull(): Authentication?                          // null fallback, idiomatic with ?:
inline fun <T> currentAuthenticationOrElse(default: T, block: (Authentication) -> T): T  // scope-style for single-expr bodies
```

The `OrElse` helper is **generic via inline lambda** — the compiler specialises per call site, so each call's return type is inferred from the `default` argument. No `Any` casts, no type-safety loss.

## Migration

| Group | Pattern | Helper | Sites |
|---|---|---|---|
| A | `?: throw UnauthorizedException(...)` | `currentAuthentication()` | 17 |
| B (multi-return) | `?: return X` (3+ early returns) | `currentAuthenticationOrNull()` | 3 |
| B (single-expr) | one-line auth-conditional body | `currentAuthenticationOrElse(default, block)` | 2 |
| C (filters) | filters that **set** the context | unchanged — out of scope | — |

Per Issue #336's tabular breakdown — see commit body for the per-file count.

## One observable behaviour change (documented inline)

`GET /api/v1/namespaces/{ns}/members/me` previously returned a raw `ResponseEntity.status(401).build()` with an empty body when no authentication was present. It now throws `UnauthorizedException` which `GlobalExceptionHandler` converts to a structured 401 with the same JSON envelope every other endpoint uses. No client contract change beyond response-body shape.

## Tests

`CurrentAuthenticationTest` — 9 cases:
- All three helpers: happy path + no-auth path
- `OrElse`: type inference for `Boolean`, type inference for nullable `Pair<String?, Boolean?>`, exception propagation through the block

## Verification

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessApply` — clean
- [x] No `SecurityContextHolder.getContext().authentication` reads remain in scope (only the 3 filters that *set* the context, plus the helper implementations themselves).

## References

- Issue #336 — full migration table
- Origin of `currentAuthentication()`: #285 (`refactor: replace !! assertions with requireNotNull and currentAuthentication`)
- Discussion that surfaced the gap: PR #335 (`resolveVisibility` was migrated to `hasRole` but its own `?: return PUBLIC` line was one of the call sites this PR fixes)