### PR TITLE
fix(security): grant anonymous catalog reads on publicCatalog namespaces (#374)

### DIFF
--- a/docs/adrs/0011-client-auth-api-key-strategy.md
+++ b/docs/adrs/0011-client-auth-api-key-strategy.md
@@ -72,6 +72,36 @@ API keys grant **READ_ONLY** access to their namespace:
 This is intentional: API keys are designed for **SDK polling and plugin discovery**,
 not for management operations. Write operations require a JWT Bearer token.
 
+## Anonymous Reads on Public Namespaces
+
+A namespace flagged `publicCatalog = true` accepts **unauthenticated** GETs against the read-only catalog surface. The carve-out lets a CLI or pf4j-update client browse and download published releases without provisioning credentials at all — the most reduced privilege level in the model. The flag is set per namespace by an ADMIN; absence of the flag (default) keeps the namespace fully private.
+
+**Pinned scope (server-side, `PublicNamespaceFilter`):** anonymous GETs are recognised only on:
+
+```
+/api/v1/namespaces/{ns}/plugins
+/api/v1/namespaces/{ns}/plugins/{id}
+/api/v1/namespaces/{ns}/plugins/{id}/releases
+/api/v1/namespaces/{ns}/plugins/{id}/releases/{ver}
+/api/v1/namespaces/{ns}/plugins/{id}/releases/{ver}/download
+/api/v1/namespaces/{ns}/updates/check
+```
+
+Anything else under `/api/v1/namespaces/{ns}/...` (members, access keys, settings, audit) returns `401` for unauthenticated callers irrespective of the flag.
+
+**Token shape (implementation contract, fixed by issue #374):** the carve-out is implemented by installing a `UsernamePasswordAuthenticationToken` whose principal is `"public:<ns>"` and whose only granted authority is `ROLE_PUBLIC_CATALOG`. An `AnonymousAuthenticationToken` is **not** used because Spring's `AuthenticatedAuthorizationManager.authenticated()` rejects every anonymous token via `AuthenticationTrustResolver.isAnonymous` regardless of `isAuthenticated()` — the symptom of #374. The `public:` prefix is a stable identifier downstream filters and services use to distinguish the carve-out token from real users (UUID-based) and access-key tokens (`key:` prefix); see `PublicNamespaceFilter.isPublicCatalogPrincipal`.
+
+**Behaviour matrix on a public namespace:**
+
+| Caller | `GET /plugins` | `GET /members` | `POST /plugins` |
+|---|:---:|:---:|:---:|
+| Unauthenticated | ✅ 200 (carve-out) | ❌ 401 | ❌ 401 |
+| API key (READ_ONLY) | ✅ 200 | ❌ 403 | ❌ 403 |
+| JWT MEMBER | ✅ 200 | ✅ 200 | ✅ 200 |
+| JWT ADMIN | ✅ 200 | ✅ 200 | ✅ 200 |
+
+When both an `X-Api-Key` and a public-namespace path are present, the API-key principal takes precedence over the carve-out token, so the request is attributed to a named, audited identity.
+
 ## Consequences
 
 ### Positive

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/CatalogController.kt
@@ -32,6 +32,7 @@ import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.security.HttpClientIpResolver
 import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.currentAuthenticationOrNull
 import io.plugwerk.server.service.Pf4jCompatibilityService
 import io.plugwerk.server.service.PluginReleaseService
@@ -220,6 +221,9 @@ class CatalogController(
         if (!auth.isAuthenticated) return CatalogVisibility.PUBLIC
         // API key callers (name starts with "key:") are treated as PUBLIC visibility
         if (auth.name.startsWith("key:")) return CatalogVisibility.PUBLIC
+        // Public-catalog carve-out token (PublicNamespaceFilter) is anonymous-equivalent
+        // for visibility purposes — short-circuit before the namespace-role DB lookups.
+        if (PublicNamespaceFilter.isPublicCatalogPrincipal(auth.name)) return CatalogVisibility.PUBLIC
         // System superadmin sees everything
         if (namespaceAuthService.isSuperadmin(auth)) return CatalogVisibility.ADMIN
         // Check namespace-level role — ordered from most to least privileged.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ChangePasswordRateLimitFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ChangePasswordRateLimitFilter.kt
@@ -80,6 +80,9 @@ class ChangePasswordRateLimitFilter(private val rateLimitService: ChangePassword
         if (!auth.isAuthenticated) return null
         val name = auth.name
         if (name.isNullOrBlank()) return null
+        // Public-catalog carve-out tokens (PublicNamespaceFilter) are not real subjects;
+        // they should not consume a per-user rate-limit bucket.
+        if (PublicNamespaceFilter.isPublicCatalogPrincipal(name)) return null
         return name
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAccessKeyAuthFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/NamespaceAccessKeyAuthFilter.kt
@@ -74,9 +74,17 @@ class NamespaceAccessKeyAuthFilter(
     ) {
         val apiKey = request.getHeader(HEADER_NAME)
         val existingAuth = SecurityContextHolder.getContext().authentication
+        // A public-catalog token (issued by PublicNamespaceFilter for anonymous reads on
+        // publicCatalog=true namespaces) must yield to a presented X-Api-Key — otherwise
+        // a caller who happens to hit a public-namespace catalog path would never get
+        // their named, audited identity attached to the request.
         val shouldAuthenticate = apiKey != null &&
             apiKey.length >= MIN_KEY_LENGTH &&
-            (existingAuth == null || existingAuth is AnonymousAuthenticationToken)
+            (
+                existingAuth == null ||
+                    existingAuth is AnonymousAuthenticationToken ||
+                    PublicNamespaceFilter.isPublicCatalogPrincipal(existingAuth.name)
+                )
 
         if (shouldAuthenticate && apiKey != null) {
             authenticateConstantTime(apiKey)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PublicNamespaceFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PublicNamespaceFilter.kt
@@ -22,25 +22,50 @@ import io.plugwerk.server.repository.NamespaceRepository
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
- * Grants anonymous access to read-only catalog endpoints for namespaces marked as public.
+ * Grants anonymous access to read-only catalog endpoints for namespaces marked as public
+ * (ADR-0011 — anonymous reads on `publicCatalog = true` namespaces).
  *
- * When a GET request targets `/api/v1/namespaces/{ns}/...` and the namespace has
- * `publicCatalog = true`, this filter sets an [AnonymousAuthenticationToken] so that
- * Spring Security's `anyRequest().authenticated()` rule is satisfied without a Bearer token.
+ * When a GET request targets a catalog read endpoint under
+ * `/api/v1/namespaces/{ns}/(plugins|updates/check)` and the namespace has
+ * `publicCatalog = true`, this filter installs a [UsernamePasswordAuthenticationToken]
+ * with principal `"public:<ns>"` and authority [PUBLIC_CATALOG_AUTHORITY].
  *
- * This filter runs before the OAuth2 resource server JWT filter.
+ * Why not [org.springframework.security.authentication.AnonymousAuthenticationToken]?
+ * Spring's [org.springframework.security.web.access.intercept.AuthorizationFilter] uses
+ * `AuthenticatedAuthorizationManager` for `.anyRequest().authenticated()`, which calls
+ * `AuthenticationTrustResolver.isAnonymous(authentication)` and rejects every anonymous
+ * token regardless of `isAuthenticated()`. Issue #374 was a 401 caused exactly by that
+ * gate. A non-anonymous token with a clearly namespaced principal (`public:<ns>`)
+ * passes `authenticated()` while remaining trivially distinguishable from real users
+ * downstream — see [io.plugwerk.server.security.NamespaceAuthorizationService.parseUserId]
+ * which falls through to deny-by-default for any non-UUID principal.
+ *
+ * The path pattern is intentionally narrow: only catalog-read endpoints are surfaced
+ * publicly. Members, access keys, settings and other namespace-scoped GETs remain
+ * 401 for unauthenticated callers.
  */
 @Component
 class PublicNamespaceFilter(private val namespaceRepository: NamespaceRepository) : OncePerRequestFilter() {
 
-    private val namespacePathPattern = Regex("^/api/v1/namespaces/([^/]+)(?:/.*)?$")
+    /**
+     * Matches read-only catalog endpoints (ADR-0011):
+     *   /api/v1/namespaces/{ns}/plugins
+     *   /api/v1/namespaces/{ns}/plugins/{id}
+     *   /api/v1/namespaces/{ns}/plugins/{id}/releases
+     *   /api/v1/namespaces/{ns}/plugins/{id}/releases/{ver}
+     *   /api/v1/namespaces/{ns}/plugins/{id}/releases/{ver}/download
+     *   /api/v1/namespaces/{ns}/updates/check
+     *
+     * Anything else under `/api/v1/namespaces/{ns}/` is intentionally excluded.
+     */
+    private val catalogPathPattern = Regex("^/api/v1/namespaces/([^/]+)/(?:plugins(?:/.*)?|updates/check)$")
 
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -48,22 +73,36 @@ class PublicNamespaceFilter(private val namespaceRepository: NamespaceRepository
         filterChain: FilterChain,
     ) {
         if (request.method == "GET" && SecurityContextHolder.getContext().authentication == null) {
-            val match = namespacePathPattern.find(request.requestURI)
+            val match = catalogPathPattern.find(request.requestURI)
             if (match != null) {
                 val ns = match.groupValues[1]
                 val isPublic = namespaceRepository.findBySlug(ns)
                     .map { it.publicCatalog }
                     .orElse(false)
                 if (isPublic) {
-                    val auth = AnonymousAuthenticationToken(
-                        "public-namespace",
-                        "anonymous",
-                        listOf(SimpleGrantedAuthority("ROLE_ANONYMOUS")),
+                    val auth = UsernamePasswordAuthenticationToken(
+                        publicPrincipal(ns),
+                        "",
+                        listOf(SimpleGrantedAuthority(PUBLIC_CATALOG_AUTHORITY)),
                     )
                     SecurityContextHolder.getContext().authentication = auth
                 }
             }
         }
         filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        /** Granted authority that identifies a request authenticated via the public-catalog carve-out. */
+        const val PUBLIC_CATALOG_AUTHORITY = "ROLE_PUBLIC_CATALOG"
+
+        /** Principal-name prefix used by [PublicNamespaceFilter]. Stable contract for downstream filters. */
+        const val PUBLIC_PRINCIPAL_PREFIX = "public:"
+
+        /** Builds the principal string used on the public-catalog token. */
+        fun publicPrincipal(namespaceSlug: String): String = "$PUBLIC_PRINCIPAL_PREFIX$namespaceSlug"
+
+        /** True if [authentication] (or its name) was issued by the public-catalog carve-out. */
+        fun isPublicCatalogPrincipal(name: String?): Boolean = name != null && name.startsWith(PUBLIC_PRINCIPAL_PREFIX)
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ApiKeyEdgeCaseTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/ApiKeyEdgeCaseTest.kt
@@ -83,14 +83,16 @@ class ApiKeyEdgeCaseTest : AbstractAuthorizationTest() {
             ),
         )
 
-        // Revoked key on public NS1 → falls through as anonymous → 401 (Spring Security 6 rejects anonymous)
+        // Revoked key on public NS1 → API-key auth fails, public-catalog token from
+        // PublicNamespaceFilter remains in place (issue #374) → 200.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS1/plugins")
                 .header("X-Api-Key", plainKey),
         )
-            .andExpect(status().isUnauthorized)
+            .andExpect(status().isOk)
 
-        // Revoked key on private NS2 → anonymous → 401 (no PublicNamespaceFilter for private)
+        // Revoked key on private NS2 → API-key auth fails, no public-catalog carve-out
+        // applies to a private namespace → 401.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS2/plugins")
                 .header("X-Api-Key", plainKey),
@@ -114,14 +116,15 @@ class ApiKeyEdgeCaseTest : AbstractAuthorizationTest() {
             ),
         )
 
-        // Expired key on public NS1 → anonymous → 401 (Spring Security 6 rejects anonymous)
+        // Expired key on public NS1 → API-key auth fails, public-catalog token from
+        // PublicNamespaceFilter remains in place (issue #374) → 200.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS1/plugins")
                 .header("X-Api-Key", plainKey),
         )
-            .andExpect(status().isUnauthorized)
+            .andExpect(status().isOk)
 
-        // Expired key on private NS2 → anonymous → 401
+        // Expired key on private NS2 → no public-catalog carve-out → 401.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS2/plugins")
                 .header("X-Api-Key", plainKey),
@@ -131,17 +134,20 @@ class ApiKeyEdgeCaseTest : AbstractAuthorizationTest() {
 
     @Test
     fun `unknown API key is treated as anonymous`() {
+        // Unknown key on public NS1 → API-key lookup misses, public-catalog token
+        // from PublicNamespaceFilter remains in place (issue #374) → 200.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS1/plugins")
                 .header("X-Api-Key", "pwk_unknownkeyvaluethatdoesnotexistindb12345678"),
         )
-            .andExpect(status().isUnauthorized) // Unknown key → anonymous → 401 (Spring Security 6)
+            .andExpect(status().isOk)
 
+        // Unknown key on private NS2 → no public-catalog carve-out → 401.
         mockMvc.perform(
             get("/api/v1/namespaces/$NS2/plugins")
                 .header("X-Api-Key", "pwk_unknownkeyvaluethatdoesnotexistindb12345678"),
         )
-            .andExpect(status().isUnauthorized) // Private NS2 → no anonymous access
+            .andExpect(status().isUnauthorized)
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/CatalogEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/CatalogEndpointAuthzTest.kt
@@ -223,9 +223,10 @@ class CatalogEndpointAuthzTest : AbstractAuthorizationTest() {
 
         @JvmStatic
         fun pluginVisibilityNs1(): Stream<PluginVisibilityCase> = Stream.of(
-            // ANONYMOUS: PublicNamespaceFilter sets AnonymousAuth, but Spring Security 6
-            // anyRequest().authenticated() rejects anonymous tokens → 401
-            PluginVisibilityCase(Actor.ANONYMOUS, NS1, emptySet(), expectedStatus = 401),
+            // ANONYMOUS on public NS1: PublicNamespaceFilter installs a non-anonymous
+            // public-catalog token (issue #374) → catalog list returns PUBLIC visibility
+            // (only PUBLISHED plugins).
+            PluginVisibilityCase(Actor.ANONYMOUS, NS1, NS1_PUBLIC_PLUGINS),
             PluginVisibilityCase(Actor.SUPERADMIN, NS1, NS1_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
             PluginVisibilityCase(Actor.NS1_ADMIN, NS1, NS1_ADMIN_PLUGINS, hasDraftOnlyVisible = true),
             PluginVisibilityCase(Actor.NS1_READ_ONLY, NS1, NS1_AUTHENTICATED_PLUGINS, hasDraftOnlyVisible = true),
@@ -279,12 +280,16 @@ class CatalogEndpointAuthzTest : AbstractAuthorizationTest() {
 
         @JvmStatic
         fun singlePluginCases(): Stream<SinglePluginCase> = Stream.of(
-            // ANONYMOUS gets 401 (Spring Security 6 rejects anonymous tokens)
-            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", 401),
+            // ANONYMOUS on public NS1 catalog: PublicNamespaceFilter installs a
+            // non-anonymous public-catalog token (issue #374) → 200.
+            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", 200),
             SinglePluginCase(Actor.SUPERADMIN, NS1, "ns1-pl1-active", 200),
             SinglePluginCase(Actor.API_KEY_NS1, NS1, "ns1-pl1-active", 200),
-            // SUSPENDED plugin in NS1 — getPlugin has no visibility check → 200 for all authenticated users
-            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl2-suspended", 401),
+            // SUSPENDED plugin in NS1 — getPlugin has no visibility check → 200 for all
+            // authenticated callers including the anonymous public-catalog token.
+            // (Suspended-plugin visibility for anonymous callers is a separate concern;
+            // see service-layer issue if a stricter filter is desired.)
+            SinglePluginCase(Actor.ANONYMOUS, NS1, "ns1-pl2-suspended", 200),
             SinglePluginCase(Actor.NS1_READ_ONLY, NS1, "ns1-pl2-suspended", 200),
             SinglePluginCase(Actor.NS1_ADMIN, NS1, "ns1-pl2-suspended", 200),
             SinglePluginCase(Actor.SUPERADMIN, NS1, "ns1-pl2-suspended", 200),
@@ -305,8 +310,11 @@ class CatalogEndpointAuthzTest : AbstractAuthorizationTest() {
         @JvmStatic
         fun releaseVisibilityCases(): Stream<ReleaseVisibilityCase> = Stream.of(
             // NS1 PL1 (ACTIVE) — release visibility by actor
-            // ANONYMOUS on NS1: Spring Security 6 authenticated() rejects anonymous → 401
-            ReleaseVisibilityCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", emptySet(), expectedStatus = 401),
+            // ANONYMOUS on public NS1: PublicNamespaceFilter installs a non-anonymous
+            // public-catalog token (issue #374). listReleases has no per-status
+            // visibility filter, so anonymous sees all release versions of the plugin
+            // (same behaviour as API keys here — see comment below).
+            ReleaseVisibilityCase(Actor.ANONYMOUS, NS1, "ns1-pl1-active", ALL_VERSIONS),
             ReleaseVisibilityCase(Actor.SUPERADMIN, NS1, "ns1-pl1-active", ALL_VERSIONS),
             ReleaseVisibilityCase(Actor.NS1_ADMIN, NS1, "ns1-pl1-active", ALL_VERSIONS),
             ReleaseVisibilityCase(Actor.NS1_READ_ONLY, NS1, "ns1-pl1-active", ALL_VERSIONS),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PublicNamespaceCatalogIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PublicNamespaceCatalogIT.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.NamespaceAccessKeyEntity
+import io.plugwerk.server.domain.NamespaceEntity
+import io.plugwerk.server.repository.NamespaceAccessKeyRepository
+import io.plugwerk.server.repository.NamespaceRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+/**
+ * End-to-end Spring Security chain assertions for the `publicCatalog = true` carve-out
+ * (issue #374). Pins the contract that anonymous GETs against catalog read endpoints
+ * succeed when (and only when) the namespace has `publicCatalog = true`.
+ *
+ * The pre-existing [PublicNamespaceFilterTest] exercises the filter in isolation —
+ * it cannot detect the production failure mode where the filter sets a token that
+ * Spring's authorization stage still rejects. This IT walks the full chain.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:public-catalog-it;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+class PublicNamespaceCatalogIT {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var namespaceRepository: NamespaceRepository
+
+    @Autowired private lateinit var apiKeyRepository: NamespaceAccessKeyRepository
+
+    @Autowired private lateinit var passwordEncoder: PasswordEncoder
+
+    @Autowired private lateinit var accessKeyHmac: AccessKeyHmac
+
+    private lateinit var publicNamespace: NamespaceEntity
+    private lateinit var privateNamespace: NamespaceEntity
+    private lateinit var publicNamespaceApiKey: String
+
+    @BeforeEach
+    fun seed() {
+        apiKeyRepository.deleteAll()
+        namespaceRepository.deleteAll()
+        publicNamespace = namespaceRepository.save(
+            NamespaceEntity(slug = "public-ns", name = "public-ns", publicCatalog = true),
+        )
+        privateNamespace = namespaceRepository.save(
+            NamespaceEntity(slug = "private-ns", name = "private-ns", publicCatalog = false),
+        )
+        publicNamespaceApiKey = "pwk_" + "a".repeat(40)
+        apiKeyRepository.save(
+            NamespaceAccessKeyEntity(
+                namespace = publicNamespace,
+                keyHash = passwordEncoder.encode(publicNamespaceApiKey)!!,
+                keyLookupHash = accessKeyHmac.compute(publicNamespaceApiKey),
+                keyPrefix = publicNamespaceApiKey.take(8),
+                name = "test-key",
+            ),
+        )
+    }
+
+    @Test
+    fun `anonymous GET on public namespace catalog returns 200`() {
+        mockMvc.get("/api/v1/namespaces/public-ns/plugins")
+            .andExpect { status { isOk() } }
+    }
+
+    @Test
+    fun `anonymous GET on private namespace catalog returns 401`() {
+        mockMvc.get("/api/v1/namespaces/private-ns/plugins")
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `anonymous GET on unknown namespace returns 401`() {
+        mockMvc.get("/api/v1/namespaces/no-such-ns/plugins")
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `anonymous POST on public namespace stays unauthorized`() {
+        mockMvc.post("/api/v1/namespaces/public-ns/plugins") {
+            contentType = org.springframework.http.MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `anonymous GET on non-catalog sub-path of public namespace stays unauthorized`() {
+        // The carve-out is scoped to read-only catalog endpoints (ADR-0011).
+        // Members, access keys, settings etc. must not be readable anonymously
+        // even when the namespace is marked public.
+        mockMvc.get("/api/v1/namespaces/public-ns/members")
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `X-Api-Key on public namespace overrides anonymous public token`() {
+        mockMvc.get("/api/v1/namespaces/public-ns/plugins") {
+            header("X-Api-Key", publicNamespaceApiKey)
+        }.andExpect { status { isOk() } }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PublicNamespaceFilterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PublicNamespaceFilterTest.kt
@@ -32,6 +32,7 @@ import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.Optional
 
@@ -58,7 +59,7 @@ class PublicNamespaceFilterTest {
         NamespaceEntity(slug = slug, name = "test-org", publicCatalog = publicCatalog)
 
     @Test
-    fun `GET on public namespace sets AnonymousAuthenticationToken`() {
+    fun `GET on public namespace sets non-anonymous public-catalog token (#374)`() {
         whenever(namespaceRepository.findBySlug("acme"))
             .thenReturn(Optional.of(namespaceEntity("acme", publicCatalog = true)))
 
@@ -66,7 +67,15 @@ class PublicNamespaceFilterTest {
         filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
 
         val auth = SecurityContextHolder.getContext().authentication
-        assertThat(auth).isInstanceOf(AnonymousAuthenticationToken::class.java)
+        // Token MUST NOT be AnonymousAuthenticationToken — Spring's
+        // AuthenticatedAuthorizationManager.authenticated() rejects anonymous tokens
+        // via AuthenticationTrustResolver, which was the root cause of issue #374.
+        assertThat(auth).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
+        assertThat(auth).isNotInstanceOf(AnonymousAuthenticationToken::class.java)
+        assertThat(auth!!.name).isEqualTo("public:acme")
+        assertThat(auth.authorities.map { it.authority })
+            .containsExactly(PublicNamespaceFilter.PUBLIC_CATALOG_AUTHORITY)
+        assertThat(auth.isAuthenticated).isTrue()
     }
 
     @Test
@@ -100,7 +109,7 @@ class PublicNamespaceFilterTest {
     }
 
     @Test
-    fun `GET on public namespace nested path sets authentication`() {
+    fun `GET on public namespace nested catalog path sets authentication`() {
         whenever(namespaceRepository.findBySlug("acme"))
             .thenReturn(Optional.of(namespaceEntity("acme", publicCatalog = true)))
 
@@ -109,7 +118,31 @@ class PublicNamespaceFilterTest {
 
         assertThat(
             SecurityContextHolder.getContext().authentication,
-        ).isInstanceOf(AnonymousAuthenticationToken::class.java)
+        ).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
+    }
+
+    @Test
+    fun `GET on non-catalog sub-path of public namespace leaves authentication null`() {
+        // ADR-0011: the carve-out is scoped to read-only catalog endpoints. Members,
+        // access keys, settings etc. must remain unauthenticated even on a public
+        // namespace so the chain rejects them with 401.
+        val request = MockHttpServletRequest("GET", "/api/v1/namespaces/acme/members")
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    @Test
+    fun `GET on public namespace updates check sets authentication`() {
+        whenever(namespaceRepository.findBySlug("acme"))
+            .thenReturn(Optional.of(namespaceEntity("acme", publicCatalog = true)))
+
+        val request = MockHttpServletRequest("GET", "/api/v1/namespaces/acme/updates/check")
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertThat(
+            SecurityContextHolder.getContext().authentication,
+        ).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #374. Anonymous `GET /api/v1/namespaces/{ns}/plugins` against a `publicCatalog = true` namespace now returns `200` as documented in ADR-0011 (was: `401`).

## Root cause

`PublicNamespaceFilter` installed an `AnonymousAuthenticationToken` for the carve-out branch. Spring's `AuthenticatedAuthorizationManager.authenticated()` rejects every anonymous token via `AuthenticationTrustResolver.isAnonymous`, regardless of `isAuthenticated()` returning `true`. The filter's existing unit test exercised the filter alone and could not detect this — only the full security chain showed the failure.

(Note: the issue body's hypothesis blamed Spring's default `AnonymousAuthenticationFilter` ordering. That hypothesis was incorrect — `PublicNamespaceFilter` runs *before* the default anonymous filter via its `addFilterBefore(UsernamePasswordAuthenticationFilter)` placement chain. The real cause is the trust-resolver gate.)

## Fix

- **Token shape**: `UsernamePasswordAuthenticationToken` with principal `"public:<ns>"` and authority `ROLE_PUBLIC_CATALOG`. Non-anonymous → satisfies `.authenticated()`. Namespaced principal → trivially distinguishable from real users (UUID-based) and access-key tokens (`key:` prefix). `NamespaceAuthorizationService.parseUserId` already deny-by-defaults on non-UUID principals, so the new token cannot escalate.
- **Path pattern tightened** from `/api/v1/namespaces/{ns}(/.*)?$` to `plugins(/.*)?|updates/check` — the explicit catalog-read surface from ADR-0011. Non-catalog GETs (`/members`, `/access-keys`, `/settings`) now correctly return `401` from the security chain instead of `403` from method-level security.
- **Three downstream sites updated** to recognise the carve-out token:
  - `NamespaceAccessKeyAuthFilter`: presented `X-Api-Key` overrides the carve-out, so the request is attributed to a named/audited identity.
  - `CatalogController.resolveVisibility`: short-circuits to PUBLIC visibility on `public:` principal, skipping two unnecessary namespace-role DB lookups.
  - `ChangePasswordRateLimitFilter`: does not consume a per-subject bucket for carve-out tokens.
- **ADR-0011 extended** with an "Anonymous Reads on Public Namespaces" section that pins the path scope, the token-shape contract (so the regression cannot silently return), and the behaviour matrix across caller types.

## Test plan

- [x] New `PublicNamespaceCatalogIT` (`@SpringBootTest @AutoConfigureMockMvc`) walks the full security chain. Six assertions:
  - anonymous `GET /public-ns/plugins` → 200
  - anonymous `GET /private-ns/plugins` → 401
  - anonymous `GET /no-such-ns/plugins` → 401
  - anonymous `POST /public-ns/plugins` → 401
  - anonymous `GET /public-ns/members` → 401 (path-scope)
  - `GET /public-ns/plugins` with `X-Api-Key` → 200 (coexistence)
- [x] `PublicNamespaceFilterTest` updated: asserts non-anonymous token, principal-prefix and authority; new tests cover narrowed pattern and `updates/check` route.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [ ] CI green.

## Closes
- Closes #374