### PR TITLE
ci(security): add backend SBOM CVE scan via CycloneDX + trivy sbom (#297)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -74,3 +74,113 @@ jobs:
           name: trivy-sarif-report
           path: trivy-results.sarif
           retention-days: 30
+
+  # Backend runtime-classpath CVE scan via CycloneDX SBOM + `trivy sbom`.
+  # Closes coverage gap from issue #297 / audit calibration note: `trivy fs`
+  # cannot parse `build.gradle.kts`, so the Kotlin backend classpath was
+  # invisible to the pre-merge gate. See ADR-0030.
+  backend-sbom-scan:
+    name: Backend SBOM vulnerability scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+
+      - name: Generate CycloneDX SBOM (runtimeClasspath)
+        run: ./gradlew :plugwerk-server:plugwerk-server-backend:cyclonedxDirectBom --no-daemon
+
+      # Smoke test: assert the SBOM actually covers the runtime classpath.
+      # If any of these four transitive deps of spring-boot-starter-web are
+      # missing, the scan would silently degrade — fail loudly instead.
+      - name: SBOM smoke test (#297 acceptance criterion)
+        run: |
+          set -euo pipefail
+          BOM=plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          for purl_fragment in tomcat-embed-core jackson-databind logback-classic spring-boot-starter-web; do
+            count=$(jq --arg p "$purl_fragment" '[.components[] | select(.purl | contains($p))] | length' "$BOM")
+            if [ "$count" -lt 1 ]; then
+              echo "::error::SBOM missing expected component: $purl_fragment"
+              exit 1
+            fi
+          done
+          total=$(jq '.components | length' "$BOM")
+          echo "SBOM smoke test passed ($total components)"
+
+      # Hard gate: CRITICAL CVE in the runtime classpath fails the build.
+      - name: Trivy SBOM scan (CRITICAL — fail on findings)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: sbom
+          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          format: sarif
+          output: trivy-backend-sbom-critical.sarif
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: false
+          scanners: vuln
+
+      # Soft gate: HIGH findings warn but do not fail.
+      - name: Trivy SBOM scan (HIGH — warn only)
+        if: always()
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: sbom
+          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          format: sarif
+          output: trivy-backend-sbom-high.sarif
+          severity: HIGH
+          exit-code: '0'
+          ignore-unfixed: false
+          scanners: vuln
+
+      # MEDIUM kept in JSON-only artefact for offline review.
+      - name: Trivy SBOM scan (MEDIUM — artefact only)
+        if: always()
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: sbom
+          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          format: json
+          output: trivy-backend-sbom-medium.json
+          severity: MEDIUM
+          exit-code: '0'
+          ignore-unfixed: false
+          scanners: vuln
+
+      # Upload CRITICAL+HIGH SARIF to the Security tab. Separate `category` from
+      # the `trivy` job above so GitHub does not de-dupe and overwrite either.
+      - name: Upload CRITICAL SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        if: always()
+        with:
+          sarif_file: trivy-backend-sbom-critical.sarif
+          category: trivy-backend-sbom-critical
+
+      - name: Upload HIGH SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        if: always()
+        with:
+          sarif_file: trivy-backend-sbom-high.sarif
+          category: trivy-backend-sbom-high
+
+      - name: Upload backend SBOM scan artefacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: trivy-backend-sbom-report
+          path: |
+            plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+            trivy-backend-sbom-critical.sarif
+            trivy-backend-sbom-high.sarif
+            trivy-backend-sbom-medium.json
+          retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,9 +116,25 @@ jobs:
           total=$(jq '.components | length' "$BOM")
           echo "SBOM smoke test passed ($total components)"
 
-      # Human-readable summary printed BEFORE the gating steps so findings
-      # are visible in the job log even when CRITICAL fails the build.
-      # Renders to GitHub Step Summary too — same content, two surfaces.
+      # Single Trivy invocation produces machine-readable JSON across CRITICAL,
+      # HIGH and MEDIUM. Gating logic (CRITICAL fail / HIGH warn / MEDIUM info)
+      # runs on this file via jq. Using JSON instead of SARIF here is deliberate:
+      # trivy-action's `severity` filter does NOT apply to SARIF output, so a
+      # SARIF-driven gate would fire on any finding regardless of severity.
+      - name: Trivy SBOM scan (JSON for gating logic)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: sbom
+          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          format: json
+          output: trivy-backend-sbom.json
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: '0'
+          ignore-unfixed: false
+          scanners: vuln
+
+      # Human-readable table for the job log. Identical input as the JSON step
+      # above; ensures findings are visible without digging into artefacts.
       - name: Trivy SBOM scan (table summary for log)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
@@ -154,62 +170,52 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Hard gate: CRITICAL CVE in the runtime classpath fails the build.
-      - name: Trivy SBOM scan (CRITICAL — fail on findings)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: sbom
-          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
-          format: sarif
-          output: trivy-backend-sbom-critical.sarif
-          severity: CRITICAL
-          exit-code: '1'
-          ignore-unfixed: false
-          scanners: vuln
+      # Custom severity gate: count findings per severity bucket via jq, fail
+      # the build only on CRITICAL. HIGH/MEDIUM emit annotations but do not fail.
+      - name: Enforce severity gate (CRITICAL fail / HIGH warn)
+        run: |
+          set -euo pipefail
+          JSON=trivy-backend-sbom.json
+          crit=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' "$JSON")
+          high=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' "$JSON")
+          med=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' "$JSON")
+          echo "Severity buckets: CRITICAL=$crit HIGH=$high MEDIUM=$med"
+          {
+            echo
+            echo "**Severity buckets:** CRITICAL=$crit, HIGH=$high, MEDIUM=$med"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$crit" -gt 0 ]; then
+            echo "::error::Found $crit CRITICAL vulnerability/ies in runtime classpath — failing build"
+            exit 1
+          fi
+          if [ "$high" -gt 0 ]; then
+            echo "::warning::Found $high HIGH vulnerability/ies in runtime classpath (warn-only)"
+          fi
 
-      # Soft gate: HIGH findings warn but do not fail.
-      - name: Trivy SBOM scan (HIGH — warn only)
+      # Re-run for SARIF so the GitHub Security tab gets all findings tagged
+      # with their actual severity. trivy-action ignores `severity` for SARIF
+      # output, so we just feed it the broadest band we want surfaced.
+      - name: Trivy SBOM scan (SARIF for Security tab)
         if: always()
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: sbom
           scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
           format: sarif
-          output: trivy-backend-sbom-high.sarif
-          severity: HIGH
+          output: trivy-backend-sbom.sarif
+          severity: CRITICAL,HIGH
           exit-code: '0'
           ignore-unfixed: false
           scanners: vuln
 
-      # MEDIUM kept in JSON-only artefact for offline review.
-      - name: Trivy SBOM scan (MEDIUM — artefact only)
-        if: always()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: sbom
-          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
-          format: json
-          output: trivy-backend-sbom-medium.json
-          severity: MEDIUM
-          exit-code: '0'
-          ignore-unfixed: false
-          scanners: vuln
-
-      # Upload CRITICAL+HIGH SARIF to the Security tab. Separate `category` from
-      # the `trivy` job above so GitHub does not de-dupe and overwrite either.
-      - name: Upload CRITICAL SARIF to GitHub Security
+      # Upload SARIF under a distinct category so it does not de-dupe with the
+      # existing `trivy` (frontend + secret) upload.
+      - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         if: always()
         with:
-          sarif_file: trivy-backend-sbom-critical.sarif
-          category: trivy-backend-sbom-critical
-
-      - name: Upload HIGH SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
-        if: always()
-        with:
-          sarif_file: trivy-backend-sbom-high.sarif
-          category: trivy-backend-sbom-high
+          sarif_file: trivy-backend-sbom.sarif
+          category: trivy-backend-sbom
 
       - name: Upload backend SBOM scan artefacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -219,7 +225,6 @@ jobs:
           path: |
             plugwerk-server/plugwerk-server-backend/build/reports/bom.json
             trivy-backend-sbom-summary.txt
-            trivy-backend-sbom-critical.sarif
-            trivy-backend-sbom-high.sarif
-            trivy-backend-sbom-medium.json
+            trivy-backend-sbom.json
+            trivy-backend-sbom.sarif
           retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,6 +116,44 @@ jobs:
           total=$(jq '.components | length' "$BOM")
           echo "SBOM smoke test passed ($total components)"
 
+      # Human-readable summary printed BEFORE the gating steps so findings
+      # are visible in the job log even when CRITICAL fails the build.
+      # Renders to GitHub Step Summary too — same content, two surfaces.
+      - name: Trivy SBOM scan (table summary for log)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: sbom
+          scan-ref: plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+          format: table
+          output: trivy-backend-sbom-summary.txt
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: '0'
+          ignore-unfixed: false
+          scanners: vuln
+
+      - name: Surface findings to log and Step Summary
+        run: |
+          set -euo pipefail
+          SUMMARY=trivy-backend-sbom-summary.txt
+          echo "::group::Trivy SBOM scan findings (CRITICAL / HIGH / MEDIUM)"
+          if [ -s "$SUMMARY" ]; then
+            cat "$SUMMARY"
+          else
+            echo "No findings at CRITICAL/HIGH/MEDIUM severity."
+          fi
+          echo "::endgroup::"
+          {
+            echo "## Backend SBOM scan findings"
+            echo
+            if [ -s "$SUMMARY" ]; then
+              echo '```'
+              cat "$SUMMARY"
+              echo '```'
+            else
+              echo "_No findings at CRITICAL/HIGH/MEDIUM severity._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Hard gate: CRITICAL CVE in the runtime classpath fails the build.
       - name: Trivy SBOM scan (CRITICAL — fail on findings)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -180,6 +218,7 @@ jobs:
           name: trivy-backend-sbom-report
           path: |
             plugwerk-server/plugwerk-server-backend/build/reports/bom.json
+            trivy-backend-sbom-summary.txt
             trivy-backend-sbom-critical.sarif
             trivy-backend-sbom-high.sarif
             trivy-backend-sbom-medium.json

--- a/docs/adrs/0030-backend-dependency-scanning.md
+++ b/docs/adrs/0030-backend-dependency-scanning.md
@@ -1,0 +1,79 @@
+# ADR-0030: Backend dependency scanning via CycloneDX SBOM and `trivy sbom`
+
+## Status
+
+Accepted
+
+## Context
+
+Issue [#297](https://github.com/plugwerk/plugwerk/issues/297) (M-3 calibration finding from the 1.0.0-beta.1 security audit) surfaced a coverage gap in the pre-merge security gate.
+
+`.github/workflows/security.yml` runs `trivy fs` against the repository root with `skip-dirs: build,.gradle,…`. With those directories excluded — and they must be excluded; CI does not check generated build artefacts into the repo — Trivy sees no backend dependency manifest. It does not understand `build.gradle.kts` or the version catalog (`gradle/libs.versions.toml`), so the Kotlin runtime classpath is invisible to the scanner. Frontend coverage works only because `package-lock.json` is a checked-in lockfile that Trivy can parse natively.
+
+This is a calibration gap, not an active vulnerability. Phase 3 of the audit manually verified the runtime classpath (Tomcat 11.0.20, Jackson 3.1.0, logback 1.5.32) clean against published CVE feeds. The risk is preventive: the scanner currently cannot catch a regression introduced by a future dependency bump, even though Renovate already manages those bumps.
+
+Renovate (configured in `.github/renovate.json`) handles dependency *update* PRs across all ecosystems. The gap is orthogonal — Renovate does not perform CVE matching; it only proposes version bumps.
+
+## Decision
+
+Generate a CycloneDX SBOM for the backend's `runtimeClasspath` during CI and scan it with `trivy sbom` in a dedicated, parallel workflow job.
+
+Concretely:
+
+1. **Plugin**: `org.cyclonedx.bom` v3.2.4 (Gradle Plugin Portal coordinate, declared in `gradle/libs.versions.toml` so Renovate's existing `gradle` manager keeps it current).
+2. **Scope**: Only `runtimeClasspath` — test and compile-only dependencies are not shipped in the production artefact and would only add false-positive noise.
+3. **Output**: JSON-only SBOM at `plugwerk-server/plugwerk-server-backend/build/reports/bom.json` (XML output disabled via `xmlOutput.unsetConvention()`).
+4. **CI job**: New `backend-sbom-scan` job in `.github/workflows/security.yml`, parallel to the existing `trivy` job. Three Trivy invocations:
+   - **CRITICAL → fail**: `exit-code: '1'`, SARIF uploaded to GitHub Security (`category: trivy-backend-sbom-critical`).
+   - **HIGH → warn**: `exit-code: '0'`, SARIF uploaded to GitHub Security (`category: trivy-backend-sbom-high`).
+   - **MEDIUM → artefact-only**: JSON file in the workflow artefact bundle, no SARIF, no Security-tab entry. Reviewed offline if needed.
+5. **Smoke test**: Before scanning, a bash step asserts that `tomcat-embed-core`, `jackson-databind`, `logback-classic`, and `spring-boot-starter-web` are present in the BOM. If a future change silently degrades the SBOM scope, the build fails loudly instead of producing an empty-but-passing scan.
+6. **Artefact retention**: 30 days, parity with the existing `trivy-sarif-report` artefact.
+
+## Considered Alternatives
+
+### Option B — Dependabot for the Gradle ecosystem
+
+Rejected. The repository already uses Renovate (`.github/renovate.json`) with carefully tuned package rules: grouped Spring Boot, Kotlin, Jackson, OkHttp, JUnit/Mockito/Testcontainers, and GitHub Actions PRs. Enabling Dependabot in parallel would produce competing update PRs against the same dependencies, cause merge conflicts, and force every Renovate group to fight a Dependabot equivalent.
+
+Beyond the Renovate conflict, Dependabot is not a pre-merge gate. Its alerts surface in the Security tab asynchronously — the issue's acceptance criterion "fail the workflow on CRITICAL vulns in the runtime classpath" cannot be satisfied by Dependabot alone.
+
+### Option C — OWASP Dependency-Check Gradle plugin
+
+Rejected. Three reasons:
+
+1. **Performance**: `dependencyCheckAggregate` requires a full NVD database pull on first run and incremental updates afterwards. Without an `NVD_API_KEY` secret, NIST rate-limits the API and CI runs frequently take 5–10 minutes or fail outright. With the key, a new repository secret must be provisioned and rotated.
+2. **False-positive rate**: Dependency-Check matches by CPE heuristically; Spring and Jackson regularly produce false matches that require an `dependency-check-suppressions.xml` file to keep the build green. Trivy matches by PURL extracted directly from the CycloneDX BOM, which is exact.
+3. **Toolchain divergence**: The frontend scan already uses Trivy. Adopting Trivy for the backend keeps one scanner, one SARIF-upload pattern, one artefact convention, and one set of action SHAs to manage in the CI.
+
+## Consequences
+
+### Easier
+
+- Pre-merge CVE gate covers the backend runtime classpath, closing the audit calibration gap.
+- Same scanner family (Trivy) for frontend and backend simplifies CI maintenance and ADR-0026 SHA-pinning hygiene.
+- The SBOM artefact is downloadable from every CI run — useful for ad-hoc supply-chain queries, license audits, and customer-facing SBOM disclosure if requested.
+- Renovate continues to drive dependency updates, including the CycloneDX plugin itself, with no configuration change.
+
+### More difficult
+
+- The SBOM is regenerated on every CI run rather than checked in. Local reviewers cannot read the BOM offline without either running `./gradlew :plugwerk-server:plugwerk-server-backend:cyclonedxDirectBom` themselves or downloading the latest CI artefact.
+- Workflow time grows by an additional parallel job. Expected runtime: ~2 minutes (JDK setup, Gradle dependency resolution, three Trivy scans, three uploads). Acceptable on top of the existing ~3-minute frontend scan.
+- HIGH findings without an upstream fix may accumulate in the Security tab. If volume becomes blocking, follow the rollback ladder below.
+
+## Rollback ladder
+
+If the SBOM scan produces unmanageable false-positive volume in practice:
+
+1. **Suppress targeted findings**: Add `.trivyignore` at the repo root with `CVE-XXXX-YYYY` entries, each annotated with reason and review date (max 90 days). Extend the `trivy-action` step with `trivyignores: .trivyignore`.
+2. **Severity downshift**: Move the `CRITICAL → fail` step to `exit-code: '0'` (warn-only), making the entire backend scan informational. Document on the relevant PR.
+3. **Disable the job**: Set `if: false` on `backend-sbom-scan`, mark this ADR `Superseded by ADR-NNNN`, and re-open issue #297 with a postmortem. The frontend `trivy fs` job continues unaffected.
+
+## References
+
+- Issue: [#297](https://github.com/plugwerk/plugwerk/issues/297)
+- Replaces: [#256](https://github.com/plugwerk/plugwerk/issues/256) (closed not-planned, framing was incorrect)
+- Audit report: `docs/audits/1.0.0-beta.1-security-audit.md` → "Calibration notes"
+- Related ADRs: [ADR-0026](0026-sha-pin-actions-and-base-images.md) for action SHA-pinning rules that this job follows
+- Plugin: [CycloneDX/cyclonedx-gradle-plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) v3.2.4
+- Trivy SBOM scan mode: <https://aquasecurity.github.io/trivy/latest/docs/target/sbom/>

--- a/docs/adrs/0030-backend-dependency-scanning.md
+++ b/docs/adrs/0030-backend-dependency-scanning.md
@@ -23,12 +23,18 @@ Concretely:
 1. **Plugin**: `org.cyclonedx.bom` v3.2.4 (Gradle Plugin Portal coordinate, declared in `gradle/libs.versions.toml` so Renovate's existing `gradle` manager keeps it current).
 2. **Scope**: Only `runtimeClasspath` — test and compile-only dependencies are not shipped in the production artefact and would only add false-positive noise.
 3. **Output**: JSON-only SBOM at `plugwerk-server/plugwerk-server-backend/build/reports/bom.json` (XML output disabled via `xmlOutput.unsetConvention()`).
-4. **CI job**: New `backend-sbom-scan` job in `.github/workflows/security.yml`, parallel to the existing `trivy` job. Three Trivy invocations:
-   - **CRITICAL → fail**: `exit-code: '1'`, SARIF uploaded to GitHub Security (`category: trivy-backend-sbom-critical`).
-   - **HIGH → warn**: `exit-code: '0'`, SARIF uploaded to GitHub Security (`category: trivy-backend-sbom-high`).
-   - **MEDIUM → artefact-only**: JSON file in the workflow artefact bundle, no SARIF, no Security-tab entry. Reviewed offline if needed.
-5. **Smoke test**: Before scanning, a bash step asserts that `tomcat-embed-core`, `jackson-databind`, `logback-classic`, and `spring-boot-starter-web` are present in the BOM. If a future change silently degrades the SBOM scope, the build fails loudly instead of producing an empty-but-passing scan.
-6. **Artefact retention**: 30 days, parity with the existing `trivy-sarif-report` artefact.
+4. **CI job**: New `backend-sbom-scan` job in `.github/workflows/security.yml`, parallel to the existing `trivy` job. Architecture:
+   - One Trivy invocation in `format: json` produces the canonical findings file (`trivy-backend-sbom.json`).
+   - One Trivy invocation in `format: table` produces the human-readable log/Step-Summary surface.
+   - One shell step (`jq`) reads the JSON, counts findings per severity, and applies the gate policy explicitly:
+     - **CRITICAL** → emit `::error::` annotation, exit 1, fail the build.
+     - **HIGH** → emit `::warning::` annotation, do not fail.
+     - **MEDIUM** → counted and reported in the Step Summary, no annotation, no failure.
+   - One Trivy invocation in `format: sarif` (CRITICAL+HIGH band) feeds the GitHub Code Scanning tab under category `trivy-backend-sbom`.
+5. **Why the gate is jq-based, not trivy-action `exit-code`**: `trivy-action` does not apply its `severity` filter to SARIF output (Code Scanning needs all severity levels for its own filtering UI). As a side effect, an `exit-code: '1'` paired with `severity: CRITICAL` fires on *any* finding in the SARIF, regardless of severity. Routing the gate through JSON + jq makes the policy deterministic and reviewable: severity buckets are explicit shell variables, not a property of the scanner's output mode.
+6. **Smoke test**: Before scanning, a bash step asserts that `tomcat-embed-core`, `jackson-databind`, `logback-classic`, and `spring-boot-starter-web` are present in the BOM. If a future change silently degrades the SBOM scope, the build fails loudly instead of producing an empty-but-passing scan.
+7. **Findings visibility**: Three surfaces — collapsible log group with the full Trivy table, GitHub Step Summary with the same table, and the Security tab. Operators do not need to download the artefact to triage.
+8. **Artefact retention**: 30 days, parity with the existing `trivy-sarif-report` artefact. Bundle includes the BOM, the table, the JSON gate input, and the SARIF.
 
 ## Considered Alternatives
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ yasson = "3.0.4"
 bucket4j = "8.17.0"
 caffeine = "3.2.3"
 spotless = "7.0.4"
+cyclonedx = "3.2.4"
 
 [libraries]
 # Kotlin
@@ -104,3 +105,4 @@ spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -4,8 +4,23 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.cyclonedx.bom)
     `maven-publish`
     signing
+}
+
+// CycloneDX SBOM generation for CI vulnerability scanning (issue #297, ADR-0030).
+// Restricted to runtimeClasspath: only deps that ship in the production artefact
+// are security-relevant. Test/compile-only deps would add false-positive noise.
+tasks.cyclonedxDirectBom {
+    projectType = org.cyclonedx.model.Component.Type.APPLICATION
+    includeConfigs = listOf("runtimeClasspath")
+    xmlOutput.unsetConvention()
+    jsonOutput =
+        layout.buildDirectory
+            .file("reports/bom.json")
+            .get()
+            .asFile
 }
 
 kotlin {


### PR DESCRIPTION
## Summary

- Closes the audit calibration gap from issue #297 (M-3): the Kotlin backend `runtimeClasspath` was invisible to the pre-merge Trivy gate because `trivy fs` cannot parse `build.gradle.kts` and `build/` is — correctly — excluded.
- Adds the **`org.cyclonedx.bom` Gradle plugin (v3.2.4)** to `plugwerk-server-backend`, scoped to `runtimeClasspath` only, JSON-only output at `build/reports/bom.json`.
- Adds a **parallel CI job `backend-sbom-scan`** in `.github/workflows/security.yml`:
  - regenerates the SBOM on every PR/push;
  - smoke-tests the BOM via `jq` for `tomcat-embed-core` / `jackson-databind` / `logback-classic` / `spring-boot-starter-web` (silent scope degradation now fails loudly);
  - runs three Trivy scans with abgestufter Severity: **CRITICAL fail / HIGH warn / MEDIUM artefact-only**;
  - uploads CRITICAL + HIGH SARIF under separate categories (`trivy-backend-sbom-critical`, `trivy-backend-sbom-high`) so GitHub Code Scanning does not de-dupe against the existing `trivy` upload;
  - bundles BOM + all three reports as a 30-day artefact.
- Existing `trivy` job (frontend lockfile + secret scan) is untouched.

## Architecture decision

[ADR-0030](docs/adrs/0030-backend-dependency-scanning.md) documents the option matrix:

| Option | Verdict | Reason |
|---|---|---|
| A — CycloneDX + `trivy sbom` | **Accepted** | Same toolchain as frontend, exact PURL matching, no NVD-key secret, Renovate-orthogonal |
| B — Dependabot Gradle | Rejected | Collides with Renovate (`.github/renovate.json` already manages all ecosystems); not a pre-merge gate |
| C — OWASP Dependency-Check | Rejected | NVD rate-limit/performance, high CPE-based FP rate, toolchain divergence |

ADR includes a three-stage rollback ladder (`.trivyignore` → severity downshift → job-disable) for when HIGH-finding volume becomes blocking.

## Local verification

```
$ ./gradlew :plugwerk-server:plugwerk-server-backend:cyclonedxDirectBom
BUILD SUCCESSFUL
$ jq '.components | length' plugwerk-server/plugwerk-server-backend/build/reports/bom.json
142
```

All four smoke-test targets present in the BOM. Full backend `:check` green.

## Test plan
- [x] Local: `cyclonedxDirectBom` produces a valid CycloneDX 1.6 JSON SBOM
- [x] Local: smoke-test bash logic finds tomcat / jackson / logback / spring-boot-starter-web
- [x] Local: full `:plugwerk-server:plugwerk-server-backend:check` passes
- [ ] CI: `backend-sbom-scan` job runs green on this PR
- [ ] CI: existing `trivy` job stays green (no frontend regression)
- [ ] CI: SARIF artefacts appear under both new categories in the Security tab

## Closes
- Closes #297