### PR TITLE
chore(dev): add local Keycloak service + test realm for OIDC development (#79)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,7 +334,34 @@ If `MANIFEST.MF` is absent, the server falls back to `plugin.properties`.
 ./gradlew :plugwerk-api:plugwerk-api-endpoint:openApiGenerate :plugwerk-api:plugwerk-api-model:openApiGenerate  # Regenerate backend DTOs/interfaces from OpenAPI YAML
 ./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
 docker compose up -d postgres                     # Start dev database
+docker compose --profile keycloak up -d           # Start local Keycloak for OIDC dev (issue #79)
 ```
+
+### Local Keycloak for OIDC development (issue #79)
+
+The `keycloak` Docker Compose profile runs a single-node Keycloak that backs the
+browser-based OIDC login flow. It is **localhost-only** and ships a fixed test
+realm with weak credentials — never expose it beyond your machine.
+
+```bash
+docker compose --profile keycloak up -d           # Start Keycloak
+docker compose --profile keycloak down            # Stop Keycloak (data persists)
+docker compose --profile keycloak down -v         # Stop and wipe the realm/state
+```
+
+| Resource | Value |
+|---|---|
+| Admin console | <http://localhost:8081> (`admin` / `admin`) |
+| Issuer URI    | `http://localhost:8081/realms/plugwerk` |
+| Client ID     | `plugwerk-local` |
+| Client secret | `local-dev-secret-do-not-use-in-prod` |
+| Test users    | `alice` / `password` and `bob` / `password` (both with `<name>@plugwerk.test`) |
+
+After Keycloak is up, register the issuer in the Plugwerk Admin UI under
+**Admin → OIDC Providers → Add Provider** with type `KEYCLOAK`. The realm
+definition lives in `docker/keycloak/plugwerk-realm.json`; edit it there and
+restart the container with `down -v` to pick up changes (Keycloak only
+imports realms that don't already exist).
 
 ### Frontend (run from `plugwerk-server/plugwerk-server-frontend/`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,49 @@ services:
     ports:
       - "8080:8080"
 
+  # Keycloak — local-only OIDC provider for developing #79 (browser login flow).
+  # Not started by default; enable via the `keycloak` profile:
+  #   docker compose --profile keycloak up -d
+  #
+  # The realm `plugwerk` is created from docker/keycloak/plugwerk-realm.json
+  # at first start. It contains:
+  #   - one OAuth2 client `plugwerk-local` (confidential, with PKCE),
+  #     redirect URI http://localhost:8080/login/oauth2/code/* and webOrigin
+  #     http://localhost:5173 for the Vite dev server.
+  #   - two test users (alice / bob), password `password`, both with the
+  #     verified email <name>@plugwerk.test.
+  #
+  # Issuer URI to register in the Plugwerk Admin UI:
+  #   http://localhost:8081/realms/plugwerk
+  # Client ID:     plugwerk-local
+  # Client secret: local-dev-secret-do-not-use-in-prod
+  #
+  # Keycloak admin console: http://localhost:8081 (admin/admin).
+  # Both the admin password and the client secret are intentionally weak —
+  # this stack must never be exposed beyond localhost.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    profiles: ["keycloak"]
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./docker/keycloak:/opt/keycloak/data/import:ro
+      - keycloak-data:/opt/keycloak/data
+    ports:
+      - "127.0.0.1:8081:8080"
+    healthcheck:
+      # `start-dev` exposes a management endpoint on port 9000 once the realm
+      # is loaded; that is the canonical readiness probe for Keycloak 26+.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q '200'"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
 volumes:
   postgres-data:
   plugwerk-artifacts:
+  keycloak-data:

--- a/docker/keycloak/plugwerk-realm.json
+++ b/docker/keycloak/plugwerk-realm.json
@@ -1,0 +1,78 @@
+{
+  "realm": "plugwerk",
+  "displayName": "Plugwerk (local development)",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+
+  "clients": [
+    {
+      "clientId": "plugwerk-local",
+      "name": "Plugwerk (local backend)",
+      "description": "Local-only OAuth2 client used by plugwerk-server on http://localhost:8080. The realm + client secret + user passwords are weak on purpose — never deploy beyond localhost. Tracked in issue #79.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-dev-secret-do-not-use-in-prod",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/login/oauth2/code/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080",
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:8080/*##http://localhost:5173/*"
+      },
+      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access"]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "alice",
+      "email": "alice@plugwerk.test",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Tester",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "bob",
+      "email": "bob@plugwerk.test",
+      "emailVerified": true,
+      "firstName": "Bob",
+      "lastName": "Tester",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
First half of #79 — the OAuth2 browser-login flow. This PR is **infrastructure only**: a profile-gated Keycloak in \`docker-compose.yml\` plus a pre-configured test realm. The actual Spring \`oauth2Login\` wiring and the frontend "Login with Keycloak" button land in the follow-up PR.

Stand-alone value: anyone touching #79 can already point Plugwerk at a real Keycloak via the Admin UI without setting up their own realm.

## Usage

\`\`\`bash
docker compose --profile keycloak up -d           # start
docker compose --profile keycloak down            # stop (data persists)
docker compose --profile keycloak down -v         # wipe and restart fresh
\`\`\`

| Resource | Value |
|---|---|
| Admin console | <http://localhost:8081> (\`admin\` / \`admin\`) |
| Issuer URI    | \`http://localhost:8081/realms/plugwerk\` |
| Client ID     | \`plugwerk-local\` |
| Client secret | \`local-dev-secret-do-not-use-in-prod\` |
| Test users    | \`alice\` / \`password\` and \`bob\` / \`password\` (both with \`<name>@plugwerk.test\`) |

## What's inside

- **\`docker-compose.yml\`** — new \`keycloak\` service under profile \`keycloak\` (default \`docker compose up\` is unaffected). Image \`quay.io/keycloak/keycloak:26.0\`, port \`8081\` (so it doesn't collide with the backend on \`8080\`). Healthcheck targets the management endpoint on port 9000 that Keycloak 26 exposes once \`start-dev\` finishes loading.
- **\`docker/keycloak/plugwerk-realm.json\`** — auto-imported on first start. Contains:
  - one **confidential** OAuth2 client \`plugwerk-local\` with **PKCE (S256)**, \`redirectUris=http://localhost:8080/login/oauth2/code/*\`, \`webOrigins=http://localhost:8080,http://localhost:5173\` (Vite dev server). Shared secret deliberately weak — never deploy beyond localhost.
  - two test users: \`alice\` and \`bob\`, password \`password\`, verified emails \`<name>@plugwerk.test\`.
  - default scopes: \`openid\`, \`email\`, \`profile\`.
- **\`AGENTS.md\`** — new section "Local Keycloak for OIDC development" with the table above and a reminder that the stack is localhost-only.

Realm import note: Keycloak's \`--import-realm\` is idempotent and only creates a realm that doesn't already exist. Edit the JSON, then \`down -v\` to wipe the volume and re-import on next start.

## Smoke test (run locally before commit)

\`\`\`bash
$ PLUGWERK_AUTH_JWT_SECRET=… PLUGWERK_AUTH_ENCRYPTION_KEY=… \\
    docker compose --profile keycloak up -d keycloak
$ curl -fs http://localhost:8081/realms/plugwerk/.well-known/openid-configuration | jq
\`\`\`

Returns:

\`\`\`json
{
  "issuer": "http://localhost:8081/realms/plugwerk",
  "authorization_endpoint": "http://localhost:8081/realms/plugwerk/protocol/openid-connect/auth",
  "token_endpoint": "http://localhost:8081/realms/plugwerk/protocol/openid-connect/token",
  "jwks_uri": "http://localhost:8081/realms/plugwerk/protocol/openid-connect/certs",
  "code_challenge_methods_supported": ["plain", "S256"]
}
\`\`\`

Authorization code flow with PKCE-S256 is offered as expected.

## What's NOT in this PR

- No Spring code changes. \`SecurityConfiguration\`, \`OidcProviderRegistry\`, \`AuthController\` etc. are untouched.
- No frontend changes. The login page does not yet render Keycloak buttons.
- No new tests. Compose YAML + realm JSON are both validated by the smoke test above; we don't ship integration tests against a Keycloak container at this stage.

These all land in **PR-B** (\`feat/79b-oidc-browser-login\`), which will:
1. Migrate \`ConfigController\` to the generated \`ServerConfigApi\` interface (tech-debt fix that surfaced during planning)
2. Extend \`/config\` with \`auth.oidcProviders\` so the frontend can render login buttons
3. Wire Spring's \`oauth2Login\` against a \`DbClientRegistrationRepository\` backed by the existing \`oidc_provider\` table (#77)
4. Add a custom success handler that mints a local Plugwerk JWT after the OIDC callback
5. Render \`Login with <provider>\` buttons on the login page

## Related

- Closes part of #79 (OAuth2 Authorization Code Flow). Sibling PR will close the rest.
- Builds on #77 (Phase 2 OIDC Resource Server + provider admin UI).