### PR TITLE
chore(deps): bump Spring Boot 4.0.6 + Jackson 3.1.2 (closes 4 CVEs surfaced by #297 gate)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 kotlin = "2.3.20"
-spring-boot = "4.0.5"
+spring-boot = "4.0.6"
 spring-dependency-management = "1.1.7"
 openapi-generator = "7.14.0"
 pf4j = "3.15.0"
 okhttp = "5.3.2"
-jackson = "3.1.0"
+jackson = "3.1.2"
 jackson-annotations = "2.21"
 liquibase = "5.0.2"
 postgresql = "42.7.10"


### PR DESCRIPTION
## Summary

PR #370 introduced the backend SBOM CVE gate from issue #297, and the gate immediately surfaced four real HIGH-severity findings in the runtime classpath. This PR closes them in one minimal-scope bump.

## Changes

- `spring-boot` `4.0.5 → 4.0.6` — pulls Tomcat from `11.0.20` to `11.0.21`, fixing:
  - **CVE-2026-34483** — Apache Tomcat: information disclosure via improper encoding in `JsonAccessLogValve`
  - **CVE-2026-34487** — Apache Tomcat: information disclosure via sensitive data in log files
  - **CVE-2026-34500** — Apache Tomcat: authentication bypass via client certificate misconfiguration (MEDIUM)
- `jackson` `3.1.0 → 3.1.2` — fixes:
  - **GHSA-2m67-wjpj-xhg9** — Jackson Core: document-length constraint bypass in blocking, async, and DataInput parsers

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green locally
- [ ] CI green
- [ ] After merge: rebase PR #370; the next backend SBOM scan should report `Severity buckets: CRITICAL=0 HIGH=0 MEDIUM=0`

## Merge order

This PR should merge **before** PR #370 so that the gate's first appearance on `main` lands on a clean classpath. PR #370 will then need a rebase to pick up these versions.

## References

- Gate that surfaced these findings: #370 (issue #297)
- Audit calibration note: `docs/audits/1.0.0-beta.1-security-audit.md`