### PR TITLE
feat(audit): expose lastLoginAt on UserDto for LOCAL and OIDC users (#367)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2602,6 +2602,17 @@ components:
         createdAt:
           type: string
           format: date-time
+        lastLoginAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Timestamp of the most recent fresh, credential-validated login —
+            either a successful `POST /auth/login` (LOCAL) or a successful OIDC
+            callback. NOT bumped on `/auth/refresh`, on resource-server bearer
+            traffic, or on `X-Api-Key` requests. `null` for accounts that have
+            never logged in (e.g. provisioned via `POST /admin/users` and never
+            used yet).
         namespaceMembershipCount:
           type: integer
           format: int32

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -92,6 +92,7 @@ class AdminUserController(
         passwordChangeRequired = passwordChangeRequired,
         isSuperadmin = isSuperadmin,
         createdAt = createdAt,
+        lastLoginAt = lastLoginAt,
         namespaceMembershipCount = namespaceMemberRepository.countByUserId(id!!).toInt(),
     )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthController.kt
@@ -72,7 +72,12 @@ class AuthController(
         // the JWT subject + refresh-token row).
         val user = userRepository.findByUsernameAndSource(loginRequest.username, UserSource.LOCAL).orElse(null)
             ?: return ResponseEntity.status(401).build()
-        return issueLoginResponse(user)
+        // Record the fresh, credential-validated login (issue #367). The bump is
+        // intentionally here and not in /auth/refresh, the bearer-token filter, or
+        // the X-Api-Key filter — those would turn the value into "any-activity"
+        // which is a different signal entirely.
+        val refreshed = userService.bumpLastLogin(user.id!!)
+        return issueLoginResponse(refreshed)
     }
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/UserEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/UserEntity.kt
@@ -115,6 +115,19 @@ class UserEntity(
     @Column(name = "password_invalidated_before")
     var passwordInvalidatedBefore: OffsetDateTime? = null,
 
+    /**
+     * Most recent fresh, credential-validated login (issue #367). Bumped by
+     * [io.plugwerk.server.service.UserService.bumpLastLogin] from
+     * [io.plugwerk.server.controller.AuthController.login] (LOCAL) and from
+     * [io.plugwerk.server.service.OidcIdentityService.upsertOnLogin] (OIDC).
+     * Explicitly NOT bumped on `/auth/refresh`, bearer-token reuse, or
+     * `X-Api-Key` traffic — those would inflate the value into uselessness.
+     * `null` for accounts that have never logged in (e.g. provisioned via
+     * `POST /admin/users` and never used yet).
+     */
+    @Column(name = "last_login_at")
+    var lastLoginAt: OffsetDateTime? = null,
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: OffsetDateTime = OffsetDateTime.now(),

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
@@ -46,6 +46,7 @@ import java.time.ZoneOffset
 class OidcIdentityService(
     private val oidcIdentityRepository: OidcIdentityRepository,
     private val userRepository: UserRepository,
+    private val userService: UserService,
 ) {
 
     private val log = LoggerFactory.getLogger(OidcIdentityService::class.java)
@@ -70,18 +71,24 @@ class OidcIdentityService(
         val providerId = requireNotNull(provider.id) {
             "OidcProviderEntity must be persisted before upsertOnLogin"
         }
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
         val existing = oidcIdentityRepository.findByOidcProviderIdAndSubject(providerId, subject).orElse(null)
         if (existing != null) {
-            existing.lastLoginAt = OffsetDateTime.now(ZoneOffset.UTC)
-            return existing.user
+            // Two distinct timestamps end up equal in the happy path but track different
+            // things conceptually: the binding-level last_login_at on oidc_identity (used
+            // later for stale-binding cleanup) and the user-level last_login_at on
+            // plugwerk_user (issue #367, surfaced in UserDto).
+            existing.lastLoginAt = now
+            return userService.bumpLastLogin(existing.user.id!!, now)
         }
-        return createNewIdentityAndUser(provider, subject, claims)
+        return createNewIdentityAndUser(provider, subject, claims, now)
     }
 
     private fun createNewIdentityAndUser(
         provider: OidcProviderEntity,
         subject: String,
         claims: Map<String, Any>,
+        loginAt: OffsetDateTime,
     ): UserEntity {
         val email = (claims["email"] as? String)?.trim()?.takeIf { it.isNotBlank() }
             ?: throw OidcEmailMissingException(provider.name)
@@ -92,6 +99,9 @@ class OidcIdentityService(
         val displayName = (claims["name"] as? String)?.trim()?.takeIf { it.isNotBlank() }
             ?: (claims["preferred_username"] as? String)?.trim()?.takeIf { it.isNotBlank() }
             ?: subject
+        // First OIDC login is still a login (issue #367) — set lastLoginAt at
+        // creation so the user surfaces as "active" immediately rather than as
+        // "never logged in" until the second callback.
         val user = userRepository.save(
             UserEntity(
                 displayName = displayName,
@@ -102,6 +112,7 @@ class OidcIdentityService(
                 enabled = true,
                 passwordChangeRequired = false,
                 isSuperadmin = false,
+                lastLoginAt = loginAt,
             ),
         )
         oidcIdentityRepository.save(

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
@@ -26,6 +26,8 @@ import io.plugwerk.server.repository.UserRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Service
@@ -84,6 +86,24 @@ class UserService(
     fun setEnabled(id: UUID, enabled: Boolean): UserEntity {
         val user = findById(id)
         user.enabled = enabled
+        return userRepository.save(user)
+    }
+
+    /**
+     * Records a fresh, credential-validated login (issue #367). Sole writer for
+     * `plugwerk_user.last_login_at`. Callers:
+     *   - [io.plugwerk.server.controller.AuthController.login] (LOCAL credential validation succeeds).
+     *   - [io.plugwerk.server.service.OidcIdentityService.upsertOnLogin] (OIDC callback succeeds, both first-login and existing-binding paths).
+     *
+     * Explicitly NOT called from `/auth/refresh`, the resource-server bearer-token
+     * filter, or the namespace API-key filter — those would inflate the value
+     * into uselessness. Negative-test guarded.
+     *
+     * @param at injectable for tests; defaults to `OffsetDateTime.now(ZoneOffset.UTC)`.
+     */
+    fun bumpLastLogin(id: UUID, at: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)): UserEntity {
+        val user = findById(id)
+        user.lastLoginAt = at
         return userRepository.save(user)
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0018_oidc_provider_type_consolidation.yaml
   - include:
       file: db/changelog/migrations/0019_user_setting_user_id_fk.yaml
+  - include:
+      file: db/changelog/migrations/0020_user_last_login_at.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0020_user_last_login_at.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0020_user_last_login_at.yaml
@@ -1,0 +1,34 @@
+# Add nullable plugwerk_user.last_login_at for the audit-trail sliver of #135
+# (issue #367). Bumped on every fresh credential-validated login (LOCAL via
+# AuthController.login, OIDC via OidcIdentityService.upsertOnLogin), surfaced
+# via UserDto.lastLoginAt for the admin user list.
+#
+# Why nullable, no default, no backfill:
+#   Accuracy over convenience. A user created via POST /admin/users who has
+#   never logged in legitimately has no value. Backfilling to created_at or
+#   now() would make the column lie about historic state and inflate "last
+#   active" reports for accounts that never authenticated.
+#
+# Why not reuse oidc_identity.last_login_at:
+#   That column tracks the binding ("when did this OIDC identity last activate"
+#   — useful for stale-binding cleanup later). plugwerk_user.last_login_at
+#   tracks the user-level "last activity" signal independent of auth source.
+#   The two are usually equal in the OIDC happy path; conceptually distinct.
+
+databaseChangeLog:
+  - changeSet:
+      id: 0020-add-user-last-login-at
+      author: plugwerk
+      changes:
+        - addColumn:
+            tableName: plugwerk_user
+            columns:
+              - column:
+                  name: last_login_at
+                  type: timestamptz
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: plugwerk_user
+            columnName: last_login_at

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerRefreshIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerRefreshIT.kt
@@ -126,6 +126,37 @@ class AuthControllerRefreshIT {
     }
 
     @Test
+    fun `login bumps lastLoginAt but refresh does NOT (#367)`() {
+        // Pre-login the column is null — the user was created via repository.save in
+        // setUp, never authenticated.
+        val before = userRepository.findByUsernameAndSource(username, io.plugwerk.server.domain.UserSource.LOCAL)
+            .orElseThrow()
+        assertThat(before.lastLoginAt).isNull()
+
+        val loginCookie = loginAndExtractCookie()
+        val afterLogin = userRepository.findByUsernameAndSource(username, io.plugwerk.server.domain.UserSource.LOCAL)
+            .orElseThrow()
+        // Login is a fresh credential check → bumps the column.
+        assertThat(afterLogin.lastLoginAt).isNotNull()
+        val loginStamp = afterLogin.lastLoginAt
+
+        // Sleep 10ms so any accidental bump is timestamp-distinguishable from
+        // the login bump.
+        Thread.sleep(10)
+
+        mockMvc.post("/api/v1/auth/refresh") {
+            cookie(loginCookie)
+            with(csrf())
+        }.andExpect { status { isOk() } }
+
+        val afterRefresh = userRepository.findByUsernameAndSource(username, io.plugwerk.server.domain.UserSource.LOCAL)
+            .orElseThrow()
+        // Refresh is silent session renewal, NOT a fresh credential check —
+        // the column must remain at its login-time value.
+        assertThat(afterRefresh.lastLoginAt).isEqualTo(loginStamp)
+    }
+
+    @Test
     fun `refresh without cookie returns 401`() {
         mockMvc.post("/api/v1/auth/refresh") {
             with(csrf())

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
@@ -138,6 +138,7 @@ class AuthControllerTest {
         whenever(jwtTokenService.tokenValiditySeconds()).thenReturn(28800L)
         whenever(userRepository.findByUsernameAndSource("alice", io.plugwerk.server.domain.UserSource.LOCAL))
             .thenReturn(Optional.of(user))
+        whenever(userService.bumpLastLogin(eq(userId), org.mockito.kotlin.any())).thenReturn(user)
 
         mockMvc.post("/api/v1/auth/login") {
             contentType = MediaType.APPLICATION_JSON
@@ -150,6 +151,8 @@ class AuthControllerTest {
             jsonPath("$.userId") { value(userId.toString()) }
             jsonPath("$.displayName") { value("Alice") }
         }
+        // The credential-validated login MUST bump lastLoginAt (#367).
+        org.mockito.Mockito.verify(userService).bumpLastLogin(eq(userId), org.mockito.kotlin.any())
     }
 
     @Test
@@ -169,6 +172,7 @@ class AuthControllerTest {
         whenever(jwtTokenService.tokenValiditySeconds()).thenReturn(28800L)
         whenever(userRepository.findByUsernameAndSource("alice", io.plugwerk.server.domain.UserSource.LOCAL))
             .thenReturn(Optional.of(user))
+        whenever(userService.bumpLastLogin(eq(userId), org.mockito.kotlin.any())).thenReturn(user)
 
         mockMvc.post("/api/v1/auth/login") {
             contentType = MediaType.APPLICATION_JSON

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcIdentityRepository
+import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Pins the contract that [OidcIdentityService.upsertOnLogin] bumps both
+ * `oidc_identity.last_login_at` (binding-level) AND `plugwerk_user.last_login_at`
+ * (user-level, issue #367) — for the existing-identity branch and the
+ * first-login `createNewIdentityAndUser` branch.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:oidc-identity-service-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+class OidcIdentityServiceTest {
+
+    @Autowired private lateinit var service: OidcIdentityService
+
+    @Autowired private lateinit var oidcProviderRepository: OidcProviderRepository
+
+    @Autowired private lateinit var oidcIdentityRepository: OidcIdentityRepository
+
+    @Autowired private lateinit var userRepository: UserRepository
+
+    private lateinit var provider: OidcProviderEntity
+
+    @BeforeEach
+    fun setUp() {
+        oidcIdentityRepository.deleteAll()
+        userRepository.deleteAll()
+        oidcProviderRepository.deleteAll()
+        provider = oidcProviderRepository.save(
+            OidcProviderEntity(
+                name = "test-provider",
+                providerType = OidcProviderType.OIDC,
+                enabled = true,
+                clientId = "client-id",
+                clientSecretEncrypted = "encrypted-placeholder",
+                issuerUri = "https://idp.example/",
+            ),
+        )
+    }
+
+    @Test
+    fun `first-login creates identity and sets user lastLoginAt (#367)`() {
+        val before = java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC)
+
+        val user = service.upsertOnLogin(
+            provider,
+            subject = "alice-sub",
+            claims = mapOf("email" to "alice@example.com", "name" to "Alice"),
+        )
+
+        assertThat(user.lastLoginAt)
+            .isNotNull()
+            .isAfterOrEqualTo(before)
+        // Reload to confirm the value was persisted, not just set on the
+        // returned managed entity.
+        val reloaded = userRepository.findById(requireNotNull(user.id)).orElseThrow()
+        assertThat(reloaded.lastLoginAt).isEqualTo(user.lastLoginAt)
+    }
+
+    @Test
+    fun `existing-identity bumps both oidc_identity and plugwerk_user lastLoginAt (#367)`() {
+        // First call provisions the identity.
+        val initial = service.upsertOnLogin(
+            provider,
+            subject = "bob-sub",
+            claims = mapOf("email" to "bob@example.com", "name" to "Bob"),
+        )
+        val initialUserStamp = requireNotNull(initial.lastLoginAt)
+
+        // Sleep 10ms to make second-call timestamp strictly newer than the first.
+        Thread.sleep(10)
+
+        // Second call must bump both timestamps.
+        val refreshed = service.upsertOnLogin(
+            provider,
+            subject = "bob-sub",
+            claims = mapOf("email" to "bob@example.com", "name" to "Bob"),
+        )
+
+        assertThat(refreshed.lastLoginAt)
+            .isNotNull()
+            .isAfter(initialUserStamp)
+
+        val reloadedUser = userRepository.findById(requireNotNull(refreshed.id)).orElseThrow()
+        assertThat(reloadedUser.lastLoginAt).isEqualTo(refreshed.lastLoginAt)
+
+        val identityRow = oidcIdentityRepository
+            .findByOidcProviderIdAndSubject(requireNotNull(provider.id), "bob-sub")
+            .orElseThrow()
+        // Binding-level timestamp also bumped — both surfaces stay aligned.
+        assertThat(identityRow.lastLoginAt).isAfter(initialUserStamp)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
@@ -86,11 +86,14 @@ class OidcIdentityServiceTest {
 
         assertThat(user.lastLoginAt)
             .isNotNull()
-            .isAfterOrEqualTo(before)
+            .isAfterOrEqualTo(before.truncatedTo(java.time.temporal.ChronoUnit.MICROS))
         // Reload to confirm the value was persisted, not just set on the
-        // returned managed entity.
+        // returned managed entity. H2 TIMESTAMPTZ truncates to microseconds,
+        // OffsetDateTime.now() carries nanos — compare with millisecond fuzz
+        // rather than strict equality.
         val reloaded = userRepository.findById(requireNotNull(user.id)).orElseThrow()
-        assertThat(reloaded.lastLoginAt).isEqualTo(user.lastLoginAt)
+        assertThat(reloaded.lastLoginAt)
+            .isCloseTo(user.lastLoginAt, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS))
     }
 
     @Test
@@ -117,8 +120,10 @@ class OidcIdentityServiceTest {
             .isNotNull()
             .isAfter(initialUserStamp)
 
+        // Reload roundtrip: H2 truncates nanos → use millisecond fuzz.
         val reloadedUser = userRepository.findById(requireNotNull(refreshed.id)).orElseThrow()
-        assertThat(reloadedUser.lastLoginAt).isEqualTo(refreshed.lastLoginAt)
+        assertThat(reloadedUser.lastLoginAt)
+            .isCloseTo(refreshed.lastLoginAt, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS))
 
         val identityRow = oidcIdentityRepository
             .findByOidcProviderIdAndSubject(requireNotNull(provider.id), "bob-sub")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
@@ -93,7 +93,10 @@ class OidcIdentityServiceTest {
         // rather than strict equality.
         val reloaded = userRepository.findById(requireNotNull(user.id)).orElseThrow()
         assertThat(reloaded.lastLoginAt)
-            .isCloseTo(user.lastLoginAt, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS))
+            .isCloseTo(
+                user.lastLoginAt,
+                org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS),
+            )
     }
 
     @Test
@@ -123,7 +126,10 @@ class OidcIdentityServiceTest {
         // Reload roundtrip: H2 truncates nanos → use millisecond fuzz.
         val reloadedUser = userRepository.findById(requireNotNull(refreshed.id)).orElseThrow()
         assertThat(reloadedUser.lastLoginAt)
-            .isCloseTo(refreshed.lastLoginAt, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS))
+            .isCloseTo(
+                refreshed.lastLoginAt,
+                org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS),
+            )
 
         val identityRow = oidcIdentityRepository
             .findByOidcProviderIdAndSubject(requireNotNull(provider.id), "bob-sub")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
@@ -106,4 +106,23 @@ class UserServiceTest {
             .isInstanceOf(ConflictException::class.java)
             .hasMessageContaining("frank")
     }
+
+    @Test
+    fun `bumpLastLogin persists the supplied timestamp and returns the refreshed entity (#367)`() {
+        val created = service.create("greta", "greta@example.com", "password-123")
+        assertThat(created.lastLoginAt).isNull() // never logged in yet
+
+        val at = java.time.OffsetDateTime.parse("2026-04-15T08:30:00Z")
+        val returned = service.bumpLastLogin(requireNotNull(created.id), at)
+
+        assertThat(returned.lastLoginAt).isEqualTo(at)
+        val reloaded = userRepository.findById(requireNotNull(created.id)).orElseThrow()
+        assertThat(reloaded.lastLoginAt).isEqualTo(at)
+    }
+
+    @Test
+    fun `bumpLastLogin throws EntityNotFoundException for unknown user id`() {
+        assertThatThrownBy { service.bumpLastLogin(java.util.UUID.randomUUID()) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+    }
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -215,6 +215,15 @@ export function UsersSection() {
       ),
     },
     {
+      key: "lastLogin",
+      header: "Last login",
+      render: (user) => (
+        <Typography variant="caption" color="text.disabled">
+          <Timestamp date={user.lastLoginAt} variant="relative" />
+        </Typography>
+      ),
+    },
+    {
       key: "enabled",
       header: "Enabled",
       render: (user) => (


### PR DESCRIPTION
## Summary

Closes the audit-trail sliver of #135 (closed as obsolete) by surfacing **"when did this user last actually authenticate"** uniformly across both login methods.

- New nullable column `plugwerk_user.last_login_at` (migration 0020).
- Bumped on every fresh credential-validated login: LOCAL `POST /auth/login` and OIDC `OidcIdentityService.upsertOnLogin` (both first-login and existing-binding paths).
- **Not** bumped on `/auth/refresh`, bearer-token reuse, or `X-Api-Key` traffic — guarded by a dedicated negative IT.
- Surfaced via `UserDto.lastLoginAt` (OpenAPI nullable date-time) and rendered as a "Last login" column in the admin user list using `<Timestamp variant="relative">`.

## Architecture

- `oidc_identity.last_login_at` (binding-level, from #351) stays for future stale-binding tooling.
- `plugwerk_user.last_login_at` (user-level, this PR) is the cross-source "last activity" signal.
- The two are equal in the OIDC happy path but conceptually distinct: user vs binding.
- All bumps route through a new `UserService.bumpLastLogin(id, at)` so the `@Transactional` boundary mirrors `setEnabled` / `resetPassword`. Sole writer for the column.

## What was decided beyond the issue body

- **OIDC `createNewIdentityAndUser` first-login path** also sets `lastLoginAt` — semantically a first login is still a login. The issue text left this implicit; flagged in plan, confirmed before coding.
- **`LoginResponse` left untouched** — the field surfaces via `GET /admin/users` and any future user-profile fetch. Adding it to the immediate login response is a separate UX feature.
- **Frontend null label**: `Timestamp`'s built-in `—` (consistent with the `Created` column).

## Test plan

- [x] `UserServiceTest` — bumpLastLogin persists, returns refreshed entity, throws on unknown id.
- [x] `OidcIdentityServiceTest` (new) — both branches bump `user.lastLoginAt`; binding-level `oidc_identity.last_login_at` also stays bumped.
- [x] `AuthControllerTest` — happy-path login verifies the bump call via Mockito.
- [x] `AuthControllerRefreshIT` — login bumps the column, refresh does NOT.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green (covers `LiquibaseRollbackIT` for the new migration).
- [x] `npm run build` + `npm test` (315 vitest tests) green.
- [ ] CI green.

## Out of scope

- Tracking last activity (any authenticated request, not just login).
- Per-IP / per-device login history.
- Renaming or removing `oidc_identity.last_login_at`.

## Closes
- Closes #367