### PR TITLE
feat(auth): 'Stay logged in' checkbox toggles refresh-cookie persistence (#317)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1799,6 +1799,15 @@ components:
           minLength: 1
           description: The account password (transmitted over HTTPS, never stored in plain text)
           example: changeme
+        rememberMe:
+          type: boolean
+          nullable: true
+          description: |
+            When true (default), the refresh cookie persists across browser restarts for
+            the configured TTL (7 days). When false, the cookie has no Max-Age attribute —
+            browsers drop it on close, giving the user a "shared computer" mode. The
+            server-side TTL on the refresh-token row is identical in both modes.
+          example: true
       required:
         - username
         - password

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
@@ -72,7 +72,9 @@ class AuthController(
         // the JWT subject + refresh-token row).
         val user = userRepository.findByUsernameAndSource(loginRequest.username, UserSource.LOCAL).orElse(null)
             ?: return ResponseEntity.status(401).build()
-        return issueLoginResponse(user)
+        // rememberMe absent OR explicit-null both default to true (#317): preserves
+        // the pre-flag behaviour for any client that has not been updated.
+        return issueLoginResponse(user, persistent = loginRequest.rememberMe ?: true)
     }
 
     /**
@@ -163,12 +165,24 @@ class AuthController(
             .build()
     }
 
-    /** Issues a fresh access token + refresh cookie pair for [user] and returns the response. */
-    private fun issueLoginResponse(user: UserEntity): ResponseEntity<LoginResponse> {
+    /**
+     * Issues a fresh access token + refresh cookie pair for [user] and returns the response.
+     *
+     * [persistent] controls the cookie's `Max-Age` attribute (#317):
+     *   - `true` (default): persistent cookie, survives browser restart.
+     *   - `false`: session cookie, dropped on browser close.
+     *
+     * The server-side refresh-token TTL is unaffected. Note: `/auth/refresh` does not
+     * carry the persistent flag forward — a session-cookie login is rotated to a
+     * persistent cookie on the first refresh round-trip. Tracked as a known limitation
+     * on #317; remembering the choice across rotations would need a column on
+     * `refresh_token` (out of scope for this issue).
+     */
+    private fun issueLoginResponse(user: UserEntity, persistent: Boolean = true): ResponseEntity<LoginResponse> {
         val userId = requireNotNull(user.id) { "User ${user.username} has no id — entity not persisted?" }
         val accessToken = jwtTokenService.generateToken(userId.toString())
         val refresh = refreshTokenService.issue(userId)
-        val cookie = refreshTokenCookieFactory.build(refresh.plaintext, refresh.maxAge)
+        val cookie = refreshTokenCookieFactory.build(refresh.plaintext, refresh.maxAge, persistent)
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, cookie.toString())
             .body(buildLoginResponse(user, accessToken))

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactory.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactory.kt
@@ -68,14 +68,28 @@ class RefreshTokenCookieFactory(private val props: PlugwerkProperties) {
         }
     }
 
-    /** Builds the cookie for a freshly-issued refresh token. */
-    fun build(plaintext: String, maxAge: Duration): ResponseCookie = ResponseCookie.from(COOKIE_NAME, plaintext)
-        .httpOnly(true)
-        .secure(props.auth.cookieSecure)
-        .sameSite(SAME_SITE)
-        .path(COOKIE_PATH)
-        .maxAge(maxAge)
-        .build()
+    /**
+     * Builds the cookie for a freshly-issued refresh token.
+     *
+     * [persistent] toggles the "Stay logged in" behaviour from #317:
+     *   - `true` (default): cookie carries `Max-Age=<refresh-TTL>` and survives
+     *     browser restarts — current behaviour, preserved for existing clients
+     *     that don't send the new flag.
+     *   - `false`: `Max-Age` is intentionally omitted. Per RFC 6265 §5.3 a
+     *     Set-Cookie without `Max-Age` and without `Expires` is a session
+     *     cookie that the browser drops on close. The server-side TTL on the
+     *     refresh-token row is identical either way; only the cookie's
+     *     persistence changes.
+     */
+    fun build(plaintext: String, maxAge: Duration, persistent: Boolean = true): ResponseCookie {
+        val builder = ResponseCookie.from(COOKIE_NAME, plaintext)
+            .httpOnly(true)
+            .secure(props.auth.cookieSecure)
+            .sameSite(SAME_SITE)
+            .path(COOKIE_PATH)
+        if (persistent) builder.maxAge(maxAge)
+        return builder.build()
+    }
 
     /** Builds a clearing cookie (empty value, `Max-Age=0`) for logout / failed refresh. */
     fun clear(): ResponseCookie = ResponseCookie.from(COOKIE_NAME, "")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
@@ -110,10 +111,16 @@ class AuthControllerTest {
                 rowId = UUID.randomUUID(),
             )
         }
