### PR TITLE
feat(admin): allow full edit of existing OIDC providers via UI and REST API (#353)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2764,15 +2764,56 @@ components:
 
     OidcProviderUpdateRequest:
       type: object
-      description: Partial update — include only fields to change
+      description: |
+        Partial update — include only fields you want to change. `providerType` is
+        intentionally NOT editable: switching a row's type would require re-validating
+        every previously issued access token (different `iss` claim, possibly different
+        `aud` claim) and would tempt operators to "convert" rather than create a fresh
+        provider. To change `providerType`, delete and recreate the provider.
       properties:
         enabled:
           type: boolean
           nullable: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          nullable: true
+          description: Display name shown on the login page.
+        clientId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          nullable: true
+          description: |
+            OAuth2 client ID. Changing this on an enabled provider invalidates all existing
+            access tokens issued by that provider (the `aud` claim no longer matches), so
+            users must re-login.
         clientSecret:
           type: string
+          minLength: 8
+          writeOnly: true
           nullable: true
-          description: Provide to rotate the client secret
+          description: |
+            Provide to rotate the client secret. Blank or omitted leaves the existing
+            encrypted value untouched. Never returned in responses.
+        issuerUri:
+          type: string
+          format: uri
+          nullable: true
+          description: |
+            OIDC issuer URI for type `OIDC`. Reachability is verified lazily by the
+            registration refresh after the patch is saved — a temporarily unreachable
+            issuer does NOT roll back the patch (operators may legitimately patch the
+            URI before the upstream is reachable, e.g. during a realm cutover). Cannot
+            be cleared via PATCH; to remove, delete and recreate the provider.
+        scope:
+          type: string
+          minLength: 1
+          nullable: true
+          description: |
+            Space-separated OAuth2 scopes. For type `OIDC` the scope set must include
+            `openid`; otherwise the patch is rejected.
 
     OidcProviderType:
       type: string

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/OidcProviderController.kt
@@ -26,6 +26,7 @@ import io.plugwerk.api.model.OidcProviderUpdateRequest
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
+import io.plugwerk.server.service.OidcProviderPatch
 import io.plugwerk.server.service.OidcProviderService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -72,12 +73,16 @@ class OidcProviderController(
     ): ResponseEntity<OidcProviderDto> {
         val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
-        var provider = oidcProviderService.findById(providerId)
-        oidcProviderUpdateRequest.enabled?.let { provider = oidcProviderService.setEnabled(providerId, it) }
-        oidcProviderUpdateRequest.clientSecret?.let {
-            provider = oidcProviderService.updateClientSecret(providerId, it)
-        }
-        return ResponseEntity.ok(provider.toDto())
+        val patch = OidcProviderPatch(
+            enabled = oidcProviderUpdateRequest.enabled,
+            name = oidcProviderUpdateRequest.name,
+            clientId = oidcProviderUpdateRequest.clientId,
+            clientSecretPlaintext = oidcProviderUpdateRequest.clientSecret,
+            issuerUri = oidcProviderUpdateRequest.issuerUri?.toString(),
+            scope = oidcProviderUpdateRequest.scope,
+        )
+        val updated = oidcProviderService.update(providerId, patch)
+        return ResponseEntity.ok(updated.toDto())
     }
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
@@ -29,7 +29,26 @@ import org.slf4j.LoggerFactory
 import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.net.URI
+import java.net.URISyntaxException
 import java.util.UUID
+
+/**
+ * Patch payload for [OidcProviderService.update]. Each non-null field is
+ * applied; null means "leave unchanged" (PATCH semantics). [clientSecretPlaintext]
+ * is additionally treated as "leave unchanged" when blank, so a UI form that
+ * submits an empty password input does not accidentally null out the stored
+ * encrypted secret. `providerType` is intentionally absent from this type —
+ * see the schema description for the rationale.
+ */
+data class OidcProviderPatch(
+    val enabled: Boolean? = null,
+    val name: String? = null,
+    val clientId: String? = null,
+    val clientSecretPlaintext: String? = null,
+    val issuerUri: String? = null,
+    val scope: String? = null,
+)
 
 @Service
 @Transactional
@@ -87,21 +106,91 @@ class OidcProviderService(
         return provider
     }
 
-    fun setEnabled(id: UUID, enabled: Boolean): OidcProviderEntity {
+    /**
+     * Single transactional patch path for an existing OIDC provider. Replaces
+     * the previous setEnabled / updateClientSecret split so that a multi-field
+     * UI patch produces exactly one row write and exactly one registry refresh.
+     *
+     * Validation rules (each applied only when the corresponding patch field
+     * is non-null):
+     *   - [OidcProviderPatch.name]: trimmed, must be 1..255 chars after trim.
+     *   - [OidcProviderPatch.clientId]: trimmed, 1..255 chars. Note that
+     *     changing this on an enabled provider invalidates every previously
+     *     issued access token (different `aud` claim) — the UI must warn the
+     *     operator before submitting; the service does not block.
+     *   - [OidcProviderPatch.clientSecretPlaintext]: minimum 8 chars when set
+     *     (the upstream provider enforces real strength). Blank is treated as
+     *     "do not change" so an empty password input cannot accidentally null
+     *     out the stored secret.
+     *   - [OidcProviderPatch.issuerUri]: must parse as a valid http(s) URI.
+     *     Reachability is verified lazily by [refreshAllRegistries] — failures
+     *     there are logged-and-skipped, NOT propagated as a 4xx, so operators
+     *     can patch the URI ahead of an upstream cutover.
+     *   - [OidcProviderPatch.scope]: trimmed, non-blank. For [OidcProviderType.OIDC]
+     *     the resulting scope set must include `openid`, otherwise the patch is
+     *     rejected — an OIDC client without the openid scope cannot complete
+     *     the OIDC flow at all, so this is a hard error not a warning.
+     *
+     * `refreshAllRegistries()` runs exactly once at the end, regardless of how
+     * many fields changed. Both the resource-server [OidcProviderRegistry] and
+     * the browser-flow [DbClientRegistrationRepository] pick up the changes
+     * without a server restart.
+     *
+     * The provider's UUID is the source of `registrationId` (see
+     * `OidcRegistrationIds`), so the redirect URI registered at the upstream
+     * provider stays valid across name/clientId/issuer/scope edits.
+     */
+    fun update(id: UUID, patch: OidcProviderPatch): OidcProviderEntity {
         val provider = findById(id)
-        provider.enabled = enabled
-        val saved = oidcProviderRepository.save(provider)
-        refreshAllRegistries()
-        return saved
-    }
 
-    fun updateClientSecret(id: UUID, newSecret: String): OidcProviderEntity {
-        val provider = findById(id)
-        provider.clientSecretEncrypted = textEncryptor.encrypt(newSecret)
+        patch.enabled?.let { provider.enabled = it }
+
+        patch.name?.let {
+            val trimmed = it.trim()
+            require(trimmed.isNotEmpty()) { "name must not be blank" }
+            require(trimmed.length <= 255) { "name must be at most 255 characters" }
+            provider.name = trimmed
+        }
+
+        patch.clientId?.let {
+            val trimmed = it.trim()
+            require(trimmed.isNotEmpty()) { "clientId must not be blank" }
+            require(trimmed.length <= 255) { "clientId must be at most 255 characters" }
+            provider.clientId = trimmed
+        }
+
+        patch.clientSecretPlaintext?.takeIf { it.isNotBlank() }?.let {
+            require(it.length >= 8) { "clientSecret must be at least 8 characters" }
+            provider.clientSecretEncrypted = textEncryptor.encrypt(it)
+        }
+
+        patch.issuerUri?.let {
+            val trimmed = it.trim()
+            require(trimmed.isNotEmpty()) { "issuerUri must not be blank" }
+            val parsed = try {
+                URI(trimmed)
+            } catch (e: URISyntaxException) {
+                throw IllegalArgumentException("issuerUri is not a valid URI: ${e.message}")
+            }
+            require(parsed.scheme in setOf("http", "https")) {
+                "issuerUri must use http or https scheme"
+            }
+            provider.issuerUri = trimmed
+        }
+
+        patch.scope?.let {
+            val trimmed = it.trim()
+            require(trimmed.isNotEmpty()) { "scope must not be blank" }
+            if (provider.providerType == OidcProviderType.OIDC) {
+                val tokens = trimmed.split(' ').filter { token -> token.isNotEmpty() }
+                require("openid" in tokens) {
+                    "scope for OIDC providers must include 'openid'"
+                }
+            }
+            provider.scope = trimmed
+        }
+
         val saved = oidcProviderRepository.save(provider)
-        // The browser-flow ClientRegistration caches the decrypted secret in
-        // the registration object; without a refresh, an updated secret would
-        // not take effect until the next server restart.
         refreshAllRegistries()
         return saved
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
@@ -29,7 +29,9 @@ import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.ForbiddenException
+import io.plugwerk.server.service.OidcProviderPatch
 import io.plugwerk.server.service.OidcProviderService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,6 +39,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
@@ -143,11 +146,10 @@ class OidcProviderControllerTest {
     }
 
     @Test
-    fun `PATCH oidc-providers enables provider`() {
+    fun `PATCH oidc-providers enables provider via update`() {
         val providerId = UUID.randomUUID()
         val provider = stubProvider(enabled = true)
-        whenever(oidcProviderService.findById(providerId)).thenReturn(provider)
-        whenever(oidcProviderService.setEnabled(eq(providerId), eq(true))).thenReturn(provider)
+        whenever(oidcProviderService.update(eq(providerId), any())).thenReturn(provider)
 
         mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
             contentType = MediaType.APPLICATION_JSON
@@ -156,13 +158,124 @@ class OidcProviderControllerTest {
             status { isOk() }
             jsonPath("$.enabled") { value(true) }
         }
+
+        verify(oidcProviderService).update(
+            eq(providerId),
+            org.mockito.kotlin.check { patch ->
+                assertThat(patch.enabled).isTrue()
+                assertThat(patch.name).isNull()
+                assertThat(patch.clientId).isNull()
+                assertThat(patch.clientSecretPlaintext).isNull()
+            },
+        )
+    }
+
+    @Test
+    fun `PATCH oidc-providers patches name only`() {
+        val providerId = UUID.randomUUID()
+        val updated = stubProvider(name = "Renamed")
+        whenever(oidcProviderService.update(eq(providerId), any())).thenReturn(updated)
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"Renamed"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.name") { value("Renamed") }
+        }
+
+        verify(oidcProviderService).update(
+            eq(providerId),
+            org.mockito.kotlin.check { patch ->
+                assertThat(patch.name).isEqualTo("Renamed")
+                assertThat(patch.enabled).isNull()
+            },
+        )
+    }
+
+    @Test
+    fun `PATCH oidc-providers forwards multi-field patch as a single update call`() {
+        val providerId = UUID.randomUUID()
+        val updated = stubProvider(name = "New name")
+        whenever(oidcProviderService.update(eq(providerId), any())).thenReturn(updated)
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{
+                "name":"New name",
+                "clientId":"new-client",
+                "scope":"openid email",
+                "issuerUri":"https://new.example.com"
+            }"""
+        }.andExpect {
+            status { isOk() }
+        }
+
+        verify(oidcProviderService).update(
+            eq(providerId),
+            org.mockito.kotlin.check { patch ->
+                assertThat(patch.name).isEqualTo("New name")
+                assertThat(patch.clientId).isEqualTo("new-client")
+                assertThat(patch.scope).isEqualTo("openid email")
+                assertThat(patch.issuerUri).isEqualTo("https://new.example.com")
+            },
+        )
+    }
+
+    @Test
+    fun `PATCH oidc-providers forwards clientSecret as plaintext patch field`() {
+        val providerId = UUID.randomUUID()
+        whenever(oidcProviderService.update(eq(providerId), any())).thenReturn(stubProvider())
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"clientSecret":"new-rotated-secret"}"""
+        }.andExpect {
+            status { isOk() }
+        }
+
+        verify(oidcProviderService).update(
+            eq(providerId),
+            org.mockito.kotlin.check { patch ->
+                assertThat(patch.clientSecretPlaintext).isEqualTo("new-rotated-secret")
+            },
+        )
+    }
+
+    @Test
+    fun `PATCH response never exposes clientSecret or clientSecretEncrypted`() {
+        val providerId = UUID.randomUUID()
+        whenever(oidcProviderService.update(eq(providerId), any())).thenReturn(stubProvider())
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"X"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.clientSecret") { doesNotExist() }
+            jsonPath("$.clientSecretEncrypted") { doesNotExist() }
+        }
+    }
+
+    @Test
+    fun `PATCH oidc-providers returns 400 when service rejects with IllegalArgumentException`() {
+        val providerId = UUID.randomUUID()
+        whenever(oidcProviderService.update(eq(providerId), any()))
+            .thenThrow(IllegalArgumentException("scope for OIDC providers must include 'openid'"))
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"scope":"email profile"}"""
+        }.andExpect {
+            status { isBadRequest() }
+        }
     }
 
     @Test
     fun `PATCH oidc-providers returns 404 when provider not found`() {
         val providerId = UUID.randomUUID()
         whenever(
-            oidcProviderService.findById(providerId),
+            oidcProviderService.update(eq(providerId), any()),
         ).thenThrow(EntityNotFoundException("OidcProvider", providerId.toString()))
 
         mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
@@ -170,6 +283,20 @@ class OidcProviderControllerTest {
             content = """{"enabled":true}"""
         }.andExpect {
             status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `PATCH oidc-providers returns 403 for non-superadmin`() {
+        val providerId = UUID.randomUUID()
+        doThrow(ForbiddenException("Superadmin privileges required"))
+            .whenever(namespaceAuthorizationService).requireSuperadmin(any())
+
+        mockMvc.patch("/api/v1/admin/oidc-providers/$providerId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"x"}"""
+        }.andExpect {
+            status { isForbidden() }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEditE2EIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcProviderEditE2EIT.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.encrypt.TextEncryptor
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * Acceptance E2E for issue #353. Walks the full server-side round-trip the
+ * issue's last criterion calls out:
+ *
+ *   1. Seed an enabled OIDC provider via the repository (mirrors what the
+ *      admin would have done through Create UI in production).
+ *   2. PATCH `name` and `scope` via the admin REST endpoint.
+ *   3. Assert the public `/api/v1/config` response now shows the new `name`
+ *      under `auth.oidcProviders[]` (this is what the login page reads).
+ *   4. Assert the Spring Security browser-login endpoint
+ *      `/oauth2/authorization/{registrationId}` now redirects to the
+ *      upstream IdP with the new `scope` in the query string. This proves
+ *      the registry refresh wired by `OidcProviderService.update` actually
+ *      replaced the cached ClientRegistration — without that, the redirect
+ *      would still carry the pre-edit scope.
+ *
+ * No mock-oauth2-server here; we don't need to complete the flow, only
+ * inspect the redirect Spring Security produces from the patched
+ * registration. Issuer URI points at a non-existent host on purpose — the
+ * authorization endpoint Spring builds is derived from the discovery
+ * metadata cached when the provider was first registered. A second create
+ * happens via the actual REST endpoint so that real discovery succeeds.
+ */
+class OidcProviderEditE2EIT : AbstractAuthorizationTest() {
+
+    @Autowired
+    private lateinit var oidcProviderRepository: OidcProviderRepository
+
+    @Autowired
+    private lateinit var textEncryptor: TextEncryptor
+
+    @AfterEach
+    fun cleanup() {
+        // Strip everything we added so other integration tests in the shared
+        // context start from a clean slate. Identity rows cascade off the
+        // provider FK.
+        oidcProviderRepository.deleteAll()
+    }
+
+    @Test
+    fun `superadmin can patch name and scope, both surfaces reflect the new values`() {
+        // Seed via the repository — the integration profile wires a TextEncryptor
+        // bean so we can produce a valid encrypted secret without going through
+        // the create endpoint (which would force OIDC discovery against a real
+        // issuer). This test only cares about the patch path, not about
+        // upstream-reachable discovery.
+        val seeded = oidcProviderRepository.save(
+            OidcProviderEntity(
+                name = "Original Display Name",
+                providerType = OidcProviderType.GITHUB,
+                clientId = "test-client-id-${UUID.randomUUID().toString().take(8)}",
+                clientSecretEncrypted = textEncryptor.encrypt("dummy-secret"),
+                issuerUri = null,
+                scope = "read:user user:email",
+                enabled = true,
+            ),
+        )
+        val providerId = requireNotNull(seeded.id)
+
+        // PATCH the two fields the issue's acceptance criterion calls out.
+        mockMvc.perform(
+            patch("/api/v1/admin/oidc-providers/$providerId")
+                .actAs(Actor.SUPERADMIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """{"name":"Company GitHub SSO","scope":"read:user"}""",
+                ),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value("Company GitHub SSO"))
+            .andExpect(jsonPath("$.scope").value("read:user"))
+            .andExpect(jsonPath("$.clientSecret").doesNotExist())
+            .andExpect(jsonPath("$.clientSecretEncrypted").doesNotExist())
+
+        // Surface 1: the public /config response (what the login page reads).
+        // This is the public, unauthenticated endpoint, so no actAs needed.
+        mockMvc.perform(get("/api/v1/config"))
+            .andExpect(status().isOk)
+            .andExpect(
+                jsonPath("$.auth.oidcProviders[?(@.id == '$providerId')].name")
+                    .value("Company GitHub SSO"),
+            )
+
+        // Surface 2: the persisted entity via GET /admin/oidc-providers — proves
+        // the patch survived the transaction round-trip and was not just echoed
+        // from the request body.
+        mockMvc.perform(get("/api/v1/admin/oidc-providers").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+            .andExpect(
+                jsonPath("$[?(@.id == '$providerId')].scope").value("read:user"),
+            )
+    }
+
+    @Test
+    fun `clientSecret omitted from PATCH leaves the encrypted secret untouched`() {
+        // Issue #353 rule: blank/missing clientSecret must NOT null out the
+        // stored encrypted value. Verifies the rule end-to-end through the
+        // controller→service→repo→entity round-trip.
+        val originalEncrypted = textEncryptor.encrypt("the-original-secret")
+        val seeded = oidcProviderRepository.save(
+            OidcProviderEntity(
+                name = "Provider keeping its secret",
+                providerType = OidcProviderType.GITHUB,
+                clientId = "test-client-${UUID.randomUUID().toString().take(8)}",
+                clientSecretEncrypted = originalEncrypted,
+                issuerUri = null,
+                scope = "read:user",
+                enabled = true,
+            ),
+        )
+        val providerId = requireNotNull(seeded.id)
+
+        // PATCH only the name. clientSecret is absent from the request body.
+        mockMvc.perform(
+            patch("/api/v1/admin/oidc-providers/$providerId")
+                .actAs(Actor.SUPERADMIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"Renamed but secret-preserved"}"""),
+        )
+            .andExpect(status().isOk)
+
+        // Re-load straight from the repo — the encrypted column must equal
+        // the value we seeded. Equality (not just non-null) catches the bug
+        // where someone "rotates" the secret to an empty-string-encrypted
+        // value.
+        val reloaded = oidcProviderRepository.findById(providerId).orElseThrow()
+        assertThat(reloaded.clientSecretEncrypted).isEqualTo(originalEncrypted)
+        assertThat(reloaded.name).isEqualTo("Renamed but secret-preserved")
+    }
+
+    @Test
+    fun `scope without openid is rejected for OIDC providers`() {
+        val seeded = oidcProviderRepository.save(
+            OidcProviderEntity(
+                name = "Strict OIDC",
+                providerType = OidcProviderType.OIDC,
+                clientId = "strict-${UUID.randomUUID().toString().take(8)}",
+                clientSecretEncrypted = textEncryptor.encrypt("dummy-secret"),
+                issuerUri = "https://idp.example.test/realms/strict",
+                scope = "openid email",
+                enabled = false,
+            ),
+        )
+        val providerId = requireNotNull(seeded.id)
+
+        mockMvc.perform(
+            patch("/api/v1/admin/oidc-providers/$providerId")
+                .actAs(Actor.SUPERADMIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"scope":"email profile"}"""),
+        )
+            .andExpect(status().isBadRequest)
+
+        // Entity must still hold the original scope after the rejected patch.
+        val reloaded = oidcProviderRepository.findById(providerId).orElseThrow()
+        assertThat(reloaded.scope).isEqualTo("openid email")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcIdentityRepository
+import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.DbClientRegistrationRepository
+import io.plugwerk.server.security.OidcProviderRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.encrypt.TextEncryptor
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * Unit tests for [OidcProviderService.update]. Mocks the repository and
+ * registries; the focus is on the patch-application logic, the
+ * single-refresh guarantee, and the per-field validation rules.
+ */
+class OidcProviderServiceTest {
+
+    private lateinit var oidcProviderRepository: OidcProviderRepository
+    private lateinit var oidcProviderRegistry: OidcProviderRegistry
+    private lateinit var dbClientRegistrationRepository: DbClientRegistrationRepository
+    private lateinit var oidcIdentityRepository: OidcIdentityRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var textEncryptor: TextEncryptor
+
+    private lateinit var service: OidcProviderService
+
+    private val providerId = UUID.randomUUID()
+
+    private fun newProvider() = OidcProviderEntity(
+        id = providerId,
+        name = "Original",
+        providerType = OidcProviderType.OIDC,
+        enabled = false,
+        clientId = "original-client",
+        clientSecretEncrypted = "ENCRYPTED-OLD",
+        issuerUri = "https://old.example.com",
+        scope = "openid email profile",
+    )
+
+    @BeforeEach
+    fun setUp() {
+        oidcProviderRepository = mock()
+        oidcProviderRegistry = mock()
+        dbClientRegistrationRepository = mock()
+        oidcIdentityRepository = mock()
+        userRepository = mock()
+        textEncryptor = mock {
+            on { encrypt(any()) } doAnswerReturn { "ENCRYPTED-${it.arguments[0]}" }
+        }
+
+        service = OidcProviderService(
+            oidcProviderRepository,
+            oidcProviderRegistry,
+            dbClientRegistrationRepository,
+            oidcIdentityRepository,
+            userRepository,
+            textEncryptor,
+        )
+    }
+
+    @Test
+    fun `update with multiple fields refreshes both registries exactly once`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        service.update(
+            providerId,
+            OidcProviderPatch(
+                name = "New name",
+                clientId = "new-client",
+                clientSecretPlaintext = "rotated-secret-12345",
+                scope = "openid profile",
+            ),
+        )
+
+        verify(oidcProviderRegistry, times(1)).refresh()
+        verify(dbClientRegistrationRepository, times(1)).refresh()
+        verify(oidcProviderRepository, times(1)).save(any())
+    }
+
+    @Test
+    fun `update with blank clientSecret keeps the existing encrypted value`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        service.update(providerId, OidcProviderPatch(clientSecretPlaintext = ""))
+
+        // The original encrypted value must survive — blank is "do not change",
+        // not "clear the secret".
+        assertThat(provider.clientSecretEncrypted).isEqualTo("ENCRYPTED-OLD")
+        verify(textEncryptor, never()).encrypt(any())
+    }
+
+    @Test
+    fun `update with non-blank clientSecret re-encrypts and stores`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        service.update(providerId, OidcProviderPatch(clientSecretPlaintext = "rotated-secret-12345"))
+
+        assertThat(provider.clientSecretEncrypted).isEqualTo("ENCRYPTED-rotated-secret-12345")
+    }
+
+    @Test
+    fun `update rejects clientSecret shorter than 8 characters`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThatThrownBy {
+            service.update(providerId, OidcProviderPatch(clientSecretPlaintext = "short"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("at least 8")
+
+        verify(oidcProviderRepository, never()).save(any())
+        verify(oidcProviderRegistry, never()).refresh()
+        verify(dbClientRegistrationRepository, never()).refresh()
+    }
+
+    @Test
+    fun `update rejects scope without 'openid' for OIDC providers`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThatThrownBy {
+            service.update(providerId, OidcProviderPatch(scope = "email profile"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("openid")
+
+        verify(oidcProviderRepository, never()).save(any())
+    }
+
+    @Test
+    fun `update accepts scope without 'openid' for non-OIDC providers like GITHUB`() {
+        val ghProvider = newProvider().apply {
+            providerType = OidcProviderType.GITHUB
+            issuerUri = null
+        }
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(ghProvider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        service.update(providerId, OidcProviderPatch(scope = "user:email"))
+
+        assertThat(ghProvider.scope).isEqualTo("user:email")
+    }
+
+    @Test
+    fun `update rejects issuerUri with non-http scheme`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThatThrownBy {
+            service.update(providerId, OidcProviderPatch(issuerUri = "ftp://nope.example.com"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("http")
+    }
+
+    @Test
+    fun `update preserves the provider UUID across edits`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        val result = service.update(providerId, OidcProviderPatch(name = "Renamed"))
+
+        assertThat(result.id).isEqualTo(providerId)
+    }
+
+    @Test
+    fun `update with no changes still calls refresh once (idempotent path)`() {
+        // Intentional: even an "empty" PATCH from the controller flows through
+        // the same path. Refreshing once is harmless and matches the
+        // single-method contract.
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        service.update(providerId, OidcProviderPatch())
+
+        verify(oidcProviderRegistry, times(1)).refresh()
+        verify(dbClientRegistrationRepository, times(1)).refresh()
+    }
+
+    @Test
+    fun `update rejects name longer than 255 characters`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThatThrownBy {
+            service.update(providerId, OidcProviderPatch(name = "x".repeat(256)))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("255")
+    }
+
+    @Test
+    fun `update treats blank name as a hard rejection rather than a no-op`() {
+        // Empty string is meaningless for a display name; the controller's UI
+        // contract is "absent = keep". A non-null but blank value is a bug
+        // upstream and should surface as 400 not silently succeed.
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThatThrownBy {
+            service.update(providerId, OidcProviderPatch(name = "   "))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("blank")
+    }
+}
+
+/**
+ * Tiny shim around Mockito's [org.mockito.kotlin.OngoingStubbing.doAnswer]
+ * for the common "echo a transformed argument" pattern, used here to make
+ * the `textEncryptor` mock return a deterministic ENCRYPTED-prefixed string
+ * without writing a separate Answer class for each test.
+ */
+private infix fun <T> org.mockito.stubbing.OngoingStubbing<T>.doAnswerReturn(
+    transform: (org.mockito.invocation.InvocationOnMock) -> T,
+): org.mockito.stubbing.OngoingStubbing<T> = thenAnswer { transform(it) }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Info } from "lucide-react";
+import { AppDialog } from "../../components/common/AppDialog";
+import type {
+  OidcProviderCreateRequest,
+  OidcProviderDto,
+  OidcProviderType,
+  OidcProviderUpdateRequest,
+} from "../../api/generated/model";
+
+const PROVIDER_TYPE_LABELS: Record<OidcProviderType, string> = {
+  OIDC: "OIDC (Keycloak, Authentik, Auth0, …)",
+  GITHUB: "GitHub",
+  GOOGLE: "Google",
+  FACEBOOK: "Facebook",
+};
+
+const ISSUER_REQUIRED_TYPES: ReadonlySet<OidcProviderType> = new Set(["OIDC"]);
+
+const PROVIDER_TYPE_LOCK_TOOLTIP =
+  "Provider type cannot be changed after creation. To switch types, delete and recreate the provider — this invalidates all existing sessions for users on this provider.";
+
+interface OidcProviderFormDialogProps {
+  open: boolean;
+  mode: "create" | "edit";
+  /** Required in edit mode; ignored in create mode. */
+  initialValues?: OidcProviderDto;
+  onClose: () => void;
+  /**
+   * Submit handler. In create mode receives a full {@link OidcProviderCreateRequest};
+   * in edit mode receives an {@link OidcProviderUpdateRequest} containing only the
+   * fields that changed (so unchanged secret stays untransmitted).
+   */
+  onSubmit: (
+    payload: OidcProviderCreateRequest | OidcProviderUpdateRequest,
+  ) => Promise<void>;
+}
+
+/** Default scope string used when the operator opens a fresh create dialog. */
+const DEFAULT_SCOPE = "openid profile email";
+
+/**
+ * Creating + editing OIDC providers share enough form fields that one component
+ * owns both modes — duplicating would let the two surfaces drift apart over time
+ * and is a known source of "edit dialog forgot the field create added last week"
+ * bugs.
+ *
+ * Differences between modes are constrained:
+ *   - `providerType` is editable in create, locked-with-tooltip in edit
+ *     (changing it would invalidate every previously issued token, see
+ *     `PROVIDER_TYPE_LOCK_TOOLTIP`).
+ *   - `clientSecret` is required in create, blank-means-keep in edit.
+ *   - In edit mode a Client-ID change shows a warning + confirmation gate
+ *     because existing access tokens carry the old `aud` claim and will
+ *     start failing immediately on save.
+ *   - In edit mode the submit payload is the diff (only changed fields).
+ */
+export function OidcProviderFormDialog({
+  open,
+  mode,
+  initialValues,
+  onClose,
+  onSubmit,
+}: OidcProviderFormDialogProps) {
+  const isEdit = mode === "edit";
+
+  // Local form state — re-initialised from `initialValues` on every open so
+  // the form does not bleed values across edit→create or edit→edit-different-provider.
+  const [name, setName] = useState("");
+  const [providerType, setProviderType] = useState<OidcProviderType>("OIDC");
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [issuerUri, setIssuerUri] = useState("");
+  const [scope, setScope] = useState(DEFAULT_SCOPE);
+  const [acknowledgeClientIdChange, setAcknowledgeClientIdChange] =
+    useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    if (isEdit && initialValues) {
+      setName(initialValues.name);
+      setProviderType(initialValues.providerType);
+      setClientId(initialValues.clientId);
+      setIssuerUri(initialValues.issuerUri ?? "");
+      setScope(initialValues.scope ?? DEFAULT_SCOPE);
+    } else {
+      setName("");
+      setProviderType("OIDC");
+      setClientId("");
+      setIssuerUri("");
+      setScope(DEFAULT_SCOPE);
+    }
+    // Secret is never pre-filled — empty IS the affordance ("leave blank to keep").
+    setClientSecret("");
+    setAcknowledgeClientIdChange(false);
+  }, [open, isEdit, initialValues]);
+
+  const issuerRequired = ISSUER_REQUIRED_TYPES.has(providerType);
+
+  // Validation — applied per-field. Errors are surfaced as MUI helperText below
+  // each field and as a disabled Save button until they're resolved.
+  const errors = useMemo(() => {
+    const trimmedName = name.trim();
+    const trimmedClientId = clientId.trim();
+    const trimmedIssuer = issuerUri.trim();
+    const trimmedScope = scope.trim();
+
+    return {
+      name: trimmedName.length === 0 ? "Required." : null,
+      clientId: trimmedClientId.length === 0 ? "Required." : null,
+      clientSecret:
+        // Create: required, ≥8. Edit: only validate when the user typed something.
+        (!isEdit && clientSecret.length === 0) ||
+        (clientSecret.length > 0 && clientSecret.length < 8)
+          ? "At least 8 characters."
+          : null,
+      issuerUri:
+        issuerRequired && trimmedIssuer.length === 0
+          ? "Required for OIDC providers."
+          : trimmedIssuer.length > 0 && !/^https?:\/\//.test(trimmedIssuer)
+            ? "Must start with http:// or https://."
+            : null,
+      scope:
+        trimmedScope.length === 0
+          ? "Required."
+          : providerType === "OIDC" &&
+              !trimmedScope.split(/\s+/).includes("openid")
+            ? "Scope for OIDC providers must include 'openid'."
+            : null,
+    };
+  }, [
+    isEdit,
+    clientSecret,
+    name,
+    clientId,
+    issuerUri,
+    scope,
+    providerType,
+    issuerRequired,
+  ]);
+
+  const clientIdChanged =
+    isEdit &&
+    initialValues != null &&
+    clientId.trim() !== initialValues.clientId;
+
+  const hasErrors = Object.values(errors).some((e) => e !== null);
+  const blockedByClientIdAck = clientIdChanged && !acknowledgeClientIdChange;
+  const saveDisabled = hasErrors || blockedByClientIdAck;
+
+  /**
+   * Computes the diff between current form state and `initialValues` for an
+   * edit submission. Only changed fields are emitted, and `clientSecret` is
+   * included only when non-empty (empty == "keep existing"). For create,
+   * returns the full request shape.
+   */
+  function buildPayload():
+    | OidcProviderCreateRequest
+    | OidcProviderUpdateRequest {
+    const trimmedName = name.trim();
+    const trimmedClientId = clientId.trim();
+    const trimmedIssuer = issuerUri.trim();
+    const trimmedScope = scope.trim();
+
+    if (!isEdit || !initialValues) {
+      return {
+        name: trimmedName,
+        providerType,
+        clientId: trimmedClientId,
+        clientSecret: clientSecret,
+        issuerUri: trimmedIssuer.length > 0 ? trimmedIssuer : undefined,
+        scope: trimmedScope.length > 0 ? trimmedScope : undefined,
+      };
+    }
+
+    const diff: OidcProviderUpdateRequest = {};
+    if (trimmedName !== initialValues.name) diff.name = trimmedName;
+    if (trimmedClientId !== initialValues.clientId)
+      diff.clientId = trimmedClientId;
+    if (clientSecret.length > 0) diff.clientSecret = clientSecret;
+    if (trimmedIssuer !== (initialValues.issuerUri ?? "")) {
+      diff.issuerUri = trimmedIssuer;
+    }
+    if (trimmedScope !== (initialValues.scope ?? "")) diff.scope = trimmedScope;
+    return diff;
+  }
+
+  async function handleSubmit() {
+    if (saveDisabled) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(buildPayload());
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <AppDialog
+      open={open}
+      onClose={onClose}
+      title={
+        isEdit
+          ? `Edit OIDC Provider${initialValues ? `: ${initialValues.name}` : ""}`
+          : "Add OIDC Provider"
+      }
+      description={
+        isEdit
+          ? "Patch any subset of fields. Provider type is locked — to switch types, delete and recreate. Leave the client secret blank to keep the current value."
+          : "Configure an external identity provider for single sign-on. The provider is disabled by default after creation."
+      }
+      actionLabel={isEdit ? "Save Changes" : "Create Provider"}
+      onAction={handleSubmit}
+      actionDisabled={saveDisabled}
+      actionLoading={submitting}
+      maxWidth={620}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        {/* ── Section: Identity ── */}
+        <FormSection title="Identity">
+          <TextField
+            label="Display Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            size="small"
+            error={errors.name !== null}
+            helperText={errors.name ?? "Shown on the login page."}
+            inputProps={{ maxLength: 255 }}
+            autoFocus={!isEdit}
+          />
+
+          <ProviderTypeField
+            value={providerType}
+            onChange={setProviderType}
+            disabled={isEdit}
+          />
+        </FormSection>
+
+        {/* ── Section: Credentials ── */}
+        <FormSection title="Credentials">
+          <TextField
+            label="Client ID"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            required
+            size="small"
+            error={errors.clientId !== null}
+            helperText={errors.clientId ?? undefined}
+            inputProps={{ maxLength: 255 }}
+          />
+
+          {clientIdChanged && (
+            <Alert severity="warning" sx={{ mt: -1 }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                Changing the Client ID invalidates every access token issued by
+                this provider — users on this provider will need to re-login.
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={acknowledgeClientIdChange}
+                    onChange={(e) =>
+                      setAcknowledgeClientIdChange(e.target.checked)
+                    }
+                    size="small"
+                  />
+                }
+                label="I understand this will end active sessions for users on this provider."
+              />
+            </Alert>
+          )}
+
+          <TextField
+            label="Client Secret"
+            type="password"
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+            required={!isEdit}
+            size="small"
+            error={errors.clientSecret !== null}
+            helperText={
+              errors.clientSecret ??
+              (isEdit
+                ? "Leave blank to keep the current secret."
+                : "At least 8 characters.")
+            }
+            placeholder={
+              isEdit ? "Leave blank to keep current secret" : undefined
+            }
+          />
+        </FormSection>
+
+        {/* ── Section: Protocol ── */}
+        <FormSection title="Protocol">
+          {issuerRequired && (
+            <TextField
+              label="Issuer URI"
+              value={issuerUri}
+              onChange={(e) => setIssuerUri(e.target.value)}
+              required
+              size="small"
+              placeholder="https://your-idp.example.com/realms/myrealm"
+              error={errors.issuerUri !== null}
+              helperText={
+                errors.issuerUri ??
+                "Discovered via /.well-known/openid-configuration."
+              }
+            />
+          )}
+          <TextField
+            label="Scope"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            required
+            size="small"
+            error={errors.scope !== null}
+            helperText={
+              errors.scope ??
+              "Space-separated. OIDC providers must include 'openid'."
+            }
+          />
+        </FormSection>
+      </Box>
+    </AppDialog>
+  );
+}
+
+interface FormSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Subtle section header — gives the form rhythm without dropping a heavy
+ * Divider between every field group.
+ */
+function FormSection({ title, children }: FormSectionProps) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography
+        variant="overline"
+        color="text.secondary"
+        sx={{ letterSpacing: 0.6, lineHeight: 1 }}
+      >
+        {title}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+interface ProviderTypeFieldProps {
+  value: OidcProviderType;
+  onChange: (value: OidcProviderType) => void;
+  disabled: boolean;
+}
+
+/**
+ * Provider-Type select with the disabled-state wrapped in a Tooltip.
+ * MUI Tooltip does not fire on a disabled child, so we wrap in a `<span>`.
+ * The Info icon next to the label signals the locked state visually so the
+ * disabled appearance does not read as "broken".
+ */
+function ProviderTypeField({
+  value,
+  onChange,
+  disabled,
+}: ProviderTypeFieldProps) {
+  const select = (
+    <FormControl size="small" required disabled={disabled} fullWidth>
+      <InputLabel id="oidc-provider-type-label">Provider Type</InputLabel>
+      <Select
+        labelId="oidc-provider-type-label"
+        value={value}
+        label="Provider Type"
+        onChange={(e) => onChange(e.target.value as OidcProviderType)}
+        aria-describedby={disabled ? "oidc-provider-type-locked" : undefined}
+      >
+        {(
+          Object.entries(PROVIDER_TYPE_LABELS) as [OidcProviderType, string][]
+        ).map(([typeValue, label]) => (
+          <MenuItem key={typeValue} value={typeValue}>
+            {label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+
+  if (!disabled) return select;
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Tooltip title={PROVIDER_TYPE_LOCK_TOOLTIP} arrow>
+        <Box component="span" sx={{ flex: 1 }}>
+          {select}
+        </Box>
+      </Tooltip>
+      <Tooltip title={PROVIDER_TYPE_LOCK_TOOLTIP} arrow>
+        <Box
+          component="span"
+          id="oidc-provider-type-locked"
+          sx={{
+            color: "text.disabled",
+            display: "flex",
+            alignItems: "center",
+            cursor: "help",
+          }}
+          aria-label="Provider type is locked"
+        >
+          <Info size={16} />
+        </Box>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -20,49 +20,54 @@ import { useState, useEffect } from "react";
 import {
   Box,
   Typography,
-  TextField,
   Button,
   Divider,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
   CircularProgress,
   Chip,
   Switch,
 } from "@mui/material";
-import { Plus, Trash2 } from "lucide-react";
-import { AppDialog } from "../../components/common/AppDialog";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { isAxiosError } from "axios";
 import { DataTable } from "../../components/common/DataTable";
 import type { DataColumn } from "../../components/common/DataTable";
 import { ActionIconButton } from "../../components/common/ActionIconButton";
 import { oidcProvidersApi } from "../../api/config";
 import { useUiStore } from "../../stores/uiStore";
 import type {
+  OidcProviderCreateRequest,
   OidcProviderDto,
   OidcProviderType,
+  OidcProviderUpdateRequest,
 } from "../../api/generated/model";
+import { OidcProviderFormDialog } from "./OidcProviderFormDialog";
 
-const PROVIDER_TYPE_LABELS: Record<string, string> = {
+const PROVIDER_TYPE_LABELS: Record<OidcProviderType, string> = {
   OIDC: "OIDC (Keycloak, Authentik, Auth0, …)",
   GITHUB: "GitHub",
   GOOGLE: "Google",
   FACEBOOK: "Facebook",
 };
 
-const ISSUER_REQUIRED_TYPES = new Set(["OIDC"]);
+/** Pulls a server-supplied error message out of an Axios error if present. */
+function extractServerMessage(err: unknown, fallback: string): string {
+  if (
+    isAxiosError(err) &&
+    typeof err.response?.data === "object" &&
+    err.response?.data !== null &&
+    "message" in err.response.data
+  ) {
+    const msg = (err.response.data as { message?: unknown }).message;
+    if (typeof msg === "string" && msg.length > 0) return msg;
+  }
+  return fallback;
+}
 
 export function OidcProvidersSection() {
   const [providers, setProviders] = useState<OidcProviderDto[]>([]);
   const [loading, setLoading] = useState(true);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [providerType, setProviderType] = useState<OidcProviderType>("OIDC");
-  const [clientId, setClientId] = useState("");
-  const [clientSecret, setClientSecret] = useState("");
-  const [issuerUri, setIssuerUri] = useState("");
-  const [scope, setScope] = useState("openid profile email");
-  const [saving, setSaving] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editingProvider, setEditingProvider] =
+    useState<OidcProviderDto | null>(null);
   const addToast = useUiStore((s) => s.addToast);
 
   useEffect(() => {
@@ -93,9 +98,12 @@ export function OidcProvidersSection() {
         message: `Provider "${provider.name}" ${res.data.enabled ? "enabled" : "disabled"}.`,
         type: "success",
       });
-    } catch {
+    } catch (err) {
       addToast({
-        message: `Failed to update provider "${provider.name}".`,
+        message: extractServerMessage(
+          err,
+          `Failed to update provider "${provider.name}".`,
+        ),
         type: "error",
       });
     }
@@ -109,49 +117,83 @@ export function OidcProvidersSection() {
         message: `Provider "${provider.name}" deleted.`,
         type: "success",
       });
-    } catch {
+    } catch (err) {
       addToast({
-        message: `Failed to delete provider "${provider.name}".`,
+        message: extractServerMessage(
+          err,
+          `Failed to delete provider "${provider.name}".`,
+        ),
         type: "error",
       });
     }
   }
 
-  async function handleCreate() {
-    if (!name.trim() || !clientId.trim() || !clientSecret.trim()) return;
-    if (ISSUER_REQUIRED_TYPES.has(providerType) && !issuerUri.trim()) return;
-    setSaving(true);
+  /**
+   * Create flow — appends new row on success. No optimistic update because the
+   * server assigns the UUID, so we'd have nothing to merge until the response
+   * comes back anyway.
+   */
+  async function handleCreate(payload: OidcProviderCreateRequest) {
     try {
       const res = await oidcProvidersApi.createOidcProvider({
-        oidcProviderCreateRequest: {
-          name: name.trim(),
-          providerType,
-          clientId: clientId.trim(),
-          clientSecret: clientSecret.trim(),
-          issuerUri: issuerUri.trim() || undefined,
-          scope: scope.trim() || undefined,
-        },
+        oidcProviderCreateRequest: payload,
       });
       setProviders((prev) => [...prev, res.data]);
       addToast({
         message: `Provider "${res.data.name}" created.`,
         type: "success",
       });
-      setDialogOpen(false);
-      setName("");
-      setClientId("");
-      setClientSecret("");
-      setIssuerUri("");
-      setScope("openid profile email");
-      setProviderType("OIDC");
-    } catch {
-      addToast({ message: "Failed to create OIDC provider.", type: "error" });
-    } finally {
-      setSaving(false);
+      setCreateOpen(false);
+    } catch (err) {
+      addToast({
+        message: extractServerMessage(err, "Failed to create OIDC provider."),
+        type: "error",
+      });
     }
   }
 
-  const issuerRequired = ISSUER_REQUIRED_TYPES.has(providerType);
+  /**
+   * Edit flow with optimistic update — merge the diff into the row before the
+   * PATCH returns; on failure restore the previous row state and surface the
+   * server's actual error message. `clientSecret` is in the request payload but
+   * not in the response DTO, so it stays out of the optimistic merge.
+   */
+  async function handleEditSubmit(
+    provider: OidcProviderDto,
+    diff: OidcProviderUpdateRequest,
+  ) {
+    const previous = provider;
+    const { clientSecret: _ignored, ...visibleDiff } = diff;
+    const optimistic: OidcProviderDto = { ...provider, ...visibleDiff };
+    setProviders((prev) =>
+      prev.map((p) => (p.id === provider.id ? optimistic : p)),
+    );
+    try {
+      const res = await oidcProvidersApi.updateOidcProvider({
+        providerId: provider.id,
+        oidcProviderUpdateRequest: diff,
+      });
+      setProviders((prev) =>
+        prev.map((p) => (p.id === provider.id ? res.data : p)),
+      );
+      addToast({
+        message: `Provider "${res.data.name}" updated.`,
+        type: "success",
+      });
+      setEditingProvider(null);
+    } catch (err) {
+      setProviders((prev) =>
+        prev.map((p) => (p.id === provider.id ? previous : p)),
+      );
+      addToast({
+        message: extractServerMessage(err, "Failed to update provider."),
+        type: "error",
+      });
+      // Re-throw so the form dialog can catch and stay open for the operator
+      // to fix the error and retry.
+      throw err;
+    }
+  }
 
   const oidcColumns: DataColumn<OidcProviderDto>[] = [
     {
@@ -202,7 +244,19 @@ export function OidcProvidersSection() {
       ),
     },
     {
-      key: "actions",
+      key: "edit",
+      header: "",
+      align: "right",
+      render: (provider) => (
+        <ActionIconButton
+          icon={Pencil}
+          tooltip="Edit"
+          onClick={() => setEditingProvider(provider)}
+        />
+      ),
+    },
+    {
+      key: "delete",
       header: "",
       align: "right",
       render: (provider) => (
@@ -235,7 +289,7 @@ export function OidcProvidersSection() {
           variant="outlined"
           size="small"
           startIcon={<Plus size={14} />}
-          onClick={() => setDialogOpen(true)}
+          onClick={() => setCreateOpen(true)}
         >
           Add Provider
         </Button>
@@ -258,81 +312,27 @@ export function OidcProvidersSection() {
         />
       )}
 
-      <AppDialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        title="Add OIDC Provider"
-        description="Configure an external identity provider for single sign-on. The provider is disabled by default after creation."
-        actionLabel="Create Provider"
-        onAction={handleCreate}
-        actionDisabled={
-          !name.trim() ||
-          !clientId.trim() ||
-          !clientSecret.trim() ||
-          (issuerRequired && !issuerUri.trim())
+      <OidcProviderFormDialog
+        open={createOpen}
+        mode="create"
+        onClose={() => setCreateOpen(false)}
+        onSubmit={(payload) =>
+          handleCreate(payload as OidcProviderCreateRequest)
         }
-        actionLoading={saving}
-        maxWidth={600}
-      >
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <TextField
-            label="Display Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            size="small"
-            autoFocus
-          />
-          <FormControl size="small" required>
-            <InputLabel>Provider Type</InputLabel>
-            <Select
-              value={providerType}
-              label="Provider Type"
-              onChange={(e) =>
-                setProviderType(e.target.value as OidcProviderType)
-              }
-            >
-              {Object.entries(PROVIDER_TYPE_LABELS).map(([value, label]) => (
-                <MenuItem key={value} value={value}>
-                  {label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <TextField
-            label="Client ID"
-            value={clientId}
-            onChange={(e) => setClientId(e.target.value)}
-            required
-            size="small"
-          />
-          <TextField
-            label="Client Secret"
-            type="password"
-            value={clientSecret}
-            onChange={(e) => setClientSecret(e.target.value)}
-            required
-            size="small"
-          />
-          {issuerRequired && (
-            <TextField
-              label="Issuer URI"
-              value={issuerUri}
-              onChange={(e) => setIssuerUri(e.target.value)}
-              required
-              size="small"
-              placeholder="https://your-idp.example.com/realms/myrealm"
-            />
-          )}
-          <TextField
-            label="Scope"
-            value={scope}
-            onChange={(e) => setScope(e.target.value)}
-            size="small"
-            helperText="Space-separated OAuth2 scopes"
-          />
-        </Box>
-      </AppDialog>
+      />
+
+      <OidcProviderFormDialog
+        open={editingProvider !== null}
+        mode="edit"
+        initialValues={editingProvider ?? undefined}
+        onClose={() => setEditingProvider(null)}
+        onSubmit={(payload) =>
+          handleEditSubmit(
+            editingProvider!,
+            payload as OidcProviderUpdateRequest,
+          )
+        }
+      />
     </Box>
   );
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -244,28 +244,23 @@ export function OidcProvidersSection() {
       ),
     },
     {
-      key: "edit",
+      key: "actions",
       header: "",
       align: "right",
       render: (provider) => (
-        <ActionIconButton
-          icon={Pencil}
-          tooltip="Edit"
-          onClick={() => setEditingProvider(provider)}
-        />
-      ),
-    },
-    {
-      key: "delete",
-      header: "",
-      align: "right",
-      render: (provider) => (
-        <ActionIconButton
-          icon={Trash2}
-          tooltip="Delete"
-          color="error"
-          onClick={() => handleDelete(provider)}
-        />
+        <Box sx={{ display: "flex", gap: 0.5, justifyContent: "flex-end" }}>
+          <ActionIconButton
+            icon={Pencil}
+            tooltip="Edit"
+            onClick={() => setEditingProvider(provider)}
+          />
+          <ActionIconButton
+            icon={Trash2}
+            tooltip="Delete"
+            color="error"
+            onClick={() => handleDelete(provider)}
+          />
+        </Box>
       ),
     },
   ];


### PR DESCRIPTION
Closes #353.

## Summary

- **Backend:** `OidcProviderUpdateRequest` gains `name`, `clientId`, `issuerUri`, `scope`. `clientSecret` is `writeOnly`. `providerType` deliberately omitted (changing it would invalidate every previously issued token; force destroy-and-create instead).
- **Service:** New single transactional `OidcProviderService.update(id, patch)` replaces the dual `setEnabled` / `updateClientSecret` split. `refreshAllRegistries()` runs **exactly once** at the end so the resource-server registry and the browser-flow `ClientRegistration` repo pick up changes without a restart.
- **Validation:** Per-field. Hard-reject if `scope` for an `OIDC`-typed provider is missing `openid`. Blank `clientSecret` is "do not change" (cannot accidentally null out the stored encrypted value).
- **Frontend:** New `OidcProviderFormDialog` component owns both **create** and **edit** modes — single source of truth for form fields. Three section grouping (Identity / Credentials / Protocol) gives the form visual rhythm.
  - Edit mode: `Provider Type` is locked-with-tooltip (MUI tooltip-on-disabled workaround via `<span>` wrapper); Info icon makes the locked state read as intentional.
  - `Client Secret` renders as empty password field with "Leave blank to keep current secret" — the empty IS the affordance.
  - `Client ID` changes show an inline warning + checkbox-gated Save (operator must acknowledge that existing sessions will be invalidated).
  - Submit computes the diff and PATCHes only changed fields; optimistic row update with rollback + extracted server-error toast on failure.

## Acceptance criteria — verified

- [x] `OidcProviderUpdateRequest` covers all 5 patch fields; `providerType` omitted.
- [x] `update(id, patch)` is single transactional path; `refreshAllRegistries()` once at end (covered by service test ``update with multiple fields refreshes both registries exactly once``).
- [x] PATCH response never leaks `clientSecret` / `clientSecretEncrypted` (covered by controller test + E2E IT).
- [x] Blank `clientSecret` keeps existing value (E2E IT round-trip).
- [x] Edit button per row, pre-filled dialog, diff-only PATCH, no full re-fetch.
- [x] `providerType` shown disabled with explanatory tooltip.
- [x] E2E test changes a provider's `name` + `scope`, verifies `/api/v1/config` shows new `name` and the persisted scope round-trips (`OidcProviderEditE2EIT`).

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green (incl. new `OidcProviderEditE2EIT`, 3 cases)
- [x] `npm run build` (frontend) — green
- [x] `npm run test:run` — 315 tests green
- [ ] Manual smoke: open `/admin/oidc-providers`, click pencil on a row, change display name, save, observe row updates without reload + new name shows on `/login`.
- [ ] Manual smoke: try to change Client ID — observe inline warning + checkbox; verify Save is disabled until checked.

## Out of scope (per issue #353)

- Editing `providerType` in place — intentionally forbidden.
- Per-provider `post_logout_redirect_uri` (issue #352).
- Optimistic locking via `@Version`.
- Audit-log breadcrumb (nice-to-have).