### PR TITLE
chore(ci): rename Node 20 step labels to Node 24 (#372 cosmetic cleanup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew dependencies --configuration runtimeClasspath > /dev/null 2>&1 || true
 
       # npm — ensure lock file is present for frontend scanning
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -36,7 +36,7 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         if: steps.check.outputs.is_snapshot == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -85,7 +85,7 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         if: steps.check.outputs.is_snapshot == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary

PR #392 (gh-actions major bump) raised `node-version: 20 → 24` across every workflow, but the human-readable step name (`name: Set up Node.js 20`) was left untouched in five places. The runs since #392 all execute on Node 24 — the deprecation warning is gone and the substantive migration for #372 is complete — so this PR is purely a label cleanup so logs and the GitHub UI stop announcing "Node.js 20" while actually running 24.

Five labels in four files. No behaviour change.

## Closes
- Closes #372

(See PR #392 for the substantive migration. Issue #373 (CodeQL v3 → v4) is also covered by #392 — `github/codeql-action/upload-sarif` is now pinned at v4.35.2 in `security.yml`.)