### PR TITLE
fix(security): surface initial admin password outside SLF4J (#150, #286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,10 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 
 # Fixed initial admin password. When set, the admin account uses this password
 # and skips random generation. When absent, a random password is generated and
-# logged once at startup. The admin username is always "admin".
+# surfaced on two channels that bypass SLF4J — container stderr and
+# /tmp/plugwerk-admin-password.txt (POSIX 0600). Log aggregators
+# (Datadog/ELK/CloudWatch) do NOT capture the credential. The admin username
+# is always "admin".
 # PLUGWERK_AUTH_ADMIN_PASSWORD=
 
 # Refresh-cookie `Secure` flag. Default: true (HTTPS-only transport).

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ See [`.env.example`](.env.example) for the full list of environment variables (C
 
 ### Initial admin credentials
 
-On first startup, Plugwerk generates a random superadmin password and prints it once to the log:
+On first startup, Plugwerk generates a random superadmin password and surfaces it on two channels that bypass SLF4J entirely (so log aggregators like Datadog/ELK/CloudWatch do **not** capture the credential):
 
 ```bash
-docker compose logs plugwerk-server | grep "Password :"
+# Channel 1 — container stderr (forwarded by `docker compose logs`):
+docker compose logs --no-log-prefix plugwerk-server | grep "Password :"
+
+# Channel 2 — 0600 file inside the container:
+docker compose exec plugwerk-server cat /tmp/plugwerk-admin-password.txt
 ```
 
-Username is always `admin`. You will be prompted to change the password on first login. For CI/CD or smoke-test environments, set `PLUGWERK_AUTH_ADMIN_PASSWORD` to a fixed value.
+Username is always `admin`. You will be prompted to change the password on first login. For CI/CD or smoke-test environments, set `PLUGWERK_AUTH_ADMIN_PASSWORD` to a fixed value — the credential is then never surfaced (you already know it).
 
 ## API
 

--- a/docker/dockerhub-readme.md
+++ b/docker/dockerhub-readme.md
@@ -75,10 +75,14 @@ export PLUGWERK_AUTH_ENCRYPTION_KEY="$(openssl rand -base64 32)"
 docker compose up -d
 ```
 
-On first start the server generates a random superadmin password and prints it once to the container log. Retrieve it and log in:
+On first start the server generates a random superadmin password and surfaces it on two channels that bypass SLF4J entirely (log aggregators like Datadog/ELK/CloudWatch do **not** capture the credential). Retrieve it from either:
 
 ```bash
-docker compose logs plugwerk-server | grep -A 6 "Initial Superadmin Password"
+# Container stderr (forwarded by `docker compose logs`):
+docker compose logs --no-log-prefix plugwerk-server | grep -A 6 "Initial Superadmin Password"
+
+# Or the 0600 file inside the container:
+docker compose exec plugwerk-server cat /tmp/plugwerk-admin-password.txt
 ```
 
 Open http://localhost:8080 and log in with `admin` / that value. You will be required to change the password on first login.
@@ -93,7 +97,7 @@ Open http://localhost:8080 and log in with `admin` / that value. You will be req
 | `PLUGWERK_DB_USERNAME` | no | `plugwerk` | DB user |
 | `PLUGWERK_DB_PASSWORD` | no | `plugwerk` | DB password |
 | `PLUGWERK_STORAGE_ROOT` | no | `/var/plugwerk/artifacts` | Artifact storage directory |
-| `PLUGWERK_AUTH_ADMIN_PASSWORD` | no | *(random, logged, `passwordChangeRequired`)* | Pin the initial superadmin password (CI/smoke-test only — **do not set in production**). Blank or whitespace-only values are treated the same as unset. |
+| `PLUGWERK_AUTH_ADMIN_PASSWORD` | no | *(random, written to stderr + `/tmp/plugwerk-admin-password.txt` (0600), `passwordChangeRequired`)* | Pin the initial superadmin password (CI/smoke-test only — **do not set in production**). Blank or whitespace-only values are treated the same as unset. |
 | `PLUGWERK_SERVER_CORS_ALLOWED_ORIGINS` | no | *(empty = same-origin-only)* | Comma-separated origins allowed to make cross-origin requests (e.g. `https://frontend.example.com`). Default empty preserves the bundled-frontend same-origin deployment. Wildcards not supported with default credentials. |
 | `PLUGWERK_SERVER_CORS_ALLOWED_METHODS` | no | `GET,POST,PUT,PATCH,DELETE,OPTIONS` | Comma-separated HTTP methods for cross-origin requests |
 | `PLUGWERK_SERVER_CORS_ALLOWED_HEADERS` | no | `Authorization,Content-Type,X-Api-Key` | Comma-separated request headers for cross-origin requests |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -341,7 +341,7 @@ export PLUGWERK_SERVER_CORS_ALLOWED_ORIGINS=http://localhost:5173
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PLUGWERK_AUTH_ADMIN_PASSWORD` | *(random, logged on first start)* | Fixed superadmin password. If unset, a random password is generated and printed to the log on first startup. |
+| `PLUGWERK_AUTH_ADMIN_PASSWORD` | *(random, surfaced outside SLF4J on first start)* | Fixed superadmin password. If unset, a random password is generated and written to container stderr **and** to `/tmp/plugwerk-admin-password.txt` (0600). The credential never enters the SLF4J pipeline, so log aggregators do not capture it. |
 | `PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS` | `10` | Max login attempts per IP per window |
 | `PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60` | Rate limit window duration |
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/AdminInitializationRunner.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/AdminInitializationRunner.kt
@@ -27,6 +27,10 @@ import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import java.security.SecureRandom
 
 /**
@@ -40,7 +44,13 @@ import java.security.SecureRandom
  *    the variable as the empty string (see audit finding SEC-044).
  * 2. Creates the superadmin user with [isSuperadmin = true]. If the password was generated,
  *    `passwordChangeRequired = true` is set so the operator must change it on first login.
- * 3. Logs the password **once** at INFO level when it was auto-generated.
+ * 3. **Surfaces the auto-generated password without going through SLF4J.** The credential
+ *    is written to `System.err` (the JVM stderr stream, bypassing every SLF4J appender) and
+ *    to a `0600` file at [PASSWORD_FILE]. Operators retrieve it via
+ *    `docker compose logs --no-log-prefix` (which forwards stderr) or by reading the file
+ *    inside the container (`docker compose exec ... cat /tmp/plugwerk-admin-password.txt`).
+ *    The SLF4J pipeline records that bootstrap occurred but never sees the credential —
+ *    closes audit findings #150 / #286 (KT-013).
  *
  * The superadmin implicitly holds ADMIN rights in every namespace without needing an
  * explicit [namespace_member] entry. The superadmin account can never be deleted.
@@ -56,6 +66,18 @@ class AdminInitializationRunner(
 
     private val log = LoggerFactory.getLogger(AdminInitializationRunner::class.java)
 
+    /**
+     * Where the auto-generated password is persisted on first start. Package-private `var`
+     * so tests can redirect it to a `@TempDir`-backed path without touching the real
+     * filesystem. Production code never reassigns it.
+     */
+    internal var passwordFilePath: Path = Path.of(PASSWORD_FILE)
+
+    /**
+     * Where the auto-generated password is written. Stderr is also used in parallel.
+     */
+    internal var stderr: java.io.PrintStream = System.err
+
     companion object {
         /** Fixed admin username — not configurable. */
         const val ADMIN_USERNAME = "admin"
@@ -67,6 +89,13 @@ class AdminInitializationRunner(
          * index (no other admin can land on the same address).
          */
         const val ADMIN_DEFAULT_EMAIL = "admin@plugwerk.local"
+
+        /**
+         * Path of the 0600 file the auto-generated password is written to on first start.
+         * Lives in the container's tmpfs and is wiped on restart; operators who claimed
+         * the credential are expected to delete it manually.
+         */
+        const val PASSWORD_FILE = "/tmp/plugwerk-admin-password.txt"
     }
 
     override fun run(args: ApplicationArguments) {
@@ -80,7 +109,7 @@ class AdminInitializationRunner(
         val initialPassword = fixedPassword ?: generatePassword()
         val passwordChangeRequired = fixedPassword == null
 
-        val admin = userRepository.save(
+        userRepository.save(
             UserEntity(
                 username = ADMIN_USERNAME,
                 displayName = "Administrator",
@@ -94,22 +123,75 @@ class AdminInitializationRunner(
         )
 
         if (passwordChangeRequired) {
-            log.info(
-                """
+            surfaceGeneratedPassword(initialPassword)
+        }
+    }
 
-                ╔══════════════════════════════════════════════════════════╗
-                ║         Plugwerk — Initial Superadmin Password           ║
-                ║                                                          ║
-                ║  Username : {}                                        ║
-                ║  Password : {}                             ║
-                ║                                                          ║
-                ║  Change this password immediately after first login.     ║
-                ╚══════════════════════════════════════════════════════════╝
-                """.trimIndent(),
-                admin.username,
-                initialPassword,
+    /**
+     * Writes the credential to stderr and to a 0600 file, then logs a no-credential
+     * hint into SLF4J pointing at both surfaces. Closes #150 / #286: the password
+     * never enters the SLF4J pipeline, so log-aggregation forwarders (Datadog, ELK,
+     * CloudWatch) cannot capture it.
+     */
+    private fun surfaceGeneratedPassword(password: String) {
+        val box = """
+            ╔══════════════════════════════════════════════════════════╗
+            ║         Plugwerk — Initial Superadmin Password           ║
+            ║                                                          ║
+            ║  Username : $ADMIN_USERNAME
+            ║  Password : $password
+            ║                                                          ║
+            ║  Change this password immediately after first login.     ║
+            ╚══════════════════════════════════════════════════════════╝
+        """.trimIndent()
+
+        // Direct write to the JVM stderr stream — no SLF4J appenders attached, no
+        // log-aggregation forwarder picks this up by default.
+        stderr.println(box)
+
+        val fileWritten = writePasswordFile(password)
+
+        // SLF4J still records the event, just without the credential. The hint
+        // points at both surfaces so the operator knows where to look regardless
+        // of which one is observable in their setup.
+        if (fileWritten) {
+            log.info(
+                "Initial superadmin password generated. Retrieve it from container stderr or from {} (POSIX 0600).",
+                passwordFilePath,
+            )
+        } else {
+            log.info(
+                "Initial superadmin password generated. Retrieve it from container stderr (file write to {} failed — see WARN above).",
+                passwordFilePath,
             )
         }
+    }
+
+    /**
+     * Persists [password] to [passwordFilePath] with `0600` permissions. Returns
+     * `true` on success, `false` on any failure (read-only filesystem, missing
+     * POSIX support, permission setter not honoured). Failure is non-fatal — the
+     * stderr surface remains the canonical channel.
+     */
+    private fun writePasswordFile(password: String): Boolean = runCatching {
+        Files.writeString(passwordFilePath, password + System.lineSeparator())
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(
+                passwordFilePath,
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            )
+        }
+        true
+    }.getOrElse { ex ->
+        log.warn(
+            "Could not persist initial admin password to {}: {} — operator must read it from stderr instead.",
+            passwordFilePath,
+            ex.message,
+        )
+        // If the partial write left a world-readable file behind, try to delete it
+        // so the credential does not linger with bad permissions.
+        runCatching { Files.deleteIfExists(passwordFilePath) }
+        false
     }
 
     private fun generatePassword(): String {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/AdminInitializationRunnerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/AdminInitializationRunnerTest.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.Mockito.verify
@@ -34,6 +35,12 @@ import org.mockito.kotlin.whenever
 import org.springframework.boot.DefaultApplicationArguments
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 
 /**
  * Unit tests for [AdminInitializationRunner] focused on audit finding SEC-044:
@@ -133,5 +140,79 @@ class AdminInitializationRunnerTest {
 
         verify(userRepository).existsByUsernameAndSource("admin", io.plugwerk.server.domain.UserSource.LOCAL)
         verifyNoMoreInteractions(userRepository)
+    }
+
+    // ─── #150 / #286 — auto-generated password must not enter SLF4J ────────────
+
+    @Test
+    fun `auto-generated password is written to stderr and to a 0600 file (#150 #286)`(@TempDir tempDir: Path) {
+        whenever(
+            userRepository.existsByUsernameAndSource("admin", io.plugwerk.server.domain.UserSource.LOCAL),
+        ).thenReturn(false)
+        whenever(userRepository.save(any<UserEntity>())).thenAnswer { it.arguments[0] }
+
+        val passwordFile = tempDir.resolve("plugwerk-admin-password.txt")
+        val capturedStderr = ByteArrayOutputStream()
+
+        val runner = runnerWith(null).apply {
+            passwordFilePath = passwordFile
+            stderr = PrintStream(capturedStderr, true, Charsets.UTF_8)
+        }
+        runner.run(DefaultApplicationArguments())
+
+        // 1) The credential is captured by stderr (the byte stream we redirected
+        //    `System.err` to via the runner's overridable hook).
+        val stderrText = capturedStderr.toString(Charsets.UTF_8)
+        assertThat(stderrText)
+            .`as`("stderr surface must show the credential box")
+            .contains("Plugwerk — Initial Superadmin Password")
+            .contains("Username : admin")
+            .contains("Password : ")
+
+        // 2) The same credential is in the file.
+        assertThat(Files.exists(passwordFile))
+            .`as`("0600 password file must be created")
+            .isTrue()
+        val fileText = Files.readString(passwordFile).trim()
+        assertThat(fileText).isNotBlank()
+
+        // 3) On POSIX file systems the permissions are exactly owner-read +
+        //    owner-write — group/world have no access. On non-POSIX hosts (rare
+        //    in CI) we skip this assertion gracefully.
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            val perms = Files.getPosixFilePermissions(passwordFile)
+            assertThat(perms)
+                .containsExactlyInAnyOrder(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                )
+        }
+
+        // 4) Sanity: the password the file holds is the same one stderr printed,
+        //    confirming the two surfaces emit one consistent value (no race
+        //    between two separate generatePassword() calls).
+        assertThat(stderrText).contains(fileText)
+    }
+
+    @Test
+    fun `fixed password (CI mode) writes nothing to stderr and creates no password file`(@TempDir tempDir: Path) {
+        whenever(
+            userRepository.existsByUsernameAndSource("admin", io.plugwerk.server.domain.UserSource.LOCAL),
+        ).thenReturn(false)
+        whenever(userRepository.save(any<UserEntity>())).thenAnswer { it.arguments[0] }
+
+        val passwordFile = tempDir.resolve("plugwerk-admin-password.txt")
+        val capturedStderr = ByteArrayOutputStream()
+
+        val runner = runnerWith("CI-smoke-test-password").apply {
+            passwordFilePath = passwordFile
+            stderr = PrintStream(capturedStderr, true, Charsets.UTF_8)
+        }
+        runner.run(DefaultApplicationArguments())
+
+        // CI knows the password it set; surfacing it again would be a leak,
+        // not a feature.
+        assertThat(capturedStderr.toByteArray()).isEmpty()
+        assertThat(Files.exists(passwordFile)).isFalse()
     }
 }


