### PR TITLE
ci: fix circular wait between prepare-release.yml and release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -111,6 +111,11 @@ jobs:
           git push origin main "v${{ inputs.release_version }}"
 
       - name: Wait for release workflow
+        # release.yml is triggered by the tag push (above) and owns the
+        # entire publish + GitHub-Release lifecycle — Maven Central,
+        # GitHub Packages, the GitHub Release itself, asset upload, and
+        # the website-sync dispatches. We just wait here so the operator
+        # sees the full chain green/red in one place.
         run: |
           PUSH_TIME="${{ steps.push.outputs.PUSH_TIME }}"
           TAG="v${{ inputs.release_version }}"
@@ -145,14 +150,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create GitHub Release
-        run: |
-          gh release create "v${{ inputs.release_version }}" \
-            --title "v${{ inputs.release_version }}" \
-            --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Notify downstream repositories
         if: success()
         run: |
@@ -184,5 +181,5 @@ jobs:
           echo "| Version bump to \`${{ inputs.release_version }}\` | ✅ |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Tag \`v${{ inputs.release_version }}\` created | ✅ |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Next snapshot \`${{ inputs.next_version }}\` | ✅ |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Maven Central publish | ✅ |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| GitHub Release created | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Maven Central publish (release.yml) | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GitHub Release created (release.yml) | ✅ |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,25 +97,25 @@ jobs:
           echo "📦 Collected artifacts:"
           ls -lh "$STAGING_DIR/"
 
+      - name: Create GitHub Release
+        # release.yml owns the GitHub Release lifecycle. Previously
+        # prepare-release.yml created it after waiting for release.yml to
+        # finish, while release.yml waited 5 minutes for that release to
+        # appear before falling back to creating it itself; the two
+        # workflows deadlocked and prepare-release's create step then
+        # failed with HTTP 422 "tag_name already exists". Now there is
+        # exactly one creator: this step.
+        run: |
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          echo "📦 Creating GitHub Release $TAG..."
+          gh release create "$TAG" --title "$TAG" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload assets to GitHub Release
         run: |
           STAGING_DIR="${{ steps.artifacts.outputs.STAGING_DIR }}"
           TAG="v${{ steps.version.outputs.VERSION }}"
-
-          # Wait for the GitHub Release to exist (created by prepare-release.yml)
-          for i in $(seq 1 30); do
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              break
-            fi
-            echo "  Waiting for GitHub Release $TAG to be created... ($i/30)"
-            sleep 10
-          done
-
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            echo "⚠️  GitHub Release $TAG not found — creating it now"
-            gh release create "$TAG" --title "$TAG" --generate-notes
-          fi
-
           echo "📤 Uploading assets to GitHub Release $TAG..."
           gh release upload "$TAG" "$STAGING_DIR"/* --clobber
           echo "✅ Assets uploaded"


### PR DESCRIPTION
## Background

The v1.0.0-beta.1 release surfaced a deadlock between the two release workflows. Both tried to be the canonical creator of the GitHub Release, neither knew about the other:

```
prepare-release.yml                  release.yml (triggered by tag push)
───────────────────                  ──────────────────────────────────
pushes tag v1.0.0-beta.1
                ─────► triggers ────► publishes to Maven Central +
                                      GitHub Packages, then …
"Wait for release workflow" ⏳        "Upload assets to GitHub Release"
                                      ⏳ waits up to 5 min for the
                                        GitHub Release to exist
                                      ⚠ fallback: creates the release
                                      ✓ uploads assets and finishes
unblocks
"Create GitHub Release"
💥 HTTP 422 — release.tag_name already exists
```

The 5-minute fallback in `release.yml` won the race; the terminal step in `prepare-release.yml` then failed with `422 Validation Failed` on duplicate tag. See [run 25021662694](https://github.com/plugwerk/plugwerk/actions/runs/25021662694/job/73283332850) for the live failure.

## Fix

Per operator preference, ownership of the GitHub Release lifecycle moves to `release.yml`. `prepare-release.yml` is now purely a **tag pusher + observer**.

- **`release.yml`** gains an explicit `Create GitHub Release` step that runs unconditionally between artifact collection and the upload step. The previous 5-minute wait loop and the conditional fallback are removed — there is now exactly one creator.
- **`prepare-release.yml`** drops its `Create GitHub Release` step entirely. It still pushes the version-bump commits + tag, waits for `release.yml` to complete (so the operator sees the full chain green/red in one place), and forwards downstream notifications. Step summary updated to attribute the Maven Central publish + GitHub Release creation to `release.yml`.

## Effects

- The redundant 5-minute wait disappears.
- The duplicate-create error disappears.
- The ownership boundary is now obvious from reading either workflow alone.
- No change to who runs the release (still operator-triggered via `prepare-release.yml`'s `workflow_dispatch`).

## Test plan

- [x] YAML syntax validated locally on both files.
- [ ] Verify on the next release that `release.yml` creates the GitHub Release without a wait loop and `prepare-release.yml` does not attempt a duplicate create.
- [ ] Verify the operator-facing step summary still lists all five status rows.