### PR TITLE
chore(renovate): unblock scheduling and migrate deprecated matchPackagePatterns

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 6am every weekday"],
   "timezone": "Europe/Berlin",
   "automerge": false,
   "dependencyDashboard": true,
@@ -16,10 +16,10 @@
     {
       "description": "Spring Boot starters, BOM, and dependency management plugin",
       "matchManagers": ["gradle", "gradle-wrapper"],
-      "matchPackagePatterns": [
-        "^org\\.springframework\\.boot",
-        "^org\\.springframework\\.security",
-        "^io\\.spring\\.dependency-management"
+      "matchPackageNames": [
+        "/^org\\.springframework\\.boot/",
+        "/^org\\.springframework\\.security/",
+        "/^io\\.spring\\.dependency-management/"
       ],
       "groupName": "Spring Boot",
       "groupSlug": "spring-boot"
@@ -27,17 +27,17 @@
     {
       "description": "Kotlin stdlib, reflect, and compiler plugins",
       "matchManagers": ["gradle"],
-      "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
+      "matchPackageNames": ["/^org\\.jetbrains\\.kotlin/"],
       "groupName": "Kotlin",
       "groupSlug": "kotlin"
     },
     {
       "description": "JUnit 5, Mockito, and Testcontainers",
       "matchManagers": ["gradle"],
-      "matchPackagePatterns": [
-        "^org\\.junit",
-        "^org\\.mockito",
-        "^org\\.testcontainers"
+      "matchPackageNames": [
+        "/^org\\.junit/",
+        "/^org\\.mockito/",
+        "/^org\\.testcontainers/"
       ],
       "groupName": "Test dependencies",
       "groupSlug": "test-deps"
@@ -45,9 +45,9 @@
     {
       "description": "Jackson 3.x (tools.jackson) and legacy annotations (com.fasterxml)",
       "matchManagers": ["gradle"],
-      "matchPackagePatterns": [
-        "^tools\\.jackson",
-        "^com\\.fasterxml\\.jackson"
+      "matchPackageNames": [
+        "/^tools\\.jackson/",
+        "/^com\\.fasterxml\\.jackson/"
       ],
       "groupName": "Jackson",
       "groupSlug": "jackson"
@@ -55,7 +55,7 @@
     {
       "description": "OkHttp client and MockWebServer",
       "matchManagers": ["gradle"],
-      "matchPackagePatterns": ["^com\\.squareup\\.okhttp3"],
+      "matchPackageNames": ["/^com\\.squareup\\.okhttp3/"],
       "groupName": "OkHttp",
       "groupSlug": "okhttp"
     },


### PR DESCRIPTION
## Why

Renovate has been silent since the app was installed on `2026-04-08`. No update PRs, no Dependency Dashboard issue, no `Action Required: Fix Renovate Configuration` notification. Two compounding causes were identified during investigation.

### Cause A — schedule allowed a single 6-hour window per week

```json
"schedule": ["before 6am on monday"]
```

Renovate gates **all repository-side activity** on `schedule`, including the first-run Dependency Dashboard creation and config-error issue surfacing. A Mend Cloud poll outside the window is a no-op — silent. Three Monday slots have passed since installation with zero observable output, which is consistent with a schedule that misfired or with strict-validation failure (cause B) running inside those slots.

### Cause B — `matchPackagePatterns` is deprecated, fails strict-mode validation

Local validation against Renovate `43.150.0`:

| Mode | Exit |
|---|---|
| `renovate-config-validator .github/renovate.json` (default, with auto-migration) | `0` (silently rewrites to `matchPackageNames` with `/regex/` notation) |
| `renovate-config-validator --strict .github/renovate.json` | **`1`** |

Mend Cloud runs in strict mode by default. A strict failure kills the run *before* any Dashboard or update PR is produced — which matches the observed silence.

## What this PR changes

- `schedule` → `before 6am every weekday`. Five 6-hour off-hours windows per week instead of one. Existing rate caps (`prHourlyLimit: 2`, `prConcurrentLimit: 5`) already throttle PR volume — this change does not increase noise risk.
- Every `matchPackagePatterns` entry migrated to `matchPackageNames` with `/regex/` notation. Same regex, same anchors, same semantics — only the format moves to the supported one. Local `--strict` validation now exits `0`.

## Verification

- [x] `npx --package=renovate@latest -- renovate-config-validator --strict .github/renovate.json` → `INFO: Config validated successfully`, exit 0
- [ ] After merge: first Mend Cloud poll inside the new weekday window produces the initial **Dependency Dashboard** issue
- [ ] Pending update PRs (Spring Boot 4.0.6, Jackson 3.1.2 already shipped manually via #371; expect at least the cyclonedx-bom plugin and any other minor/patch bumps to appear)

## Out of scope

- Mend Cloud-side job logs (only available via `developer.mend.io`); operator action.
- Switching `extends` from `config:recommended` to `config:best-practices` — possible follow-up, not required to unblock the current pipeline.

## References

- Renovate scheduling docs: https://docs.renovatebot.com/configuration-options/#schedule
- `matchPackagePatterns` deprecation: https://docs.renovatebot.com/configuration-options/#matchpackagepatterns (deprecated since Renovate 38)
- Repo memory: Renovate (not Dependabot) is the canonical update tool — this PR keeps that constraint