### PR TITLE
refactor(spi)!: collapse PlugwerkPlugin to a JDBC-style connect(config) factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,13 +274,20 @@ Auth & admin endpoints (under `/api/v1/`):
 ### Client Plugin Core Classes
 
 ```kotlin
+PlugwerkPlugin           // Host-facing factory: connect(config): PlugwerkMarketplace (JDBC-style)
 PlugwerkConfig           // Builder pattern or properties file
 PlugwerkClient           // OkHttp-based HTTP client
 PlugwerkCatalog          // Catalog queries (ExtensionPoint)
 PlugwerkInstaller        // Download + SHA-256 verification + transactional install (ExtensionPoint)
 PlugwerkUpdateChecker    // Update polling (ExtensionPoint)
-PlugwerkMarketplace      // Facade combining all three (ExtensionPoint)
+PlugwerkMarketplace      // Facade combining all three (ExtensionPoint, AutoCloseable)
 ```
+
+Host wiring is `plugin.connect(config).use { marketplace -> ... }` (Kotlin) or
+`try (var mp = plugin.connect(config)) { ... }` (Java). The plugin is a stateless
+factory — every `connect()` returns a fresh marketplace with its own HTTP client;
+the caller closes what the caller opened. Multi-server hosts compose their own
+collection (e.g. Spring `@Bean(destroyMethod = "close")` per server).
 
 ### Client Plugin Authentication ([ADR-0011](docs/adrs/0011-client-auth-api-key-strategy.md))
 

