### PR TITLE
chore(renovate): pin eclipse-temurin to Java 21.x, ignore future majors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -89,6 +89,12 @@
       "groupSlug": "docker-base-images"
     },
     {
+      "description": "Pin eclipse-temurin to Java 21.x. Plugwerk targets Java 21 (gradle/libs.versions.toml jvmToolchain(21), CI setup-java java-version: 21). Patch and minor bumps inside 21.x flow through; major bumps to 22/23/24/25 are ignored entirely. Remove this rule when the project intentionally moves to a new LTS.",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["eclipse-temurin"],
+      "allowedVersions": "/^21\\./"
+    },
+    {
       "description": "npm minor and patch updates (grouped)",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Why

Renovate opened #391 to bump the Dockerfile base images from `eclipse-temurin:21.0.10_7` to `25.0.2_10`. Plugwerk intentionally targets **Java 21**:

- `gradle/libs.versions.toml` / build script: `kotlin { jvmToolchain(21) }`
- Every CI workflow: `actions/setup-java` with `java-version: 21`
- `Dockerfile` build + runtime stages and `plugwerk-server-backend/src/dist/Dockerfile` runtime: `eclipse-temurin:21.*-alpine`

A surprise base-image major bump would diverge the production runtime from the compile-time toolchain. We don't want that — we want the LTS we declared.

## What this PR changes

Adds a single packageRule in `.github/renovate.json` that constrains `eclipse-temurin` to versions matching the regex `^21\.`. Effects:

- ✅ Patch and minor bumps **inside 21.x** (e.g. `21.0.10` → `21.0.11`, `21.1.x`) flow through the existing `docker-base-images` group as before.
- ❌ Bumps to **22/23/24/25** are ignored entirely — no PR, no Dependency Dashboard entry, no churn.

When the project intentionally moves to a future LTS (likely 25 LTS), remove the rule.

## Verification

- [x] `npx --package=renovate@latest -- renovate-config-validator --strict .github/renovate.json` → `Config validated successfully`, exit 0.
- [ ] After merge: Renovate's next poll auto-closes #391 because `25.x` no longer satisfies `allowedVersions`. If it doesn't auto-close within one window, close it manually.

## References

- Pinned PR: #391 (chore(deps): update docker base images to v25 (major))
- Renovate docs: <https://docs.renovatebot.com/configuration-options/#allowedversions>