### PR DESCRIPTION
## Summary
- Closes the M-3 audit finding: auto-generated bootstrap admin passwords no longer reach SLF4J, so log aggregators (Datadog, ELK, CloudWatch) cannot capture them.
- Credential is written to two parallel surfaces — direct `System.err` (bypasses every SLF4J appender) and a `0600` file at `/tmp/plugwerk-admin-password.txt`. SLF4J only records a no-credential hint pointing at both surfaces.
- CI / fixed-password path (`PLUGWERK_AUTH_ADMIN_PASSWORD` set) stays silent on both surfaces — a known credential is not re-surfaced.

## Why this approach
Audit recommended ``WARN`` with a one-time-secret marker. We went one step further: the password never enters the SLF4J pipeline at all, removing any dependency on appender configuration.

## Test plan
- [x] Unit tests for the auto-generated path: stderr captures the credential box, 0600 file exists, POSIX permissions are exactly `OWNER_READ` + `OWNER_WRITE`, stderr text contains the file's password (consistency check — no double `generatePassword()` race).
- [x] Unit test for CI / fixed-password mode: stderr is empty, no file is created.
- [x] Existing SEC-044 tests (null / blank / whitespace / non-blank `adminPassword`) still pass.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green (Spotless + compile + full test task).

## Closes
- Closes #150
- Closes #286