-        whenever(refreshTokenCookieFactory.build(any(), any())).thenAnswer {
-            ResponseCookie.from("plugwerk_refresh", "stub-refresh-plaintext")
+        // Stub the 3-arg signature introduced in #317. Note the third arg
+        // (persistent) is a Boolean; the answer below faithfully toggles
+        // Max-Age so the persistent=false branch tests can assert on the
+        // returned header without re-stubbing.
+        whenever(refreshTokenCookieFactory.build(any(), any(), any())).thenAnswer { invocation ->
+            val persistent = invocation.arguments[2] as Boolean
+            val builder = ResponseCookie.from("plugwerk_refresh", "stub-refresh-plaintext")
                 .httpOnly(true).secure(false).sameSite("Strict").path("/api/v1/auth")
-                .maxAge(Duration.ofHours(168)).build()
+            if (persistent) builder.maxAge(Duration.ofHours(168))
+            builder.build()
         }
         whenever(refreshTokenCookieFactory.clear()).thenAnswer {
             ResponseCookie.from("plugwerk_refresh", "")
@@ -150,6 +157,86 @@ class AuthControllerTest {
             jsonPath("$.userId") { value(userId.toString()) }
             jsonPath("$.displayName") { value("Alice") }
         }
+    }
+
+    @Test
+    fun `POST login with rememberMe=true forwards persistent=true to the cookie factory`() {
+        stubValidLogin("alice", "secret")
+
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"username":"alice","password":"secret","rememberMe":true}"""
+        }.andExpect {
+            status { isOk() }
+            // Stub builds Max-Age=604800 (= 168h) when persistent=true.
+            header { string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=604800")) }
+        }
+
+        verify(refreshTokenCookieFactory).build(any(), any(), eq(true))
+    }
+
+    @Test
+    fun `POST login with rememberMe=false forwards persistent=false and the cookie has no Max-Age`() {
+        stubValidLogin("alice", "secret")
+
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"username":"alice","password":"secret","rememberMe":false}"""
+        }.andExpect {
+            status { isOk() }
+            header {
+                string(
+                    "Set-Cookie",
+                    org.hamcrest.Matchers.allOf(
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("Max-Age")),
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("Expires")),
+                        org.hamcrest.Matchers.containsString("HttpOnly"),
+                        org.hamcrest.Matchers.containsString("SameSite=Strict"),
+                        org.hamcrest.Matchers.containsString("Path=/api/v1/auth"),
+                    ),
+                )
+            }
+        }
+
+        verify(refreshTokenCookieFactory).build(any(), any(), eq(false))
+    }
+
+    @Test
+    fun `POST login without rememberMe field defaults to persistent=true (back-compat)`() {
+        stubValidLogin("alice", "secret")
+
+        mockMvc.post("/api/v1/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            // No rememberMe key in the body — pre-#317 client shape.
+            content = """{"username":"alice","password":"secret"}"""
+        }.andExpect {
+            status { isOk() }
+            header { string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=604800")) }
+        }
+
+        verify(refreshTokenCookieFactory).build(any(), any(), eq(true))
+    }
+
+    /**
+     * Shared stub for the three `rememberMe`-variant login tests so each test
+     * stays focused on the cookie behaviour rather than re-stating the user
+     * lookup / token-generation plumbing.
+     */
+    private fun stubValidLogin(username: String, password: String) {
+        val userId = UUID.randomUUID()
+        val user = UserEntity(
+            id = userId,
+            username = username,
+            displayName = "Alice",
+            email = "$username@example.test",
+            source = io.plugwerk.server.domain.UserSource.LOCAL,
+            passwordHash = "\$2a\$12\$hash",
+        )
+        whenever(credentialValidator.validate(username, password)).thenReturn(true)
+        whenever(jwtTokenService.generateToken(userId.toString())).thenReturn("tok.abc.xyz")
+        whenever(jwtTokenService.tokenValiditySeconds()).thenReturn(28800L)
+        whenever(userRepository.findByUsernameAndSource(username, io.plugwerk.server.domain.UserSource.LOCAL))
+            .thenReturn(Optional.of(user))
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactoryTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/**
+ * Pins the cookie-attribute contract for the refresh-cookie factory. The
+ * load-bearing assertion for issue #317 lives here: when `persistent=false`,
+ * the resulting Set-Cookie header has neither `Max-Age` nor `Expires`, while
+ * every other security attribute (`HttpOnly`, `Secure`, `SameSite=Strict`,
+ * `Path=/api/v1/auth`) stays untouched. RFC 6265 §5.3 promotes a cookie with
+ * neither expiry attribute to a session cookie that the browser drops on close.
+ */
+class RefreshTokenCookieFactoryTest {
+
+    private fun factory(cookieSecure: Boolean = true): RefreshTokenCookieFactory {
+        val props = PlugwerkProperties(
+            server = PlugwerkProperties.ServerProperties(baseUrl = "https://example.test"),
+            auth = PlugwerkProperties.AuthProperties(cookieSecure = cookieSecure),
+        )
+        return RefreshTokenCookieFactory(props)
+    }
+
+    @Test
+    fun `persistent default carries Max-Age matching the requested duration`() {
+        val cookie = factory().build("plain", Duration.ofDays(7))
+        val header = cookie.toString()
+
+        // 7 days = 604800 seconds — Spring's ResponseCookie serialises Max-Age
+        // in seconds, so the literal value is what the browser receives.
+        assertThat(header).contains("Max-Age=604800")
+        assertThat(header).contains("HttpOnly")
+        assertThat(header).contains("Secure")
+        assertThat(header).contains("SameSite=Strict")
+        assertThat(header).contains("Path=/api/v1/auth")
+    }
+
+    @Test
+    fun `explicit persistent=true is identical to the default`() {
+        val implicit = factory().build("plain", Duration.ofDays(7)).toString()
+        val explicit = factory().build("plain", Duration.ofDays(7), persistent = true).toString()
+        assertThat(explicit).isEqualTo(implicit)
+    }
+
+    @Test
+    fun `persistent=false produces a session cookie without Max-Age or Expires`() {
+        val cookie = factory().build("plain", Duration.ofDays(7), persistent = false)
+        val header = cookie.toString()
+
+        // The load-bearing assertion: neither expiry attribute may appear.
+        // Either one would convert the cookie back to persistent and defeat
+        // the entire point of the unticked checkbox.
+        assertThat(header).doesNotContain("Max-Age")
+        assertThat(header).doesNotContain("Expires")
+
+        // All other attributes must be unchanged — the cookie is still
+        // HttpOnly + Secure + SameSite=Strict + scoped to /api/v1/auth.
+        assertThat(header).contains("HttpOnly")
+        assertThat(header).contains("Secure")
+        assertThat(header).contains("SameSite=Strict")
+        assertThat(header).contains("Path=/api/v1/auth")
+        assertThat(header).startsWith("plugwerk_refresh=plain")
+    }
+
+    @Test
+    fun `persistent=false respects cookieSecure=false for plain-HTTP dev`() {
+        // Even when the operator opts out of `Secure` for local HTTP dev, the
+        // session-vs-persistent toggle must still work — they are independent
+        // dimensions.
+        val header = factory(cookieSecure = false).build("plain", Duration.ofDays(7), persistent = false).toString()
+        assertThat(header).doesNotContain("Max-Age")
+        assertThat(header).doesNotContain("Secure")
+        assertThat(header).contains("HttpOnly")
+    }
+
+    @Test
+    fun `clear cookie is unaffected by the persistent toggle`() {
+        // The clearing cookie always carries Max-Age=0 — this is how the
+        // browser is asked to delete the existing cookie. Issue #317 only
+        // changes the build path, not the clear path.
+        val header = factory().clear().toString()
+        assertThat(header).contains("Max-Age=0")
+        assertThat(header).contains("plugwerk_refresh=")
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.test.tsx
@@ -83,7 +83,9 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: /sign in/i }));
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith("alice", "secret");
+      // Default rememberMe=true preserves pre-#317 behaviour for any client
+      // that does not explicitly toggle the checkbox.
+      expect(mockLogin).toHaveBeenCalledWith("alice", "secret", true);
     });
   });
 
