### PR TITLE
chore(oidc): drop redundant oidc_identity.last_login_at (#367 cleanup)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/OidcIdentityEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/OidcIdentityEntity.kt
@@ -56,10 +56,10 @@ import java.util.UUID
  * @property subject The provider's `sub` claim — provider-local identifier.
  * @property user The Plugwerk identity hub row this OIDC subject maps to.
  *   Stored as `user_id` UUID column with UNIQUE constraint.
- * @property createdAt First-login timestamp.
- * @property lastLoginAt Updated by `OidcIdentityService.upsertOnLogin` on
- *   every subsequent successful OIDC callback. Useful for stale-account
- *   reporting later.
+ * @property createdAt First-login timestamp. The user-level "last login"
+ *   signal lives on [UserEntity.lastLoginAt] and is bumped by
+ *   [io.plugwerk.server.service.OidcIdentityService.upsertOnLogin]
+ *   on every successful OIDC callback (issue #367).
  */
 @Entity
 @Table(
@@ -97,7 +97,4 @@ class OidcIdentityEntity(
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: OffsetDateTime = OffsetDateTime.now(),
-
-    @Column(name = "last_login_at", nullable = false)
-    var lastLoginAt: OffsetDateTime = OffsetDateTime.now(),
 )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/OidcIdentityRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/OidcIdentityRepository.kt
@@ -28,8 +28,8 @@ interface OidcIdentityRepository : JpaRepository<OidcIdentityEntity, UUID> {
     /**
      * Lookup by `(provider, sub)` — the upstream identifier pair. Used by
      * `OidcIdentityService.upsertOnLogin` on every OIDC callback to decide
-     * whether to issue a fresh `plugwerk_user` row or refresh `lastLoginAt`
-     * on an existing one.
+     * whether to issue a fresh `plugwerk_user` row or bump
+     * `plugwerk_user.last_login_at` on an existing one.
      */
     fun findByOidcProviderIdAndSubject(oidcProviderId: UUID, subject: String): Optional<OidcIdentityEntity>
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
@@ -32,9 +32,9 @@ import java.time.ZoneOffset
 
 /**
  * OIDC-side counterpart of [UserService]. Materialises Plugwerk identities for
- * OIDC subjects on the first successful callback and refreshes `lastLoginAt`
- * on every subsequent one (issue #351, replaces PR #350's JIT-`plugwerk_user`
- * hack).
+ * OIDC subjects on the first successful callback and bumps
+ * `plugwerk_user.last_login_at` (#367) on every subsequent one (issue #351,
+ * replaces PR #350's JIT-`plugwerk_user` hack).
  *
  * **No identity linking by policy.** A given `(provider, subject)` pair always
  * maps to exactly one [UserEntity]; the schema enforces this with
@@ -55,7 +55,8 @@ class OidcIdentityService(
      * Resolves or creates the [UserEntity] for an OIDC callback. Returns the
      * resolved user — never null. Side effects:
      *
-     *   - **Existing identity** → bumps `lastLoginAt`, returns the linked user.
+     *   - **Existing identity** → bumps `plugwerk_user.last_login_at` via
+     *     [UserService.bumpLastLogin] (#367), returns the linked user.
      *   - **New identity** → creates a fresh [UserEntity] with `source = OIDC`
      *     plus the matching [OidcIdentityEntity] row, returns the new user.
      *
@@ -74,11 +75,6 @@ class OidcIdentityService(
         val now = OffsetDateTime.now(ZoneOffset.UTC)
         val existing = oidcIdentityRepository.findByOidcProviderIdAndSubject(providerId, subject).orElse(null)
         if (existing != null) {
-            // Two distinct timestamps end up equal in the happy path but track different
-            // things conceptually: the binding-level last_login_at on oidc_identity (used
-            // later for stale-binding cleanup) and the user-level last_login_at on
-            // plugwerk_user (issue #367, surfaced in UserDto).
-            existing.lastLoginAt = now
             return userService.bumpLastLogin(existing.user.id!!, now)
         }
         return createNewIdentityAndUser(provider, subject, claims, now)

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0019_user_setting_user_id_fk.yaml
   - include:
       file: db/changelog/migrations/0020_user_last_login_at.yaml
+  - include:
+      file: db/changelog/migrations/0021_drop_oidc_identity_last_login_at.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0021_drop_oidc_identity_last_login_at.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0021_drop_oidc_identity_last_login_at.yaml
@@ -1,0 +1,43 @@
+# Drop the now-redundant oidc_identity.last_login_at (issue #367 follow-up).
+#
+# History:
+#   - Added by 0017 (identity-hub split, #351). Tracked the binding-level
+#     "when did this OIDC identity last activate" timestamp.
+#   - Migration 0020 (#367) added plugwerk_user.last_login_at as the
+#     uniform user-level "last activity" signal across LOCAL and OIDC.
+#
+# Why drop now:
+#   - Plugwerk does not perform identity linking — every OIDC callback
+#     produces a 1:1 oidc_identity ↔ plugwerk_user row pair (see
+#     OidcIdentityService Javadoc: "Same human across multiple providers
+#     ⇒ multiple unrelated UserEntity rows"). The two timestamps therefore
+#     always carried the same value.
+#   - There is no current consumer: no repository query, no service method,
+#     no DTO, no UI surface ever read oidc_identity.last_login_at.
+#   - The "useful later for stale-binding tooling" justification on the
+#     original column was YAGNI under the 1:1 model. If identity linking
+#     ever lands, the column can be re-added by a forward migration that
+#     also fills it from plugwerk_user.last_login_at.
+#
+# Rollback restores the column nullable (the original was NOT NULL with
+# default now() — a rollback to that exact shape would require a default
+# now() backfill that does not match historic state. Nullable is the
+# accurate restore: rows created post-drop genuinely have no value.)
+
+databaseChangeLog:
+  - changeSet:
+      id: 0021-drop-oidc-identity-last-login-at
+      author: plugwerk
+      changes:
+        - dropColumn:
+            tableName: oidc_identity
+            columnName: last_login_at
+      rollback:
+        - addColumn:
+            tableName: oidc_identity
+            columns:
+              - column:
+                  name: last_login_at
+                  type: timestamptz
+                  constraints:
+                    nullable: true

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
@@ -204,17 +204,20 @@ class OidcWebLoginIT {
 
         val firstUser = userBySubject(sub)
         val firstUserId = requireNotNull(firstUser.id)
-        val firstLoginAt = oidcIdentityRepository.findByUserId(firstUserId).orElseThrow().lastLoginAt
+        // last_login_at moved from oidc_identity to plugwerk_user (issue #367 cleanup,
+        // migration 0021). The user-level column is now the canonical signal.
+        val firstLoginAt = requireNotNull(firstUser.lastLoginAt)
 
         Thread.sleep(50)
         enqueueIdToken(sub = sub, email = email, name = "Alice Anderson")
         performAuthorizeRoundtrip()
 
-        val identityAfter = oidcIdentityRepository.findByOidcProviderIdAndSubject(providerId, sub).orElseThrow()
-        assertThat(identityAfter.lastLoginAt).`as`("lastLoginAt should advance on re-login").isAfter(firstLoginAt)
         // Same plugwerk_user; no second row provisioned.
         val secondUser = userBySubject(sub)
         assertThat(secondUser.id).`as`("same user, no fresh provisioning").isEqualTo(firstUserId)
+        assertThat(secondUser.lastLoginAt)
+            .`as`("plugwerk_user.last_login_at should advance on re-login")
+            .isAfter(firstLoginAt)
 
         val refreshTokens = refreshTokenRepository.findAll().filter { it.userId == firstUserId }
         assertThat(refreshTokens).hasSize(2)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
@@ -32,10 +32,10 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 
 /**
- * Pins the contract that [OidcIdentityService.upsertOnLogin] bumps both
- * `oidc_identity.last_login_at` (binding-level) AND `plugwerk_user.last_login_at`
- * (user-level, issue #367) — for the existing-identity branch and the
- * first-login `createNewIdentityAndUser` branch.
+ * Pins the contract that [OidcIdentityService.upsertOnLogin] bumps
+ * `plugwerk_user.last_login_at` on every successful callback (issue #367) —
+ * for the existing-identity branch and the first-login
+ * `createNewIdentityAndUser` branch.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -100,7 +100,7 @@ class OidcIdentityServiceTest {
     }
 
     @Test
-    fun `existing-identity bumps both oidc_identity and plugwerk_user lastLoginAt (#367)`() {
+    fun `existing-identity bumps plugwerk_user lastLoginAt (#367)`() {
         // First call provisions the identity.
         val initial = service.upsertOnLogin(
             provider,
@@ -130,11 +130,5 @@ class OidcIdentityServiceTest {
                 refreshed.lastLoginAt,
                 org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MILLIS),
             )
-
-        val identityRow = oidcIdentityRepository
-            .findByOidcProviderIdAndSubject(requireNotNull(provider.id), "bob-sub")
-            .orElseThrow()
-        // Binding-level timestamp also bumped — both surfaces stay aligned.
-        assertThat(identityRow.lastLoginAt).isAfter(initialUserStamp)
     }
 }


### PR DESCRIPTION
## Why

PR #400 added `plugwerk_user.last_login_at` as the cross-source "last activity" signal, but the older binding-level `oidc_identity.last_login_at` column from #351 was left in place. Two facts make it dead weight:

1. **No identity linking.** Plugwerk's contract (`OidcIdentityService` Javadoc): *"Same human across multiple providers ⇒ multiple unrelated `UserEntity` rows"*. Every OIDC callback produces a 1:1 `oidc_identity ↔ plugwerk_user` pair, so the two timestamps always carried the same value.

2. **No consumer.** No repository query, no service method, no DTO, no UI surface ever read `oidc_identity.last_login_at`. The "useful later for stale-binding tooling" justification was YAGNI under the 1:1 model — when identity linking ever lands, a forward migration can reintroduce the column and backfill it.

## What this PR changes

- **Migration 0021** drops `oidc_identity.last_login_at`. Rollback restores it nullable (the original `NOT NULL DEFAULT now()` would require a `now()`-backfill that doesn't reflect historic state — nullable is the accurate inverse).
- **`OidcIdentityEntity`** loses the field; doc-block points at `UserEntity.lastLoginAt` as the canonical signal.
- **`OidcIdentityService.upsertOnLogin`** existing-identity branch loses the redundant in-memory mutation. `userService.bumpLastLogin(...)` (added in PR #400) becomes the sole remaining writer.
- **`OidcIdentityRepository`** doc-block updated.
- **`OidcIdentityServiceTest`** drops the binding-level assertion that's no longer meaningful; user-level assertions stay.
- **`OidcWebLoginIT`** rewritten to read `plugwerk_user.lastLoginAt` instead of the removed column.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green (covers `LiquibaseRollbackIT` for migration 0021).
- [ ] CI green.

## Out of scope

- Reintroducing `oidc_identity.last_login_at` if identity linking ever lands — that will be a forward migration on its own with a backfill from `plugwerk_user.last_login_at` for linking-relevant rows.

## References

- Predecessor: #400 (added `plugwerk_user.last_login_at`)
- Origin of the dropped column: #351 / migration 0017 (identity-hub split)
- Audit-trail tracking issue: #367