### PR TITLE
refactor(domain): replace user_setting.user_subject with user_id FK to plugwerk_user (#360)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/UserSettingsController.kt
@@ -21,8 +21,7 @@ package io.plugwerk.server.controller
 import io.plugwerk.api.UserSettingsApi
 import io.plugwerk.api.model.UserSettingsResponse
 import io.plugwerk.api.model.UserSettingsUpdateRequest
-import io.plugwerk.server.security.currentAuthentication
-import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.security.CurrentUserResolver
 import io.plugwerk.server.service.settings.UserSettingsService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -31,11 +30,18 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1")
-class UserSettingsController(private val userSettingsService: UserSettingsService) : UserSettingsApi {
+class UserSettingsController(
+    private val userSettingsService: UserSettingsService,
+    private val currentUserResolver: CurrentUserResolver,
+) : UserSettingsApi {
 
     override fun getUserSettings(): ResponseEntity<UserSettingsResponse> {
-        val subject = requireAuthenticatedSubject()
-        val settings = userSettingsService.getAll(subject)
+        // CurrentUserResolver throws UnauthorizedException (→ 401) when the
+        // request lacks an auth or carries a non-UUID subject. API-key callers
+        // present `key:<id>` as their auth name; that fails the UUID parse
+        // and gets the same 401 the previous explicit guard returned.
+        val userId = currentUserResolver.currentUserId()
+        val settings = userSettingsService.getAll(userId)
         return ResponseEntity.ok(UserSettingsResponse(settings = settings))
     }
 
@@ -43,17 +49,8 @@ class UserSettingsController(private val userSettingsService: UserSettingsServic
     override fun updateUserSettings(
         userSettingsUpdateRequest: UserSettingsUpdateRequest,
     ): ResponseEntity<UserSettingsResponse> {
-        val subject = requireAuthenticatedSubject()
-        val updated = userSettingsService.update(subject, userSettingsUpdateRequest.settings)
+        val userId = currentUserResolver.currentUserId()
+        val updated = userSettingsService.update(userId, userSettingsUpdateRequest.settings)
         return ResponseEntity.ok(UserSettingsResponse(settings = updated))
-    }
-
-    private fun requireAuthenticatedSubject(): String {
-        val auth = currentAuthentication()
-        val name = auth.name
-        if (name.isNullOrBlank() || name.startsWith("key:")) {
-            throw UnauthorizedException("User settings are not available for API key authentication")
-        }
-        return name
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/UserSettingEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/UserSettingEntity.kt
@@ -33,8 +33,8 @@ import java.util.UUID
     name = "user_setting",
     uniqueConstraints = [
         UniqueConstraint(
-            name = "uq_user_setting_subject_key",
-            columnNames = ["user_subject", "setting_key"],
+            name = "uq_user_setting_user_key",
+            columnNames = ["user_id", "setting_key"],
         ),
     ],
 )
@@ -44,8 +44,8 @@ class UserSettingEntity(
     @Column(name = "id", updatable = false)
     var id: UUID? = null,
 
-    @Column(name = "user_subject", nullable = false, length = 255, updatable = false)
-    var userSubject: String,
+    @Column(name = "user_id", nullable = false, updatable = false)
+    var userId: UUID,
 
     @Column(name = "setting_key", nullable = false, length = 128, updatable = false)
     var settingKey: String,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserSettingRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserSettingRepository.kt
@@ -28,9 +28,9 @@ import java.util.UUID
 
 @Repository
 interface UserSettingRepository : JpaRepository<UserSettingEntity, UUID> {
-    fun findByUserSubject(userSubject: String): List<UserSettingEntity>
-    fun findByUserSubjectAndSettingKey(userSubject: String, settingKey: String): Optional<UserSettingEntity>
-    fun deleteByUserSubject(userSubject: String)
+    fun findByUserId(userId: UUID): List<UserSettingEntity>
+    fun findByUserIdAndSettingKey(userId: UUID, settingKey: String): Optional<UserSettingEntity>
+    fun deleteByUserId(userId: UUID)
 
     @Modifying
     @Query(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/UserSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/UserSettingsService.kt
@@ -22,6 +22,7 @@ import io.plugwerk.server.domain.UserSettingEntity
 import io.plugwerk.server.repository.UserSettingRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 /**
  * Reads and writes per-user settings (ADR-0018).
@@ -33,22 +34,22 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserSettingsService(private val repository: UserSettingRepository) {
 
-    fun getAll(userSubject: String): Map<String, String> {
-        val stored = repository.findByUserSubject(userSubject).associate { it.settingKey to (it.settingValue ?: "") }
+    fun getAll(userId: UUID): Map<String, String> {
+        val stored = repository.findByUserId(userId).associate { it.settingKey to (it.settingValue ?: "") }
         return UserSettingKey.entries.associate { key ->
             key.key to (stored[key.key]?.ifEmpty { null } ?: key.defaultValue)
         }
     }
 
-    fun get(userSubject: String, key: UserSettingKey): String {
-        val entity = repository.findByUserSubjectAndSettingKey(userSubject, key.key).orElse(null)
+    fun get(userId: UUID, key: UserSettingKey): String {
+        val entity = repository.findByUserIdAndSettingKey(userId, key.key).orElse(null)
         val value = entity?.settingValue
         return if (value.isNullOrEmpty()) key.defaultValue else value
     }
 
     @Transactional
-    fun update(userSubject: String, settings: Map<String, String>): Map<String, String> {
-        val existingByKey = repository.findByUserSubject(userSubject).associateBy { it.settingKey }
+    fun update(userId: UUID, settings: Map<String, String>): Map<String, String> {
+        val existingByKey = repository.findByUserId(userId).associateBy { it.settingKey }
         val toSave = mutableListOf<UserSettingEntity>()
         for ((rawKey, rawValue) in settings) {
             val key = UserSettingKey.byKey(rawKey)
@@ -62,19 +63,19 @@ class UserSettingsService(private val repository: UserSettingRepository) {
                 toSave += existing
             } else {
                 toSave += UserSettingEntity(
-                    userSubject = userSubject,
+                    userId = userId,
                     settingKey = key.key,
                     settingValue = rawValue,
                 )
             }
         }
         repository.saveAll(toSave)
-        return getAll(userSubject)
+        return getAll(userId)
     }
 
     @Transactional
-    fun deleteAll(userSubject: String) {
-        repository.deleteByUserSubject(userSubject)
+    fun deleteAll(userId: UUID) {
+        repository.deleteByUserId(userId)
     }
 
     @Transactional

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0017_identity_hub_split.yaml
   - include:
       file: db/changelog/migrations/0018_oidc_provider_type_consolidation.yaml
+  - include:
+      file: db/changelog/migrations/0019_user_setting_user_id_fk.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0017_identity_hub_split.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0017_identity_hub_split.yaml
@@ -297,7 +297,9 @@ databaseChangeLog:
               --     carries plugwerk_user.id, so existing rows keyed by the old
               --     username/<provider>:<sub> string would silently disappear
               --     for the user. The free-text shape is unchanged — only the
-              --     value format flips.
+              --     value format flips. (Migration 0019 / issue #360 finishes
+              --     the job by converting this column to a proper UUID FK and
+              --     dropping `user_subject`.)
               UPDATE user_setting us
                  SET user_subject = pu.id::text
                 FROM plugwerk_user pu

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0017_identity_hub_split.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0017_identity_hub_split.yaml
@@ -297,9 +297,7 @@ databaseChangeLog:
               --     carries plugwerk_user.id, so existing rows keyed by the old
               --     username/<provider>:<sub> string would silently disappear
               --     for the user. The free-text shape is unchanged — only the
-              --     value format flips. (Migration 0019 / issue #360 finishes
-              --     the job by converting this column to a proper UUID FK and
-              --     dropping `user_subject`.)
+              --     value format flips.
               UPDATE user_setting us
                  SET user_subject = pu.id::text
                 FROM plugwerk_user pu

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0019_user_setting_user_id_fk.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0019_user_setting_user_id_fk.yaml
@@ -1,0 +1,184 @@
+# user_setting.user_subject (free text) → user_setting.user_id (uuid FK on
+# plugwerk_user). Issue #360.
+#
+# Background: every other user-referencing table was converted to a proper
+# UUID FK in #351 / migration 0017. user_setting was missed. Migration 0017
+# already rewrote the *values* in user_subject to plugwerk_user.id UUID
+# strings (see 0017_identity_hub_split.yaml changeset 0017-data-migration,
+# step 4f) — this migration just finishes the job by tightening the schema.
+#
+# Effects:
+#   - Adds user_id uuid FK with ON DELETE CASCADE so user deletes via
+#     /admin/users no longer leak orphan setting rows.
+#   - Drops the misleading user_subject column whose name implied "any JWT
+#     sub" but in practice held only UUIDs post-#351.
+#   - Replaces the (user_subject, setting_key) unique constraint with one
+#     on (user_id, setting_key). The constraint's btree index also serves
+#     prefix lookups by user_id alone, so no separate idx_user_setting_user_id
+#     is needed (the previous idx_user_setting_subject was redundant for the
+#     same reason).
+databaseChangeLog:
+  # ===========================================================================
+  # 1) Safety probe — abort if any user_subject is not UUID-shaped. After 0017
+  #    every value should be a canonical UUID; if this fires, 0017 missed a row
+  #    and we want a loud failure rather than an INSERT NULL or a cast crash.
+  # ===========================================================================
+  - changeSet:
+      id: 0019-precheck-all-user-subjects-are-uuids
+      author: plugwerk
+      preConditions:
+        - onFail: HALT
+        - sqlCheck:
+            expectedResult: 0
+            sql: >
+              SELECT count(*) FROM user_setting
+               WHERE user_subject !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      changes:
+        - sql:
+            sql: "SELECT 1"
+      rollback:
+        - sql:
+            sql: "SELECT 1"
+
+  # ===========================================================================
+  # 2) Add the new FK column nullable so the backfill (step 3) can populate it
+  #    before NOT NULL is enforced (step 4).
+  # ===========================================================================
+  - changeSet:
+      id: 0019-add-user-id-column
+      author: plugwerk
+      changes:
+        - addColumn:
+            tableName: user_setting
+            columns:
+              - column:
+                  name: user_id
+                  type: uuid
+      rollback:
+        - dropColumn:
+            tableName: user_setting
+            columnName: user_id
+
+  # ===========================================================================
+  # 3) Backfill: cast every existing user_subject to UUID. Safe because of
+  #    step 1's precondition — without that probe a single malformed row would
+  #    crash the whole migration.
+  # ===========================================================================
+  - changeSet:
+      id: 0019-backfill-user-id
+      author: plugwerk
+      changes:
+        - sql:
+            sql: |
+              UPDATE user_setting
+                 SET user_id = user_subject::uuid;
+      rollback:
+        - sql:
+            sql: |
+              UPDATE user_setting
+                 SET user_id = NULL;
+
+  # ===========================================================================
+  # 4) Lock down: NOT NULL + FK with ON DELETE CASCADE. CASCADE is the same
+  #    semantics #351 chose for namespace_member.user_id and
+  #    oidc_identity.user_id — deleting a user removes their setting rows
+  #    rather than leaving them orphaned.
+  # ===========================================================================
+  - changeSet:
+      id: 0019-user-id-not-null
+      author: plugwerk
+      changes:
+        - addNotNullConstraint:
+            tableName: user_setting
+            columnName: user_id
+            columnDataType: uuid
+      rollback:
+        - dropNotNullConstraint:
+            tableName: user_setting
+            columnName: user_id
+            columnDataType: uuid
+
+  - changeSet:
+      id: 0019-user-id-fk
+      author: plugwerk
+      changes:
+        - addForeignKeyConstraint:
+            constraintName: fk_user_setting_user
+            baseTableName: user_setting
+            baseColumnNames: user_id
+            referencedTableName: plugwerk_user
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: user_setting
+            constraintName: fk_user_setting_user
+
+  # ===========================================================================
+  # 5) Constraint + index swap. The new unique constraint creates a btree
+  #    index that also serves "WHERE user_id = ?" prefix lookups, so a
+  #    separate idx_user_setting_user_id would be redundant — same reason
+  #    idx_user_setting_subject was redundant before this migration.
+  # ===========================================================================
+  - changeSet:
+      id: 0019-drop-old-unique-and-index
+      author: plugwerk
+      changes:
+        - dropUniqueConstraint:
+            tableName: user_setting
+            constraintName: uq_user_setting_subject_key
+        - dropIndex:
+            tableName: user_setting
+            indexName: idx_user_setting_subject
+      rollback:
+        - createIndex:
+            tableName: user_setting
+            indexName: idx_user_setting_subject
+            columns:
+              - column:
+                  name: user_subject
+        - addUniqueConstraint:
+            tableName: user_setting
+            columnNames: user_subject, setting_key
+            constraintName: uq_user_setting_subject_key
+
+  - changeSet:
+      id: 0019-add-new-unique
+      author: plugwerk
+      changes:
+        - addUniqueConstraint:
+            tableName: user_setting
+            columnNames: user_id, setting_key
+            constraintName: uq_user_setting_user_key
+      rollback:
+        - dropUniqueConstraint:
+            tableName: user_setting
+            constraintName: uq_user_setting_user_key
+
+  # ===========================================================================
+  # 6) Drop the legacy column. Rollback recreates it and re-populates from
+  #    user_id::text so LiquibaseRollbackIT continues to land on a usable
+  #    schema state.
+  # ===========================================================================
+  - changeSet:
+      id: 0019-drop-user-subject
+      author: plugwerk
+      changes:
+        - dropColumn:
+            tableName: user_setting
+            columnName: user_subject
+      rollback:
+        - addColumn:
+            tableName: user_setting
+            columns:
+              - column:
+                  name: user_subject
+                  type: varchar(255)
+        - sql:
+            sql: |
+              UPDATE user_setting
+                 SET user_subject = user_id::text;
+        - addNotNullConstraint:
+            tableName: user_setting
+            columnName: user_subject
+            columnDataType: varchar(255)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NPlusOneRegressionTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/NPlusOneRegressionTest.kt
@@ -23,7 +23,9 @@ import io.plugwerk.server.countingStatements
 import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSettingEntity
+import io.plugwerk.server.domain.UserSource
 import io.plugwerk.server.service.settings.UserSettingKey
 import io.plugwerk.server.service.settings.UserSettingsService
 import io.plugwerk.spi.model.PluginStatus
@@ -139,17 +141,17 @@ class NPlusOneRegressionTest : AbstractRepositoryTest() {
 
     @Test
     fun `DB-018 UserSettingsService update uses statement count independent of number of keys`() {
-        val subjectSmall = "user-small"
-        val subjectLarge = "user-large"
+        val userSmall = seedTestUser("user-small")
+        val userLarge = seedTestUser("user-large")
         val allKeys = UserSettingKey.entries
 
         // Pre-seed so both updates hit the UPDATE path uniformly
         allKeys.forEach { key ->
             entityManager.persist(
-                UserSettingEntity(userSubject = subjectSmall, settingKey = key.key, settingValue = "x"),
+                UserSettingEntity(userId = userSmall, settingKey = key.key, settingValue = "x"),
             )
             entityManager.persist(
-                UserSettingEntity(userSubject = subjectLarge, settingKey = key.key, settingValue = "x"),
+                UserSettingEntity(userId = userLarge, settingKey = key.key, settingValue = "x"),
             )
         }
         entityManager.flush()
@@ -159,10 +161,10 @@ class NPlusOneRegressionTest : AbstractRepositoryTest() {
         val largeInput = allKeys.associate { it.key to it.defaultValue }
 
         val (_, smallCount) = entityManager.countingStatements {
-            userSettingsService.update(subjectSmall, smallInput)
+            userSettingsService.update(userSmall, smallInput)
         }
         val (_, largeCount) = entityManager.countingStatements {
-            userSettingsService.update(subjectLarge, largeInput)
+            userSettingsService.update(userLarge, largeInput)
         }
 
         assertThat(smallCount)
@@ -176,6 +178,25 @@ class NPlusOneRegressionTest : AbstractRepositoryTest() {
                 allKeys.size,
             )
             .isEqualTo(smallCount)
+    }
+
+    /**
+     * Persists a minimal LOCAL-source [UserEntity] and returns its assigned id.
+     * Required since #360 introduced a FK from `user_setting.user_id` to
+     * `plugwerk_user(id)` — the previous fixture seeded raw subject strings
+     * without backing user rows, which would now violate the constraint.
+     */
+    private fun seedTestUser(usernameSuffix: String): java.util.UUID {
+        val user = UserEntity(
+            displayName = "Test $usernameSuffix",
+            email = "$usernameSuffix@plugwerk.test",
+            source = UserSource.LOCAL,
+            username = usernameSuffix,
+            passwordHash = "\$2a\$12\$dummyhash",
+        )
+        entityManager.persist(user)
+        entityManager.flush()
+        return requireNotNull(user.id)
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/UserSettingUserIdFkMigrationIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/UserSettingUserIdFkMigrationIT.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import liquibase.Contexts
+import liquibase.LabelExpression
+import liquibase.Liquibase
+import liquibase.database.DatabaseFactory
+import liquibase.database.jvm.JdbcConnection
+import liquibase.resource.ClassLoaderResourceAccessor
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.postgresql.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.UUID
+
+/**
+ * Verifies migration 0019 — `user_setting.user_subject` (varchar) is replaced
+ * by a `user_id` UUID FK to `plugwerk_user(id)` with `ON DELETE CASCADE`
+ * (issue #360). The migration finishes the job migration 0017 started: 0017
+ * rewrote the *values* in `user_subject` to UUID strings, 0019 tightens the
+ * *schema* to match.
+ *
+ * Same Testcontainers-without-Spring pattern as `IdentityHubSplitMigrationIT`:
+ * we apply Liquibase up through 0018, seed pre-0019 fixture data with
+ * UUID-shaped `user_subject` values, then apply 0019 and assert the resulting
+ * schema + data + CASCADE behaviour.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UserSettingUserIdFkMigrationIT {
+
+    private lateinit var postgres: PostgreSQLContainer
+
+    private val userId = UUID.randomUUID()
+    private val otherUserId = UUID.randomUUID()
+
+    @BeforeAll
+    fun setUp() {
+        postgres = PostgreSQLContainer("postgres:18-alpine").apply { start() }
+        // Apply through 0018, then seed.
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            runLiquibaseUpTo(conn, "0019_user_setting_user_id_fk.yaml")
+            seedPreMigrationData(conn)
+        }
+        // Apply 0019.
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            runLiquibaseUpdate(conn)
+        }
+    }
+
+    @AfterAll
+    fun tearDown() {
+        postgres.stop()
+    }
+
+    /**
+     * Apply EVERYTHING then roll back the changesets in [stopBeforeFile] —
+     * mirrors the pattern from `IdentityHubSplitMigrationIT` and is safe
+     * because 0019 only touches `user_setting`, which `runLiquibaseUpdate`
+     * later re-applies cleanly.
+     */
+    private fun runLiquibaseUpTo(conn: Connection, stopBeforeFile: String) {
+        val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
+        Liquibase("db/changelog/db.changelog-master.yaml", ClassLoaderResourceAccessor(), database).use { liquibase ->
+            liquibase.update(Contexts(), LabelExpression())
+            val changesetCount = liquibase.databaseChangeLog.changeSets
+                .count { it.filePath.endsWith(stopBeforeFile) }
+            check(changesetCount > 0) { "no changesets found in $stopBeforeFile" }
+            liquibase.rollback(changesetCount, "")
+        }
+    }
+
+    private fun runLiquibaseUpdate(conn: Connection) {
+        val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
+        Liquibase("db/changelog/db.changelog-master.yaml", ClassLoaderResourceAccessor(), database).use { liquibase ->
+            liquibase.update(Contexts(), LabelExpression())
+        }
+    }
+
+    /**
+     * Seeds two `plugwerk_user` rows (FK target) and four `user_setting` rows:
+     * three for [userId] (covering the multi-row case the unique constraint
+     * has to handle) and one for [otherUserId] (to assert the CASCADE delete
+     * is scoped, not global).
+     */
+    private fun seedPreMigrationData(conn: Connection) {
+        conn.prepareStatement(
+            """
+            INSERT INTO plugwerk_user
+              (id, username, email, password_hash, source, display_name,
+               enabled, password_change_required, is_superadmin, created_at, updated_at)
+            VALUES (?, 'alice', 'alice@example.test', 'hash', 'LOCAL', 'Alice',
+              true, false, false, now(), now())
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.setObject(1, userId)
+            stmt.executeUpdate()
+        }
+        conn.prepareStatement(
+            """
+            INSERT INTO plugwerk_user
+              (id, username, email, password_hash, source, display_name,
+               enabled, password_change_required, is_superadmin, created_at, updated_at)
+            VALUES (?, 'bob', 'bob@example.test', 'hash', 'LOCAL', 'Bob',
+              true, false, false, now(), now())
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.setObject(1, otherUserId)
+            stmt.executeUpdate()
+        }
+
+        // Three settings for alice — uses UUID-shaped strings exactly like
+        // the post-0017 production data shape.
+        listOf("timezone" to "UTC", "default-namespace" to "ns1", "theme" to "dark").forEach { (k, v) ->
+            conn.prepareStatement(
+                """
+                INSERT INTO user_setting (id, user_subject, setting_key, setting_value, updated_at)
+                VALUES (?, ?, ?, ?, now())
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setObject(1, UUID.randomUUID())
+                stmt.setString(2, userId.toString())
+                stmt.setString(3, k)
+                stmt.setString(4, v)
+                stmt.executeUpdate()
+            }
+        }
+
+        // One setting for bob — survives if alice is deleted; gets removed if
+        // bob himself is deleted.
+        conn.prepareStatement(
+            """
+            INSERT INTO user_setting (id, user_subject, setting_key, setting_value, updated_at)
+            VALUES (?, ?, 'timezone', 'Europe/Berlin', now())
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.setObject(1, UUID.randomUUID())
+            stmt.setString(2, otherUserId.toString())
+            stmt.executeUpdate()
+        }
+    }
+
+    private inline fun <R> withConn(block: (Connection) -> R): R =
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use(block)
+
+    @Test
+    fun `0019 drops the legacy user_subject column`() = withConn { conn ->
+        conn.prepareStatement(
+            """
+            SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'user_setting' AND column_name = 'user_subject'
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                assertThat(rs.next()).`as`("user_subject column should be dropped").isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `0019 backfills user_id from the previous user_subject UUID strings`() = withConn { conn ->
+        conn.prepareStatement(
+            "SELECT user_id FROM user_setting WHERE setting_key = 'timezone' AND setting_value = 'UTC'",
+        ).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                assertThat(rs.getObject("user_id", UUID::class.java)).isEqualTo(userId)
+            }
+        }
+    }
+
+    @Test
+    fun `0019 user_id column is NOT NULL with the expected uuid type`() = withConn { conn ->
+        conn.prepareStatement(
+            """
+            SELECT is_nullable, data_type FROM information_schema.columns
+             WHERE table_name = 'user_setting' AND column_name = 'user_id'
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                assertThat(rs.getString("is_nullable")).isEqualTo("NO")
+                assertThat(rs.getString("data_type")).isEqualTo("uuid")
+            }
+        }
+    }
+
+    @Test
+    fun `0019 installs ON DELETE CASCADE FK on plugwerk_user`() = withConn { conn ->
+        conn.prepareStatement(
+            """
+            SELECT confdeltype FROM pg_constraint
+             WHERE conname = 'fk_user_setting_user'
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                check(rs.next()) { "fk_user_setting_user constraint should exist" }
+                // 'c' = CASCADE in pg_constraint.confdeltype.
+                assertThat(rs.getString("confdeltype")).isEqualTo("c")
+            }
+        }
+    }
+
+    @Test
+    fun `0019 unique constraint on user_id+setting_key blocks duplicates`() = withConn { conn ->
+        assertThatThrownBy {
+            conn.prepareStatement(
+                """
+                INSERT INTO user_setting (id, user_id, setting_key, setting_value, updated_at)
+                VALUES (?, ?, 'timezone', 'America/New_York', now())
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setObject(1, UUID.randomUUID())
+                stmt.setObject(2, userId)
+                stmt.executeUpdate()
+            }
+        }.isInstanceOf(SQLException::class.java)
+    }
+
+    @Test
+    fun `0019 deleting a plugwerk_user CASCADE-removes their user_setting rows`() = withConn { conn ->
+        // Sanity: alice has 3 settings before delete.
+        val before = countSettingsFor(conn, userId)
+        assertThat(before).isEqualTo(3)
+
+        conn.prepareStatement("DELETE FROM plugwerk_user WHERE id = ?").use { stmt ->
+            stmt.setObject(1, userId)
+            stmt.executeUpdate()
+        }
+
+        // After delete: alice has 0 settings, bob still has his 1.
+        assertThat(countSettingsFor(conn, userId)).isEqualTo(0)
+        assertThat(countSettingsFor(conn, otherUserId)).isEqualTo(1)
+    }
+
+    private fun countSettingsFor(conn: Connection, uid: UUID): Int {
+        conn.prepareStatement("SELECT count(*) FROM user_setting WHERE user_id = ?").use { stmt ->
+            stmt.setObject(1, uid)
+            stmt.executeQuery().use { rs ->
+                rs.next()
+                return rs.getInt(1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #360.

## Summary

Migration 0019 finishes what migration 0017 started: 0017 had already rewritten the *values* in `user_subject` to `plugwerk_user.id` UUID strings, but left the column as `varchar(255)` with no FK. This PR converts the schema to match the values:

- Adds `user_id uuid` column with `ON DELETE CASCADE` FK on `plugwerk_user(id)` — same pattern as `namespace_member.user_id` and `oidc_identity.user_id` since #351. User deletes via `/admin/users` no longer leak orphan setting rows.
- Drops the legacy `user_subject` column whose name implied "any JWT sub" but in practice only ever held UUIDs post-#351.
- Replaces the `(user_subject, setting_key)` unique constraint with one on `(user_id, setting_key)`. The constraint's btree index also serves `WHERE user_id = ?` lookups, so a separate `idx_user_setting_user_id` would be redundant — same reason `idx_user_setting_subject` was redundant before this migration. (Q4 in the planning round.)
- Migration is preceded by a Liquibase preCondition that aborts if any `user_subject` is not UUID-shaped — paranoia-guard against an unmigrated row sneaking past 0017.

## Code sweep — UUID end-to-end, no more String plumbing

- `UserSettingEntity`: `userSubject: String` → `userId: UUID` (schmale Variante; no `@ManyToOne` since the service does not navigate user fields).
- `UserSettingRepository`: `findByUserSubject` → `findByUserId` (Spring Data derives the new query from the rename).
- `UserSettingsService`: 4 method signatures `String` → `UUID`.
- `UserSettingsController`: drops the local `requireAuthenticatedSubject()` helper and uses `CurrentUserResolver.currentUserId()` (introduced in #336). The API-key 401 guard is preserved — `currentUserId()` throws `UnauthorizedException` for non-UUID auth names, which is exactly what `key:<id>` subjects produce.

## Acceptance criteria — all checked

- [x] `user_setting.user_subject` is gone.
- [x] `user_setting.user_id` is a non-null `uuid` FK to `plugwerk_user(id)` with `ON DELETE CASCADE`.
- [x] Unique constraint on `(user_id, setting_key)`. (No separate index — see PR description above.)
- [x] `UserSettingsService` and the repository use `UUID` end-to-end.
- [x] `UserSettingsController` uses `CurrentUserResolver.currentUserId()`; API-key callers still get 401.
- [x] Deleting a `plugwerk_user` row removes its `user_setting` rows (verified by `UserSettingUserIdFkMigrationIT`).
- [x] Liquibase rollback restores `user_subject` populated from `user_id::text` and the old constraint/index, so `LiquibaseRollbackIT` continues to pass.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green, incl. new `UserSettingUserIdFkMigrationIT` (6 cases: column dropped, backfill correctness, NOT NULL UUID type, CASCADE FK installed via `pg_constraint.confdeltype = 'c'`, unique-constraint blocks duplicates, end-to-end CASCADE delete).
- [x] `LiquibaseRollbackIT` exercises the down-migration end-to-end and passes.
- [ ] Manual smoke: log in, change a profile setting (timezone or default namespace), reload — setting persists.
- [ ] Manual smoke: delete a user via `/admin/users` — verify that user's `user_setting` rows are gone (psql or `SELECT count(*) FROM user_setting WHERE user_id = ?`).

## Related

- #336 — `CurrentUserResolver` consolidation (the helper this PR's controller now uses).
- #351 — identity-hub split (introduced the UUID-as-sub model that this PR finishes).
- Migration 0017 — already migrated the `user_subject` *values* but kept the *schema* shape; this PR finishes that job. A breadcrumb comment was added to 0017's data-migration step pointing at 0019.