@@ -98,7 +100,9 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: /sign in/i }));
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith("alice", "secret");
+      // Default rememberMe=true preserves pre-#317 behaviour for any client
+      // that does not explicitly toggle the checkbox.
+      expect(mockLogin).toHaveBeenCalledWith("alice", "secret", true);
     });
   });
 
@@ -126,5 +130,48 @@ describe("LoginPage", () => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /close/i }));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // ─── #317 "Stay logged in" checkbox ────────────────────────────────────────
+
+  it("renders the Stay logged in checkbox checked by default", () => {
+    renderWithRouter(<LoginPage />);
+    const checkbox = screen.getByRole("checkbox", { name: /stay logged in/i });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeChecked();
+  });
+
+  it("forwards rememberMe=false to login when the checkbox is unticked", async () => {
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    useAuthStore.setState({ login: mockLogin } as never);
+
+    const user = userEvent.setup();
+    renderWithRouter(<LoginPage />);
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("checkbox", { name: /stay logged in/i }));
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith("alice", "secret", false);
+    });
+  });
+
+  it("forwards rememberMe=true after toggling the checkbox off and back on", async () => {
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    useAuthStore.setState({ login: mockLogin } as never);
+
+    const user = userEvent.setup();
+    renderWithRouter(<LoginPage />);
+    const checkbox = screen.getByRole("checkbox", { name: /stay logged in/i });
+    await user.click(checkbox); // off
+    await user.click(checkbox); // on again
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith("alice", "secret", true);
+    });
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -23,7 +23,9 @@ import {
   TextField,
   Button,
   Alert,
+  Checkbox,
   Divider,
+  FormControlLabel,
   Typography,
 } from "@mui/material";
 import { AuthCard } from "../components/auth/AuthCard";