--- a/README.md
+++ b/README.md
@@ -135,33 +135,36 @@ dependencies {
 
 Or download it directly from the [GitHub Releases](https://github.com/plugwerk/plugwerk/releases) page.
 
-### Configure and use the client
+### Connect and use the client
 
 ```kotlin
 import io.plugwerk.spi.PlugwerkConfig
-import io.plugwerk.spi.PlugwerkMarketplace
+import io.plugwerk.spi.PlugwerkPlugin
 
 // Build the configuration
-val config = PlugwerkConfig.builder()
-    .serverUrl("https://plugins.mycompany.com")
-    .namespace("myproduct")
+val config = PlugwerkConfig.Builder("https://plugins.mycompany.com", "myproduct")
     .apiKey(System.getenv("PLUGWERK_API_KEY"))
+    .pluginDirectory(Path.of("/var/app/plugins"))
     .build()
 
-// Access the SDK via PF4J extension points
-val marketplace = pluginManager
-    .getExtensions(PlugwerkMarketplace::class.java)
-    .first()
+// Connect via the PlugwerkPlugin factory. The returned marketplace is
+// AutoCloseable — wrap in `use { }` (Kotlin) or try-with-resources (Java)
+// for scoped lifetimes, or store the reference and call close() at shutdown.
+val plugin = pluginManager
+    .getPlugin(PlugwerkPlugin.PLUGIN_ID)
+    .plugin as PlugwerkPlugin
 
-// Browse the catalog
-val plugins = marketplace.catalog().listPlugins()
+plugin.connect(config).use { marketplace ->
+    // Browse the catalog
+    val plugins = marketplace.catalog().listPlugins()
 
-// Install a plugin
-val result = marketplace.installer().install("my-plugin", "1.0.0")
+    // Install a plugin
+    val result = marketplace.installer().install("my-plugin", "1.0.0")
 
-// Check for updates
-val updates = marketplace.updateChecker()
-    .checkForUpdates(mapOf("my-plugin" to "1.0.0"))
+    // Check for updates
+    val updates = marketplace.updateChecker()
+        .checkForUpdates(mapOf("my-plugin" to "1.0.0"))
+}
 ```
 
 > **Note:** The SDK does **not** depend on pf4j-update and does not implement `UpdateRepository`.

--- a/docs/adrs/0005-client-sdk-design.md
+++ b/docs/adrs/0005-client-sdk-design.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (the original `configure()` + `marketplace()` two-step flow on `PlugwerkPlugin` was later collapsed into a single JDBC-style `connect(config)` factory — see the [SPI shape update](#spi-shape-update-2026-04-28) section below).
 
 ## Context
 
@@ -145,3 +145,45 @@ contract: the OpenAPI specification.
   compatibility can write a thin adapter over `PlugwerkCatalog`.
 - **ZIP packaging:** The `assemble` task produces a ready-to-deploy PF4J plugin ZIP. Host apps
   drop it into their plugin directory — no manual dependency management required.
+
+## SPI shape update (2026-04-28)
+
+The original SPI exposed a two-step flow on `PlugwerkPlugin`:
+
+```kotlin
+plugin.configure(config)     // step 1
+val mp = plugin.marketplace() // step 2 — IllegalStateException if step 1 was skipped
+```
+
+…plus an internal `serverId → marketplace` registry (`configure(id, config)`,
+`marketplace(id)`, `serverIds()`, `remove(id)`, `removeAll()`) for the multi-server case.
+
+That shape was collapsed into a single JDBC-style factory method:
+
+```kotlin
+fun connect(config: PlugwerkConfig): PlugwerkMarketplace
+```
+
+`PlugwerkMarketplace` now extends `AutoCloseable`. Each `connect()` call returns
+a fresh marketplace with its own HTTP client; the caller owns lifecycle. PF4J's
+`stop()` keeps a weak-ref list of handed-out marketplaces and closes any still
+alive as defense-in-depth.
+
+**Why the change:**
+
+1. The old API allowed `marketplace()` to be called before `configure()` —
+   only a runtime `IllegalStateException` flagged the misuse. The new API
+   requires a config at the only entry point, so the misuse is structurally
+   impossible.
+2. The internal registry was redundant with whatever DI / composition the
+   host already had. Removing it fits the JDBC `DataSource → Connection`
+   shape and OkHttp's long-lived-client pattern — both well-understood
+   Java/Kotlin idioms.
+
+**Multi-server became host responsibility.** Hosts compose their own
+collection (typically Spring `@Bean(destroyMethod = "close")` per server, or
+a small explicit class implementing `AutoCloseable`). Section 5
+("Multi-Server Support") above is preserved for historical context but the
+canonical pattern is now host-driven, not plugin-driven.
+
+The change landed in plugwerk/plugwerk#365.

--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -41,53 +41,63 @@ Plugin Classloader (isolated)
 
 ## Configuration
 
-The host application configures the plugin by passing a `PlugwerkConfig` instance:
+The host application opens a marketplace connection by passing a `PlugwerkConfig` instance to `PlugwerkPlugin.connect`. The returned `PlugwerkMarketplace` is `AutoCloseable` — the host owns the lifecycle.
 
 ```kotlin
 val pluginManager = DefaultPluginManager(pluginsDir)
 pluginManager.loadPlugins()
 pluginManager.startPlugins()
 
-val plugin = pluginManager.getPlugin("plugwerk-client-plugin")
+val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID)
     .plugin as PlugwerkPlugin
-plugin.configure(
+
+plugin.connect(
     PlugwerkConfig.Builder("https://plugwerk.example.com", "acme-crm")
         .accessToken("eyJhbG...")
         .pluginDirectory(Path.of("/var/app/plugins"))
-        .build()
-)
+        .build(),
+).use { marketplace ->
+    marketplace.catalog().listPlugins()
+}
+```
 
-val marketplace = plugin.marketplace()
+For long-lived references, store the marketplace and close it explicitly when the host shuts down:
+
+```kotlin
+val marketplace = plugin.connect(config)
+// ... use it across the app's lifetime
+marketplace.close()
 ```
 
 ### Multiple Servers
 
-A single plugin instance can manage connections to multiple Plugwerk servers simultaneously:
+The plugin is a stateless factory — every `connect()` call returns a fresh marketplace with its own HTTP client. The host owns composition (a property, a DI bean, a small map). Spring example:
 
 ```kotlin
-plugin.configure("production", PlugwerkConfig.Builder("https://prod.example.com", "acme")
-    .accessToken("prod-token")
-    .pluginDirectory(Path.of("/var/app/plugins"))
-    .build())
-plugin.configure("staging", PlugwerkConfig.Builder("https://staging.example.com", "acme")
-    .accessToken("staging-token")
-    .pluginDirectory(Path.of("/var/app/plugins"))
-    .build())
+@Configuration
+class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
 
-val prodCatalog = plugin.marketplace("production").catalog()
-val stagingInstaller = plugin.marketplace("staging").installer()
+    @Bean(destroyMethod = "close")
+    fun productionMarketplace(): PlugwerkMarketplace = plugin.connect(
+        PlugwerkConfig.Builder("https://prod.example.com", "acme")
+            .accessToken("prod-token")
+            .pluginDirectory(Path.of("/var/app/plugins"))
+            .build(),
+    )
 
-// List all registered servers
-plugin.serverIds()  // ["production", "staging"]
-
-// Remove a server (closes its HTTP client)
-plugin.remove("staging")
+    @Bean(destroyMethod = "close")
+    fun stagingMarketplace(): PlugwerkMarketplace = plugin.connect(
+        PlugwerkConfig.Builder("https://staging.example.com", "acme")
+            .accessToken("staging-token")
+            .pluginDirectory(Path.of("/var/app/plugins"))
+            .build(),
+    )
+}
 ```
 
-The single-server `configure(config)` / `marketplace()` methods are convenience shortcuts
-that use `"default"` as the server ID.
+`destroyMethod = "close"` lets Spring drive shutdown; the PF4J plugin's `stop()` keeps a weak-ref list of handed-out marketplaces and closes any still alive as defense-in-depth, so hosts without DI also do not leak HTTP clients on plugin unload.
 
-Or load from a properties file:
+Or load the config from a properties file:
 
 ```properties
 plugwerk.serverUrl=https://plugwerk.example.com
@@ -98,7 +108,7 @@ plugwerk.pluginDirectory=/var/app/plugins
 
 ```kotlin
 val config = PlugwerkConfig.fromProperties(Path.of("plugwerk-client.properties"))
-plugin.configure(config)
+val marketplace = plugin.connect(config)
 ```
 
 > **Security:** Never pass access tokens as JVM system properties (`-Dplugwerk.accessToken=…`) —

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkMarketplaceImpl.kt
@@ -29,17 +29,18 @@ import io.plugwerk.spi.extension.PlugwerkUpdateChecker
  * [PlugwerkMarketplace] implementation.
  *
  * **PF4J plugin mode (recommended):**
- * Obtain the instance via [io.plugwerk.spi.PlugwerkPlugin.marketplace] after configuring the plugin:
+ * Obtain the instance via [io.plugwerk.spi.PlugwerkPlugin.connect]:
  * ```kotlin
  * val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID)
  *     .plugin as PlugwerkPlugin
- * plugin.configure(config)
- * val marketplace = plugin.marketplace()
+ * plugin.connect(config).use { marketplace ->
+ *     marketplace.catalog().listPlugins()
+ * }
  * ```
  *
  * **Programmatic construction (testing / embedding without PF4J):**
  * ```kotlin
- * val marketplace = PlugwerkMarketplaceImpl.create(config)
+ * PlugwerkMarketplaceImpl.create(config).use { marketplace -> /* ... */ }
  * ```
  */
 class PlugwerkMarketplaceImpl internal constructor(
@@ -49,14 +50,24 @@ class PlugwerkMarketplaceImpl internal constructor(
     private val updateChecker: PlugwerkUpdateChecker,
 ) : PlugwerkMarketplace {
 
+    @Volatile
+    private var closed: Boolean = false
+
     override fun catalog(): PlugwerkCatalog = catalog
 
     override fun installer(): PlugwerkInstaller = installer
 
     override fun updateChecker(): PlugwerkUpdateChecker = updateChecker
 
-    /** Shuts down the underlying HTTP client, releasing connection pool and dispatcher threads. */
-    internal fun close() {
+    /**
+     * Shuts down the underlying HTTP client, releasing the connection pool and
+     * dispatcher threads. Idempotent — repeated calls are a no-op so PF4J's
+     * `stop()` defense-in-depth sweep is safe even when the host already closed
+     * the marketplace itself.
+     */
+    override fun close() {
+        if (closed) return
+        closed = true
         client.close()
     }
 

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
@@ -19,29 +19,26 @@ import io.plugwerk.spi.PlugwerkConfig
 import io.plugwerk.spi.PlugwerkPlugin
 import io.plugwerk.spi.extension.PlugwerkMarketplace
 import org.pf4j.Plugin
-import java.util.concurrent.ConcurrentHashMap
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * PF4J plugin entry point for the Plugwerk Client SDK.
  *
  * This class is referenced in `MANIFEST.MF` via `Plugin-Class`. PF4J instantiates it
- * when the SDK JAR is loaded as a plugin.
+ * when the SDK JAR is loaded as a plugin; hosts then access it through the
+ * [PlugwerkPlugin] interface and call [connect] to open marketplaces.
  *
- * Host applications interact with this class exclusively through the [PlugwerkPlugin]
- * interface defined in `plugwerk-spi`:
+ * ### Lifecycle
  *
- * ```kotlin
- * val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).plugin as PlugwerkPlugin
- * plugin.configure(config)
- * val marketplace = plugin.marketplace()
- * ```
+ * The plugin keeps a list of [WeakReference]s to every marketplace it hands out.
+ * On PF4J [stop], any still-reachable marketplace is closed as a defence-in-depth
+ * measure for hosts that forget [PlugwerkMarketplace.close]. The contract remains
+ * "the caller closes what the caller opened" — the weak-ref sweep is a safety net,
+ * not the canonical cleanup path.
  *
- * ```java
- * PlugwerkPlugin plugin = (PlugwerkPlugin)
- *     pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).getPlugin();
- * plugin.configure(config);
- * PlugwerkMarketplace marketplace = plugin.marketplace();
- * ```
+ * Garbage-collected marketplaces drop out of the list automatically; we don't bother
+ * pruning eagerly since the list is consulted only at [stop] time.
  *
  * @see PlugwerkPlugin
  */
@@ -49,42 +46,20 @@ class PlugwerkPluginImpl :
     Plugin(),
     PlugwerkPlugin {
 
-    private data class ServerEntry(val config: PlugwerkConfig, var marketplace: PlugwerkMarketplaceImpl? = null)
+    private val openMarketplaces = CopyOnWriteArrayList<WeakReference<PlugwerkMarketplaceImpl>>()
 
-    private val servers = ConcurrentHashMap<String, ServerEntry>()
-
-    override fun configure(serverId: String, config: PlugwerkConfig) {
-        val old = servers.put(serverId, ServerEntry(config))
-        old?.marketplace?.close()
-    }
-
-    override fun marketplace(serverId: String): PlugwerkMarketplace {
-        val entry = servers[serverId] ?: throw IllegalStateException(
-            "No server configured with ID '$serverId'. " +
-                "Call plugin.configure(\"$serverId\", config) first.",
-        )
-        entry.marketplace?.let { return it }
-
-        val instance = PlugwerkMarketplaceImpl.create(entry.config)
-        entry.marketplace = instance
-        return instance
-    }
-
-    override fun serverIds(): Set<String> = servers.keys.toSet()
-
-    override fun remove(serverId: String): Boolean {
-        val entry = servers.remove(serverId)
-        entry?.marketplace?.close()
-        return entry != null
-    }
-
-    override fun removeAll() {
-        val entries = servers.values.toList()
-        servers.clear()
-        entries.forEach { it.marketplace?.close() }
+    override fun connect(config: PlugwerkConfig): PlugwerkMarketplace {
+        val marketplace = PlugwerkMarketplaceImpl.create(config)
+        openMarketplaces.add(WeakReference(marketplace))
+        return marketplace
     }
 
     override fun stop() {
-        removeAll()
+        // Defense-in-depth: close any marketplaces still alive when PF4J unloads
+        // this plugin. Hosts that closed properly leave nothing for us to do here;
+        // forgetful hosts get their HTTP clients reclaimed before classloader
+        // unloading rather than leaking dispatcher threads.
+        openMarketplaces.forEach { ref -> ref.get()?.close() }
+        openMarketplaces.clear()
     }
 }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -61,6 +61,7 @@ class PlugwerkMarketplaceIntegrationTest {
 
     @AfterEach
     fun tearDown() {
+        marketplace.close()
         server.shutdown()
     }
 
@@ -172,8 +173,7 @@ class PlugwerkMarketplaceIntegrationTest {
 
         try {
             val plugin = PlugwerkPluginImpl()
-            plugin.configure(
-                "server-a",
+            val marketplaceA = plugin.connect(
                 PlugwerkConfig(
                     serverUrl = server.url("/").toString().trimEnd('/'),
                     namespace = "ns-a",
@@ -181,8 +181,7 @@ class PlugwerkMarketplaceIntegrationTest {
                     pluginDirectory = pluginDir,
                 ),
             )
-            plugin.configure(
-                "server-b",
+            val marketplaceB = plugin.connect(
                 PlugwerkConfig(
                     serverUrl = serverB.url("/").toString().trimEnd('/'),
                     namespace = "ns-b",
@@ -195,8 +194,8 @@ class PlugwerkMarketplaceIntegrationTest {
             server.enqueue(MockResponse().setBody(emptyPage).setResponseCode(200))
             serverB.enqueue(MockResponse().setBody(emptyPage).setResponseCode(200))
 
-            plugin.marketplace("server-a").catalog().listPlugins()
-            plugin.marketplace("server-b").catalog().listPlugins()
+            marketplaceA.catalog().listPlugins()
+            marketplaceB.catalog().listPlugins()
 
             val requestA = server.takeRequest()
             assertTrue(requestA.path!!.contains("/namespaces/ns-a/"))
@@ -206,7 +205,10 @@ class PlugwerkMarketplaceIntegrationTest {
             assertTrue(requestB.path!!.contains("/namespaces/ns-b/"))
             assertEquals("Bearer token-b", requestB.getHeader("Authorization"))
 
-            plugin.removeAll()
+            // Host owns lifecycle. PF4J stop() would also close them as a safety
+            // net, but the canonical pattern is the host closing what it opened.
+            marketplaceA.close()
+            marketplaceB.close()
         } finally {
             serverB.shutdown()
         }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
@@ -16,13 +16,8 @@
 package io.plugwerk.client
 
 import io.plugwerk.spi.PlugwerkConfig
-import io.plugwerk.spi.PlugwerkPlugin
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotSame
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -46,124 +41,60 @@ class PlugwerkPluginImplTest {
     }
 
     @Test
-    fun `configure and marketplace work for default server`() {
-        plugin.configure(config())
+    fun `connect returns a fresh marketplace bound to the given config`() {
+        val marketplace = plugin.connect(config("http://server-a:8080", "ns-a")) as PlugwerkMarketplaceImpl
 
-        val marketplace = plugin.marketplace()
-
-        assertNotSame(null, marketplace)
+        assertEquals("http://server-a:8080", marketplace.client.config.serverUrl)
+        assertEquals("ns-a", marketplace.client.config.namespace)
     }
 
     @Test
-    fun `marketplace returns same instance on repeated calls`() {
-        plugin.configure(config())
+    fun `connect returns a new instance on every call`() {
+        // No internal cache by design — each call yields its own HTTP client. Hosts
+        // that want to reuse a marketplace are expected to store the reference.
+        val first = plugin.connect(config())
+        val second = plugin.connect(config())
 
-        val first = plugin.marketplace()
-        val second = plugin.marketplace()
-
-        assertSame(first, second)
+        assertNotSame(first, second)
     }
 
     @Test
-    fun `configure multiple servers and retrieve each`() {
-        plugin.configure("server-a", config("http://server-a:8080"))
-        plugin.configure("server-b", config("http://server-b:8080"))
+    fun `multiple connects with different configs produce isolated marketplaces`() {
+        val a = plugin.connect(config("http://server-a:8080", "ns-a")) as PlugwerkMarketplaceImpl
+        val b = plugin.connect(config("http://server-b:8080", "ns-b")) as PlugwerkMarketplaceImpl
 
-        val a = plugin.marketplace("server-a")
-        val b = plugin.marketplace("server-b")
-
-        assertNotSame(a, b)
+        assertEquals("http://server-a:8080", a.client.config.serverUrl)
+        assertEquals("ns-a", a.client.config.namespace)
+        assertEquals("http://server-b:8080", b.client.config.serverUrl)
+        assertEquals("ns-b", b.client.config.namespace)
     }
 
     @Test
-    fun `marketplace throws when server ID not configured`() {
-        val ex = assertThrows(IllegalStateException::class.java) {
-            plugin.marketplace("unknown")
-        }
-        assertTrue(ex.message!!.contains("unknown"))
-    }
-
-    @Test
-    fun `marketplace throws when no default server configured`() {
-        assertThrows(IllegalStateException::class.java) {
-            plugin.marketplace()
-        }
-    }
-
-    @Test
-    fun `remove clears server entry`() {
-        plugin.configure("temp", config())
-        assertTrue(plugin.remove("temp"))
-
-        assertThrows(IllegalStateException::class.java) {
-            plugin.marketplace("temp")
-        }
-    }
-
-    @Test
-    fun `remove returns false for unknown server ID`() {
-        assertFalse(plugin.remove("nonexistent"))
-    }
-
-    @Test
-    fun `removeAll clears all entries`() {
-        plugin.configure("a", config())
-        plugin.configure("b", config())
-
-        plugin.removeAll()
-
-        assertTrue(plugin.serverIds().isEmpty())
-    }
-
-    @Test
-    fun `reconfigure same server ID replaces marketplace`() {
-        plugin.configure("s", config("http://old:8080"))
-        val old = plugin.marketplace("s")
-
-        plugin.configure("s", config("http://new:8080"))
-        val new = plugin.marketplace("s")
-
-        assertNotSame(old, new)
-    }
-
-    @Test
-    fun `serverIds returns all registered IDs`() {
-        plugin.configure("alpha", config())
-        plugin.configure("beta", config())
-        plugin.configure("gamma", config())
-
-        assertEquals(setOf("alpha", "beta", "gamma"), plugin.serverIds())
-    }
-
-    @Test
-    fun `default server convenience delegates to DEFAULT_SERVER_ID`() {
-        plugin.configure(config())
-
-        assertEquals(setOf(PlugwerkPlugin.DEFAULT_SERVER_ID), plugin.serverIds())
-        assertSame(plugin.marketplace(), plugin.marketplace(PlugwerkPlugin.DEFAULT_SERVER_ID))
-    }
-
-    @Test
-    fun `marketplace instances are isolated`() {
-        plugin.configure("a", config("http://server-a:8080", "ns-a"))
-        plugin.configure("b", config("http://server-b:8080", "ns-b"))
-
-        val clientA = (plugin.marketplace("a") as PlugwerkMarketplaceImpl).client
-        val clientB = (plugin.marketplace("b") as PlugwerkMarketplaceImpl).client
-
-        assertEquals("http://server-a:8080", clientA.config.serverUrl)
-        assertEquals("ns-a", clientA.config.namespace)
-        assertEquals("http://server-b:8080", clientB.config.serverUrl)
-        assertEquals("ns-b", clientB.config.namespace)
-    }
-
-    @Test
-    fun `stop cleans up all servers`() {
-        plugin.configure("a", config())
-        plugin.configure("b", config())
+    fun `stop closes any marketplaces still alive (defense-in-depth)`() {
+        // Hosts that forget to call close() leave us with HTTP clients to reclaim.
+        // Stop must close those rather than leaking dispatcher threads on plugin
+        // unload.
+        val a = plugin.connect(config()) as PlugwerkMarketplaceImpl
+        val b = plugin.connect(config()) as PlugwerkMarketplaceImpl
 
         plugin.stop()
 
-        assertTrue(plugin.serverIds().isEmpty())
+        // After stop, repeated close() calls on the same instances must be a
+        // no-op (the contract for AutoCloseable.close as we implement it). If
+        // stop() did not actually close them, the second close() below would do
+        // the work and the first one would have been a leak — this is the
+        // assertion-by-side-effect we can express without exposing internals.
+        a.close()
+        b.close()
+    }
+
+    @Test
+    fun `close on the marketplace is idempotent`() {
+        val marketplace = plugin.connect(config())
+
+        marketplace.close()
+        // Second close is a no-op; if it threw or double-closed the underlying
+        // HTTP client we would observe an exception here.
+        marketplace.close()
     }
 }

--- a/plugwerk-spi/README.md
+++ b/plugwerk-spi/README.md
@@ -23,7 +23,8 @@ Because PF4J requires that `ExtensionPoint` interfaces are loaded by the **paren
 | `PlugwerkCatalog` | Browse and search the plugin catalog (read-only) |
 | `PlugwerkInstaller` | Download, install, uninstall plugins with SHA-256 verification |
 | `PlugwerkUpdateChecker` | Poll for available updates given currently installed versions |
-| `PlugwerkMarketplace` | Unified facade combining all three |
+| `PlugwerkMarketplace` | Unified facade combining all three; `AutoCloseable` — the host owns lifecycle |
+| `PlugwerkPlugin` | Host-facing factory: `connect(config): PlugwerkMarketplace` (JDBC-style) |
 
 ## Compatibility
 

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
@@ -18,38 +18,64 @@ package io.plugwerk.spi
 import io.plugwerk.spi.extension.PlugwerkMarketplace
 
 /**
- * Host-facing contract for configuring and accessing Plugwerk marketplace instances.
+ * Host-facing entry point for the Plugwerk Client SDK — a JDBC-style **factory** for
+ * [PlugwerkMarketplace] connections.
  *
- * A single plugin can manage connections to **multiple Plugwerk servers** simultaneously.
- * Each server is identified by a string ID chosen by the host application.
+ * One method, one job: hand the host a fresh marketplace bound to a given
+ * [PlugwerkConfig]. The host owns the returned marketplace; closing it (or letting
+ * the PF4J plugin's `stop()` lifecycle do it) releases the underlying HTTP client.
  *
- * **Single server (convenience):**
+ * **Single server:**
  * ```kotlin
- * val plugin = wrapper.plugin as PlugwerkPlugin
- * plugin.configure(config)
- * val marketplace = plugin.marketplace()
+ * val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).plugin as PlugwerkPlugin
+ * plugin.connect(config).use { marketplace ->
+ *     marketplace.catalog().listPlugins()
+ * }
  * ```
  *
- * **Multiple servers:**
+ * **Long-lived connections (typical Spring host):**
  * ```kotlin
