### PR TITLE
feat(auth): enable browser login for Google OIDC providers (#357 phase 1)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -53,16 +53,19 @@ import java.util.concurrent.atomic.AtomicReference
  * never blocks while a refresh is in flight; readers either see the old map
  * or the new map, never a half-built one.
  *
- * ## Provider type support (Phase 1 of #79)
+ * ## Provider type support
  *
- * Browser login is currently wired only for [OidcProviderType.OIDC] — it
- * relies on RFC-8414 / OIDC discovery via `issuerUri`. The vendor providers
- * (GitHub / Google / Facebook) have
- * sufficient metadata in [OidcProviderRegistry] to validate incoming bearer
- * tokens, but the browser-flow client metadata (authorization endpoint with
- * the right vendor quirks) is not yet implemented. They are silently
- * skipped here and emit a single warning at refresh time so operators know
- * the row will not appear on the login page.
+ * Browser login is wired for [OidcProviderType.OIDC] (relies on RFC-8414 /
+ * OIDC discovery via `issuerUri`) and for [OidcProviderType.GOOGLE] (same
+ * machinery, hardcoded issuer URI — operators only configure clientId +
+ * clientSecret, see #357 Phase 1). The remaining vendor providers
+ * ([OidcProviderType.GITHUB], [OidcProviderType.FACEBOOK]) have sufficient
+ * metadata in [OidcProviderRegistry] to validate incoming bearer tokens,
+ * but the browser-flow client metadata (authorization endpoint with the
+ * right vendor quirks, OAuth2-not-OIDC principal handling) is tracked in
+ * #357 Phase 3 / 4. They are silently skipped here and emit a single
+ * warning at refresh time so operators know the row will not appear on the
+ * login page.
  *
  * ## Failure isolation
  *
@@ -125,12 +128,22 @@ class DbClientRegistrationRepository(
                 ClientRegistrations.fromIssuerLocation(issuerUri)
             }
 
+            // Google is OIDC-conformant — same `sub`, `email`, `name` claims as a
+            // generic OIDC provider. The only thing the operator should NOT have to
+            // configure is the issuer URI, which is fixed for Google's identity
+            // platform. We hardcode it and ignore any value the operator put in
+            // `provider.issuerUri` (no error: the field is documented as ignored
+            // for vendor-typed providers, see OidcProviderEntity Javadoc).
+            // Issue #357 Phase 1.
+            OidcProviderType.GOOGLE -> {
+                ClientRegistrations.fromIssuerLocation(GOOGLE_ISSUER_URI)
+            }
+
             OidcProviderType.GITHUB,
-            OidcProviderType.GOOGLE,
             OidcProviderType.FACEBOOK,
             -> error(
                 "Browser login flow not yet implemented for provider type ${provider.providerType} " +
-                    "(see Phase 1 scope of #79). The provider remains usable as a resource-server token issuer.",
+                    "(see #357). The provider remains usable as a resource-server token issuer.",
             )
         }
         return builder
@@ -139,5 +152,14 @@ class DbClientRegistrationRepository(
             .clientSecret(textEncryptor.decrypt(provider.clientSecretEncrypted))
             .scope(provider.scope.split(" ").filter { it.isNotBlank() }.toSet())
             .build()
+    }
+
+    companion object {
+        /**
+         * Google's OpenID Connect issuer URI. Hardcoded because (a) it is fixed by
+         * Google and (b) hardcoding spares operators from having to know it. The
+         * `/.well-known/openid-configuration` lives at `${this}/.well-known/...`.
+         */
+        const val GOOGLE_ISSUER_URI = "https://accounts.google.com"
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -61,6 +61,69 @@ class DbClientRegistrationRepositoryTest {
     }
 
     @Test
+    fun `Google provider type no longer hits the not-yet-implemented branch (#357 phase 1)`() {
+        // Pre-#357 GOOGLE was rejected with `error("Browser login flow not yet implemented...")`
+        // — a programmer-error throw that runCatching dutifully caught and skipped, but
+        // semantically wrong (the provider IS supported now). This test pins that the
+        // GOOGLE branch goes through `ClientRegistrations.fromIssuerLocation(GOOGLE_ISSUER_URI)`
+        // instead. We do NOT assert successful discovery — Google.com reachability in CI
+        // is environment-dependent — only that no IllegalStateException with the
+        // not-implemented marker is produced anymore.
+        val google = OidcProviderEntity(
+            id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            name = "Google",
+            providerType = OidcProviderType.GOOGLE,
+            enabled = true,
+            clientId = "google-client-id",
+            clientSecretEncrypted = "{cipher}ignored",
+            issuerUri = null, // operator no longer needs to configure this
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(google))
+
+        // Construction must not throw (the runCatching wrapper catches network failures
+        // — that's the offline-CI case — but the not-yet-implemented IllegalStateException
+        // path is gone for GOOGLE).
+        DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+    }
+
+    @Test
+    fun `GitHub and Facebook provider types still skipped (tracked in #357 phase 3 and 4)`() {
+        val github = OidcProviderEntity(
+            id = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            name = "GitHub",
+            providerType = OidcProviderType.GITHUB,
+            enabled = true,
+            clientId = "gh-client",
+            clientSecretEncrypted = "{cipher}ignored",
+            issuerUri = null,
+        )
+        val facebook = OidcProviderEntity(
+            id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            name = "Facebook",
+            providerType = OidcProviderType.FACEBOOK,
+            enabled = true,
+            clientId = "fb-client",
+            clientSecretEncrypted = "{cipher}ignored",
+            issuerUri = null,
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(github, facebook))
+
+        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+
+        // Both rows logged-and-skipped — registry is empty, lookups return null.
+        assertThat(repo.iterator().hasNext()).isFalse()
+        assertThat(repo.findByRegistrationId(github.id.toString())).isNull()
+        assertThat(repo.findByRegistrationId(facebook.id.toString())).isNull()
+    }
+
+    @Test
+    fun `Google issuer URI constant points at the documented Google identity platform`() {
+        // Pinning the constant — a regression here would silently route Google logins
+        // to the wrong issuer and the discovery would fail with a confusing error.
+        assertThat(DbClientRegistrationRepository.GOOGLE_ISSUER_URI).isEqualTo("https://accounts.google.com")
+    }
+
+    @Test
     fun `unreachable issuer is skipped, other providers continue to load (failure isolation)`() {
         // Build a single provider whose issuerUri is a syntactically-valid URL
         // pointing at a port nothing is listening on — Spring's


### PR DESCRIPTION
## Summary

Phase 1 of #357 — minimal, additive. Routes the `GOOGLE` provider-type branch in `DbClientRegistrationRepository.buildRegistration` to the same OIDC-discovery machinery that handles the generic `OIDC` provider type, with the issuer URI hardcoded to `https://accounts.google.com` so operators only need to configure `clientId` + `clientSecret`.

## Why this is small

Google is fully OIDC-conformant — same `sub`, `email`, `name` claims as Keycloak / Authentik / Auth0. The login-success path needs no changes: `OidcPrincipalAdapter` (delivered in PR #402, phase 0) already claims the `GOOGLE` provider type and treats the principal identically to a generic OIDC user.

## What this PR changes

- **`DbClientRegistrationRepository.buildRegistration`** — new `OidcProviderType.GOOGLE` branch using `ClientRegistrations.fromIssuerLocation(GOOGLE_ISSUER_URI)`. `GOOGLE_ISSUER_URI` is a public companion constant pinned to `"https://accounts.google.com"`.
- **`DbClientRegistrationRepository` Javadoc** updated to reflect the new support matrix; remaining vendor providers (GitHub, Facebook) are now flagged as #357 Phase 3 / 4.
- **`error()` message** for the still-rejected GitHub/Facebook branches updated to point at #357 instead of the now-closed #79.

## What this PR does NOT change

- No frontend changes — `LoginPage` is provider-agnostic.
- No new adapter (Phase 0 already covers GOOGLE).
- `OidcProviderEntity.issuerUri` validation (set-but-ignored for GOOGLE) is part of Phase 5 cleanup.

## Test plan

- [x] `DbClientRegistrationRepositoryTest` — three new cases:
  - `Google provider type no longer hits the not-yet-implemented branch (#357 phase 1)`
  - `GitHub and Facebook provider types still skipped (tracked in #357 phase 3 and 4)`
  - `Google issuer URI constant points at the documented Google identity platform`
- [x] Existing offline failure-isolation test unchanged.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green.
- [ ] CI green.

## Operator instructions for new Google providers

1. Create OAuth credentials in Google Cloud Console: APIs & Services → Credentials → Create OAuth 2.0 Client IDs (Web application). Authorized redirect URI: `https://<plugwerk-host>/login/oauth2/code/<provider-uuid>`.
2. In the Plugwerk admin UI: Add Provider → type Google → paste clientId + clientSecret. **Issuer URI field can be left blank** (hardcoded internally).
3. Click "Login with <provider name>" on the login page.

## Closes (partial)

Phase 1 of #357. Phase 2 (email-NOT-NULL policy α), Phase 3 (GitHub), Phase 4 (Facebook), Phase 5 (cleanup + ADR) follow as separate PRs.