### PR TITLE
refactor(auth): introduce ProviderPrincipalAdapter sealed boundary (#357 phase 0)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandler.kt
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
-import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -62,6 +61,7 @@ class OidcLoginSuccessHandler(
     private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
     private val oidcIdentityService: OidcIdentityService,
     private val oidcProviderRepository: OidcProviderRepository,
+    private val adapterRegistry: ProviderPrincipalAdapterRegistry,
 ) : AuthenticationSuccessHandler {
 
     private val log = LoggerFactory.getLogger(OidcLoginSuccessHandler::class.java)
@@ -78,14 +78,6 @@ class OidcLoginSuccessHandler(
                     "${authentication.javaClass.name}. Spring Security wiring is broken.",
             )
         val registrationId = oauthToken.authorizedClientRegistrationId
-        val principal = requireNotNull(oauthToken.principal) {
-            "OAuth2AuthenticationToken for $registrationId has no principal"
-        }
-        val sub = principal.attributes["sub"] as? String
-            ?: error(
-                "OIDC provider $registrationId returned a token without a `sub` claim — " +
-                    "cannot map to a Plugwerk user.",
-            )
 
         // The registrationId is the OIDC provider's UUID (see OidcRegistrationIds.of).
         // It must exist in the DB or the OAuth2 client filter could not have built a
@@ -97,10 +89,21 @@ class OidcLoginSuccessHandler(
             IllegalStateException("OIDC provider $providerId no longer exists in the database")
         }
 
+        // Per-provider extraction of subject / email / displayName / upstreamIdToken.
+        // The handler stays provider-agnostic — every provider-specific quirk
+        // (GitHub's no-id_token, Facebook's `id`-as-subject, OIDC's claims map)
+        // lives behind this boundary (#357 Phase 0).
+        val resolved = adapterRegistry.forProviderType(provider.providerType).resolve(oauthToken)
+
         val user = try {
-            oidcIdentityService.upsertOnLogin(provider, sub, principal.attributes)
+            oidcIdentityService.upsertOnLogin(provider, resolved)
         } catch (e: OidcEmailMissingException) {
-            log.warn("Rejecting OIDC login for provider={} sub={}: {}", provider.name, sub, e.message)
+            log.warn(
+                "Rejecting OIDC login for provider={} sub={}: {}",
+                provider.name,
+                resolved.subject,
+                e.message,
+            )
             // 400 + plain-text body — operator-actionable misconfiguration, not a
             // user-fixable condition. The browser shows it as a Spring whitelabel
             // page, which is acceptable for a setup-time error.
@@ -108,15 +111,16 @@ class OidcLoginSuccessHandler(
             return
         }
 
-        // Capture the upstream ID token so logout can perform RP-Initiated Logout
-        // against the IdP later (#352). Pure-OAuth2 (non-OIDC) flows have no ID
-        // token and pass null — RP-Initiated Logout falls back gracefully.
-        val idTokenValue = (principal as? OidcUser)?.idToken?.tokenValue
         val userId = requireNotNull(user.id) { "Newly upserted UserEntity has no id" }
-        val refresh = refreshTokenService.issue(userId, idTokenValue)
+        val refresh = refreshTokenService.issue(userId, resolved.upstreamIdToken)
         val cookie = refreshTokenCookieFactory.build(refresh.plaintext, refresh.maxAge)
 
-        log.info("OIDC login success — provider={} sub={} user_id={}", provider.name, sub, userId)
+        log.info(
+            "OIDC login success — provider={} sub={} user_id={}",
+            provider.name,
+            resolved.subject,
+            userId,
+        )
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString())
         // Always redirect to the SPA root; the frontend's hydrate() will run

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcPrincipalAdapter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcPrincipalAdapter.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.stereotype.Component
+
+/**
+ * Adapter for fully OIDC-conformant providers. Covers
+ * [OidcProviderType.OIDC] (Keycloak / Authentik / Auth0 / Dex /
+ * any provider that publishes `/.well-known/openid-configuration`) and
+ * [OidcProviderType.GOOGLE] (which is OIDC-conformant; the only difference
+ * from `OIDC` is the hard-coded issuer URI in
+ * [DbClientRegistrationRepository], not the principal shape).
+ *
+ * The principal Spring hands us is an [OidcUser], so all four
+ * [ResolvedPrincipal] fields come straight from the ID token claims; no
+ * out-of-band HTTP calls are needed.
+ */
+@Component
+class OidcPrincipalAdapter : ProviderPrincipalAdapter {
+
+    override val providerTypes: Set<OidcProviderType> =
+        setOf(OidcProviderType.OIDC, OidcProviderType.GOOGLE)
+
+    override fun resolve(authentication: OAuth2AuthenticationToken): ResolvedPrincipal {
+        val registrationId = authentication.authorizedClientRegistrationId
+        val principal = requireNotNull(authentication.principal) {
+            "OAuth2AuthenticationToken for $registrationId has no principal"
+        }
+        val subject = principal.attributes["sub"] as? String
+            ?: error(
+                "OIDC provider $registrationId returned a token without a `sub` claim — " +
+                    "cannot map to a Plugwerk user.",
+            )
+        val email = (principal.attributes["email"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+        // displayName precedence:
+        //   1. `name` (full name, what most IdPs render in their own UIs)
+        //   2. `preferred_username` (handle / login alias)
+        //   3. null (caller falls back to subject)
+        val displayName = (principal.attributes["name"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+            ?: (principal.attributes["preferred_username"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+        val upstreamIdToken = (principal as? OidcUser)?.idToken?.tokenValue
+        return ResolvedPrincipal(
+            subject = subject,
+            email = email,
+            displayName = displayName,
+            upstreamIdToken = upstreamIdToken,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapter.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+
+/**
+ * Per-provider extraction of the four facts Plugwerk needs from an OAuth2/OIDC
+ * callback in order to materialise a `plugwerk_user` row and a refresh-token cookie:
+ *
+ *  - **subject** — stable, provider-local user identifier. For OIDC providers this
+ *    is the `sub` claim; for pure-OAuth2 providers (GitHub, Facebook) it is the
+ *    provider's own integer/string id surfaced as `attributes["id"]`.
+ *  - **email** — required by [io.plugwerk.server.domain.UserEntity.email]. May be
+ *    `null` for providers that do not surface it in the userinfo response (e.g.
+ *    GitHub when the user has no public email and the `user:email` scope was not
+ *    granted, or when the primary email is private). Callers translate `null`
+ *    into [io.plugwerk.server.service.OidcEmailMissingException].
+ *  - **displayName** — best-effort human label. Falls back to the subject when
+ *    no claim/attribute is suitable.
+ *  - **upstreamIdToken** — captured for RP-Initiated Logout (#352). `null` for
+ *    pure-OAuth2 providers; the logout path handles that gracefully.
+ *
+ * Implementations live in [OidcPrincipalAdapter] (covers `OIDC` and `GOOGLE`),
+ * [GitHubPrincipalAdapter] (#357 Phase 3), and [FacebookPrincipalAdapter] (#357
+ * Phase 4). Lookup happens via [ProviderPrincipalAdapterRegistry] keyed on
+ * [io.plugwerk.server.domain.OidcProviderType].
+ */
+sealed interface ProviderPrincipalAdapter {
+
+    /** Provider types this adapter handles. Registry uses this for lookup. */
+    val providerTypes: Set<OidcProviderType>
+
+    /**
+     * Pulls the four [ResolvedPrincipal] fields out of the authenticated token
+     * Spring Security hands us. Implementations may perform additional HTTP
+     * calls to the provider (e.g. GitHub's `/user/emails`) when the principal
+     * itself does not carry every needed value.
+     */
+    fun resolve(authentication: OAuth2AuthenticationToken): ResolvedPrincipal
+}
+
+/**
+ * Provider-agnostic snapshot of the four facts a successful login produces.
+ * Crossing this boundary, callers no longer care which provider type backed
+ * the login — the downstream `OidcIdentityService.upsertOnLogin` and
+ * `OidcLoginSuccessHandler` work uniformly off this struct.
+ *
+ * `email = null` is the explicit "no email available" signal; downstream
+ * raises [io.plugwerk.server.service.OidcEmailMissingException].
+ */
+data class ResolvedPrincipal(
+    val subject: String,
+    val email: String?,
+    val displayName: String?,
+    val upstreamIdToken: String?,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistry.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistry.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.springframework.stereotype.Component
+
+/**
+ * Lookup boundary for [ProviderPrincipalAdapter] implementations. Builds a
+ * `OidcProviderType → adapter` map at construction time from every
+ * [ProviderPrincipalAdapter] bean Spring discovers, fails fast on duplicates
+ * (two adapters claiming the same provider type) and on lookups for
+ * unconfigured types (the early signal a new provider type was added without
+ * a matching adapter, see [OidcProviderType] vs adapter coverage).
+ */
+@Component
+class ProviderPrincipalAdapterRegistry(adapters: List<ProviderPrincipalAdapter>) {
+
+    private val byType: Map<OidcProviderType, ProviderPrincipalAdapter> = buildMap {
+        for (adapter in adapters) {
+            for (type in adapter.providerTypes) {
+                val previous = put(type, adapter)
+                require(previous == null) {
+                    "Multiple ProviderPrincipalAdapter beans claim provider type $type: " +
+                        "${previous!!.javaClass.simpleName} and ${adapter.javaClass.simpleName}. " +
+                        "Each provider type must map to exactly one adapter."
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the adapter for [providerType]. Throws [IllegalStateException]
+     * with an actionable message if no adapter is registered — that signals a
+     * new entry in [OidcProviderType] without a matching adapter implementation.
+     */
+    fun forProviderType(providerType: OidcProviderType): ProviderPrincipalAdapter = byType[providerType]
+        ?: error(
+            "No ProviderPrincipalAdapter registered for provider type $providerType — " +
+                "browser login flow is not implemented for this provider type yet. " +
+                "See issue #357 for the rollout plan.",
+        )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
 import io.plugwerk.server.repository.OidcIdentityRepository
 import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.ResolvedPrincipal
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -52,8 +53,8 @@ class OidcIdentityService(
     private val log = LoggerFactory.getLogger(OidcIdentityService::class.java)
 
     /**
-     * Resolves or creates the [UserEntity] for an OIDC callback. Returns the
-     * resolved user — never null. Side effects:
+     * Resolves or creates the [UserEntity] for an OIDC / OAuth2 callback.
+     * Returns the resolved user — never null. Side effects:
      *
      *   - **Existing identity** → bumps `plugwerk_user.last_login_at` via
      *     [UserService.bumpLastLogin] (#367), returns the linked user.
@@ -62,39 +63,36 @@ class OidcIdentityService(
      *
      * @param provider Source OIDC provider — the row is required to have a
      *   non-null `id` (already persisted at the time of the call).
-     * @param subject Upstream `sub` claim — provider-local identifier.
-     * @param claims Decoded ID-token claims. `email` must be present and
-     *   non-blank — Plugwerk requires an email for every account (see
-     *   [OidcEmailMissingException] callers and the `email NOT NULL`
-     *   constraint introduced in migration 0017).
+     * @param principal Provider-agnostic snapshot produced by a
+     *   [io.plugwerk.server.security.ProviderPrincipalAdapter] (#357 Phase 0).
+     *   `principal.email == null` triggers [OidcEmailMissingException] —
+     *   `plugwerk_user.email` is `NOT NULL` (migration 0017, ADR-0029 §5).
      */
-    fun upsertOnLogin(provider: OidcProviderEntity, subject: String, claims: Map<String, Any>): UserEntity {
+    fun upsertOnLogin(provider: OidcProviderEntity, principal: ResolvedPrincipal): UserEntity {
         val providerId = requireNotNull(provider.id) {
             "OidcProviderEntity must be persisted before upsertOnLogin"
         }
         val now = OffsetDateTime.now(ZoneOffset.UTC)
-        val existing = oidcIdentityRepository.findByOidcProviderIdAndSubject(providerId, subject).orElse(null)
+        val existing = oidcIdentityRepository
+            .findByOidcProviderIdAndSubject(providerId, principal.subject)
+            .orElse(null)
         if (existing != null) {
             return userService.bumpLastLogin(existing.user.id!!, now)
         }
-        return createNewIdentityAndUser(provider, subject, claims, now)
+        return createNewIdentityAndUser(provider, principal, now)
     }
 
     private fun createNewIdentityAndUser(
         provider: OidcProviderEntity,
-        subject: String,
-        claims: Map<String, Any>,
+        principal: ResolvedPrincipal,
         loginAt: OffsetDateTime,
     ): UserEntity {
-        val email = (claims["email"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+        val email = principal.email?.trim()?.takeIf { it.isNotBlank() }
             ?: throw OidcEmailMissingException(provider.name)
-        // displayName precedence:
-        //   1. `name` claim (full name, what most IdPs render in their own UIs)
-        //   2. `preferred_username` claim (handle / login alias)
-        //   3. `subject` itself, as a last-resort visible identifier
-        val displayName = (claims["name"] as? String)?.trim()?.takeIf { it.isNotBlank() }
-            ?: (claims["preferred_username"] as? String)?.trim()?.takeIf { it.isNotBlank() }
-            ?: subject
+        // displayName falls back to subject as a last-resort visible identifier when
+        // the adapter could not produce one (e.g. a provider that returns no name claim).
+        val displayName = principal.displayName?.trim()?.takeIf { it.isNotBlank() }
+            ?: principal.subject
         // First OIDC login is still a login (issue #367) — set lastLoginAt at
         // creation so the user surfaces as "active" immediately rather than as
         // "never logged in" until the second callback.
@@ -114,14 +112,14 @@ class OidcIdentityService(
         oidcIdentityRepository.save(
             OidcIdentityEntity(
                 oidcProvider = provider,
-                subject = subject,
+                subject = principal.subject,
                 user = user,
             ),
         )
         log.info(
             "Provisioned new OIDC identity: provider={} sub={} user_id={}",
             provider.name,
-            subject,
+            principal.subject,
             user.id,
         )
         return user

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
@@ -64,6 +64,11 @@ class OidcLoginSuccessHandlerTest {
 
     @Mock lateinit var oidcProviderRepository: OidcProviderRepository
 
+    // Real adapter (no Spring), wrapped in a real registry. Real `OidcPrincipalAdapter`
+    // covers OIDC + GOOGLE — both test-relevant principal shapes here. GitHub/Facebook
+    // adapters get their own dedicated unit tests (#357 Phase 3 / 4).
+    private val adapterRegistry = ProviderPrincipalAdapterRegistry(listOf(OidcPrincipalAdapter()))
+
     private val cookieFactory = RefreshTokenCookieFactory(
         PlugwerkProperties(
             auth = PlugwerkProperties.AuthProperties(
@@ -103,14 +108,23 @@ class OidcLoginSuccessHandlerTest {
             idTokenValue = tokenValue,
         )
         whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
-        whenever(oidcIdentityService.upsertOnLogin(eq(provider), eq("alice-sub"), any())).thenReturn(resolvedUser)
+        whenever(oidcIdentityService.upsertOnLogin(eq(provider), any<ResolvedPrincipal>())).thenReturn(resolvedUser)
         whenever(refreshTokenService.issue(eq(resolvedUser.id!!), anyOrNull())).thenReturn(stubIssuedToken())
 
         val handler =
-            OidcLoginSuccessHandler(refreshTokenService, cookieFactory, oidcIdentityService, oidcProviderRepository)
+            OidcLoginSuccessHandler(
+                refreshTokenService,
+                cookieFactory,
+                oidcIdentityService,
+                oidcProviderRepository,
+                adapterRegistry,
+            )
         handler.onAuthenticationSuccess(MockHttpServletRequest(), MockHttpServletResponse(), token)
 
-        verify(oidcIdentityService).upsertOnLogin(eq(provider), eq("alice-sub"), any())
+        verify(oidcIdentityService).upsertOnLogin(
+            eq(provider),
+            org.mockito.kotlin.argThat { p -> p.subject == "alice-sub" },
+        )
         verify(refreshTokenService).issue(eq(resolvedUser.id!!), eq(tokenValue))
     }
 
@@ -122,11 +136,17 @@ class OidcLoginSuccessHandlerTest {
             idTokenValue = "eyJ.x.y",
         )
         whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
-        whenever(oidcIdentityService.upsertOnLogin(any(), any(), any())).thenReturn(resolvedUser)
+        whenever(oidcIdentityService.upsertOnLogin(any(), any<ResolvedPrincipal>())).thenReturn(resolvedUser)
         whenever(refreshTokenService.issue(any<UUID>(), anyOrNull())).thenReturn(stubIssuedToken())
 
         val handler =
-            OidcLoginSuccessHandler(refreshTokenService, cookieFactory, oidcIdentityService, oidcProviderRepository)
+            OidcLoginSuccessHandler(
+                refreshTokenService,
+                cookieFactory,
+                oidcIdentityService,
+                oidcProviderRepository,
+                adapterRegistry,
+            )
         val response = MockHttpServletResponse()
 
         handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
@@ -147,11 +167,17 @@ class OidcLoginSuccessHandlerTest {
             idTokenValue = "eyJ.x.y",
         )
         whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
-        whenever(oidcIdentityService.upsertOnLogin(any(), any(), any()))
+        whenever(oidcIdentityService.upsertOnLogin(any(), any<ResolvedPrincipal>()))
             .thenThrow(OidcEmailMissingException(provider.name))
 
         val handler =
-            OidcLoginSuccessHandler(refreshTokenService, cookieFactory, oidcIdentityService, oidcProviderRepository)
+            OidcLoginSuccessHandler(
+                refreshTokenService,
+                cookieFactory,
+                oidcIdentityService,
+                oidcProviderRepository,
+                adapterRegistry,
+            )
         val response = MockHttpServletResponse()
 
         handler.onAuthenticationSuccess(MockHttpServletRequest(), response, token)
@@ -163,11 +189,17 @@ class OidcLoginSuccessHandlerTest {
     fun `passes null id_token for non-OIDC OAuth2 principals (graceful degradation, #352)`() {
         val token = oauth2AuthenticationTokenFor(registrationId = providerId.toString(), sub = "alice-sub")
         whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
-        whenever(oidcIdentityService.upsertOnLogin(any(), any(), any())).thenReturn(resolvedUser)
+        whenever(oidcIdentityService.upsertOnLogin(any(), any<ResolvedPrincipal>())).thenReturn(resolvedUser)
         whenever(refreshTokenService.issue(any<UUID>(), anyOrNull())).thenReturn(stubIssuedToken())
 
         val handler =
-            OidcLoginSuccessHandler(refreshTokenService, cookieFactory, oidcIdentityService, oidcProviderRepository)
+            OidcLoginSuccessHandler(
+                refreshTokenService,
+                cookieFactory,
+                oidcIdentityService,
+                oidcProviderRepository,
+                adapterRegistry,
+            )
         handler.onAuthenticationSuccess(MockHttpServletRequest(), MockHttpServletResponse(), token)
 
         verify(refreshTokenService).issue(eq(resolvedUser.id!!), eq(null))
@@ -176,7 +208,13 @@ class OidcLoginSuccessHandlerTest {
     @Test
     fun `non-OAuth2 authentication is treated as a wiring bug and fails loudly`() {
         val handler =
-            OidcLoginSuccessHandler(refreshTokenService, cookieFactory, oidcIdentityService, oidcProviderRepository)
+            OidcLoginSuccessHandler(
+                refreshTokenService,
+                cookieFactory,
+                oidcIdentityService,
+                oidcProviderRepository,
+                adapterRegistry,
+            )
         val plainAuth = TestingAuthenticationToken("alice", "irrelevant")
 
         assertThatThrownBy {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcPrincipalAdapterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcPrincipalAdapterTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import java.time.Instant
+
+class OidcPrincipalAdapterTest {
+
+    private val adapter = OidcPrincipalAdapter()
+
+    @Test
+    fun `claims OIDC and GOOGLE provider types`() {
+        assertThat(adapter.providerTypes)
+            .containsExactlyInAnyOrder(OidcProviderType.OIDC, OidcProviderType.GOOGLE)
+    }
+
+    @Test
+    fun `extracts subject email displayName and upstreamIdToken from OidcUser principal`() {
+        val now = Instant.now()
+        val idToken = OidcIdToken(
+            "eyJraWQ.fake.signature",
+            now,
+            now.plusSeconds(300),
+            mapOf(
+                "sub" to "alice-sub",
+                "email" to "alice@example.test",
+                "name" to "Alice Anderson",
+            ),
+        )
+        val user = DefaultOidcUser(emptyList(), idToken)
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        val resolved = adapter.resolve(token)
+
+        assertThat(resolved.subject).isEqualTo("alice-sub")
+        assertThat(resolved.email).isEqualTo("alice@example.test")
+        assertThat(resolved.displayName).isEqualTo("Alice Anderson")
+        assertThat(resolved.upstreamIdToken).isEqualTo("eyJraWQ.fake.signature")
+    }
+
+    @Test
+    fun `falls back to preferred_username when name claim is absent`() {
+        val now = Instant.now()
+        val idToken = OidcIdToken(
+            "tok",
+            now,
+            now.plusSeconds(300),
+            mapOf(
+                "sub" to "bob-sub",
+                "email" to "bob@example.test",
+                "preferred_username" to "bob",
+            ),
+        )
+        val user = DefaultOidcUser(emptyList(), idToken)
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        val resolved = adapter.resolve(token)
+
+        assertThat(resolved.displayName).isEqualTo("bob")
+    }
+
+    @Test
+    fun `returns null displayName when neither name nor preferred_username present (caller falls back to subject)`() {
+        val now = Instant.now()
+        val idToken = OidcIdToken(
+            "tok",
+            now,
+            now.plusSeconds(300),
+            mapOf("sub" to "carol-sub", "email" to "carol@example.test"),
+        )
+        val user = DefaultOidcUser(emptyList(), idToken)
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        assertThat(adapter.resolve(token).displayName).isNull()
+    }
+
+    @Test
+    fun `returns null email when claim is missing or blank (caller raises OidcEmailMissingException)`() {
+        val now = Instant.now()
+        val idToken = OidcIdToken(
+            "tok",
+            now,
+            now.plusSeconds(300),
+            mapOf("sub" to "dave-sub"),
+        )
+        val user = DefaultOidcUser(emptyList(), idToken)
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        assertThat(adapter.resolve(token).email).isNull()
+    }
+
+    @Test
+    fun `upstreamIdToken is null for non-OIDC OAuth2 principals (caller passes null to refresh-token issue)`() {
+        // DefaultOAuth2User has no idToken — emulates a future Google flow stub
+        // or any provider where the principal is OAuth2 not OIDC. The adapter
+        // still returns a usable ResolvedPrincipal; only upstreamIdToken is null.
+        val user = DefaultOAuth2User(
+            emptyList(),
+            mapOf("sub" to "eve-sub", "email" to "eve@example.test"),
+            "sub",
+        )
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        val resolved = adapter.resolve(token)
+
+        assertThat(resolved.subject).isEqualTo("eve-sub")
+        assertThat(resolved.upstreamIdToken).isNull()
+    }
+
+    @Test
+    fun `throws when sub claim is missing (wiring failure, not user-facing)`() {
+        val now = Instant.now()
+        val idToken = OidcIdToken(
+            "tok",
+            now,
+            now.plusSeconds(300),
+            mapOf("email" to "x@example.test", "iss" to "https://idp.example/"),
+        )
+        val user = DefaultOidcUser(emptyList(), idToken, "iss")
+        val token = OAuth2AuthenticationToken(user, emptyList(), "registration-id")
+
+        assertThatThrownBy { adapter.resolve(token) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("sub")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+class ProviderPrincipalAdapterRegistryTest {
+
+    @Test
+    fun `routes by provider type`() {
+        val oidc = OidcPrincipalAdapter()
+        val registry = ProviderPrincipalAdapterRegistry(listOf(oidc))
+
+        assertThat(registry.forProviderType(OidcProviderType.OIDC)).isSameAs(oidc)
+        assertThat(registry.forProviderType(OidcProviderType.GOOGLE)).isSameAs(oidc)
+    }
+
+    @Test
+    fun `fails with actionable message for unconfigured provider type`() {
+        val registry = ProviderPrincipalAdapterRegistry(listOf(OidcPrincipalAdapter()))
+
+        assertThatThrownBy { registry.forProviderType(OidcProviderType.GITHUB) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("GITHUB")
+            .hasMessageContaining("#357")
+    }
+
+    @Test
+    fun `rejects duplicate registrations at construction time`() {
+        // Two adapter instances claiming the same provider type set is a bean-wiring
+        // bug — fail fast at construction. Sealed interface forbids anonymous test
+        // implementations, so we provoke the duplicate with two real adapter
+        // instances (both claim OIDC + GOOGLE).
+        val first = OidcPrincipalAdapter()
+        val duplicate = OidcPrincipalAdapter()
+
+        assertThatThrownBy { ProviderPrincipalAdapterRegistry(listOf(first, duplicate)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Multiple ProviderPrincipalAdapter")
+            .hasMessageContaining("OIDC")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcIdentityServiceTest.kt
@@ -80,8 +80,12 @@ class OidcIdentityServiceTest {
 
         val user = service.upsertOnLogin(
             provider,
-            subject = "alice-sub",
-            claims = mapOf("email" to "alice@example.com", "name" to "Alice"),
+            io.plugwerk.server.security.ResolvedPrincipal(
+                subject = "alice-sub",
+                email = "alice@example.com",
+                displayName = "Alice",
+                upstreamIdToken = null,
+            ),
         )
 
         assertThat(user.lastLoginAt)
@@ -104,8 +108,12 @@ class OidcIdentityServiceTest {
         // First call provisions the identity.
         val initial = service.upsertOnLogin(
             provider,
-            subject = "bob-sub",
-            claims = mapOf("email" to "bob@example.com", "name" to "Bob"),
+            io.plugwerk.server.security.ResolvedPrincipal(
+                subject = "bob-sub",
+                email = "bob@example.com",
+                displayName = "Bob",
+                upstreamIdToken = null,
+            ),
         )
         val initialUserStamp = requireNotNull(initial.lastLoginAt)
 
@@ -115,8 +123,12 @@ class OidcIdentityServiceTest {
         // Second call must bump both timestamps.
         val refreshed = service.upsertOnLogin(
             provider,
-            subject = "bob-sub",
-            claims = mapOf("email" to "bob@example.com", "name" to "Bob"),
+            io.plugwerk.server.security.ResolvedPrincipal(
+                subject = "bob-sub",
+                email = "bob@example.com",
+                displayName = "Bob",
+                upstreamIdToken = null,
+            ),
         )
 
         assertThat(refreshed.lastLoginAt)


### PR DESCRIPTION
## Summary

Phase 0 of #357 — pure refactor, no behavior change. Extracts the per-provider principal-extraction logic out of `OidcLoginSuccessHandler` behind a sealed `ProviderPrincipalAdapter` interface, so that GitHub / Google / Facebook can land as additive adapter implementations in subsequent PRs without growing the in-handler `if/else` chain.

## What this PR changes

- **`ProviderPrincipalAdapter` (sealed interface) + `ResolvedPrincipal` (data class)** — the boundary contract. Four fields: `subject`, `email?`, `displayName?`, `upstreamIdToken?`.
- **`OidcPrincipalAdapter`** — covers `OidcProviderType.OIDC` and `GOOGLE`. Google is fully OIDC-conformant; only the issuer URI differs in `DbClientRegistrationRepository`, not the principal shape.
- **`ProviderPrincipalAdapterRegistry`** — Spring-bean lookup, fails fast on duplicate registrations and on lookups for unconfigured types. The unconfigured-type error message points at #357 so a future maintainer who adds a new `OidcProviderType` without an adapter sees the right next step.
- **`OidcLoginSuccessHandler`** — collapses the inlined `principal.attributes["sub"]` / `(principal as? OidcUser)?.idToken` logic into `adapterRegistry.forProviderType(...).resolve(...)`. No provider-specific branches in the handler anymore.
- **`OidcIdentityService.upsertOnLogin`** — signature change from `(provider, subject, claims: Map<String, Any>)` to `(provider, principal: ResolvedPrincipal)`. Email and displayName resolution moves into the adapter, keeping the service free of provider-specific quirks.

## Architecture rationale (Confirmation Gate item d, accepted)

The three remaining providers split along the OIDC-vs-OAuth2 line: Google is OIDC-conformant but pure-OAuth2 GitHub and Facebook need different subject extraction (`attributes["id"]` not `"sub"`), no `id_token`, and email-out-of-band fetches. Doing this in-place in the handler would require three new branches and three new casts — the boundary in this PR makes Phase 3/4 reduce to "add a class, implement a method, register the bean."

## Test plan

- [x] `OidcLoginSuccessHandlerTest` keeps all four prior assertions (happy path, cookie+redirect, `OidcEmailMissingException` → 400, non-OAuth2 fail-fast); constructed with the new registry holding a real `OidcPrincipalAdapter`.
- [x] `OidcPrincipalAdapterTest` (new) — claims set, OIDC + OAuth2 principal shapes, displayName fallback chain, null-email signal, null-displayName signal, sub-missing fail-fast.
- [x] `ProviderPrincipalAdapterRegistryTest` (new) — routing OIDC → adapter, GOOGLE → same adapter, unconfigured GITHUB → error mentioning #357, duplicate registration → fail at construction.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green.
- [ ] CI green.

## Out of scope (subsequent PRs against #357)

- Phase 1 — Google `DbClientRegistrationRepository` branch (~1h)
- Phase 2 — Email-NOT-NULL policy: better reject message (option α from the plan; verified that no email-verification pipeline exists today, so the onboarding-page path β would be its own feature)
- Phase 3 — `GitHubPrincipalAdapter` + `GitHubEmailFetcher` + registration branch
- Phase 4 — `FacebookPrincipalAdapter` + registration branch
- Phase 5 — `issuerUri`-validation cleanup + ADR-0031

## References

- Tracking issue: #357
- Predecessor: PR #350 (delivered the OIDC/Keycloak browser flow)
- Related (now closed as superseded): #79