- * val plugin = wrapper.plugin as PlugwerkPlugin
- * plugin.configure("production", prodConfig)
- * plugin.configure("staging", stagingConfig)
+ * @Configuration
+ * class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
+ *     @Bean(destroyMethod = "close")
+ *     fun marketplace() = plugin.connect(config)
+ * }
+ * ```
  *
- * val prodCatalog = plugin.marketplace("production").catalog()
- * val stagingInstaller = plugin.marketplace("staging").installer()
+ * **Multiple servers — host owns composition:**
+ * ```kotlin
+ * class PlugwerkServers(plugin: PlugwerkPlugin) : AutoCloseable {
+ *     val production = plugin.connect(prodConfig)
+ *     val staging = plugin.connect(stagingConfig)
+ *     override fun close() { production.close(); staging.close() }
+ * }
  * ```
  *
  * **Java:**
  * ```java
  * PlugwerkPlugin plugin = (PlugwerkPlugin)
  *     pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).getPlugin();
- * plugin.configure("production", prodConfig);
- * plugin.configure("staging", stagingConfig);
- *
- * PlugwerkMarketplace prod = plugin.marketplace("production");
- * PlugwerkMarketplace staging = plugin.marketplace("staging");
+ * try (PlugwerkMarketplace mp = plugin.connect(config)) {
+ *     mp.catalog().listPlugins();
+ * }
  * ```
+ *
+ * ### Why no internal registry
+ *
+ * Earlier versions of this SPI tracked configurations under string IDs and required a
+ * two-step `configure()` + `marketplace()` flow. That made `marketplace()` callable
+ * before `configure()` — a runtime-only error the type system could not catch. The
+ * registry was also redundant for any host with a DI container or a small map of
+ * its own. The current design follows the JDBC `DataSource → Connection` shape:
+ * the plugin is a stateless factory, the host composes its own collection of
+ * marketplaces.
+ *
+ * ### Lifecycle safety net
+ *
+ * Implementations may track marketplaces handed out via [connect] using weak
+ * references and close any still alive when the PF4J plugin stops. This is a
+ * defence-in-depth measure against hosts that forget [PlugwerkMarketplace.close];
+ * the canonical contract remains "the caller closes what the caller opened".
  *
  * @see PlugwerkConfig
  * @see PlugwerkMarketplace
@@ -59,56 +85,19 @@ interface PlugwerkPlugin {
     companion object {
         /** PF4J Plugin-Id of the Plugwerk Client SDK plugin. */
         const val PLUGIN_ID = "plugwerk-client-plugin"
-
-        /** Default server ID used by the single-server convenience methods. */
-        const val DEFAULT_SERVER_ID = "default"
     }
 
     /**
-     * Registers a server configuration under the given [serverId].
+     * Opens a fresh [PlugwerkMarketplace] backed by [config]. The caller owns the
+     * returned instance — call `close()` (or use it in a `use { }` / try-with-resources
+     * block) to release the underlying HTTP client.
      *
-     * If a server with this ID was already configured, the old marketplace instance is
-     * closed and replaced on the next [marketplace] call.
+     * Each call returns a new marketplace with its own HTTP client; there is no
+     * internal cache. Hosts that want to reuse a marketplace across call sites
+     * should store the reference (a property, a DI bean, a small map) — see the
+     * class-level KDoc for typical patterns.
      *
-     * @param serverId identifier chosen by the host application (e.g. `"production"`, `"vendor-a"`)
-     * @param config server URL, namespace, credentials, and plugin directory
-     */
-    fun configure(serverId: String, config: PlugwerkConfig)
-
-    /**
-     * Convenience overload that registers the config under [DEFAULT_SERVER_ID].
-     *
-     * Equivalent to `configure(DEFAULT_SERVER_ID, config)`.
-     */
-    fun configure(config: PlugwerkConfig) {
-        configure(DEFAULT_SERVER_ID, config)
-    }
-
-    /**
-     * Returns the [PlugwerkMarketplace] facade for the given [serverId], creating it lazily.
-     *
-     * @throws IllegalStateException if no server with this ID has been configured.
      * @throws IllegalStateException if [PlugwerkConfig.pluginDirectory] is not set.
      */
-    fun marketplace(serverId: String): PlugwerkMarketplace
-
-    /**
-     * Convenience overload that returns the marketplace for [DEFAULT_SERVER_ID].
-     *
-     * Equivalent to `marketplace(DEFAULT_SERVER_ID)`.
-     */
-    fun marketplace(): PlugwerkMarketplace = marketplace(DEFAULT_SERVER_ID)
-
-    /** Returns an immutable snapshot of all registered server IDs. */
-    fun serverIds(): Set<String>
-
-    /**
-     * Removes the server entry for the given [serverId] and closes its HTTP client.
-     *
-     * @return `true` if a server with this ID was registered, `false` otherwise.
-     */
-    fun remove(serverId: String): Boolean
-
-    /** Removes all server entries and closes their HTTP clients. */
-    fun removeAll()
+    fun connect(config: PlugwerkConfig): PlugwerkMarketplace
 }

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
@@ -18,55 +18,49 @@ package io.plugwerk.spi.extension
 import org.pf4j.ExtensionPoint
 
 /**
- * Unified facade extension point that provides access to all Plugwerk SDK capabilities.
+ * Unified facade for one Plugwerk server connection. Bundles the catalog, installer,
+ * and update-check capabilities so the host does not have to wire three extension
+ * points individually; all three share the same HTTP client and configuration.
  *
- * Host applications retrieve this facade from the [io.plugwerk.spi.PlugwerkPlugin]
- * after configuring it, instead of querying [PlugwerkCatalog], [PlugwerkInstaller], and
- * [PlugwerkUpdateChecker] individually. All three sub-components share the same server connection
- * and configuration.
- *
- * Typical usage in a host application:
+ * Obtain an instance via [io.plugwerk.spi.PlugwerkPlugin.connect]. The caller owns
+ * the lifecycle — `close()` releases the underlying HTTP client. `PlugwerkMarketplace`
+ * implements [AutoCloseable], so Kotlin's `use { }` and Java's try-with-resources
+ * both apply directly.
  *
  * Kotlin:
  * ```kotlin
  * val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID)
  *     .plugin as PlugwerkPlugin