@@ -49,6 +51,10 @@ export function LoginPage() {
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  // Default checked → preserves the pre-#317 behaviour where every login
+  // produced a 7-day persistent cookie. Unticking gives the user a
+  // shared-computer mode: cookie is dropped when the browser closes.
+  const [rememberMe, setRememberMe] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -61,7 +67,7 @@ export function LoginPage() {
     setError(null);
     setLoading(true);
     try {
-      await login(username.trim(), password);
+      await login(username.trim(), password, rememberMe);
       await useAuthStore.getState().initNamespace();
       const { passwordChangeRequired, namespace } = useAuthStore.getState();
       if (passwordChangeRequired) {
@@ -119,6 +125,20 @@ export function LoginPage() {
           required
           autoComplete="current-password"
           size="small"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={rememberMe}
+              onChange={(e) => setRememberMe(e.target.checked)}
+              size="small"
+              inputProps={{ "aria-label": "Stay logged in" }}
+            />
+          }
+          label="Stay logged in"
+          // Tighter vertical rhythm than the default — the form already has
+          // gap=2, an extra block of margin would make this feel detached.
+          sx={{ mt: -0.5, mb: -0.5 }}
         />
         <Button
           type="submit"

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/authStore.ts
@@ -60,7 +60,11 @@ interface AuthState {
   /** `true` until hydrate() has resolved (success or 401). Blocks initial API calls. */
   isHydrating: boolean;
 
-  login: (username: string, password: string) => Promise<void>;
+  login: (
+    username: string,
+    password: string,
+    rememberMe?: boolean,
+  ) => Promise<void>;
   logout: () => Promise<void>;
   hydrate: () => Promise<void>;
   setAuth: (fields: {
@@ -171,12 +175,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     });
   },
 
-  async login(username: string, password: string) {
+  async login(username: string, password: string, rememberMe: boolean = true) {
+    // `rememberMe` toggles the refresh-cookie's persistence (#317):
+    //   true  → cookie carries Max-Age=7d, survives browser restart (default).
+    //   false → no Max-Age, session-cookie shape, dropped on browser close.
+    // The server-side TTL on the refresh-token row is unchanged either way.
     const response = await fetch("/api/v1/auth/login", {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, rememberMe }),
     });
     if (!response.ok) {
       throw new Error("Invalid credentials");


### PR DESCRIPTION
Closes #317.

## Summary

Variant A from the issue: the checkbox controls only the refresh cookie's `Max-Age` attribute, not the server-side TTL. All security mechanisms (rotation, reuse-detection, CSRF double-submit, DB expiry) are **unchanged** — only the browser's notion of "this cookie survives a restart" is.

- **Checkbox ticked (default):** cookie carries `Max-Age=604800` (7d) → persists across browser restarts. Pre-#317 behaviour, preserved for any client that does not send the new flag.
- **Checkbox unticked:** `Max-Age` is intentionally omitted. Per RFC 6265 §5.3 a Set-Cookie without `Max-Age` and without `Expires` is a session cookie; browsers drop it on close. All other attributes (`HttpOnly`, `Secure`, `SameSite=Strict`, `Path=/api/v1/auth`) stay identical.

## Backend

- `LoginRequest` gains optional `rememberMe: Boolean`. Absent or explicit-null both default to `true` server-side.
- `RefreshTokenCookieFactory.build(plaintext, maxAge, persistent = true)` — default arg keeps existing 2-arg call sites compiling unchanged. The `OidcLoginSuccessHandler` and `/auth/refresh` paths continue to produce persistent cookies.
- `AuthController.login` forwards `loginRequest.rememberMe ?: true` to `issueLoginResponse(...)`.

## Frontend

- `authStore.login(username, password, rememberMe = true)` — third arg flows to the JSON body.
- `LoginPage` adds a "Stay logged in" checkbox between the password field and the Sign In button, default checked, `size="small"` to match the compact card layout. ARIA-labelled.

## Acceptance criteria — verified

- [x] `LoginRequest` DTO has optional `rememberMe`; default `true` to preserve current behaviour.
- [x] `RefreshTokenCookieFactory.build(...)` emits no `Max-Age` / `Expires` when `persistent=false`; other attributes unchanged.
- [x] `AuthController.login` passes `rememberMe ?: true` to the factory.
- [x] Frontend checkbox renders, default checked, value flows into the login request.
- [x] **Load-bearing factory test** (`RefreshTokenCookieFactoryTest`): `persistent=false` produces a Set-Cookie header without `Max-Age` and without `Expires`, all other attributes still present.
- [x] Controller tests: `rememberMe=true` ⇒ `Set-Cookie` contains `Max-Age=604800`; `rememberMe=false` ⇒ no `Max-Age`; absent ⇒ default `true`.
- [x] Frontend Vitest: checkbox state included in login request.
- [x] `authStore.noLocalStorage` regression guard stays green — `rememberMe` is not a credential and is not persisted anywhere.

## Known limitation (documented in code + here)

`rememberMe` only governs the **login** call. `/auth/refresh` continues to issue a persistent cookie on every rotation, so a `rememberMe=false` session is upgraded to persistent on the first refresh round-trip (typically within ~30 minutes of activity). Carrying the choice across rotations would need a `persistent` column on `refresh_token` — out of scope for this issue. Document, don't fix.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (incl. new `RefreshTokenCookieFactoryTest` + 3 new login-rememberMe cases).
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green.
- [x] `npm run test:run` — 318 tests pass (3 new LoginPage cases; existing tests updated for 3-arg login).
- [ ] Manual smoke: log in with checkbox unticked → close browser, reopen → land on `/login`. Log in with checkbox ticked → close browser, reopen → still authenticated.
- [ ] Manual smoke: DevTools → Application → Cookies → after unticked-login, `plugwerk_refresh` cookie has no Expires/Max-Age.

## Out of scope

- "Logout everywhere" button.
- Per-device session-management UI.
- Carrying `rememberMe` across `/auth/refresh` (would need a column on `refresh_token`).