### PR TITLE
refactor(oidc): collapse GENERIC_OIDC + KEYCLOAK into single OIDC enum value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,7 @@ docker compose --profile keycloak down -v         # Stop and wipe the realm/stat
 | Test users    | `alice` / `password` and `bob` / `password` (both with `<name>@plugwerk.test`) |
 
 After Keycloak is up, register the issuer in the Plugwerk Admin UI under
-**Admin → OIDC Providers → Add Provider** with type `KEYCLOAK`. The realm
+**Admin → OIDC Providers → Add Provider** with type `OIDC`. The realm
 definition lives in `docker/keycloak/plugwerk-realm.json`; edit it there and
 restart the container with `down -v` to pick up changes (Keycloak only
 imports realms that don't already exist).

--- a/docs/adrs/0006-phase2-auth-and-rbac.md
+++ b/docs/adrs/0006-phase2-auth-and-rbac.md
@@ -54,7 +54,7 @@ Three new tables added via Liquibase migration `0002_user_and_rbac.yaml`:
 
 `OidcProviderRegistry` loads all enabled providers from `oidc_provider` at startup:
 - Builds a `JwtDecoder` per provider type:
-  - `GENERIC_OIDC` / `KEYCLOAK`: `NimbusJwtDecoder.withIssuerLocation(issuerUri)` (OIDC discovery)
+  - `OIDC`: `NimbusJwtDecoder.withIssuerLocation(issuerUri)` (OIDC discovery — covers Keycloak, Authentik, Auth0, Dex, …)
   - `GITHUB` / `GOOGLE` / `FACEBOOK`: pre-configured well-known JWKS URLs
 - Stores decoders in an `AtomicReference<List<JwtDecoder>>` for thread-safe live reload
 - `refresh()` is called by `OidcProviderService.setEnabled()` and `delete()` so changes take effect without restart

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -203,8 +203,9 @@ tags:
       Manage external OIDC / OAuth2 providers for token validation.
 
       Plugwerk acts as an OAuth2 Resource Server: it validates `Authorization: Bearer` tokens
-      issued by any enabled provider. Each provider type has pre-configured JWKS endpoints;
-      only `GENERIC_OIDC` and `KEYCLOAK` require an explicit `issuerUri`.
+      issued by any enabled provider. The `GITHUB`, `GOOGLE`, and `FACEBOOK` types ship with
+      pre-configured JWKS endpoints; the generic `OIDC` type requires an explicit `issuerUri`
+      and works with any standards-compliant provider (Keycloak, Authentik, Auth0, Dex, …).
 
       All providers are disabled by default. Requires server-admin authentication.
 
@@ -2751,7 +2752,7 @@ components:
         issuerUri:
           type: string
           nullable: true
-          description: Required for GENERIC_OIDC and KEYCLOAK provider types
+          description: Required for the OIDC provider type
         scope:
           type: string
           default: openid email profile
@@ -2776,15 +2777,15 @@ components:
     OidcProviderType:
       type: string
       enum:
-        - GENERIC_OIDC
-        - KEYCLOAK
+        - OIDC
         - GITHUB
         - GOOGLE
         - FACEBOOK
       description: |
         Provider type. Pre-configured providers (GITHUB, GOOGLE, FACEBOOK) have well-known
-        endpoints embedded — only clientId and clientSecret are required.
-        GENERIC_OIDC and KEYCLOAK require an explicit issuerUri.
+        endpoints embedded — only clientId and clientSecret are required. The generic OIDC
+        type requires an explicit issuerUri and works with any standards-compliant provider
+        (Keycloak, Authentik, Auth0, Dex, …).
 
     ServerConfigResponse:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
@@ -101,16 +101,14 @@ class OidcProviderController(
     )
 
     private fun DomainType.toDto(): OidcProviderType = when (this) {
-        DomainType.GENERIC_OIDC -> OidcProviderType.GENERIC_OIDC
-        DomainType.KEYCLOAK -> OidcProviderType.KEYCLOAK
+        DomainType.OIDC -> OidcProviderType.OIDC
         DomainType.GITHUB -> OidcProviderType.GITHUB
         DomainType.GOOGLE -> OidcProviderType.GOOGLE
         DomainType.FACEBOOK -> OidcProviderType.FACEBOOK
     }
 
     private fun OidcProviderType.toDomain(): DomainType = when (this) {
-        OidcProviderType.GENERIC_OIDC -> DomainType.GENERIC_OIDC
-        OidcProviderType.KEYCLOAK -> DomainType.KEYCLOAK
+        OidcProviderType.OIDC -> DomainType.OIDC
         OidcProviderType.GITHUB -> DomainType.GITHUB
         OidcProviderType.GOOGLE -> DomainType.GOOGLE
         OidcProviderType.FACEBOOK -> DomainType.FACEBOOK

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/OidcProviderEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/OidcProviderEntity.kt
@@ -35,15 +35,13 @@ import java.util.UUID
  *
  * Pre-configured providers ([GITHUB], [GOOGLE], [FACEBOOK]) have their well-known
  * endpoints embedded in the server — the admin only needs to supply `clientId` and
- * `clientSecret`. Generic providers ([GENERIC_OIDC], [KEYCLOAK]) require an [issuerUri]
- * so the server can discover their JWKS endpoint at runtime.
+ * `clientSecret`. The generic [OIDC] type covers any standards-compliant
+ * OpenID Connect provider (Keycloak, Authentik, Auth0, Dex, …) and requires an
+ * [issuerUri] so the server can discover its JWKS endpoint at runtime.
  */
 enum class OidcProviderType {
-    /** Arbitrary OIDC-compliant provider (e.g. Auth0, Authentik, Dex). Requires [issuerUri]. */
-    GENERIC_OIDC,
-
-    /** Keycloak instance. Requires [issuerUri] (realm URL). */
-    KEYCLOAK,
+    /** Any OIDC-compliant provider (Keycloak, Authentik, Auth0, Dex, …). Requires [issuerUri]. */
+    OIDC,
 
     /** GitHub OAuth2 (no OIDC discovery; uses fixed token/JWKS endpoints). */
     GITHUB,
@@ -83,10 +81,10 @@ enum class OidcProviderType {
  *   see every token rejected.
  * @property clientSecretEncrypted Encrypted client secret. Use [OidcProviderService] to
  *   encrypt/decrypt — never access this field directly from controllers.
- * @property issuerUri OIDC issuer URI (required for [OidcProviderType.GENERIC_OIDC] and
- *   [OidcProviderType.KEYCLOAK]). Used for JWKS endpoint discovery. Ignored for the three
- *   vendor types ([OidcProviderType.GITHUB], [OidcProviderType.GOOGLE],
- *   [OidcProviderType.FACEBOOK]) which use hardcoded canonical issuers — see
+ * @property issuerUri OIDC issuer URI (required for [OidcProviderType.OIDC]). Used for
+ *   JWKS endpoint discovery. Ignored for the three vendor types
+ *   ([OidcProviderType.GITHUB], [OidcProviderType.GOOGLE], [OidcProviderType.FACEBOOK])
+ *   which use hardcoded canonical issuers — see
  *   [io.plugwerk.server.security.OidcJwtValidators].
  * @property scope Space-separated OAuth2 scopes requested during token validation.
  * @property createdAt Creation timestamp (immutable).

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -55,9 +55,9 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * ## Provider type support (Phase 1 of #79)
  *
- * Browser login is currently wired only for [OidcProviderType.KEYCLOAK] and
- * [OidcProviderType.GENERIC_OIDC] — both rely on RFC-8414 / OIDC discovery
- * via `issuerUri`. The vendor providers (GitHub / Google / Facebook) have
+ * Browser login is currently wired only for [OidcProviderType.OIDC] — it
+ * relies on RFC-8414 / OIDC discovery via `issuerUri`. The vendor providers
+ * (GitHub / Google / Facebook) have
  * sufficient metadata in [OidcProviderRegistry] to validate incoming bearer
  * tokens, but the browser-flow client metadata (authorization endpoint with
  * the right vendor quirks) is not yet implemented. They are silently
@@ -118,7 +118,7 @@ class DbClientRegistrationRepository(
     private fun buildRegistration(provider: OidcProviderEntity): ClientRegistration {
         val registrationId = OidcRegistrationIds.of(provider)
         val builder = when (provider.providerType) {
-            OidcProviderType.KEYCLOAK, OidcProviderType.GENERIC_OIDC -> {
+            OidcProviderType.OIDC -> {
                 val issuerUri = requireNotNull(provider.issuerUri) {
                     "issuerUri is required for provider type ${provider.providerType}"
                 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcJwtValidators.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcJwtValidators.kt
@@ -74,8 +74,8 @@ object OidcJwtValidators {
      *
      * @param providerType which vendor (or custom) OIDC flow this validator serves
      * @param issuerUri issuer URI from [io.plugwerk.server.domain.OidcProviderEntity.issuerUri]
-     *   — only consulted for [OidcProviderType.GENERIC_OIDC] and [OidcProviderType.KEYCLOAK];
-     *   ignored for the three vendor types which use hardcoded canonical issuers
+     *   — only consulted for [OidcProviderType.OIDC]; ignored for the three vendor types
+     *   which use hardcoded canonical issuers
      * @param expectedAudience value expected in the token's `aud` claim; must match
      *   [io.plugwerk.server.domain.OidcProviderEntity.clientId]
      */
@@ -88,7 +88,7 @@ object OidcJwtValidators {
             "expectedAudience (client_id) must not be blank for OIDC provider of type $providerType"
         }
         val issuer = when (providerType) {
-            OidcProviderType.GENERIC_OIDC, OidcProviderType.KEYCLOAK -> {
+            OidcProviderType.OIDC -> {
                 require(!issuerUri.isNullOrBlank()) {
                     "issuerUri is required for OIDC provider type $providerType"
                 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcProviderRegistry.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcProviderRegistry.kt
@@ -69,7 +69,7 @@ class OidcProviderRegistry(private val oidcProviderRepository: OidcProviderRepos
         val decoders = providers.mapNotNull { provider ->
             runCatching {
                 val decoder: NimbusJwtDecoder = when (provider.providerType) {
-                    OidcProviderType.GENERIC_OIDC, OidcProviderType.KEYCLOAK -> {
+                    OidcProviderType.OIDC -> {
                         val issuerUri = requireNotNull(provider.issuerUri) {
                             "issuerUri is required for provider type ${provider.providerType}"
                         }
@@ -92,8 +92,8 @@ class OidcProviderRegistry(private val oidcProviderRepository: OidcProviderRepos
                 // Replace Spring's default validator chain with our unified
                 // timestamp + issuer + audience chain. This closes audit findings
                 // SBS-010 (GitHub audience missing) and SBS-011 (Facebook issuer
-                // missing), and also adds audience enforcement to GENERIC_OIDC,
-                // KEYCLOAK, and GOOGLE so every provider type behaves uniformly.
+                // missing), and also adds audience enforcement to OIDC and
+                // GOOGLE so every provider type behaves uniformly.
                 decoder.setJwtValidator(
                     OidcJwtValidators.forProvider(
                         providerType = provider.providerType,

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -33,3 +33,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0016_refresh_token_upstream_id_token.yaml
   - include:
       file: db/changelog/migrations/0017_identity_hub_split.yaml
+  - include:
+      file: db/changelog/migrations/0018_oidc_provider_type_consolidation.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0002_user_and_rbac.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0002_user_and_rbac.yaml
@@ -135,7 +135,8 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  # Supported: GENERIC_OIDC, KEYCLOAK, GITHUB, GOOGLE, FACEBOOK
+                  # Supported: OIDC, GITHUB, GOOGLE, FACEBOOK (KEYCLOAK + GENERIC_OIDC
+                  # were collapsed into OIDC in migration 0018).
                   name: provider_type
                   type: varchar(50)
                   constraints:
@@ -158,7 +159,7 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  # Required for GENERIC_OIDC and KEYCLOAK; null for GITHUB/GOOGLE/FACEBOOK
+                  # Required for OIDC; null for GITHUB/GOOGLE/FACEBOOK.
                   name: issuer_uri
                   type: varchar(2048)
               - column:

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0018_oidc_provider_type_consolidation.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0018_oidc_provider_type_consolidation.yaml
@@ -1,0 +1,32 @@
+# Consolidate the GENERIC_OIDC / KEYCLOAK enum values down to a single OIDC.
+#
+# Both branches in DbClientRegistrationRepository, OidcProviderRegistry, and
+# OidcJwtValidators were already identical: ClientRegistrations.fromIssuerLocation
+# does the discovery, validators trust the issuer claim. KEYCLOAK was a label,
+# not a behavioural distinction. Operators that point at a Keycloak realm get the
+# same code path as Authentik, Dex, Auth0, etc.
+#
+# Schema-wise this is a pure data migration — provider_type stays as
+# varchar(50). Existing rows are folded forwards: KEYCLOAK and GENERIC_OIDC
+# both become OIDC. The rollback recreates the GENERIC_OIDC label only;
+# the KEYCLOAK label is intentionally not restored on rollback because no
+# code path uses it differently from GENERIC_OIDC even before this change.
+databaseChangeLog:
+  - changeSet:
+      id: 0018-rename-oidc-provider-type-values
+      author: plugwerk
+      comment: >
+        Issue #357 follow-up / Option C: collapse KEYCLOAK + GENERIC_OIDC
+        into a single OIDC enum value. No schema change — only data.
+      changes:
+        - sql:
+            sql: |
+              UPDATE oidc_provider
+                 SET provider_type = 'OIDC'
+               WHERE provider_type IN ('KEYCLOAK', 'GENERIC_OIDC');
+      rollback:
+        - sql:
+            sql: |
+              UPDATE oidc_provider
+                 SET provider_type = 'GENERIC_OIDC'
+               WHERE provider_type = 'OIDC';

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerRefreshIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerRefreshIT.kt
@@ -299,7 +299,7 @@ class AuthControllerRefreshIT {
         val provider = oidcProviderRepository.save(
             io.plugwerk.server.domain.OidcProviderEntity(
                 name = "Test KC ${UUID.randomUUID()}",
-                providerType = io.plugwerk.server.domain.OidcProviderType.KEYCLOAK,
+                providerType = io.plugwerk.server.domain.OidcProviderType.OIDC,
                 clientId = "test-client",
                 clientSecretEncrypted = "encrypted",
                 issuerUri = "https://kc/realms/test",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -126,7 +126,7 @@ class ConfigControllerTest {
                 OidcProviderEntity(
                     id = providerId,
                     name = "Keycloak Local",
-                    providerType = OidcProviderType.KEYCLOAK,
+                    providerType = OidcProviderType.OIDC,
                     enabled = true,
                     clientId = "plugwerk-local",
                     clientSecretEncrypted = "ignored-for-this-test",
@@ -162,7 +162,7 @@ class ConfigControllerTest {
                 OidcProviderEntity(
                     id = providerId,
                     name = "Internal Keycloak",
-                    providerType = OidcProviderType.KEYCLOAK,
+                    providerType = OidcProviderType.OIDC,
                     enabled = true,
                     clientId = "plugwerk-internal",
                     clientSecretEncrypted = "{cipher}leaked-secret-must-not-appear",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
@@ -97,7 +97,7 @@ class OidcProviderControllerTest {
         OidcProviderEntity(
             id = UUID.randomUUID(),
             name = name,
-            providerType = OidcProviderType.KEYCLOAK,
+            providerType = OidcProviderType.OIDC,
             enabled = enabled,
             clientId = "my-client",
             clientSecretEncrypted = "encrypted-secret",
@@ -113,7 +113,7 @@ class OidcProviderControllerTest {
         mockMvc.get("/api/v1/admin/oidc-providers").andExpect {
             status { isOk() }
             jsonPath("$[0].name") { value("My Keycloak") }
-            jsonPath("$[0].providerType") { value("KEYCLOAK") }
+            jsonPath("$[0].providerType") { value("OIDC") }
             jsonPath("$[0].enabled") { value(false) }
         }
     }
@@ -200,7 +200,7 @@ class OidcProviderControllerTest {
         mockMvc.post("/api/v1/admin/oidc-providers") {
             contentType = MediaType.APPLICATION_JSON
             content =
-                """{"name":"Rogue","providerType":"GENERIC_OIDC","clientId":"x","clientSecret":"y","issuerUri":"https://evil.example.com"}"""
+                """{"name":"Rogue","providerType":"OIDC","clientId":"x","clientSecret":"y","issuerUri":"https://evil.example.com"}"""
         }.andExpect {
             status { isForbidden() }
         }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEndpointAuthzTest.kt
@@ -56,7 +56,7 @@ class OidcProviderEndpointAuthzTest : AbstractAuthorizationTest() {
                     objectMapper.writeValueAsString(
                         mapOf(
                             "name" to "denied-${UUID.randomUUID().toString().take(8)}",
-                            "providerType" to "GENERIC_OIDC",
+                            "providerType" to "OIDC",
                             "clientId" to "test-client-id",
                             "clientSecret" to "test-client-secret",
                             "issuerUri" to "https://example.com",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
@@ -143,7 +143,7 @@ class OidcWebLoginIT {
         val provider = oidcProviderRepository.saveAndFlush(
             OidcProviderEntity(
                 name = "Mock IdP",
-                providerType = OidcProviderType.GENERIC_OIDC,
+                providerType = OidcProviderType.OIDC,
                 enabled = true,
                 clientId = MOCK_CLIENT_ID,
                 clientSecretEncrypted = textEncryptor.encrypt(MOCK_CLIENT_SECRET),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/IdentityHubSplitMigrationIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/IdentityHubSplitMigrationIT.kt
@@ -133,7 +133,11 @@ class IdentityHubSplitMigrationIT {
      * hash) plus a pure-LOCAL row plus a namespace_member each.
      */
     private fun seedPreMigrationData(conn: Connection) {
-        // OIDC provider row (referenced by the synthetic username).
+        // OIDC provider row (referenced by the synthetic username). 'KEYCLOAK'
+        // is the historical enum value that existed before migration 0018 folded
+        // it into 'OIDC'; the seed runs after 0018 has already executed (against
+        // an empty table), so the value survives untouched and exercises 0017's
+        // logic exactly as it would have run pre-consolidation.
         conn.prepareStatement(
             """
             INSERT INTO oidc_provider

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -71,7 +71,7 @@ class DbClientRegistrationRepositoryTest {
         val unreachableProvider = OidcProviderEntity(
             id = UUID.fromString("99999999-9999-9999-9999-999999999999"),
             name = "Down Keycloak",
-            providerType = OidcProviderType.KEYCLOAK,
+            providerType = OidcProviderType.OIDC,
             enabled = true,
             clientId = "ignored",
             clientSecretEncrypted = "{cipher}ignored",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcJwtValidatorsTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcJwtValidatorsTest.kt
@@ -28,7 +28,7 @@ import java.time.Instant
 
 /**
  * Covers audit findings SBS-010 (GitHub audience missing) and SBS-011 (Facebook issuer
- * missing) plus the parity audience/issuer hardening across GENERIC_OIDC, KEYCLOAK, GOOGLE.
+ * missing) plus the parity audience/issuer hardening across OIDC and GOOGLE.
  *
  * Uses `Jwt.withTokenValue` to construct decoded-JWT instances directly — no JWKS mocking,
  * no signing. The validator layer is what matters for the security gap; signature
@@ -136,13 +136,13 @@ class OidcJwtValidatorsTest {
         assertThat(result.hasErrors()).isTrue()
     }
 
-    // -------------------------- GENERIC_OIDC / KEYCLOAK --------------------------------
+    // -------------------------- OIDC (any standards-compliant provider) ---------------
 
     @Test
-    fun `GENERIC_OIDC uses configured issuerUri for validation`() {
+    fun `OIDC uses configured issuerUri for validation`() {
         val configuredIssuer = "https://keycloak.example.com/realms/plugwerk"
         val validator = OidcJwtValidators.forProvider(
-            OidcProviderType.GENERIC_OIDC,
+            OidcProviderType.OIDC,
             configuredIssuer,
             expectedAudience,
         )
@@ -152,25 +152,14 @@ class OidcJwtValidatorsTest {
     }
 
     @Test
-    fun `GENERIC_OIDC rejects token with wrong audience`() {
+    fun `OIDC rejects token with wrong audience`() {
         val configuredIssuer = "https://keycloak.example.com/realms/plugwerk"
         val validator = OidcJwtValidators.forProvider(
-            OidcProviderType.GENERIC_OIDC,
+            OidcProviderType.OIDC,
             configuredIssuer,
             expectedAudience,
         )
         assertThat(validator.validate(jwt(configuredIssuer, listOf("wrong-aud"))).hasErrors()).isTrue()
-    }
-
-    @Test
-    fun `KEYCLOAK uses configured issuerUri for validation`() {
-        val configuredIssuer = "https://keycloak.example.com/realms/plugwerk"
-        val validator = OidcJwtValidators.forProvider(
-            OidcProviderType.KEYCLOAK,
-            configuredIssuer,
-            expectedAudience,
-        )
-        assertThat(validator.validate(jwt(configuredIssuer, listOf(expectedAudience))).hasErrors()).isFalse()
     }
 
     // -------------------------- Configuration errors -----------------------------------
@@ -184,17 +173,17 @@ class OidcJwtValidatorsTest {
     }
 
     @Test
-    fun `missing issuerUri for GENERIC_OIDC is rejected as a configuration error`() {
+    fun `missing issuerUri for OIDC is rejected as a configuration error`() {
         assertThatThrownBy {
-            OidcJwtValidators.forProvider(OidcProviderType.GENERIC_OIDC, null, expectedAudience)
+            OidcJwtValidators.forProvider(OidcProviderType.OIDC, null, expectedAudience)
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("issuerUri")
     }
 
     @Test
-    fun `blank issuerUri for KEYCLOAK is rejected as a configuration error`() {
+    fun `blank issuerUri for OIDC is rejected as a configuration error`() {
         assertThatThrownBy {
-            OidcJwtValidators.forProvider(OidcProviderType.KEYCLOAK, "   ", expectedAudience)
+            OidcJwtValidators.forProvider(OidcProviderType.OIDC, "   ", expectedAudience)
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("issuerUri")
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
@@ -78,7 +78,7 @@ class OidcLoginSuccessHandlerTest {
     private val provider = OidcProviderEntity(
         id = providerId,
         name = "Test Keycloak",
-        providerType = OidcProviderType.KEYCLOAK,
+        providerType = OidcProviderType.OIDC,
         enabled = true,
         clientId = "test-client",
         clientSecretEncrypted = "encrypted",

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -44,22 +44,20 @@ import type {
 } from "../../api/generated/model";
 
 const PROVIDER_TYPE_LABELS: Record<string, string> = {
-  GENERIC_OIDC: "Generic OIDC",
-  KEYCLOAK: "Keycloak",
+  OIDC: "Generic OIDC (Keycloak, Authentik, Auth0, …)",
   GITHUB: "GitHub",
   GOOGLE: "Google",
   FACEBOOK: "Facebook",
 };
 
-const ISSUER_REQUIRED_TYPES = new Set(["GENERIC_OIDC", "KEYCLOAK"]);
+const ISSUER_REQUIRED_TYPES = new Set(["OIDC"]);
 
 export function OidcProvidersSection() {
   const [providers, setProviders] = useState<OidcProviderDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [name, setName] = useState("");
-  const [providerType, setProviderType] =
-    useState<OidcProviderType>("GENERIC_OIDC");
+  const [providerType, setProviderType] = useState<OidcProviderType>("OIDC");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [issuerUri, setIssuerUri] = useState("");
@@ -145,7 +143,7 @@ export function OidcProvidersSection() {
       setClientSecret("");
       setIssuerUri("");
       setScope("openid profile email");
-      setProviderType("GENERIC_OIDC");
+      setProviderType("OIDC");
     } catch {
       addToast({ message: "Failed to create OIDC provider.", type: "error" });
     } finally {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -44,7 +44,7 @@ import type {
 } from "../../api/generated/model";
 
 const PROVIDER_TYPE_LABELS: Record<string, string> = {
-  OIDC: "Generic OIDC (Keycloak, Authentik, Auth0, …)",
+  OIDC: "OIDC (Keycloak, Authentik, Auth0, …)",
   GITHUB: "GitHub",
   GOOGLE: "Google",
   FACEBOOK: "Facebook",


### PR DESCRIPTION
## Summary

- The `GENERIC_OIDC` and `KEYCLOAK` provider types had **identical** behaviour across `DbClientRegistrationRepository`, `OidcProviderRegistry`, and `OidcJwtValidators` — both relied on `ClientRegistrations.fromIssuerLocation` / OIDC discovery and trusted the issuer claim. `KEYCLOAK` was a label, not a behavioural distinction (any standards-compliant Keycloak realm works fine through the generic OIDC path).
- Collapse the two values into a single `OIDC` enum value.
- Migration `0018` folds existing rows forward: `KEYCLOAK` and `GENERIC_OIDC` → `OIDC`. Forward-only schema (rows-only update); rollback re-labels to `GENERIC_OIDC`.
- Frontend, OpenAPI spec, when-branches, tests, ADR-0006 and AGENTS.md updated to match. The auto-generated TypeScript client picks up the enum change at build time.
- The `KEYCLOAK_IDENTITY` / `KEYCLOAK_SESSION` mentions in `OidcEndSessionUrlResolver` are Keycloak product cookie names, unrelated to the enum — left untouched.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green (incl. `IdentityHubSplitMigrationIT`, `LiquibaseRollbackIT`, `OidcProviderEndpointAuthzTest`)
- [x] `npm run build` (frontend) — green; regenerated OpenAPI client contains only `OIDC`
- [x] `npm run test:run` (frontend) — 315 tests pass
- [ ] Manual smoke: existing dev DB with `KEYCLOAK` row migrates cleanly to `OIDC` after pulling this branch (verify by running app, opening admin/oidc-providers and confirming row shows up with `OIDC` type)