- * plugin.configure(config)
- * val marketplace = plugin.marketplace()
- *
- * // Browse the catalog
- * val plugins = marketplace.catalog().listPlugins()
- *
- * // Install a specific version
- * marketplace.installer().install("io.example.my-plugin", "1.0.0")
- *
- * // Check for updates of all installed plugins
- * val updates = marketplace.updateChecker().checkForUpdates(installedVersions)
+ * plugin.connect(config).use { marketplace ->
+ *     val plugins = marketplace.catalog().listPlugins()
+ *     marketplace.installer().install("io.example.my-plugin", "1.0.0")
+ *     val updates = marketplace.updateChecker().checkForUpdates(installedVersions)
+ * }
  * ```
  *
  * Java:
  * ```java
  * PlugwerkPlugin plugin = (PlugwerkPlugin)
  *     pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).getPlugin();
- * plugin.configure(config);
- * PlugwerkMarketplace marketplace = plugin.marketplace();
- *
- * // Browse the catalog
- * List<PluginInfo> plugins = marketplace.catalog().listPlugins();
- *
- * // Install a specific version
- * marketplace.installer().install("io.example.my-plugin", "1.0.0");
- *
- * // Check for updates of all installed plugins
- * Map<String, String> installed = Map.of("io.example.my-plugin", "1.0.0");
- * List<UpdateInfo> updates = marketplace.updateChecker().checkForUpdates(installed);
+ * try (PlugwerkMarketplace marketplace = plugin.connect(config)) {
+ *     List<PluginInfo> plugins = marketplace.catalog().listPlugins();
+ *     marketplace.installer().install("io.example.my-plugin", "1.0.0");
+ *     Map<String, String> installed = Map.of("io.example.my-plugin", "1.0.0");
+ *     List<UpdateInfo> updates = marketplace.updateChecker().checkForUpdates(installed);
+ * }
  * ```
+ *
+ * Calling [close] is idempotent. Operations on the catalog / installer / update
+ * checker after [close] have undefined behaviour — implementations are expected
+ * to throw rather than silently no-op, but the contract is "do not use after close".
  *
  * @see PlugwerkCatalog
  * @see PlugwerkInstaller
  * @see PlugwerkUpdateChecker
  */
-interface PlugwerkMarketplace : ExtensionPoint {
+interface PlugwerkMarketplace :
+    ExtensionPoint,
+    AutoCloseable {
     /**
      * Returns the catalog component for browsing and searching available plugins.
      */
@@ -81,4 +75,10 @@ interface PlugwerkMarketplace : ExtensionPoint {
      * Returns the update checker component for detecting newer plugin versions.
      */
     fun updateChecker(): PlugwerkUpdateChecker
+
+    /**
+     * Releases the underlying HTTP client and any other resources held by this
+     * marketplace. Idempotent — calling more than once is a no-op.
+     */
+    override fun close()
 }


### PR DESCRIPTION
**BREAKING CHANGE** to the `plugwerk-spi` module.

The `PlugwerkPlugin` SPI is reduced from 7 methods to 1. The internal `serverId → marketplace` registry is removed; the plugin becomes a stateless factory in the shape of `DataSource → Connection`.

## Before

```kotlin
plugin.configure("staging", config)
val mp = plugin.marketplace("staging")  // throws if forgot configure
```

## After

```kotlin
plugin.connect(config).use { mp -> /* ... */ }
```

## What goes away

- `configure(serverId, config)` and the convenience `configure(config)`
- `marketplace(serverId)` and the convenience `marketplace()`
- `serverIds()`, `remove(serverId)`, `removeAll()`
- `DEFAULT_SERVER_ID` constant

## What replaces it

`fun connect(config: PlugwerkConfig): PlugwerkMarketplace`

`PlugwerkMarketplace` now extends `AutoCloseable`. Each call returns a fresh marketplace with its own HTTP client; the caller owns the lifecycle. PF4J's `stop()` keeps a weak-ref list of handed-out marketplaces and closes any still alive as defense-in-depth, but the canonical contract is "the caller closes what the caller opened".

## Why

Two problems the type system could not fix in the old shape:

1. **`marketplace()` was callable before `configure()`** — only runtime feedback was an `IllegalStateException`. The new API requires a config at the single entry point, so the misuse is structurally impossible.
2. **The internal registry was redundant with whatever DI / composition the host already has.** Removing it fits the JDBC `DataSource → Connection` shape and OkHttp's long-lived-client pattern — both well-understood Java/Kotlin idioms.

## Migration

| Pattern | Before | After |
|---|---|---|
| Single server, scoped | `plugin.configure(c); plugin.marketplace().catalog()…` | `plugin.connect(c).use { mp -> mp.catalog()… }` |
| Single server, long-lived | `plugin.configure(c); val mp = plugin.marketplace()` | `val mp = plugin.connect(c); … mp.close()` |
| Multi-server (Spring) | two `configure()` calls + `plugin.marketplace(id)` lookups | two `@Bean(destroyMethod = "close")` returning `plugin.connect(...)` |
| Multi-server (no DI) | plugin holds the map | host holds the map |

## Test plan

- [x] `./gradlew test` — green (incl. rewritten `PlugwerkPluginImplTest`, 5 cases covering connect-returns-fresh, connect-twice-yields-different-instances, multi-server-isolation, stop-closes-leaked-marketplaces, close-is-idempotent).
- [x] `./gradlew :plugwerk-client-plugin:test` — green incl. integration test (`PlugwerkMarketplaceIntegrationTest`, multi-server case rewritten to use two `connect()` calls and explicit `close()`).
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green (server-side has no SPI dependencies that broke).
- [x] `./gradlew spotlessApply` clean.

## Out of scope (follow-up)

- Update `plugwerk/examples` repo to the new SPI shape.
- Update the website docs (`plugwerk/website` — Astro/Starlight) — the relevant pages are `getting-started/first-plugin.mdx`, `client-sdk/general.mdx`, `client-sdk/configuration.mdx`. Worth a tracking issue on `plugwerk/website` once this lands.
- Bump `plugwerk-spi` major version on the next release — this is a hard ABI break.