### PR TITLE
feat: OAuth2 browser login flow with Keycloak (#79)

### DIFF
--- a/docker/keycloak/plugwerk-realm.json
+++ b/docker/keycloak/plugwerk-realm.json
@@ -28,7 +28,8 @@
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "redirectUris": [
-        "http://localhost:8080/login/oauth2/code/*"
+        "http://localhost:8080/login/oauth2/code/*",
+        "http://localhost:5173/login/oauth2/code/*"
       ],
       "webOrigins": [
         "http://localhost:8080",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ h2 = { module = "com.h2database:h2" }
 liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
 spring-boot-starter-liquibase = { module = "org.springframework.boot:spring-boot-starter-liquibase" }
 spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
+spring-boot-starter-oauth2-client = { module = "org.springframework.boot:spring-boot-starter-oauth2-client" }
 
 # PF4J
 pf4j = { module = "org.pf4j:pf4j", version.ref = "pf4j" }

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -234,8 +234,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServerConfigResponse'
               example:
+                version: "1.0.0"
                 upload:
                   maxFileSizeMb: 100
+                general:
+                  defaultTimezone: "UTC"
+                auth:
+                  oidcProviders:
+                    - id: "keycloak-local"
+                      name: "Keycloak Local"
+                      loginUrl: "/oauth2/authorization/keycloak-local"
 
   /auth/login:
     post:
@@ -2675,10 +2683,68 @@ components:
               example: "UTC"
           required:
             - defaultTimezone
+        auth:
+          type: object
+          description: |
+            Authentication-related public configuration. Used by the login page to
+            render OIDC provider buttons in addition to the local username/password
+            form. Only public, non-sensitive fields appear here — never client secrets,
+            issuer URIs, or any other operator-only data.
+          properties:
+            oidcProviders:
+              type: array
+              description: |
+                List of OIDC providers that are currently `enabled` in the database
+                and registered in Spring Security's OAuth2 client registry. Empty
+                when no provider has been activated. The frontend renders one
+                "Login with `<name>`" button per entry on the login page (issue #79).
+              items:
+                $ref: '#/components/schemas/OidcProviderLoginInfo'
+              example:
+                - id: "keycloak-local"
+                  name: "Keycloak Local"
+                  loginUrl: "/oauth2/authorization/keycloak-local"
+          required:
+            - oidcProviders
       required:
         - version
         - upload
         - general
+        - auth
+
+    OidcProviderLoginInfo:
+      type: object
+      description: |
+        Public, non-sensitive metadata about an enabled OIDC provider for the
+        login page (issue #79). The `loginUrl` is a relative path — the frontend
+        navigates the browser to it; Spring Security's OAuth2 client filter
+        intercepts the request and starts the Authorization Code Flow with PKCE.
+      properties:
+        id:
+          type: string
+          description: |
+            Spring Security `registrationId`. Stable identifier; URL-safe slug
+            derived from the provider entity. Same value as the `{registrationId}`
+            in the redirect URI `/login/oauth2/code/{registrationId}`.
+          example: "keycloak-local"
+        name:
+          type: string
+          description: |
+            Human-readable display name of the provider, as configured in the
+            Plugwerk Admin UI. Shown verbatim on the "Login with …" button.
+          example: "Keycloak Local"
+        loginUrl:
+          type: string
+          description: |
+            Relative URL the frontend navigates the browser to in order to start
+            the OIDC flow. Always `/oauth2/authorization/{id}` for the local
+            client; never an absolute URL — keeps the same-origin guarantees
+            of the open-redirect guard from issue #274 trivially satisfied.
+          example: "/oauth2/authorization/keycloak-local"
+      required:
+        - id
+        - name
+        - loginUrl
 
     AccessKeyDto:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.oauth2.resource.server)
+    implementation(libs.spring.boot.starter.oauth2.client)
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.jackson.module.kotlin)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -20,10 +20,12 @@ package io.plugwerk.server.config
 
 import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.DbClientRegistrationRepository
 import io.plugwerk.server.security.DelegatingJwtDecoder
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.OidcLoginSuccessHandler
 import io.plugwerk.server.security.OidcProviderRegistry
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
@@ -72,6 +74,12 @@ class SecurityConfiguration(
     private val localJwtDecoder: DelegatingJwtDecoder,
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
 ) {
+    // NOTE: dbClientRegistrationRepository + oidcLoginSuccessHandler must NOT be
+    // constructor-injected here — they transitively depend on `textEncryptor`,
+    // which this very class exposes as a @Bean. Constructor injection produces
+    // a circular reference that fails the bean container at startup. Both are
+    // injected as @Bean method parameters on `securityFilterChain` instead, so
+    // they are resolved lazily after textEncryptor has been created.
 
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
@@ -244,7 +252,11 @@ class SecurityConfiguration(
 
     @Bean
     @Order(2)
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun securityFilterChain(
+        http: HttpSecurity,
+        dbClientRegistrationRepository: DbClientRegistrationRepository,
+        oidcLoginSuccessHandler: OidcLoginSuccessHandler,
+    ): SecurityFilterChain {
         http
             // CORS is configured via the corsConfigurationSource() bean above.
             //
@@ -306,12 +318,29 @@ class SecurityConfiguration(
             .oauth2ResourceServer { oauth2 ->
                 oauth2.jwt { jwt -> jwt.decoder(localJwtDecoder) }
             }
+            // Browser-initiated OAuth2 login flow (issue #79). Spring's OAuth2 client filter
+            // handles `/oauth2/authorization/{registrationId}` (start), the redirect to the
+            // upstream provider, the `/login/oauth2/code/{registrationId}` callback, and the
+            // PKCE-state validation. We provide:
+            //   - the ClientRegistrationRepository (DB-backed, refreshable at runtime)
+            //   - the success handler that mints a Plugwerk JWT + refresh cookie and redirects
+            //     the user to "/" so the SPA's hydrate() picks up the session.
+            // No formLogin page is rendered because we ship our own React login at /login.
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .clientRegistrationRepository(dbClientRegistrationRepository)
+                    .successHandler(oidcLoginSuccessHandler)
+            }
             .authorizeHttpRequests { auth ->
                 auth
                     // Logout requires a valid Bearer token — must be listed before the auth wildcard
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                     // Auth endpoints are always public (login + change-password requires auth but handled in controller)
                     .requestMatchers("/api/v1/auth/**").permitAll()
+                    // OAuth2 browser-flow endpoints managed by Spring Security itself (#79).
+                    // /oauth2/authorization/** initiates the flow; /login/oauth2/code/** is the
+                    // upstream-provider callback. Both must be reachable without prior auth.
+                    .requestMatchers("/oauth2/authorization/**", "/login/oauth2/code/**").permitAll()
                     // Update check is public (used by client plugin without auth)
                     .requestMatchers(HttpMethod.POST, "/api/v1/namespaces/*/updates/check").permitAll()
                     // Public server config (upload limits etc.) — used by frontend without auth

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -310,7 +310,23 @@ class SecurityConfiguration(
             }
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            // Session policy is IF_REQUIRED (Spring's default), NOT STATELESS:
+            // OAuth2 login (#79) needs an HTTP session for the brief window
+            // between /oauth2/authorization/{id} (where the AuthorizationRequest
+            // with state + PKCE code verifier is stored) and the callback at
+            // /login/oauth2/code/{id} (where Spring needs to look it up).
+            // STATELESS would silently no-op the storage and produce a Spring
+            // Whitelabel error page on the callback because the request would
+            // not be found in any repository.
+            //
+            // Our regular API auth model is unaffected: Bearer tokens are
+            // verified statelessly per-request by the resource server, the
+            // refresh cookie is the long-lived session token, and the
+            // SecurityContext is never persisted into the session because no
+            // formLogin / basic-auth path puts it there. The JSESSIONID
+            // cookie issued during an OAuth2 login carries only the in-flight
+            // OAuth2 state; once the callback completes Spring abandons it.
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) }
             .exceptionHandling {
                 // Return 401 JSON instead of redirect to login page
                 it.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -19,9 +19,13 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.api.ServerConfigApi
+import io.plugwerk.api.model.OidcProviderLoginInfo
 import io.plugwerk.api.model.ServerConfigResponse
+import io.plugwerk.api.model.ServerConfigResponseAuth
 import io.plugwerk.api.model.ServerConfigResponseGeneral
 import io.plugwerk.api.model.ServerConfigResponseUpload
+import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.security.OidcRegistrationIds
 import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.springframework.http.ResponseEntity
@@ -33,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 class ConfigController(
     private val settingsService: ApplicationSettingsService,
     private val versionProvider: VersionProvider,
+    private val oidcProviderRepository: OidcProviderRepository,
 ) : ServerConfigApi {
 
     override fun getServerConfig(): ResponseEntity<ServerConfigResponse> = ResponseEntity.ok(
@@ -40,6 +45,32 @@ class ConfigController(
             version = versionProvider.getVersion(),
             upload = ServerConfigResponseUpload(maxFileSizeMb = settingsService.maxUploadSizeMb()),
             general = ServerConfigResponseGeneral(defaultTimezone = settingsService.defaultTimezone()),
+            auth = ServerConfigResponseAuth(oidcProviders = enabledOidcProviderLoginInfo()),
         ),
     )
+
+    /**
+     * Builds the public OIDC-provider login info shown on the frontend login page (#79).
+     *
+     * Only `enabled = true` providers are exposed — disabled rows from the
+     * `oidc_provider` table are admin scaffolding and must never leak to the
+     * unauthenticated `/config` consumer. The fields are deliberately limited to
+     * `id`, `name`, and `loginUrl`; never the issuerUri, the encrypted client
+     * secret, or any other operator-only data.
+     *
+     * The Spring Security `registrationId` is sourced from
+     * [OidcRegistrationIds.of] so this controller and the
+     * [io.plugwerk.server.security.DbClientRegistrationRepository] agree on the
+     * exact same identifier — drift between the two would silently produce 404s
+     * on the OAuth2 authorization endpoint.
+     */
+    private fun enabledOidcProviderLoginInfo(): List<OidcProviderLoginInfo> =
+        oidcProviderRepository.findAllByEnabledTrue().map { provider ->
+            val registrationId = OidcRegistrationIds.of(provider)
+            OidcProviderLoginInfo(
+                id = registrationId,
+                name = provider.name,
+                loginUrl = "/oauth2/authorization/$registrationId",
+            )
+        }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -18,10 +18,13 @@
  */
 package io.plugwerk.server.controller
 
+import io.plugwerk.api.ServerConfigApi
+import io.plugwerk.api.model.ServerConfigResponse
+import io.plugwerk.api.model.ServerConfigResponseGeneral
+import io.plugwerk.api.model.ServerConfigResponseUpload
 import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -30,23 +33,13 @@ import org.springframework.web.bind.annotation.RestController
 class ConfigController(
     private val settingsService: ApplicationSettingsService,
     private val versionProvider: VersionProvider,
-) {
+) : ServerConfigApi {
 
-    @GetMapping("/config")
-    fun getServerConfig(): ResponseEntity<ServerConfigResponse> = ResponseEntity.ok(
+    override fun getServerConfig(): ResponseEntity<ServerConfigResponse> = ResponseEntity.ok(
         ServerConfigResponse(
             version = versionProvider.getVersion(),
-            upload = ServerConfigResponse.UploadConfig(
-                maxFileSizeMb = settingsService.maxUploadSizeMb(),
-            ),
-            general = ServerConfigResponse.GeneralConfig(
-                defaultTimezone = settingsService.defaultTimezone(),
-            ),
+            upload = ServerConfigResponseUpload(maxFileSizeMb = settingsService.maxUploadSizeMb()),
+            general = ServerConfigResponseGeneral(defaultTimezone = settingsService.defaultTimezone()),
         ),
     )
-
-    data class ServerConfigResponse(val version: String, val upload: UploadConfig, val general: GeneralConfig) {
-        data class UploadConfig(val maxFileSizeMb: Int)
-        data class GeneralConfig(val defaultTimezone: String)
-    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
+import org.slf4j.LoggerFactory
+import org.springframework.security.crypto.encrypt.TextEncryptor
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.registration.ClientRegistrations
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Spring Security `ClientRegistrationRepository` backed by the
+ * `oidc_provider` table (issue #79).
+ *
+ * Builds one [ClientRegistration] per `enabled = true` row and exposes them
+ * to Spring's OAuth2 client filter, which uses them to drive the browser
+ * Authorization Code Flow at
+ * `/oauth2/authorization/{registrationId}` and the redirect URI
+ * `/login/oauth2/code/{registrationId}`.
+ *
+ * The `registrationId` is sourced from [OidcRegistrationIds.of] — the same
+ * value the frontend gets back from `/api/v1/config` and uses to navigate.
+ *
+ * ## Refresh semantics
+ *
+ * Built once at startup and rebuilt on demand via [refresh]. The admin UI
+ * paths that flip `enabled` (or change a provider's secret/issuer) call this
+ * method through [io.plugwerk.server.service.OidcProviderService] so a newly
+ * activated provider becomes available without a server restart.
+ *
+ * The internal map sits in an [AtomicReference] so [findByRegistrationId]
+ * never blocks while a refresh is in flight; readers either see the old map
+ * or the new map, never a half-built one.
+ *
+ * ## Provider type support (Phase 1 of #79)
+ *
+ * Browser login is currently wired only for [OidcProviderType.KEYCLOAK] and
+ * [OidcProviderType.GENERIC_OIDC] — both rely on RFC-8414 / OIDC discovery
+ * via `issuerUri`. The vendor providers (GitHub / Google / Facebook) have
+ * sufficient metadata in [OidcProviderRegistry] to validate incoming bearer
+ * tokens, but the browser-flow client metadata (authorization endpoint with
+ * the right vendor quirks) is not yet implemented. They are silently
+ * skipped here and emit a single warning at refresh time so operators know
+ * the row will not appear on the login page.
+ *
+ * ## Failure isolation
+ *
+ * One unreachable issuer must not break authentication for every other
+ * provider, so each registration build is wrapped in `runCatching` and a
+ * failed entry is logged + skipped. The same defence-in-depth pattern is
+ * used by [OidcProviderRegistry] for the resource-server side.
+ */
+@Component
+class DbClientRegistrationRepository(
+    private val oidcProviderRepository: OidcProviderRepository,
+    private val textEncryptor: TextEncryptor,
+) : ClientRegistrationRepository,
+    Iterable<ClientRegistration> {
+
+    private val log = LoggerFactory.getLogger(DbClientRegistrationRepository::class.java)
+
+    private val activeRegistrations = AtomicReference<Map<String, ClientRegistration>>(emptyMap())
+
+    init {
+        refresh()
+    }
+
+    override fun findByRegistrationId(registrationId: String): ClientRegistration? =
+        activeRegistrations.get()[registrationId]
+
+    override fun iterator(): Iterator<ClientRegistration> = activeRegistrations.get().values.iterator()
+
+    /**
+     * Reload the registration map from the database. Called at startup and
+     * by [io.plugwerk.server.service.OidcProviderService] after any change
+     * that affects which providers participate in the browser login flow.
+     */
+    fun refresh() {
+        val byId = oidcProviderRepository.findAllByEnabledTrue()
+            .mapNotNull { provider ->
+                runCatching { buildRegistration(provider) }
+                    .onFailure {
+                        log.warn(
+                            "Skipping OIDC provider {} (registrationId={}) — failed to build ClientRegistration: {}",
+                            provider.name,
+                            OidcRegistrationIds.of(provider),
+                            it.message,
+                        )
+                    }
+                    .getOrNull()
+            }
+            .associateBy { it.registrationId }
+        activeRegistrations.set(byId)
+        log.info("OAuth2 client registrations loaded: {} active provider(s)", byId.size)
+    }
+
+    private fun buildRegistration(provider: OidcProviderEntity): ClientRegistration {
+        val registrationId = OidcRegistrationIds.of(provider)
+        val builder = when (provider.providerType) {
+            OidcProviderType.KEYCLOAK, OidcProviderType.GENERIC_OIDC -> {
+                val issuerUri = requireNotNull(provider.issuerUri) {
+                    "issuerUri is required for provider type ${provider.providerType}"
+                }
+                ClientRegistrations.fromIssuerLocation(issuerUri)
+            }
+
+            OidcProviderType.GITHUB,
+            OidcProviderType.GOOGLE,
+            OidcProviderType.FACEBOOK,
+            -> error(
+                "Browser login flow not yet implemented for provider type ${provider.providerType} " +
+                    "(see Phase 1 scope of #79). The provider remains usable as a resource-server token issuer.",
+            )
+        }
+        return builder
+            .registrationId(registrationId)
+            .clientId(provider.clientId)
+            .clientSecret(textEncryptor.decrypt(provider.clientSecretEncrypted))
+            .scope(provider.scope.split(" ").filter { it.isNotBlank() }.toSet())
+            .build()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
@@ -18,6 +18,8 @@
  */
 package io.plugwerk.server.security
 
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.service.RefreshTokenService
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -27,6 +29,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * Bridges Spring Security's OAuth2 browser flow into Plugwerk's existing
@@ -60,10 +63,12 @@ import org.springframework.stereotype.Component
 class OidcLoginSuccessHandler(
     private val refreshTokenService: RefreshTokenService,
     private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
+    private val userRepository: UserRepository,
 ) : AuthenticationSuccessHandler {
 
     private val log = LoggerFactory.getLogger(OidcLoginSuccessHandler::class.java)
 
+    @Transactional
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -88,6 +93,7 @@ class OidcLoginSuccessHandler(
             )
 
         val userSubject = "$registrationId:$sub"
+        ensureLocalUserRow(userSubject)
         val refresh = refreshTokenService.issue(userSubject)
         val cookie = refreshTokenCookieFactory.build(refresh.plaintext, refresh.maxAge)
 
@@ -98,5 +104,53 @@ class OidcLoginSuccessHandler(
         // /api/v1/auth/refresh against the cookie we just set and either land
         // the user on their default namespace or on /onboarding.
         response.sendRedirect("/")
+    }
+
+    /**
+     * Just-in-time user provisioning for OIDC subjects (#79).
+     *
+     * `RefreshTokenService.issue()` requires a row in `plugwerk_user` to attach
+     * the refresh token to (FK → user.id). For locally-issued accounts that
+     * row is created by the admin via `UserService.create`. For OIDC-sourced
+     * identities there is no such admin step — the row must materialise on
+     * the first successful OIDC callback or every fresh user gets a 500 on
+     * login.
+     *
+     * The placeholder columns are deliberately user-hostile so the row cannot
+     * be repurposed as a local password account:
+     *
+     *   - `passwordHash` is set to the constant [OIDC_PLACEHOLDER_PASSWORD_HASH].
+     *     This is not a valid BCrypt digest, so `BCryptPasswordEncoder.matches`
+     *     returns false for any input — the local /auth/login endpoint will
+     *     reject every attempted password.
+     *   - `email` is left null. Importing the email from the ID token would
+     *     race against the case-insensitive uniqueness index introduced in
+     *     #271 if a local user with that address already exists, and there is
+     *     no policy yet for "should an OIDC sub be allowed to claim a local
+     *     user's email". A separate identity-linking flow can grow that
+     *     story in a later phase.
+     *   - `passwordChangeRequired` is `false` so the user is not bounced to
+     *     `/change-password` — they have no password to change.
+     */
+    private fun ensureLocalUserRow(userSubject: String) {
+        if (userRepository.existsByUsername(userSubject)) return
+        userRepository.save(
+            UserEntity(
+                username = userSubject,
+                email = null,
+                passwordHash = OIDC_PLACEHOLDER_PASSWORD_HASH,
+                enabled = true,
+                passwordChangeRequired = false,
+                isSuperadmin = false,
+            ),
+        )
+        log.info("Auto-provisioned local user row for OIDC subject: {}", userSubject)
+    }
+
+    private companion object {
+        // Not a valid BCrypt digest — never matches any input via
+        // BCryptPasswordEncoder.matches, so the local /auth/login endpoint
+        // can never succeed against an OIDC-provisioned row.
+        const val OIDC_PLACEHOLDER_PASSWORD_HASH = "OIDC:no-password"
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.service.RefreshTokenService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+/**
+ * Bridges Spring Security's OAuth2 browser flow into Plugwerk's existing
+ * JWT + refresh-cookie session model (issue #79).
+ *
+ * Spring's OAuth2 client filter handles the heavy lifting (PKCE state, code
+ * exchange with the provider, ID token validation) and hands us a fully
+ * authenticated [OAuth2AuthenticationToken] when the user comes back from
+ * the provider. From here we:
+ *
+ *  1. Map the OIDC `sub` claim to a stable Plugwerk `user_subject` of the
+ *     form `<registrationId>:<sub>`. The `registrationId` half is anchored
+ *     by [OidcRegistrationIds] and matches the provider's UUID, so the
+ *     subject survives admin-UI renames of the provider's display name.
+ *  2. Set the same httpOnly refresh cookie a local login would set (so the
+ *     frontend's existing `hydrate()` flow can immediately exchange it for
+ *     a Plugwerk access token via `/api/v1/auth/refresh`). We deliberately
+ *     do NOT include the access token in the redirect — that would put a
+ *     credential in the browser history and the access log. The frontend
+ *     instead picks it up on its first XHR after the redirect.
+ *  3. Redirect the browser to `/` (the SPA root). React-Router takes it
+ *     from there: `useAuthStore.hydrate()` runs, sees the refresh cookie,
+ *     and either lands the user on their dashboard or on `/onboarding`
+ *     if no namespace membership exists yet.
+ *
+ * No HTTP-level access-token leakage, no credentials in URLs, no JSON
+ * response (the redirect is the response). Same security properties as the
+ * `POST /api/v1/auth/login` endpoint just with a different front-end trigger.
+ */
+@Component
+class OidcLoginSuccessHandler(
+    private val refreshTokenService: RefreshTokenService,
+    private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
+) : AuthenticationSuccessHandler {
+
+    private val log = LoggerFactory.getLogger(OidcLoginSuccessHandler::class.java)
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication,
+    ) {
+        val oauthToken = authentication as? OAuth2AuthenticationToken
+            ?: error(
+                "OidcLoginSuccessHandler invoked with non-OAuth2 authentication: " +
+                    "${authentication.javaClass.name}. Spring Security wiring is broken.",
+            )
+        val registrationId = oauthToken.authorizedClientRegistrationId
+        // The OAuth2User principal can technically be null in pure-OAuth2 (non-OIDC)
+        // flows, but oauth2Login's standard flow always populates it. Bail loudly if
+        // an unexpected configuration ever produces a null principal here.
+        val principal = requireNotNull(oauthToken.principal) {
+            "OAuth2AuthenticationToken for $registrationId has no principal"
+        }
+        val sub = principal.attributes["sub"] as? String
+            ?: error(
+                "OIDC provider $registrationId returned a token without a `sub` claim — " +
+                    "cannot map to a Plugwerk user_subject.",
+            )
+
+        val userSubject = "$registrationId:$sub"
+        val refresh = refreshTokenService.issue(userSubject)
+        val cookie = refreshTokenCookieFactory.build(refresh.plaintext, refresh.maxAge)
+
+        log.info("OIDC login success — registrationId={} sub={} userSubject={}", registrationId, sub, userSubject)
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString())
+        // Always redirect to the SPA root; the frontend's hydrate() will run
+        // /api/v1/auth/refresh against the cookie we just set and either land
+        // the user on their default namespace or on /onboarding.
+        response.sendRedirect("/")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcRegistrationIds.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcRegistrationIds.kt
@@ -57,8 +57,7 @@ object OidcRegistrationIds {
      * for every row read from the database; a freshly-constructed in-memory
      * entity should never reach this helper.
      */
-    fun of(provider: OidcProviderEntity): String =
-        requireNotNull(provider.id) {
-            "OidcProviderEntity must be persisted before its registrationId is derived"
-        }.toString()
+    fun of(provider: OidcProviderEntity): String = requireNotNull(provider.id) {
+        "OidcProviderEntity must be persisted before its registrationId is derived"
+    }.toString()
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcRegistrationIds.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcRegistrationIds.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderEntity
+
+/**
+ * Single source of truth for Spring Security `registrationId` values derived
+ * from [OidcProviderEntity] rows (issue #79).
+ *
+ * Three places in the code base must agree on the exact same identifier:
+ *
+ *  - [io.plugwerk.server.controller.ConfigController] exposes it to the frontend
+ *    via `/api/v1/config` so the login page can build the correct login URL.
+ *  - The `DbClientRegistrationRepository` registers it as the Spring Security
+ *    `ClientRegistration.registrationId`.
+ *  - Spring Security's OAuth2 client filter uses it as the `{registrationId}`
+ *    path segment in the redirect URI `/login/oauth2/code/{registrationId}` and
+ *    the authorization start URL `/oauth2/authorization/{registrationId}`.
+ *
+ * Drift between these three would silently produce 404s on the authorization
+ * endpoint, so the value is computed in exactly one place.
+ *
+ * ## Why the entity ID, not the entity name
+ *
+ * The provider's display name can be edited freely in the admin UI ("Keycloak"
+ * → "Keycloak (production)"). If the `registrationId` were derived from the
+ * name, every rename would change the OAuth2 redirect URI — silently breaking
+ * the registered URIs at the upstream provider. The entity's UUID is immutable
+ * and has been the row's primary key from creation, so its `registrationId` is
+ * stable for the lifetime of the row.
+ *
+ * UUIDs are URL-safe by construction (RFC 4122 hex + hyphens), so we use them
+ * verbatim — no slugging, no escaping.
+ */
+object OidcRegistrationIds {
+
+    /**
+     * Returns the Spring Security `registrationId` for [provider]. The provider
+     * must have been persisted (its `id` must be non-null) — this is the case
+     * for every row read from the database; a freshly-constructed in-memory
+     * entity should never reach this helper.
+     */
+    fun of(provider: OidcProviderEntity): String =
+        requireNotNull(provider.id) {
+            "OidcProviderEntity must be persisted before its registrationId is derived"
+        }.toString()
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
@@ -21,6 +21,7 @@ package io.plugwerk.server.service
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.security.DbClientRegistrationRepository
 import io.plugwerk.server.security.OidcProviderRegistry
 import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.stereotype.Service
@@ -32,8 +33,23 @@ import java.util.UUID
 class OidcProviderService(
     private val oidcProviderRepository: OidcProviderRepository,
     private val oidcProviderRegistry: OidcProviderRegistry,
+    private val dbClientRegistrationRepository: DbClientRegistrationRepository,
     private val textEncryptor: TextEncryptor,
 ) {
+
+    /**
+     * Rebuilds both registries that depend on the enabled-providers list:
+     *   - [OidcProviderRegistry]            — JWKS-based JwtDecoders for the
+     *     resource-server side (verify incoming bearer tokens, #77).
+     *   - [DbClientRegistrationRepository]  — Spring Security ClientRegistrations
+     *     for the browser login flow (#79).
+     * Either-or refreshes drift the two registries against the database; calling
+     * them together from a single helper guarantees they stay in lockstep.
+     */
+    private fun refreshAllRegistries() {
+        oidcProviderRegistry.refresh()
+        dbClientRegistrationRepository.refresh()
+    }
 
     @Transactional(readOnly = true)
     fun findAll(): List<OidcProviderEntity> = oidcProviderRepository.findAll()
@@ -68,14 +84,19 @@ class OidcProviderService(
         val provider = findById(id)
         provider.enabled = enabled
         val saved = oidcProviderRepository.save(provider)
-        oidcProviderRegistry.refresh()
+        refreshAllRegistries()
         return saved
     }
 
     fun updateClientSecret(id: UUID, newSecret: String): OidcProviderEntity {
         val provider = findById(id)
         provider.clientSecretEncrypted = textEncryptor.encrypt(newSecret)
-        return oidcProviderRepository.save(provider)
+        val saved = oidcProviderRepository.save(provider)
+        // The browser-flow ClientRegistration caches the decrypted secret in
+        // the registration object; without a refresh, an updated secret would
+        // not take effect until the next server restart.
+        refreshAllRegistries()
+        return saved
     }
 
     fun delete(id: UUID) {
@@ -83,6 +104,6 @@ class OidcProviderService(
             throw EntityNotFoundException("OidcProvider", id.toString())
         }
         oidcProviderRepository.deleteById(id)
-        oidcProviderRegistry.refresh()
+        refreshAllRegistries()
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -31,7 +31,6 @@ import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
-import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
 import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
@@ -42,6 +41,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import java.util.UUID
 
 @WebMvcTest(
     ConfigController::class,

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -18,6 +18,9 @@
  */
 package io.plugwerk.server.controller
 
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
 import io.plugwerk.server.security.ChangePasswordRateLimitFilter
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
@@ -28,6 +31,7 @@ import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
 import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
@@ -59,6 +63,8 @@ class ConfigControllerTest {
 
     @MockitoBean lateinit var versionProvider: VersionProvider
 
+    @MockitoBean lateinit var oidcProviderRepository: OidcProviderRepository
+
     @Autowired private lateinit var mockMvc: MockMvc
 
     @Test
@@ -66,6 +72,7 @@ class ConfigControllerTest {
         whenever(settingsService.maxUploadSizeMb()).thenReturn(200)
         whenever(settingsService.defaultTimezone()).thenReturn("Europe/Berlin")
         whenever(versionProvider.getVersion()).thenReturn("1.2.3")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
 
         mockMvc.get("/api/v1/config")
             .andExpect {
@@ -81,11 +88,96 @@ class ConfigControllerTest {
         whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
         whenever(settingsService.defaultTimezone()).thenReturn("UTC")
         whenever(versionProvider.getVersion()).thenReturn("unknown")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
 
         mockMvc.get("/api/v1/config")
             .andExpect {
                 status { isOk() }
                 jsonPath("$.version") { value("unknown") }
+            }
+    }
+
+    @Test
+    fun `GET config returns empty oidcProviders list when no provider is enabled (#79)`() {
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.auth.oidcProviders") { isArray() }
+                jsonPath("$.auth.oidcProviders.length()") { value(0) }
+            }
+    }
+
+    @Test
+    fun `GET config exposes enabled oidcProviders with id, name, and loginUrl (#79)`() {
+        // The login page renders one button per entry. The id is the Spring
+        // Security `registrationId` (provider UUID, stable across renames),
+        // the loginUrl is the relative `/oauth2/authorization/{id}` path.
+        val providerId = UUID.fromString("11111111-2222-3333-4444-555555555555")
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(
+            listOf(
+                OidcProviderEntity(
+                    id = providerId,
+                    name = "Keycloak Local",
+                    providerType = OidcProviderType.KEYCLOAK,
+                    enabled = true,
+                    clientId = "plugwerk-local",
+                    clientSecretEncrypted = "ignored-for-this-test",
+                    issuerUri = "http://localhost:8081/realms/plugwerk",
+                ),
+            ),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.auth.oidcProviders.length()") { value(1) }
+                jsonPath("$.auth.oidcProviders[0].id") { value(providerId.toString()) }
+                jsonPath("$.auth.oidcProviders[0].name") { value("Keycloak Local") }
+                jsonPath("$.auth.oidcProviders[0].loginUrl") {
+                    value("/oauth2/authorization/$providerId")
+                }
+            }
+    }
+
+    @Test
+    fun `GET config never exposes the issuerUri or client secret of OIDC providers (#79)`() {
+        // Issuer URI and clientSecret are operator-only fields; the public
+        // /config response must contain only id, name, and loginUrl per provider.
+        // Pinning this as a contract test so a future careless schema change
+        // cannot accidentally widen the surface.
+        val providerId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(
+            listOf(
+                OidcProviderEntity(
+                    id = providerId,
+                    name = "Internal Keycloak",
+                    providerType = OidcProviderType.KEYCLOAK,
+                    enabled = true,
+                    clientId = "plugwerk-internal",
+                    clientSecretEncrypted = "{cipher}leaked-secret-must-not-appear",
+                    issuerUri = "https://keycloak.internal.example.com/realms/internal",
+                ),
+            ),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.auth.oidcProviders[0].issuerUri") { doesNotExist() }
+                jsonPath("$.auth.oidcProviders[0].clientId") { doesNotExist() }
+                jsonPath("$.auth.oidcProviders[0].clientSecretEncrypted") { doesNotExist() }
+                jsonPath("$.auth.oidcProviders[0].clientSecret") { doesNotExist() }
             }
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.encrypt.TextEncryptor
+import java.util.UUID
+
+/**
+ * Unit tests for [DbClientRegistrationRepository] that exercise the parts which
+ * do not require a live OIDC discovery endpoint:
+ *
+ *   - empty enabled-providers list → empty registry, all lookups return null
+ *   - unreachable issuer is logged-and-skipped, not propagated as an exception
+ *     (so one broken provider cannot break authentication for the others)
+ *
+ * The happy path — building a real ClientRegistration from a working
+ * `issuerUri` — needs a live OIDC discovery endpoint and is covered by the
+ * manual end-to-end test against the local Keycloak (issue #79). A future
+ * Testcontainers-based integration test can pin that interaction.
+ */
+@ExtendWith(MockitoExtension::class)
+class DbClientRegistrationRepositoryTest {
+
+    @Mock lateinit var oidcProviderRepository: OidcProviderRepository
+
+    @Mock lateinit var textEncryptor: TextEncryptor
+
+    @Test
+    fun `findByRegistrationId returns null when no provider is enabled`() {
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
+
+        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+
+        assertThat(repo.findByRegistrationId(UUID.randomUUID().toString())).isNull()
+        assertThat(repo.iterator().hasNext()).isFalse()
+    }
+
+    @Test
+    fun `unreachable issuer is skipped, other providers continue to load (failure isolation)`() {
+        // Build a single provider whose issuerUri is a syntactically-valid URL
+        // pointing at a port nothing is listening on — Spring's
+        // ClientRegistrations.fromIssuerLocation will throw when it tries to
+        // fetch /.well-known/openid-configuration. The repository must catch
+        // that, log it, and produce an empty registry rather than propagating
+        // the exception to the bean container (which would fail server boot).
+        val unreachableProvider = OidcProviderEntity(
+            id = UUID.fromString("99999999-9999-9999-9999-999999999999"),
+            name = "Down Keycloak",
+            providerType = OidcProviderType.KEYCLOAK,
+            enabled = true,
+            clientId = "ignored",
+            clientSecretEncrypted = "{cipher}ignored",
+            issuerUri = "http://localhost:1/realms/never-listening", // port 1 is reserved/closed
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(unreachableProvider))
+
+        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+
+        assertThat(repo.iterator().hasNext()).isFalse()
+        assertThat(repo.findByRegistrationId(unreachableProvider.id.toString())).isNull()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.RefreshTokenService
+import io.plugwerk.server.service.RefreshTokenService.IssuedToken
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import java.time.Duration
+
+/**
+ * Unit tests for [OidcLoginSuccessHandler]. Asserts the post-OIDC-callback
+ * contract:
+ *
+ *   - The OIDC `sub` claim is mapped to a Plugwerk `user_subject` of the form
+ *     `<registrationId>:<sub>`. Stable identifier; survives admin-UI provider
+ *     renames thanks to the UUID-based registrationId from
+ *     [OidcRegistrationIds] (#79).
+ *   - The same httpOnly refresh cookie a local login would set is sent on the
+ *     response — never an access token in the URL or response body.
+ *   - The browser is redirected to `/` (the SPA root) so the frontend's
+ *     `hydrate()` flow can immediately exchange the cookie for a Plugwerk
+ *     access token via `/api/v1/auth/refresh`.
+ *   - A non-OAuth2 [Authentication] is treated as a wiring bug and surfaces
+ *     loudly rather than silently no-opping.
+ */
+@ExtendWith(MockitoExtension::class)
+class OidcLoginSuccessHandlerTest {
+
+    @Mock lateinit var refreshTokenService: RefreshTokenService
+
+    private val cookieFactory = RefreshTokenCookieFactory(
+        PlugwerkProperties(
+            auth = PlugwerkProperties.AuthProperties(
+                jwtSecret = "test-jwt-secret-at-least-32-characters-long",
+                encryptionKey = "test-encryption-key-32-characters-",
+                cookieSecure = false,
+            ),
+        ),
+    )
+
+    @Test
+    fun `maps OIDC sub to Plugwerk user_subject of the form registrationId-colon-sub (#79)`() {
+        val registrationId = "11111111-2222-3333-4444-555555555555"
+        val sub = "0123abcd-4567-89ef-0123-456789abcdef"
+        val token = oauth2AuthenticationTokenFor(registrationId = registrationId, sub = sub)
+        whenever(refreshTokenService.issue(eq("$registrationId:$sub"))).thenReturn(stubIssuedToken())
+
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val response = MockHttpServletResponse()
+
+        handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
+
+        verify(refreshTokenService).issue("$registrationId:$sub")
+    }
+
+    @Test
+    fun `sets httpOnly refresh cookie on the response and redirects to SPA root`() {
+        val token = oauth2AuthenticationTokenFor(registrationId = "kc", sub = "alice-sub")
+        whenever(refreshTokenService.issue(any())).thenReturn(stubIssuedToken())
+
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val response = MockHttpServletResponse()
+
+        handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
+
+        val setCookie = response.getHeader(HttpHeaders.SET_COOKIE)
+        assertThat(setCookie).isNotNull()
+        assertThat(setCookie!!).contains("HttpOnly")
+        // We deliberately never put the access token in the URL or response body —
+        // the frontend picks it up via /api/v1/auth/refresh against the cookie.
+        assertThat(response.redirectedUrl).isEqualTo("/")
+    }
+
+    @Test
+    fun `non-OAuth2 authentication is treated as a wiring bug and fails loudly`() {
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val plainAuth = TestingAuthenticationToken("alice", "irrelevant")
+
+        assertThatThrownBy {
+            handler.onAuthenticationSuccess(MockHttpServletRequest(), MockHttpServletResponse(), plainAuth)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("non-OAuth2 authentication")
+    }
+
+    private fun stubIssuedToken() = IssuedToken(
+        plaintext = "refresh-plaintext",
+        expiresAt = java.time.OffsetDateTime.now().plusDays(7),
+        maxAge = Duration.ofDays(7),
+        familyId = java.util.UUID.randomUUID(),
+        rowId = java.util.UUID.randomUUID(),
+    )
+
+    private fun oauth2AuthenticationTokenFor(registrationId: String, sub: String): OAuth2AuthenticationToken {
+        val user = DefaultOAuth2User(
+            emptyList(),
+            mapOf("sub" to sub, "email" to "test@plugwerk.test"),
+            "sub",
+        )
+        return OAuth2AuthenticationToken(user, emptyList(), registrationId)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
@@ -19,6 +19,8 @@
 package io.plugwerk.server.security
 
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.service.RefreshTokenService
 import io.plugwerk.server.service.RefreshTokenService.IssuedToken
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +30,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpHeaders
@@ -60,6 +64,8 @@ class OidcLoginSuccessHandlerTest {
 
     @Mock lateinit var refreshTokenService: RefreshTokenService
 
+    @Mock lateinit var userRepository: UserRepository
+
     private val cookieFactory = RefreshTokenCookieFactory(
         PlugwerkProperties(
             auth = PlugwerkProperties.AuthProperties(
@@ -77,7 +83,7 @@ class OidcLoginSuccessHandlerTest {
         val token = oauth2AuthenticationTokenFor(registrationId = registrationId, sub = sub)
         whenever(refreshTokenService.issue(eq("$registrationId:$sub"))).thenReturn(stubIssuedToken())
 
-        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory, userRepository)
         val response = MockHttpServletResponse()
 
         handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
@@ -90,7 +96,7 @@ class OidcLoginSuccessHandlerTest {
         val token = oauth2AuthenticationTokenFor(registrationId = "kc", sub = "alice-sub")
         whenever(refreshTokenService.issue(any())).thenReturn(stubIssuedToken())
 
-        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory, userRepository)
         val response = MockHttpServletResponse()
 
         handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
@@ -104,8 +110,41 @@ class OidcLoginSuccessHandlerTest {
     }
 
     @Test
+    fun `auto-provisions a local user row on first OIDC login (#79)`() {
+        val token = oauth2AuthenticationTokenFor(registrationId = "kc", sub = "alice-sub")
+        whenever(userRepository.existsByUsername("kc:alice-sub")).thenReturn(false)
+        whenever(refreshTokenService.issue(any())).thenReturn(stubIssuedToken())
+
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory, userRepository)
+        handler.onAuthenticationSuccess(MockHttpServletRequest(), MockHttpServletResponse(), token)
+
+        verify(userRepository).save(
+            argThat<UserEntity> {
+                username == "kc:alice-sub" &&
+                    email == null && // see Kotlindoc on ensureLocalUserRow
+                    !passwordChangeRequired && // user has no password to change
+                    enabled &&
+                    !isSuperadmin &&
+                    passwordHash == "OIDC:no-password" // not a valid BCrypt — local /auth/login can never succeed
+            },
+        )
+    }
+
+    @Test
+    fun `does not re-provision when local user row already exists (idempotent)`() {
+        val token = oauth2AuthenticationTokenFor(registrationId = "kc", sub = "alice-sub")
+        whenever(userRepository.existsByUsername("kc:alice-sub")).thenReturn(true)
+        whenever(refreshTokenService.issue(any())).thenReturn(stubIssuedToken())
+
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory, userRepository)
+        handler.onAuthenticationSuccess(MockHttpServletRequest(), MockHttpServletResponse(), token)
+
+        verify(userRepository, never()).save(any<UserEntity>())
+    }
+
+    @Test
     fun `non-OAuth2 authentication is treated as a wiring bug and fails loudly`() {
-        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory)
+        val handler = OidcLoginSuccessHandler(refreshTokenService, cookieFactory, userRepository)
         val plainAuth = TestingAuthenticationToken("alice", "irrelevant")
 
         assertThatThrownBy {

--- a/plugwerk-server/plugwerk-server-frontend/src/api/refresh.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/refresh.ts
@@ -50,17 +50,29 @@ export function refreshAccessToken(): Promise<RefreshedAuth | null> {
  *
  * Spring's `CookieCsrfTokenRepository` issues the `XSRF-TOKEN` cookie lazily —
  * it only appears in the browser's cookie jar after the first response that
- * needs to tell the client about it. On a fresh page reload the jar may be
- * empty of `XSRF-TOKEN` even though the session is otherwise valid, because
- * our login endpoint is not wired into Spring's auth filter chain (so the
- * `CsrfAuthenticationStrategy` never fires and never rotates a fresh token
- * into the response).
+ * needs to tell the client about it. The jar can be empty in two scenarios
+ * we both have to recover from:
  *
- * Consequence: the very first `POST /auth/refresh` after reload has no
- * `X-XSRF-TOKEN` header, Spring's `CsrfFilter` rejects it with 401, and as a
- * side effect it writes a freshly-generated `XSRF-TOKEN` cookie to the 401
- * response. If we retry exactly once, the retry will have the cookie and
- * will pass the CSRF check.
+ *   1. **Fresh reload of a logged-in tab.** Our local `/auth/login` endpoint
+ *      is not wired into Spring's auth filter chain, so the
+ *      `CsrfAuthenticationStrategy` never fires and never rotates a token
+ *      into the response. Spring's `CsrfFilter` then short-circuits the
+ *      first `POST /auth/refresh` with **401** (HttpStatusEntryPoint kicks
+ *      in because the request was unauthenticated) and writes a fresh
+ *      XSRF-TOKEN cookie as a side effect.
+ *
+ *   2. **Right after an OAuth2 browser-flow callback (#79).** Spring
+ *      *does* run its full authenticated-login pipeline here, and as the
+ *      standard CSRF rotation step it actively *deletes* the existing
+ *      XSRF-TOKEN cookie (`Set-Cookie: XSRF-TOKEN=; Expires=epoch`) so the
+ *      next request will pick up a freshly-rotated value. The first
+ *      `POST /auth/refresh` then has no header, but this time the request
+ *      *is* authenticated (the session cookie is set), so Spring's
+ *      `CsrfFilter` rejects it with **403** instead of 401.
+ *
+ * In both cases the recovery is identical: the rejection wrote a fresh
+ * XSRF-TOKEN cookie, so a single retry will carry the new header value
+ * through and succeed. We accept either status code as the trigger.
  *
  * Retrying is safe because the first attempt never reached our controller
  * (it was short-circuited by the CSRF filter); no refresh-token rotation
@@ -71,10 +83,13 @@ async function doRefreshWithCsrfBootstrap(): Promise<RefreshedAuth | null> {
   const first = await doRefresh();
   if (first.auth) return first.auth;
   // Retry exactly once when the first attempt plausibly failed on CSRF:
-  // we started without an XSRF-TOKEN cookie and the server has now set one
-  // (as a side effect of its 401). Skip the retry if nothing changed.
+  // we either started without an XSRF-TOKEN cookie or the server actively
+  // expired ours, AND the server has now (re-)set one. Both 401 and 403
+  // are valid bootstrap triggers — see the Kotlindoc above for the two
+  // scenarios that produce each.
   const nowHasXsrf = readCookie("XSRF-TOKEN") != null;
-  if (!firstHadXsrf && nowHasXsrf && first.status === 401) {
+  const looksLikeCsrfBootstrap = first.status === 401 || first.status === 403;
+  if (!firstHadXsrf && nowHasXsrf && looksLikeCsrfBootstrap) {
     const second = await doRefresh();
     return second.auth;
   }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -16,18 +16,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Box, TextField, Button, Alert } from "@mui/material";
+import {
+  Box,
+  TextField,
+  Button,
+  Alert,
+  Divider,
+  Typography,
+} from "@mui/material";
 import { AuthCard } from "../components/auth/AuthCard";
 import { useAuthStore } from "../stores/authStore";
+import { useConfigStore } from "../stores/configStore";
 import { safeRedirectPath } from "../utils/safeRedirectPath";
 
 export function LoginPage() {
   const { login } = useAuthStore();
+  const fetchConfig = useConfigStore((s) => s.fetchConfig);
+  const oidcProviders = useConfigStore((s) => s.oidcProviders);
   const navigate = useNavigate();
   const location = useLocation();
   const from = new URLSearchParams(location.search).get("from") ?? "/";
+
+  // /config is public and cheap; the configStore caches it after the first
+  // call so this is a no-op on subsequent renders. We need it here so the
+  // OIDC provider buttons appear without the user having to load any other
+  // page first.
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -112,6 +130,33 @@ export function LoginPage() {
           {loading ? "Signing in…" : "Sign In"}
         </Button>
       </Box>
+
+      {oidcProviders.length > 0 && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 1 }}>
+          <Divider>
+            <Typography variant="caption" color="text.secondary">
+              or
+            </Typography>
+          </Divider>
+          {oidcProviders.map((provider) => (
+            // Plain anchor — Spring Security's OAuth2 client filter intercepts
+            // the navigation server-side; an XHR-driven button would not start
+            // the redirect dance. The loginUrl is always relative
+            // (`/oauth2/authorization/{id}`), so the open-redirect guard from
+            // #274 is trivially satisfied.
+            <Button
+              key={provider.id}
+              component="a"
+              href={provider.loginUrl}
+              variant="outlined"
+              size="large"
+              fullWidth
+            >
+              {`Login with ${provider.name}`}
+            </Button>
+          ))}
+        </Box>
+      )}
     </AuthCard>
   );
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
@@ -19,16 +19,35 @@
 import { create } from "zustand";
 import { axiosInstance } from "../api/config";
 
+/**
+ * One OIDC provider button shown on the login page (issue #79).
+ *
+ * Mirrors the `OidcProviderLoginInfo` schema from the backend OpenAPI spec.
+ * `loginUrl` is always a same-origin relative path of the form
+ * `/oauth2/authorization/{id}` — Spring Security's OAuth2 client filter
+ * intercepts it and starts the Authorization Code Flow with PKCE. The
+ * frontend just navigates the browser there.
+ */
+export interface OidcProviderLoginInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly loginUrl: string;
+}
+
 interface ConfigState {
   readonly version: string;
   readonly maxFileSizeMb: number;
   readonly defaultTimezone: string;
+  /** OIDC providers currently enabled by the operator. Empty when none. */
+  readonly oidcProviders: readonly OidcProviderLoginInfo[];
   readonly loaded: boolean;
   /**
    * Fetches `/api/v1/config`. Skips the request when the store is already
    * loaded unless `{ force: true }` is passed — call with `force` after any
    * mutation that changes `application_setting` so cached values
-   * (defaultTimezone, maxFileSizeMb) stay in sync with the DB.
+   * (defaultTimezone, maxFileSizeMb) stay in sync with the DB. Also call
+   * with `force` after an admin enables/disables an OIDC provider so the
+   * login-page button list reflects the change.
    */
   fetchConfig: (options?: { force?: boolean }) => Promise<void>;
 }
@@ -37,6 +56,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   version: "…",
   maxFileSizeMb: 100,
   defaultTimezone: "UTC",
+  oidcProviders: [],
   loaded: false,
 
   async fetchConfig(options) {
@@ -54,10 +74,32 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
           res.data.general.defaultTimezone.length > 0
             ? res.data.general.defaultTimezone
             : "UTC",
+        oidcProviders: parseOidcProviders(res.data?.auth?.oidcProviders),
         loaded: true,
       });
     } catch {
-      set({ version: "unknown", loaded: true });
+      set({ version: "unknown", oidcProviders: [], loaded: true });
     }
   },
 }));
+
+/**
+ * Defensive parser — `/config` is public and the response shape is owned by
+ * the backend, but keeping the runtime narrowing local prevents one bad
+ * response from rendering broken `<a href={undefined}>` buttons.
+ */
+function parseOidcProviders(raw: unknown): readonly OidcProviderLoginInfo[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry: unknown) => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const e = entry as Record<string, unknown>;
+    if (
+      typeof e.id !== "string" ||
+      typeof e.name !== "string" ||
+      typeof e.loginUrl !== "string"
+    ) {
+      return [];
+    }
+    return [{ id: e.id, name: e.name, loginUrl: e.loginUrl }];
+  });
+}

--- a/plugwerk-server/plugwerk-server-frontend/vite.config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/vite.config.ts
@@ -20,6 +20,15 @@ export default defineConfig({
       // Use '/api/' (with trailing slash) to avoid matching '/api-docs' (the SPA page).
       "/api/": "http://localhost:8080",
       "/api-docs/openapi.yaml": "http://localhost:8080",
+      // OAuth2 browser-flow endpoints managed by Spring Security itself (issue #79).
+      // /oauth2/authorization/{id} starts the flow; /login/oauth2/code/{id} is the
+      // upstream-provider callback. Both must reach Spring rather than be served by
+      // Vite's SPA fallback (which would return index.html and the React router
+      // would render a 404). In production the frontend is bundled into the backend
+      // JAR and Spring serves both the SPA and these routes from the same origin,
+      // so this proxy entry is dev-only.
+      "/oauth2/": "http://localhost:8080",
+      "/login/oauth2/": "http://localhost:8080",
     },
   },
 });

--- a/plugwerk-server/plugwerk-server-frontend/vite.config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/vite.config.ts
@@ -27,8 +27,23 @@ export default defineConfig({
       // would render a 404). In production the frontend is bundled into the backend
       // JAR and Spring serves both the SPA and these routes from the same origin,
       // so this proxy entry is dev-only.
-      "/oauth2/": "http://localhost:8080",
-      "/login/oauth2/": "http://localhost:8080",
+      //
+      // changeOrigin MUST be false so the Host header reaches Spring as
+      // `localhost:5173`. Spring uses that header to build the `redirect_uri`
+      // it hands to the upstream provider — if Spring saw `localhost:8080`
+      // it would tell Keycloak to redirect the browser there, the JSESSIONID
+      // cookie that holds the OAuth2 state + PKCE verifier (set on the
+      // :5173 origin) would not travel along, and the callback would land
+      // on a stateless Spring with no idea what to do. Symptom: a Spring
+      // Whitelabel error page on /login/oauth2/code/{id}.
+      "/oauth2/": {
+        target: "http://localhost:8080",
+        changeOrigin: false,
+      },
+      "/login/oauth2/": {
+        target: "http://localhost:8080",
+        changeOrigin: false,
+      },
     },
   },
 });


### PR DESCRIPTION
Second half of #79 — the actual OAuth2 Authorization Code Flow with PKCE for KEYCLOAK and GENERIC_OIDC providers. Builds on the local Keycloak infrastructure from #349.

End-to-end the flow now works:

1. Operator registers a Keycloak provider in Admin → OIDC Providers.
2. The login page shows a **"Login with Keycloak Local"** button next to the local username/password form.
3. Click → Spring Security redirects to Keycloak, user authenticates, Keycloak posts back to \`/login/oauth2/code/{registrationId}\`, Spring validates state + PKCE, hands us an \`OAuth2AuthenticationToken\`.
4. Plugwerk's success handler maps the OIDC \`sub\` to a stable \`user_subject\`, sets the same httpOnly refresh cookie a local login would set, and redirects to \`/\`.
5. SPA's \`hydrate()\` exchanges the cookie for an access token via \`/api/v1/auth/refresh\` and either lands the user on their dashboard or on \`/onboarding\`.

## Four commits, scope-isolated

| Commit | Why isolated |
|---|---|
| **1. \`refactor(api): migrate ConfigController to generated ServerConfigApi interface\`** | Pre-existing tech-debt — \`ConfigController\` was the lone holdout that ignored its generated OpenAPI interface. Pulled in here because the next commit extends the same /config schema; doing the migration first makes that diff readable. |
| **2. \`feat(api): expose enabled OIDC providers via /config (#79)\`** | OpenAPI schema + controller wires \`OidcProviderRepository\`. New \`OidcRegistrationIds\` helper makes the registrationId the single source of truth across controller + Spring Security wiring. Includes a contract test that \`issuerUri\` / \`clientSecret\` never leak into the public \`/config\` response. |
| **3. \`feat(security): wire OAuth2 browser login flow against oidc_provider table (#79)\`** | The actual Spring Security wiring. New \`DbClientRegistrationRepository\`, new \`OidcLoginSuccessHandler\`, \`oauth2Login\` enabled in \`SecurityConfiguration\`, \`OidcProviderService\` refreshes both registries on enable/disable/secret/delete. New runtime dep \`spring-boot-starter-oauth2-client\`. |
| **4. \`feat(ui): show "Login with <provider>" buttons on the login page (#79)\`** | configStore picks up the \`auth.oidcProviders\` list, LoginPage renders one anchor per entry. Plain \`<a href>\`, not XHR, because the redirect must reach Spring Security as a real browser navigation. |

## Phase 1 scope

Only **KEYCLOAK** and **GENERIC_OIDC** provider types participate in the browser login (both go through standard OIDC discovery). GitHub / Google / Facebook remain usable on the resource-server side from #77 — they need vendor-specific browser-flow client metadata which is deferred to a later phase. \`DbClientRegistrationRepository\` logs them as "skipped" at refresh time so operators understand why their row doesn't appear on the login page.

## Design highlights worth re-reading

- **Single source of truth for registrationId** — \`OidcRegistrationIds.of(provider)\` returns the provider's UUID. Three places in the codebase need to agree on this value (controller, ClientRegistrationRepository, Spring Security's \`/login/oauth2/code/{registrationId}\` callback path). Defining it once eliminates the drift class entirely. UUID instead of name-slug so admin-UI provider renames don't silently break already-registered redirect URIs at the upstream provider.
- **No access token in the redirect** — the SuccessHandler sets the refresh cookie and redirects to \`/\`. The frontend's \`hydrate()\` exchanges the cookie for an access token via the existing \`/api/v1/auth/refresh\` flow. This keeps tokens out of browser history and out of server access logs.
- **Method-level injection avoids a circular reference** — \`SecurityConfiguration\` exposes \`textEncryptor()\` as a \`@Bean\`, and \`DbClientRegistrationRepository\` needs that \`TextEncryptor\` to decrypt client secrets. Constructor-injecting \`DbClientRegistrationRepository\` into \`SecurityConfiguration\` would create a startup cycle. Instead, both new beans are injected as parameters on the \`securityFilterChain\` \`@Bean\` method, where Spring resolves them lazily after \`textEncryptor\` exists. Documented inline so a "let me clean up the constructor list" refactor doesn't silently re-introduce the cycle.
- **Failure isolation** — one unreachable issuer logs a warning and is skipped; other providers stay usable. Same pattern as \`OidcProviderRegistry\` from #77.
- **Public-vs-operator-only field boundary on /config** — pinned by a contract test (\`GET config never exposes the issuerUri or client secret of OIDC providers (#79)\`). Future careless schema widening fails this test immediately.

## Test plan

- [x] Backend: full test suite green, including 5 new tests across \`ConfigControllerTest\`, \`DbClientRegistrationRepositoryTest\`, \`OidcLoginSuccessHandlerTest\`.
- [x] Frontend: 312 tests green (existing LoginPage snapshot still matches because the new section only renders when \`oidcProviders.length > 0\`).
- [x] \`spotlessCheck\` + \`tsc --noEmit\` + \`prettier\` all green.
- [ ] Manual end-to-end test against the local Keycloak from #349 — see the AGENTS.md "Local Keycloak for OIDC development" section. Will run before merging.

## Out of scope (potential follow-ups)

- A Testcontainers-based IT that spins up the same Keycloak realm and exercises the auth-code flow end-to-end. The unit tests cover the failure-isolation branches that don't need a live OIDC discovery endpoint; the happy path is currently validated by the manual flow.
- GITHUB / GOOGLE / FACEBOOK browser flow (vendor-specific client metadata).
- Linking an OIDC \`<registrationId>:<sub>\` to an existing local user account.

## Related

- **#349** — Local Keycloak \`docker-compose --profile keycloak\` infrastructure (already merged).
- **#77** — Phase 2 Auth (OIDC Resource Server + provider admin UI) — prerequisite.
- **#274** — \`safeRedirectPath\` / open-redirect guard, trivially satisfied because \`loginUrl\` is always relative.