### PR TITLE
fix(db): tune HikariCP pool sizing for managed Postgres / pooler setups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,16 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
 # PLUGWERK_DB_USERNAME=plugwerk
 # PLUGWERK_DB_PASSWORD=plugwerk
+
+# HikariCP pool sizing. Defaults (5 / 1 / 30s / 600s / 30s) are tuned for a
+# managed Postgres behind a connection pooler (e.g. Supabase Supavisor /
+# PgBouncer in transaction mode). For a dedicated Postgres you can raise
+# PLUGWERK_DB_POOL_MAX_SIZE.
+# PLUGWERK_DB_POOL_MAX_SIZE=5
+# PLUGWERK_DB_POOL_MIN_IDLE=1
+# PLUGWERK_DB_POOL_IDLE_TIMEOUT_MS=30000
+# PLUGWERK_DB_POOL_MAX_LIFETIME_MS=600000
+# PLUGWERK_DB_POOL_CONNECTION_TIMEOUT_MS=30000
 # PLUGWERK_BASE_URL=http://localhost:8080
 # PLUGWERK_STORAGE_TYPE=fs
 # PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -10,6 +10,26 @@ spring:
     url: ${PLUGWERK_DB_URL:jdbc:postgresql://localhost:5432/plugwerk}
     username: ${PLUGWERK_DB_USERNAME:plugwerk}
     password: ${PLUGWERK_DB_PASSWORD:plugwerk}
+    # HikariCP pool sizing. Defaults are tuned for managed Postgres with a
+    # client-facing connection pooler (e.g. Supabase Supavisor / PgBouncer in
+    # transaction mode), where the server-side pool already multiplexes — so
+    # the JDBC pool itself should stay small and connections short-lived.
+    # For a dedicated Postgres instance you can raise maximum-pool-size.
+    hikari:
+      # Env: PLUGWERK_DB_POOL_MAX_SIZE
+      maximum-pool-size: ${PLUGWERK_DB_POOL_MAX_SIZE:5}
+      # Env: PLUGWERK_DB_POOL_MIN_IDLE
+      minimum-idle: ${PLUGWERK_DB_POOL_MIN_IDLE:1}
+      # Idle connections older than this are released back to the pooler.
+      # Env: PLUGWERK_DB_POOL_IDLE_TIMEOUT_MS
+      idle-timeout: ${PLUGWERK_DB_POOL_IDLE_TIMEOUT_MS:30000}
+      # Hard cap on a single physical connection's lifetime. Keep below the
+      # pooler's own timeout to avoid mid-query disconnects.
+      # Env: PLUGWERK_DB_POOL_MAX_LIFETIME_MS
+      max-lifetime: ${PLUGWERK_DB_POOL_MAX_LIFETIME_MS:600000}
+      # Fail fast if a connection cannot be acquired within this window.
+      # Env: PLUGWERK_DB_POOL_CONNECTION_TIMEOUT_MS
+      connection-timeout: ${PLUGWERK_DB_POOL_CONNECTION_TIMEOUT_MS:30000}
 
   jpa:
     open-in-view: false


### PR DESCRIPTION
## Summary

Spring Boot's default HikariCP configuration (10 connections, 10 idle) exhausts the per-project client-connection budget on Supabase very quickly, producing a hard startup failure:

```
Caused by: liquibase.exception.DatabaseException: org.postgresql.util.PSQLException:
FATAL: Max client connections reached
```

Add explicit, environment-overridable Hikari settings tuned for managed Postgres behind a client-facing pooler (Supabase Supavisor or PgBouncer in transaction mode), where the server-side pool already multiplexes — so the JDBC pool itself should stay small and connections short-lived.

## Changes

### `application.yml` — new `spring.datasource.hikari` block

| Setting | Old default | New default | Rationale |
|---|---|---|---|
| `maximum-pool-size` | 10 | **5** | Pooler multiplexes already; leave room for other clients in the project budget |
| `minimum-idle` | 10 | **1** | Don't hold idle connections that count against the pooler's slot budget |
| `idle-timeout` | 10 min | **30 s** | Release idle connections back to the pooler quickly |
| `max-lifetime` | 30 min | **10 min** | Keep below typical pooler timeouts to avoid mid-query disconnects |
| `connection-timeout` | 30 s | 30 s (explicit) | Hikari default, made visible |

All five values are overridable via `PLUGWERK_DB_POOL_*` environment variables for deployments backed by a dedicated Postgres instance where a larger pool is appropriate.

### `.env.example`

Documents the five new environment variables in the same block as the existing `PLUGWERK_DB_*` settings, with a note explaining the Supabase-tuned defaults.

## Why these defaults

Defaults match the most constrained common deployment (Supabase Free / PgBouncer transaction mode). Raising them for a dedicated Postgres is a one-line env change and documented inline. The opposite — defaulting to Spring Boot's 10-connection pool and asking Supabase users to lower it — leads to the broken-startup experience seen here.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — full backend suite green (test profile uses its own `application-test.yml` and is unaffected)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — formatting green
- [ ] Local startup against Supabase pooler (Port 6543, `prepareThreshold=0`) — pool should report `maximumPoolSize=5` in the Hikari startup log

## Notes

- The complementary fix is to use the **session pooler** (Port 5432 on `pooler.supabase.com`) instead of the **transaction pooler** (Port 6543) — the session pooler supports server-side prepared statements and is friendlier to Spring Boot + Hibernate. That is a documentation/deployment-config decision and not part of this PR.
- For local development without a pooler, the defaults are still safe — a 5-connection pool is plenty for a single developer workstation.