### PR TITLE
chore(renovate): split npm major updates into per-package PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -96,11 +96,9 @@
       "groupSlug": "npm-deps"
     },
     {
-      "description": "npm major updates (separate PRs for deliberate review)",
+      "description": "npm major updates — one PR per package (no grouping). Bundling unrelated majors caused PR #394 to ship a broken lockfile because typescript-eslint v8 still pinned eslint <10 while the group already advanced eslint to 10. Per-package PRs let each major be reviewed and merged independently of incompatible peers.",
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "npm major updates",
-      "groupSlug": "npm-major"
+      "matchUpdateTypes": ["major"]
     }
   ]
 }


### PR DESCRIPTION
## Why

PR #394 bundled five unrelated npm major bumps (eslint, @eslint/js, @mui/material, lucide-react, typescript) into one branch under the `npm major updates` group, and Renovate's artefact step failed:

```
npm error code ERESOLVE
Found: @eslint/js@9.39.4
  dev @eslint/js@"^10.0.0" from the root project
  peer eslint@"^6.0.0 || ^7.0.0 || >=8.0.0"
    from @eslint-community/eslint-utils@4.9.1
  transitively pulled in by typescript-eslint@8.57.1
```

`typescript-eslint@8.x` still requires `eslint <10`, but the bundle advanced eslint to 10. Because the broken bump left typescript-eslint at 8, the artefact step couldn't produce a consistent lockfile, and the stale lockfile cascaded into `npm ci` failures across `build`, `smoke-test`, and `Trivy vulnerability scan`.

This is structural: any grouped major-PR can break the same way if it touches packages whose peer-deps are incompatible with non-bumped packages. The rule's own description even said *"separate PRs for deliberate review"* — but `groupName`/`groupSlug` forced them together. Self-contradiction.

## What this PR changes

Drops `groupName` / `groupSlug` from the npm-major packageRule in `.github/renovate.json`. Renovate's default behaviour is one PR per package, so the rule now serves as a documentation hook (`matchUpdateTypes: ["major"]`) explaining the intent.

## After merge

- Renovate will auto-close PR #394 (the bundled major-PR no longer matches any active grouping).
- On the next Mend Cloud poll within the schedule window, Renovate reopens **one PR per major-bumped package** — each can be reviewed and merged on its own merits, with its own peer-dep check.
- npm minor + patch grouping (`npm-deps`) is unchanged — low-risk grouping preserved.

## Verification

- [x] `npx --package=renovate@latest -- renovate-config-validator --strict .github/renovate.json` → `Config validated successfully`, exit 0.

## References

- Broken PR: #394
- Renovate docs: <https://docs.renovatebot.com/configuration-options/#groupname>