### PR TITLE
docs(readme): condense to essentials, fix Docker Compose env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,339 +2,89 @@
 
 **Self-Hosted Plugin Management and Marketplace Software for the Java/PF4J Ecosystem**
 
-Plugwerk is the missing link between [PF4J](https://github.com/pf4j/pf4j) and a product's plugin ecosystem. It gives you a central, self-hosted hub for publishing, versioning, distributing, and updating plugins at runtime — comparable to Maven Central for build dependencies, but designed for runtime plugins.
+Plugwerk is the missing link between [PF4J](https://github.com/pf4j/pf4j) and a product's plugin ecosystem: a central, self-hosted hub for publishing, versioning, distributing, and updating plugins at runtime. Application developers integrate the [`plugwerk-client-plugin`](plugwerk-client-plugin/) into their PF4J host; plugin developers upload artifacts via Web UI or REST API; operators run one server per organisation and serve multiple products via namespaces.
 
-## Who is Plugwerk for?
+📚 **Full documentation, guides, and API reference — [plugwerk.io](https://www.plugwerk.io)**
 
-| Role | How Plugwerk helps |
-|------|--------------------|
-| **Application developers** | Integrate the `plugwerk-client-plugin` into your PF4J-based application to let users discover, install, and update plugins at runtime — without shipping a new application release |
-| **Plugin developers** | Upload plugin artifacts via the Web UI or REST API, manage versions and metadata, and publish releases with a single API call from your CI/CD pipeline |
-| **Operations teams** | Deploy a self-hosted, Docker-based plugin management platform for your organization; one server can serve multiple products via namespaces |
+## Quick Start (Docker Compose)
 
-## How it works
-
-```
-Your Application                     Plugwerk Server
-┌────────────────────────────────┐    ┌─────────────────────────────┐
-│ PF4J PluginManager             │    │ REST API  /api/v1/...       │
-│  ↕ plugwerk-client-plugin      │◄──►│ Web UI    http://...        │
-│    PlugwerkMarketplace         │    │ PostgreSQL + Artifact Store │
-└────────────────────────────────┘    └─────────────────────────────┘
-         ↑ runtime install/update               ↑ upload via CI/CD
-         |                                      |
-  end users / admins                    plugin developers
-```
-
-A **namespace** scopes all plugins for one product (e.g. `acme-crm`). Plugin metadata is read from the standard `MANIFEST.MF` inside the artifact; the server extracts it automatically on upload.
-
-## Quick Start (Self-Hosted)
-
-### Prerequisites
-
-- Docker + Docker Compose
-
-### Start with Docker Compose
+Two secrets must be set before the server will start:
 
 ```bash
-git clone https://github.com/plugwerk/plugwerk.git
-cd plugwerk
+# Generate the required secrets
+echo "PLUGWERK_AUTH_JWT_SECRET=$(openssl rand -base64 32)" >  .env
+echo "PLUGWERK_AUTH_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> .env
+
+# Pull the published compose file and start the stack
+curl -sO https://www.plugwerk.io/deploy/docker-compose.yml
 docker compose up -d
 ```
 
-Wait for the server to be ready:
+Wait for `curl http://localhost:8080/actuator/health` to return `{"status":"UP"}`, then open the Web UI at [http://localhost:8080](http://localhost:8080).
 
-```bash
-curl http://localhost:8080/actuator/health
-# {"status":"UP"}
-```
-
-Open the Web UI at **http://localhost:8080**.
+See [`.env.example`](.env.example) for the full list of environment variables (CORS, storage, auth tuning).
 
 ### Initial admin credentials
 
-On first startup, Plugwerk creates a superadmin account with a **randomly generated password** and prints it once to the server log:
-
-```
-╔══════════════════════════════════════════════════════════╗
-║         Plugwerk — Initial Superadmin Password           ║
-║                                                          ║
-║  Username : admin                                        ║
-║  Password : <generated>                                  ║
-║                                                          ║
-║  Change this password immediately after first login.     ║
-╚══════════════════════════════════════════════════════════╝
-```
-
-Retrieve the password from the logs:
+On first startup, Plugwerk generates a random superadmin password and prints it once to the log:
 
 ```bash
 docker compose logs plugwerk-server | grep "Password :"
 ```
 
-You will be prompted to change the password on first login. The admin username is always `admin`.
+Username is always `admin`. You will be prompted to change the password on first login. For CI/CD or smoke-test environments, set `PLUGWERK_AUTH_ADMIN_PASSWORD` to a fixed value.
 
-> **CI/CD or smoke tests:** Set `PLUGWERK_AUTH_ADMIN_PASSWORD` to a fixed value to skip random generation and the forced password change.
+## API
 
-### Obtain a token and create a namespace
+Interactive API reference (Scalar) is served by every running instance:
 
-```bash
-# Login — use the password from the server log (see "Initial admin credentials" above)
-TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"<password-from-log>"}' | jq -r '.accessToken')
+- `http://localhost:8080/api-docs` — interactive
+- `http://localhost:8080/api-docs/openapi.yaml` — raw OpenAPI 3.1 spec
 
-# Create a namespace for your product
-curl -s -X POST http://localhost:8080/api/v1/namespaces \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"slug":"myproduct","name":"My Company","description":"My Company plugin namespace"}'
-```
+Hosted reference: [plugwerk.io/api-docs](https://www.plugwerk.io/api-docs/).
 
-### Upload and publish a plugin
-
-```bash
-# Upload a plugin JAR/ZIP — metadata is read automatically from MANIFEST.MF inside the artifact
-curl -s -X POST http://localhost:8080/api/v1/namespaces/myproduct/plugin-releases \
-  -H "Authorization: Bearer $TOKEN" \
-  -F "artifact=@my-plugin-1.0.0.jar"
-# Returns: {"id":"...","version":"1.0.0","status":"draft",...}
-
-# Publish the release (draft → published)
-RELEASE_ID="<id from above>"
-curl -s -X POST http://localhost:8080/api/v1/namespaces/myproduct/reviews/$RELEASE_ID/approve \
-  -H "Authorization: Bearer $TOKEN"
-
-# Browse the catalog
-curl -s http://localhost:8080/api/v1/namespaces/myproduct/plugins | jq .
-```
-
-## Integrating the Client Plugin into your Application
-
-The `plugwerk-client-plugin` is a PF4J plugin with an isolated classloader — it has no dependency conflicts with your application. Add it to your PF4J plugins directory and use it to connect to a Plugwerk server at runtime.
-
-### Add to your Gradle project
-
-```kotlin
-// build.gradle.kts
-dependencies {
-    // plugwerk-spi provides the ExtensionPoint interfaces
-    implementation("io.plugwerk:plugwerk-spi:<version>")
-}
-```
-
-The `plugwerk-client-plugin` ZIP is deployed as a PF4J plugin alongside your application's plugins, not as a compile-time dependency. Pull it from Maven Central using the `pf4j` classifier:
-
-```kotlin
-// Download the PF4J plugin ZIP
-val plugwerkPlugin by configurations.creating
-dependencies {
-    plugwerkPlugin("io.plugwerk:plugwerk-client-plugin:<version>:pf4j@zip")
-}
-```
-
-Or download it directly from the [GitHub Releases](https://github.com/plugwerk/plugwerk/releases) page.
-
-### Connect and use the client
-
-```kotlin
-import io.plugwerk.spi.PlugwerkConfig
-import io.plugwerk.spi.PlugwerkPlugin
-
-// Build the configuration
-val config = PlugwerkConfig.Builder("https://plugins.mycompany.com", "myproduct")
-    .apiKey(System.getenv("PLUGWERK_API_KEY"))
-    .pluginDirectory(Path.of("/var/app/plugins"))
-    .build()
-
-// Connect via the PlugwerkPlugin factory. The returned marketplace is
-// AutoCloseable — wrap in `use { }` (Kotlin) or try-with-resources (Java)
-// for scoped lifetimes, or store the reference and call close() at shutdown.
-val plugin = pluginManager
-    .getPlugin(PlugwerkPlugin.PLUGIN_ID)
-    .plugin as PlugwerkPlugin
-
-plugin.connect(config).use { marketplace ->
-    // Browse the catalog
-    val plugins = marketplace.catalog().listPlugins()
-
-    // Install a plugin
-    val result = marketplace.installer().install("my-plugin", "1.0.0")
-
-    // Check for updates
-    val updates = marketplace.updateChecker()
-        .checkForUpdates(mapOf("my-plugin" to "1.0.0"))
-}
-```
-
-> **Note:** The SDK does **not** depend on pf4j-update and does not implement `UpdateRepository`.
-> See [ADR-0005](docs/adrs/0005-client-sdk-design.md) for the rationale.
-
-### Plugin Metadata via `MANIFEST.MF`
-
-Plugwerk reads plugin metadata directly from the standard Java `MANIFEST.MF` inside your plugin JAR. PF4J-standard attributes are supported alongside custom `Plugin-*` headers:
-
-| MANIFEST.MF Attribute | Purpose | Required | PF4J Standard |
-|---|---|---|---|
-| `Plugin-Id` | Unique plugin identifier | **Yes** | Yes |
-| `Plugin-Version` | SemVer version | **Yes** | Yes |
-| `Plugin-Class` | Plugin class name | No | Yes |
-| `Plugin-Provider` | Provider/organisation | No | Yes |
-| `Plugin-Description` | Short description | No | Yes |
-| `Plugin-Dependencies` | Comma-separated deps | No | Yes |
-| `Plugin-Requires` | SemVer range for host | No | Yes |
-| `Plugin-License` | SPDX license | No | Yes |
-| `Plugin-Name` | Display name | No | No (custom) |
-| `Plugin-Tags` | Comma-separated tags | No | No (custom) |
-| `Plugin-Icon` | Icon URL/path | No | No (custom) |
-| `Plugin-Screenshots` | Comma-separated URLs | No | No (custom) |
-| `Plugin-Homepage` | Project URL | No | No (custom) |
-| `Plugin-Repository` | Source code URL | No | No (custom) |
-
-Example `MANIFEST.MF`:
-
-```
-Plugin-Id: com.example.my-plugin
-Plugin-Version: 1.2.0
-Plugin-Class: com.example.MyPlugin
-Plugin-Provider: ACME GmbH
-Plugin-Description: Exports reports as PDF with configurable templates
-Plugin-License: Apache-2.0
-Plugin-Requires: >=2.0.0 & <4.0.0
-Plugin-Dependencies: com.example.template-engine@>=1.0.0
-Plugin-Tags: pdf,report,export
-```
-
-If `MANIFEST.MF` is absent, the server falls back to `plugin.properties`.
-
-## API Documentation
-
-Interactive API reference powered by [Scalar](https://scalar.com/) — open in the browser after starting the server:
-
-```
-http://localhost:8080/api-docs
-```
-
-Raw OpenAPI 3.1 spec:
-
-```
-http://localhost:8080/api-docs/openapi.yaml
-```
-
-## Environment Variables
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `PLUGWERK_AUTH_JWT_SECRET` | **yes** | — | HMAC-SHA256 signing secret, minimum 32 characters. Generate with `openssl rand -base64 32`. |
-| `PLUGWERK_AUTH_ENCRYPTION_KEY` | **yes** | — | AES encryption key for OIDC client secrets at rest, exactly 16 characters. Generate with `openssl rand -hex 8`. |
-| `PLUGWERK_AUTH_ADMIN_PASSWORD` | no | _(random)_ | Fixed initial admin password. When set, skips random generation and the forced password change. When absent, a random password is generated and logged once. |
-| `PLUGWERK_DB_URL` | no | `jdbc:postgresql://localhost:5432/plugwerk` | PostgreSQL JDBC URL |
-| `PLUGWERK_DB_USERNAME` | no | `plugwerk` | Database username |
-| `PLUGWERK_DB_PASSWORD` | no | `plugwerk` | Database password |
-| `PLUGWERK_BASE_URL` | no | `http://localhost:8080` | Public base URL of the server (used for artifact download links) |
-| `PLUGWERK_STORAGE_ROOT` | no | `/var/plugwerk/artifacts` | Filesystem path for storing artifact binaries |
-| `PLUGWERK_STORAGE_TYPE` | no | `fs` | Storage backend: `fs` (filesystem) |
-| `PLUGWERK_SERVER_CORS_ALLOWED_ORIGINS` | no | _(empty = same-origin)_ | Comma-separated origins allowed to make cross-origin requests (e.g. `http://localhost:5173` for the Vite dev server). See [ADR-0021](docs/adrs/0021-cors-same-origin-default.md). |
-| `PLUGWERK_SERVER_CORS_ALLOWED_METHODS` | no | `GET,POST,PUT,PATCH,DELETE,OPTIONS` | Comma-separated HTTP methods for cross-origin requests |
-| `PLUGWERK_SERVER_CORS_ALLOWED_HEADERS` | no | `Authorization,Content-Type,X-Api-Key` | Comma-separated request headers for cross-origin requests |
-| `PLUGWERK_SERVER_CORS_ALLOW_CREDENTIALS` | no | `true` | Whether browsers may include credentials. Must be `false` when `PLUGWERK_SERVER_CORS_ALLOWED_ORIGINS=*`. |
-| `PLUGWERK_SERVER_CORS_MAX_AGE` | no | `3600` | Preflight cache duration in seconds (0..86400) |
-
-> **Tip:** Copy `.env.example` to `.env` and fill in the required values. The `.env` file is git-ignored.
-
-## Key Features
-
-- Searchable plugin catalog with full-text search, category and tag filters
-- Plugin upload via Web UI or REST API (CI/CD-ready)
-- SemVer-based versioning with compatibility ranges (`requires: >=2.0.0 & <4.0.0`)
-- SHA-256 checksum verification for artifact integrity
-- `plugins.json` catalog feed (familiar format for teams migrating from pf4j-update)
-- Review/approval workflow before releases are published
-- Multi-namespace support: one server serves multiple products/organizations
-- Self-hosted via Docker Compose (open source, AGPL-3.0)
-
-## Development Setup
-
-### Prerequisites
-
-- JDK 21+
-- Node.js 20+
-- Docker (for PostgreSQL)
-
-### Run locally
-
-```bash
-# Start PostgreSQL
-docker compose up -d postgres
-
-# Build all modules
-./gradlew build
-
-# Start the server
-./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
-```
-
-The server starts at `http://localhost:8080`. The Vite dev server (frontend with hot reload) starts separately:
-
-```bash
-cd plugwerk-server/plugwerk-server-frontend
-npm run dev
-# Frontend available at http://localhost:5173 (proxies /api → localhost:8080)
-```
-
-### E2E Smoke Test
-
-```bash
-./scripts/smoke-test.sh
-```
-
-Runs the full upload → catalog → download flow against a Docker Compose stack.
-
-### Build Commands
-
-| Command | Description |
-|---------|-------------|
-| `./gradlew build` | Build all modules + run all tests |
-| `./gradlew build -x test` | Build without tests |
-| `./gradlew :plugwerk-api:openApiGenerate` | Regenerate backend DTOs/interfaces from OpenAPI spec |
-| `./gradlew :plugwerk-server:plugwerk-server-backend:bootRun` | Start the backend server (port 8080) |
-| `npm run dev` | Start the Vite frontend dev server (port 5173) |
-| `npm run generate:api` | Regenerate TypeScript client from OpenAPI spec |
-| `npm run test:run` | Run frontend tests (Vitest) |
-| `npm run test:coverage` | Frontend tests with V8 coverage report |
-
-## Module Structure
+## Repository Layout
 
 ```
 plugwerk/
-├── plugwerk-api/                  # OpenAPI 3.1 spec (API-First) + generated DTOs/interfaces
-├── plugwerk-spi/                  # Shared ExtensionPoint interfaces, DTOs, constants (JVM 11)
-├── plugwerk-descriptor/           # MANIFEST.MF parser/validator + plugin.properties fallback (JVM 11)
+├── plugwerk-api/                  # OpenAPI 3.1 spec + generated DTOs/interfaces
+├── plugwerk-spi/                  # Shared ExtensionPoint interfaces (JVM 11)
+├── plugwerk-descriptor/           # MANIFEST.MF parser + plugin.properties fallback (JVM 11)
 ├── plugwerk-server/
-│   ├── plugwerk-server-backend/   # Spring Boot 4.x + Kotlin REST API (JVM 21)
-│   └── plugwerk-server-frontend/  # React + TypeScript + Material UI + Zustand (embedded in server JAR)
-├── plugwerk-client-plugin/        # PF4J plugin with isolated classloader: OkHttp + Jackson (JVM 17)
-└── examples/
-    └── plugwerk-java-cli-example/ # End-to-end example: CLI app with dynamically loaded plugins
+│   ├── plugwerk-server-backend/   # Spring Boot 4 + Kotlin REST API (JVM 21)
+│   └── plugwerk-server-frontend/  # React + TypeScript + MUI (embedded in server JAR)
+└── plugwerk-client-plugin/        # PF4J plugin: OkHttp + Jackson (JVM 17)
 ```
 
-## Documentation
+Companion repositories:
 
-- [Interactive API Reference](http://localhost:8080/api-docs) (requires running server)
-- [Example: Java CLI Application](examples/plugwerk-java-cli-example/README.md)
-- [Product Concept (EN)](docs/concepts/concept-pf4j-marketplace-en.md)
-- [Produktkonzept (DE)](docs/concepts/concept-pf4j-marketplace-de.md)
-- [Architecture Decision Records](docs/adrs/)
+- **[plugwerk/website](https://github.com/plugwerk/website)** — documentation site sources for [plugwerk.io](https://www.plugwerk.io)
+- **[plugwerk/examples](https://github.com/plugwerk/examples)** — runnable example host applications integrating the client plugin
+
+## Development
+
+Prerequisites: JDK 21+, Node.js 20+, Docker.
+
+```bash
+# Postgres only (server runs from Gradle)
+docker compose up -d postgres
+
+# Build everything + run all tests
+./gradlew build
+
+# Backend at http://localhost:8080
+./gradlew :plugwerk-server:plugwerk-server-backend:bootRun
+
+# Frontend with hot reload at http://localhost:5173
+cd plugwerk-server/plugwerk-server-frontend && npm run dev
+```
+
+For local HTTP dev set `PLUGWERK_AUTH_COOKIE_SECURE=false` — browsers drop `Secure` cookies over plain HTTP otherwise. See [`.env.example`](.env.example) for the full list and [`AGENTS.md`](AGENTS.md) for project conventions.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-- Language: **English** for all code, docs, issues, and reviews
-- Branches: `feature/<issue-id>_<short-description>` — never commit directly to `main`
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/) format
-- Use the issue and PR templates in `.github/`
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Conventional Commits format, branches `feature/<issue-id>_<short-description>`, no direct commits to `main`. PRs use the templates in [`.github/`](.github/).
 
 ## License
 
-[AGPL-3.0](LICENSE)
+[AGPL-3.0](LICENSE).


### PR DESCRIPTION
Follow-up to #365. The README condensation was originally pushed to the merged-PR branch in error and never made it onto `main` — this PR brings it over via a clean cherry-pick.

## Summary

The README had grown to 340 lines with significant content overlap with [plugwerk.io](https://www.plugwerk.io) — full Quick Start curl walkthrough, MANIFEST.MF metadata table, 12-row environment-variable table, and an integration code example. Most of it duplicates the website and rots independently.

- Trim to ~90 lines: tagline, Quick Start (Docker Compose with secret generation), admin-password retrieval, API URLs, repo layout, dev setup, contributing, license. Everything else links to plugwerk.io.
- **Fix Quick Start.** The previous flow showed `git clone` + `docker compose up -d` without mentioning that `PLUGWERK_AUTH_JWT_SECRET` and `PLUGWERK_AUTH_ENCRYPTION_KEY` must be set, so the server would fail to start on a fresh machine. New flow generates both secrets via `openssl rand -base64 32` into `.env` and pulls the compose file from plugwerk.io.
- **Drop in-tree references to `examples/`** — the example projects moved to the separate [plugwerk/examples](https://github.com/plugwerk/examples) repo. Add a "Companion repositories" section pointing at `plugwerk/website` and `plugwerk/examples`.
- Drop the integration code example, MANIFEST.MF metadata table, full env-vars table, build-commands table, E2E smoke-test snippet, and ADR-0005 cross-link from the README prose. The website covers all of those at greater depth and is auto-synced with each release.

## Test plan

- [x] No remaining references to `examples/` paths (`grep -nE "examples/|plugwerk-java-cli-example"` → 0 hits).
- [x] Docker Compose snippet pulls the published compose file from plugwerk.io and generates both required secrets.
- [x] All in-tree links (`AGENTS.md`, `.env.example`, `LICENSE`, `CONTRIBUTING.md`, `.github/`) resolve.