### PR TITLE
feat(auth): provider-aware OidcEmailMissingException message (#357 phase 2)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcIdentityService.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.service
 
 import io.plugwerk.server.domain.OidcIdentityEntity
 import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
 import io.plugwerk.server.repository.OidcIdentityRepository
@@ -88,7 +89,7 @@ class OidcIdentityService(
         loginAt: OffsetDateTime,
     ): UserEntity {
         val email = principal.email?.trim()?.takeIf { it.isNotBlank() }
-            ?: throw OidcEmailMissingException(provider.name)
+            ?: throw OidcEmailMissingException(provider)
         // displayName falls back to subject as a last-resort visible identifier when
         // the adapter could not produce one (e.g. a provider that returns no name claim).
         val displayName = principal.displayName?.trim()?.takeIf { it.isNotBlank() }
@@ -127,12 +128,47 @@ class OidcIdentityService(
 }
 
 /**
- * Thrown when an OIDC callback delivers no `email` claim. Plugwerk requires
- * an email per account (issue #351 — `plugwerk_user.email` is NOT NULL); the
- * IdP must be configured to include `email` in the returned scope.
+ * Thrown when an OIDC / OAuth2 callback resolves to a user with no usable
+ * email address. Plugwerk requires an email per account (issue #351 —
+ * `plugwerk_user.email` is `NOT NULL`, ADR-0029 §5).
+ *
+ * The remediation differs by provider type and the message is shaped
+ * accordingly so the operator (or end user, when surfaced as a 400 body)
+ * sees an actionable hint instead of a generic OIDC-only error:
+ *
+ *   - **OIDC / Google** → operator-actionable: the IdP has to be configured
+ *     to return the `email` claim in the granted scope.
+ *   - **GitHub** → user-actionable: the GitHub account has no public email,
+ *     or the `user:email` scope was not granted. The user can either set a
+ *     public email in their GitHub settings or sign in with another provider.
+ *   - **Facebook** → operator-actionable: the Facebook app has not been
+ *     approved for the `email` permission via Facebook App Review (apps in
+ *     Development mode can authenticate developer/tester accounts only).
+ *
+ * Phase 2 of #357. Phase 3 (GitHub) and Phase 4 (Facebook) become much
+ * cleaner when this message is already provider-aware — they only need to
+ * extend the existing pattern, not invent a new error path.
  */
-class OidcEmailMissingException(providerName: String) :
-    RuntimeException(
-        "OIDC provider '$providerName' returned no `email` claim — configure the IdP to include " +
-            "`email` in the requested scope (default scope is 'openid email profile').",
-    )
+class OidcEmailMissingException(provider: OidcProviderEntity) : RuntimeException(buildMessage(provider))
+
+private fun buildMessage(provider: OidcProviderEntity): String {
+    val name = provider.name
+    return when (provider.providerType) {
+        OidcProviderType.OIDC, OidcProviderType.GOOGLE ->
+            "OIDC provider '$name' returned no `email` claim — configure the IdP to include " +
+                "`email` in the requested scope (default scope is 'openid email profile')."
+
+        OidcProviderType.GITHUB ->
+            "GitHub account signing in via '$name' has no public email available. Either set a " +
+                "public primary email in your GitHub account settings (Settings → Emails → " +
+                "uncheck 'Keep my email addresses private') or sign in with a different provider. " +
+                "If the operator did not request the `user:email` scope when registering the app, " +
+                "ask them to do so."
+
+        OidcProviderType.FACEBOOK ->
+            "Facebook provider '$name' returned no `email` — the Facebook app has likely not been " +
+                "approved for the `email` permission via Facebook App Review. In Development mode " +
+                "only developer/tester accounts can authenticate; promoting the app to Live and " +
+                "completing App Review is the operator's path forward."
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/OidcLoginSuccessHandlerTest.kt
@@ -168,7 +168,7 @@ class OidcLoginSuccessHandlerTest {
         )
         whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
         whenever(oidcIdentityService.upsertOnLogin(any(), any<ResolvedPrincipal>()))
-            .thenThrow(OidcEmailMissingException(provider.name))
+            .thenThrow(OidcEmailMissingException(provider))
 
         val handler =
             OidcLoginSuccessHandler(

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcEmailMissingExceptionTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcEmailMissingExceptionTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the per-provider-type message shape for [OidcEmailMissingException]
+ * (#357 phase 2). Phase 3 (GitHub) and phase 4 (Facebook) rely on the
+ * GitHub / Facebook branches being reachable and worded usefully — without
+ * this, both phases would surface a generic OIDC-shaped message that does
+ * not match the actual remediation path.
+ */
+class OidcEmailMissingExceptionTest {
+
+    private fun providerOf(name: String, type: OidcProviderType) = OidcProviderEntity(
+        name = name,
+        providerType = type,
+        clientId = "irrelevant",
+        clientSecretEncrypted = "irrelevant",
+    )
+
+    @Test
+    fun `OIDC provider message is operator-actionable and points at scope configuration`() {
+        val exception = OidcEmailMissingException(providerOf("Keycloak Prod", OidcProviderType.OIDC))
+
+        assertThat(exception.message)
+            .contains("Keycloak Prod")
+            .contains("scope")
+            .contains("openid email profile")
+    }
+
+    @Test
+    fun `Google message reuses the OIDC-style operator hint (Google is OIDC-conformant)`() {
+        val exception = OidcEmailMissingException(providerOf("Google", OidcProviderType.GOOGLE))
+
+        assertThat(exception.message)
+            .contains("Google")
+            .contains("scope")
+    }
+
+    @Test
+    fun `GitHub message is user-actionable and names the GitHub-specific remediation steps`() {
+        val exception = OidcEmailMissingException(providerOf("GitHub Cloud", OidcProviderType.GITHUB))
+
+        assertThat(exception.message)
+            .contains("GitHub Cloud")
+            // User-facing path: tell them where in GitHub to look.
+            .contains("Settings")
+            .contains("Emails")
+            // Operator-facing fallback: tell them about the missing scope.
+            .contains("user:email")
+    }
+
+    @Test
+    fun `Facebook message names App Review as the operator's path forward`() {
+        val exception = OidcEmailMissingException(providerOf("Facebook Login", OidcProviderType.FACEBOOK))
+
+        assertThat(exception.message)
+            .contains("Facebook Login")
+            .contains("App Review")
+            .contains("Development mode")
+    }
+
+    @Test
+    fun `provider name is verbatim in every variant (no transformation, no truncation)`() {
+        val verbatim = "Provider with 'quotes' & spaces & üml@uts"
+
+        for (type in OidcProviderType.entries) {
+            val exception = OidcEmailMissingException(providerOf(verbatim, type))
+
+            assertThat(exception.message)
+                .`as`("provider name should appear verbatim for type $type")
+                .contains(verbatim)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of #357 — small, additive. Replaces the hardcoded OIDC-shaped error message with a per-provider-type one, so the upcoming GitHub (Phase 3) and Facebook (Phase 4) work doesn't surface a misleading "configure the IdP scope" hint to users when the actual remediation lives elsewhere.

## Why now (before Phase 3)

Today's message:

> *"OIDC provider 'X' returned no `email` claim — configure the IdP to include `email` in the requested scope (default scope is 'openid email profile')."*

Fine for OIDC and Google. Wrong for the upcoming providers:

- **GitHub**: there is no ID token, no `email` claim. The user's primary email is at `GET /user/emails` and is private unless they explicitly publish it. Pointing the operator at "IdP scope configuration" is misdirection on both counts (scope is configured on Plugwerk's side, not GitHub's; per-user public-email is a user setting).
- **Facebook**: Facebook apps need approval for the `email` permission via App Review. Apps in Development mode can authenticate developer/tester accounts only.

Doing this now means Phase 3 / 4 don't have to invent an error path — they extend an established one.

## What this PR changes

- `OidcEmailMissingException` constructor from `(providerName: String)` to `(provider: OidcProviderEntity)`.
- New `buildMessage(provider)` switches on `provider.providerType`:
  - **OIDC / GOOGLE** → operator-actionable scope hint (existing shape, unchanged for the active code paths).
  - **GITHUB** → user-actionable first (*"Settings → Emails → uncheck 'Keep my email addresses private'"*), with an operator-side fallback about the `user:email` scope.
  - **FACEBOOK** → operator-actionable App Review hint, names the Development-mode constraint.
- Sole caller `OidcIdentityService.createNewIdentityAndUser` updated to pass the full entity.
- Provider name appears verbatim in every variant (no transformation, no truncation).

The `OidcLoginSuccessHandler` 400-response path is unchanged — it just gets a more useful body.

## Test plan

- [x] New `OidcEmailMissingExceptionTest` — one test per provider type pinning the key remediation phrase, plus a verbatim-name test across all four types.
- [x] `OidcLoginSuccessHandlerTest` happy/sad paths still green (constructor-call updated).
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green.
- [ ] CI green.

## Out of scope

- The actual GitHub OAuth flow (Phase 3) and Facebook OAuth flow (Phase 4).
- Surfacing this 400 body more nicely to the end user (today it's a Spring whitelabel page; that's a separate UX issue if anyone ever cares — the message is still readable).

## Closes (partial)

Phase 2 of #357.