### PR TITLE
feat(auth): add GitHub OAuth2 browser-login support (#357 phase 3)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -22,6 +22,7 @@ import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
 import org.slf4j.LoggerFactory
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider
 import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
@@ -56,16 +57,18 @@ import java.util.concurrent.atomic.AtomicReference
  * ## Provider type support
  *
  * Browser login is wired for [OidcProviderType.OIDC] (relies on RFC-8414 /
- * OIDC discovery via `issuerUri`) and for [OidcProviderType.GOOGLE] (same
+ * OIDC discovery via `issuerUri`), [OidcProviderType.GOOGLE] (same
  * machinery, hardcoded issuer URI — operators only configure clientId +
- * clientSecret, see #357 Phase 1). The remaining vendor providers
- * ([OidcProviderType.GITHUB], [OidcProviderType.FACEBOOK]) have sufficient
- * metadata in [OidcProviderRegistry] to validate incoming bearer tokens,
- * but the browser-flow client metadata (authorization endpoint with the
- * right vendor quirks, OAuth2-not-OIDC principal handling) is tracked in
- * #357 Phase 3 / 4. They are silently skipped here and emit a single
- * warning at refresh time so operators know the row will not appear on the
- * login page.
+ * clientSecret, see #357 Phase 1), and [OidcProviderType.GITHUB] (pure
+ * OAuth2 via Spring's `CommonOAuth2Provider.GITHUB` template, with the
+ * `read:user` and `user:email` scopes hardcoded for this provider type
+ * because the operator-supplied scope string from the admin UI defaults to
+ * the OIDC vocabulary which GitHub does not understand, see #357 Phase 3).
+ * The remaining vendor provider [OidcProviderType.FACEBOOK] has sufficient
+ * metadata in [OidcProviderRegistry] to validate incoming bearer tokens
+ * but the browser-flow wiring is tracked in #357 Phase 4. It is silently
+ * skipped here and emits a single warning at refresh time so operators
+ * know the row will not appear on the login page.
  *
  * ## Failure isolation
  *
@@ -139,19 +142,48 @@ class DbClientRegistrationRepository(
                 ClientRegistrations.fromIssuerLocation(GOOGLE_ISSUER_URI)
             }
 
-            OidcProviderType.GITHUB,
-            OidcProviderType.FACEBOOK,
-            -> error(
+            // GitHub is pure OAuth2 (no OpenID Connect) — there is no
+            // /.well-known/openid-configuration and no ID token. Spring ships a
+            // pre-baked client-registration template at CommonOAuth2Provider.GITHUB
+            // that knows the right authorization / token / user-info endpoints.
+            // We use that as the starting point and let the post-when-block
+            // .clientId / .clientSecret / .scope chain finish it. Issue #357 Phase 3.
+            OidcProviderType.GITHUB -> {
+                CommonOAuth2Provider.GITHUB.getBuilder(registrationId)
+            }
+
+            OidcProviderType.FACEBOOK -> error(
                 "Browser login flow not yet implemented for provider type ${provider.providerType} " +
-                    "(see #357). The provider remains usable as a resource-server token issuer.",
+                    "(see #357 phase 4). The provider remains usable as a resource-server token issuer.",
             )
         }
         return builder
             .registrationId(registrationId)
             .clientId(provider.clientId)
             .clientSecret(textEncryptor.decrypt(provider.clientSecretEncrypted))
-            .scope(provider.scope.split(" ").filter { it.isNotBlank() }.toSet())
+            .scope(effectiveScopes(provider))
             .build()
+    }
+
+    /**
+     * Resolves the effective OAuth2 scope set for a provider.
+     *
+     * For OIDC and Google the operator's `provider.scope` value is honoured
+     * verbatim — both providers share the OIDC vocabulary the admin form
+     * defaults to (`openid profile email`).
+     *
+     * For GitHub the OIDC default is meaningless (GitHub ignores `openid` and
+     * `profile`), so we ALWAYS hardcode `read:user user:email`. `read:user`
+     * is what powers the `/user` response Spring's user-info call relies on;
+     * `user:email` is what makes `/user/emails` fetchable for the
+     * private-primary-email recovery path in [GitHubPrincipalAdapter]. If a
+     * future operator needs custom GitHub scopes (e.g. `repo` for an app),
+     * the override path is to remove this hardcoded branch and accept that
+     * the admin UI scope hint must then be GitHub-specific.
+     */
+    private fun effectiveScopes(provider: OidcProviderEntity): Set<String> = when (provider.providerType) {
+        OidcProviderType.GITHUB -> setOf("read:user", "user:email")
+        else -> provider.scope.split(" ").filter { it.isNotBlank() }.toSet()
     }
 
     companion object {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/GitHubEmailFetcher.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/GitHubEmailFetcher.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+/**
+ * GitHub-specific helper that resolves a user's primary verified email out
+ * of band, after the OAuth2 callback has supplied an access token but the
+ * `/user` response did not include the email (the GitHub user has set their
+ * primary email to private, so it is only reachable via `/user/emails` with
+ * the `user:email` scope).
+ *
+ * Scoped to the GitHub adapter (#357 phase 3) — generic OIDC providers
+ * surface email in the ID token claims and never need this path.
+ *
+ * Implementation notes:
+ *   - The base URL is hard-coded to `https://api.github.com`. GitHub
+ *     Enterprise Server has a different base; if Plugwerk ever needs to
+ *     support that, this base URL becomes configurable on the provider entity.
+ *   - The `Accept: application/vnd.github+json` header is the GitHub-recommended
+ *     versioned content type. Sending the older `application/json` would still
+ *     work but binds us to whatever GitHub's "v3" default is at the time of
+ *     the call rather than the explicit versioned media type.
+ *   - No retries. A failure here resolves to "no email" downstream, which the
+ *     adapter then surfaces as `OidcEmailMissingException` — that path already
+ *     has a user-actionable message (see #357 phase 2), so adding retry
+ *     complexity would only mask a legitimate "user has no public verified
+ *     primary email" condition.
+ */
+@Component
+class GitHubEmailFetcher {
+
+    private val log = LoggerFactory.getLogger(GitHubEmailFetcher::class.java)
+
+    // Spring Boot does not autoconfigure a RestClient.Builder bean in our
+    // dependency set, so building the client directly here avoids an
+    // additional bean wiring step. Tests swap this field via reflection to
+    // point at a MockWebServer — see GitHubEmailFetcherTest.
+    private val restClient: RestClient = RestClient.builder()
+        .baseUrl(GITHUB_API_BASE_URL)
+        .defaultHeader(HttpHeaders.ACCEPT, GITHUB_API_MEDIA_TYPE)
+        .build()
+
+    /**
+     * Returns the user's primary verified email address, or `null` if no such
+     * row exists or the call fails. Caller (the adapter) is responsible for
+     * translating a `null` return into the appropriate downstream behaviour
+     * (`OidcEmailMissingException`).
+     *
+     * @param accessToken The bearer token Spring Security captured from the
+     *   OAuth2 token-exchange response. Must carry the `user:email` scope.
+     */
+    fun fetchPrimaryVerified(accessToken: String): String? {
+        val emails: List<GitHubEmail>? = runCatching {
+            restClient.get()
+                .uri("/user/emails")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                .retrieve()
+                .body(EMAIL_LIST_TYPE)
+        }.onFailure { ex ->
+            log.warn("GitHub /user/emails fetch failed: {}", ex.message)
+        }.getOrNull()
+
+        return emails
+            ?.firstOrNull { it.primary && it.verified }
+            ?.email
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Subset of GitHub's `/user/emails` response shape. We only deserialize
+     * the three fields we actually need; Jackson ignores anything else
+     * (including `visibility`, which is not relevant to our primary-verified
+     * lookup).
+     */
+    data class GitHubEmail(val email: String, val primary: Boolean, val verified: Boolean)
+
+    companion object {
+        const val GITHUB_API_BASE_URL = "https://api.github.com"
+        const val GITHUB_API_MEDIA_TYPE = "application/vnd.github+json"
+
+        private val EMAIL_LIST_TYPE = object : ParameterizedTypeReference<List<GitHubEmail>>() {}
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/GitHubPrincipalAdapter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/GitHubPrincipalAdapter.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.slf4j.LoggerFactory
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.stereotype.Component
+
+/**
+ * Adapter for the pure-OAuth2 GitHub provider type (#357 phase 3).
+ *
+ * Differences from [OidcPrincipalAdapter] that justify the dedicated class:
+ *
+ *   - **Subject** lives at `attributes["id"]` (a numeric account id) and is
+ *     stable across email/handle changes. The OIDC `sub` claim does not exist.
+ *   - **No ID token.** GitHub OAuth2 returns an opaque access token, no JWT
+ *     and no JWKS. `upstreamIdToken` is therefore always `null`; downstream
+ *     RP-Initiated Logout (#352) falls back gracefully.
+ *   - **Email** may be missing from the `/user` response when the GitHub
+ *     user has set their primary email to private. The adapter recovers via
+ *     [GitHubEmailFetcher.fetchPrimaryVerified] using the access token, which
+ *     requires the `user:email` scope (configured in
+ *     [DbClientRegistrationRepository] for this provider type).
+ *   - **Display name** falls back to `login` (the @handle) when `name` is
+ *     blank — many GitHub users leave their full name unset.
+ *
+ * If the email cannot be resolved by either path (`/user` returned no email
+ * AND `/user/emails` returned no primary verified row), the adapter returns
+ * `email = null` and the downstream `OidcIdentityService` raises the
+ * provider-aware `OidcEmailMissingException` from #357 phase 2.
+ */
+@Component
+class GitHubPrincipalAdapter(
+    private val authorizedClientService: OAuth2AuthorizedClientService,
+    private val emailFetcher: GitHubEmailFetcher,
+) : ProviderPrincipalAdapter {
+
+    private val log = LoggerFactory.getLogger(GitHubPrincipalAdapter::class.java)
+
+    override val providerTypes: Set<OidcProviderType> = setOf(OidcProviderType.GITHUB)
+
+    override fun resolve(authentication: OAuth2AuthenticationToken): ResolvedPrincipal {
+        val registrationId = authentication.authorizedClientRegistrationId
+        val principal = requireNotNull(authentication.principal) {
+            "OAuth2AuthenticationToken for $registrationId has no principal"
+        }
+
+        // GitHub's user id is numeric; we keep it as a string for storage in
+        // `oidc_identity.subject` — that column is text-typed, and stringifying
+        // here keeps the per-provider schema consistent.
+        val rawId = principal.attributes["id"]
+            ?: error(
+                "GitHub provider $registrationId returned a user response without an `id` attribute — " +
+                    "cannot map to a Plugwerk user.",
+            )
+        val subject = rawId.toString()
+
+        val displayName = (principal.attributes["name"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+            ?: (principal.attributes["login"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+
+        // First try the public email from the /user response — fastest path,
+        // no extra HTTP call. If absent, fall back to /user/emails which
+        // requires the `user:email` scope and surfaces private primary emails.
+        val publicEmail = (principal.attributes["email"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+        val email = publicEmail ?: fetchPrimaryVerifiedEmail(authentication, subject)
+
+        return ResolvedPrincipal(
+            subject = subject,
+            email = email,
+            displayName = displayName,
+            upstreamIdToken = null,
+        )
+    }
+
+    private fun fetchPrimaryVerifiedEmail(authentication: OAuth2AuthenticationToken, subject: String): String? {
+        val authorizedClient = authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(
+            authentication.authorizedClientRegistrationId,
+            authentication.name,
+        )
+        val accessToken = authorizedClient?.accessToken?.tokenValue
+        if (accessToken == null) {
+            log.warn(
+                "GitHub callback for sub={} produced no access token — cannot fetch /user/emails",
+                subject,
+            )
+            return null
+        }
+        return emailFetcher.fetchPrimaryVerified(accessToken)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -87,16 +87,36 @@ class DbClientRegistrationRepositoryTest {
     }
 
     @Test
-    fun `GitHub and Facebook provider types still skipped (tracked in #357 phase 3 and 4)`() {
+    fun `GitHub provider type now produces a registration via CommonOAuth2Provider (#357 phase 3)`() {
+        whenever(textEncryptor.decrypt("{cipher}gh-secret")).thenReturn("plain-gh-secret")
         val github = OidcProviderEntity(
             id = UUID.fromString("22222222-2222-2222-2222-222222222222"),
             name = "GitHub",
             providerType = OidcProviderType.GITHUB,
             enabled = true,
             clientId = "gh-client",
-            clientSecretEncrypted = "{cipher}ignored",
+            clientSecretEncrypted = "{cipher}gh-secret",
             issuerUri = null,
         )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(github))
+
+        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val registration = repo.findByRegistrationId(github.id.toString())
+
+        assertThat(registration).isNotNull()
+        assertThat(registration!!.clientId).isEqualTo("gh-client")
+        assertThat(registration.clientSecret).isEqualTo("plain-gh-secret")
+        // Hardcoded GitHub scopes — operator-supplied OIDC scopes are intentionally
+        // ignored for this provider type because GitHub does not understand them.
+        assertThat(registration.scopes).containsExactlyInAnyOrder("read:user", "user:email")
+        // Spring's CommonOAuth2Provider.GITHUB template carries the right endpoints —
+        // pin one of them to confirm we're using it rather than a hand-rolled config.
+        assertThat(registration.providerDetails.tokenUri)
+            .isEqualTo("https://github.com/login/oauth/access_token")
+    }
+
+    @Test
+    fun `Facebook provider type still skipped (tracked in #357 phase 4)`() {
         val facebook = OidcProviderEntity(
             id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
             name = "Facebook",
@@ -106,13 +126,12 @@ class DbClientRegistrationRepositoryTest {
             clientSecretEncrypted = "{cipher}ignored",
             issuerUri = null,
         )
-        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(github, facebook))
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(facebook))
 
         val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
 
-        // Both rows logged-and-skipped — registry is empty, lookups return null.
+        // Logged-and-skipped — registry is empty, lookup returns null.
         assertThat(repo.iterator().hasNext()).isFalse()
-        assertThat(repo.findByRegistrationId(github.id.toString())).isNull()
         assertThat(repo.findByRegistrationId(facebook.id.toString())).isNull()
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/GitHubEmailFetcherTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/GitHubEmailFetcherTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.client.RestClient
+
+/**
+ * Pins the four behaviours of [GitHubEmailFetcher] that matter to callers:
+ *
+ *   1. Picks the email row whose `primary == true` and `verified == true`.
+ *   2. Returns null when no such row exists (verified-but-not-primary,
+ *      primary-but-not-verified, all-secondary, etc.).
+ *   3. Returns null on transport failure (server down, 5xx, parse error)
+ *      rather than throwing — the adapter then surfaces the absence as
+ *      `OidcEmailMissingException`, which carries a user-actionable message.
+ *   4. Sends the GitHub-versioned `Accept` header and a `Bearer` Authorization.
+ *
+ * Uses MockWebServer (already on the classpath via okhttp-mockwebserver) so
+ * we exercise the actual `RestClient` HTTP path rather than mocking it out.
+ */
+class GitHubEmailFetcherTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var fetcher: GitHubEmailFetcher
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        // The production class hard-codes its RestClient against api.github.com;
+        // for these tests we reflectively swap that field with one pointing at
+        // MockWebServer. Keeps the production constructor argument-free (no
+        // test-only injection point leaking into the API surface).
+        fetcher = GitHubEmailFetcher()
+        val mockClient = RestClient.builder()
+            .baseUrl(server.url("/").toString().trimEnd('/'))
+            .defaultHeader("Accept", GitHubEmailFetcher.GITHUB_API_MEDIA_TYPE)
+            .build()
+        val field = GitHubEmailFetcher::class.java.getDeclaredField("restClient").apply { isAccessible = true }
+        field.set(fetcher, mockClient)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `returns the primary verified email`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    [
+                      {"email":"alt@example.com","primary":false,"verified":true},
+                      {"email":"primary@example.com","primary":true,"verified":true},
+                      {"email":"unverified@example.com","primary":false,"verified":false}
+                    ]
+                    """.trimIndent(),
+                ),
+        )
+
+        val email = fetcher.fetchPrimaryVerified("gho_FAKETOKEN")
+
+        assertThat(email).isEqualTo("primary@example.com")
+    }
+
+    @Test
+    fun `returns null when no email row is both primary and verified`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    [
+                      {"email":"primary@example.com","primary":true,"verified":false},
+                      {"email":"verified@example.com","primary":false,"verified":true}
+                    ]
+                    """.trimIndent(),
+                ),
+        )
+
+        assertThat(fetcher.fetchPrimaryVerified("gho_FAKETOKEN")).isNull()
+    }
+
+    @Test
+    fun `returns null when GitHub returns an empty list`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("[]"),
+        )
+
+        assertThat(fetcher.fetchPrimaryVerified("gho_FAKETOKEN")).isNull()
+    }
+
+    @Test
+    fun `returns null on a 401 from GitHub (rather than throwing)`() {
+        // Token expired or scope revoked — the adapter should surface this as
+        // OidcEmailMissingException downstream, not crash the login flow.
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        assertThat(fetcher.fetchPrimaryVerified("gho_FAKETOKEN")).isNull()
+    }
+
+    @Test
+    fun `sends Bearer authorization and the GitHub-versioned Accept header`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""[{"email":"x@y.z","primary":true,"verified":true}]"""),
+        )
+
+        fetcher.fetchPrimaryVerified("gho_FAKETOKEN")
+        val recorded = server.takeRequest()
+
+        assertThat(recorded.path).isEqualTo("/user/emails")
+        assertThat(recorded.getHeader("Authorization")).isEqualTo("Bearer gho_FAKETOKEN")
+        assertThat(recorded.getHeader("Accept")).isEqualTo("application/vnd.github+json")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/GitHubPrincipalAdapterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/GitHubPrincipalAdapterTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class GitHubPrincipalAdapterTest {
+
+    @Mock lateinit var authorizedClientService: OAuth2AuthorizedClientService
+
+    @Mock lateinit var emailFetcher: GitHubEmailFetcher
+
+    private fun adapter() = GitHubPrincipalAdapter(authorizedClientService, emailFetcher)
+
+    private fun tokenWith(
+        attributes: Map<String, Any>,
+        registrationId: String = "gh-registration",
+    ): OAuth2AuthenticationToken {
+        // GitHub's user-id attribute is named "id" — DefaultOAuth2User needs the
+        // attribute KEY (not the value) as the third arg. Use it as the
+        // nameAttributeKey throughout these tests, which matches what
+        // CommonOAuth2Provider.GITHUB sets in production.
+        val user = DefaultOAuth2User(emptyList(), attributes, "id")
+        return OAuth2AuthenticationToken(user, emptyList(), registrationId)
+    }
+
+    @Test
+    fun `claims only the GITHUB provider type`() {
+        assertThat(adapter().providerTypes).containsExactly(OidcProviderType.GITHUB)
+    }
+
+    @Test
+    fun `extracts numeric id as subject (string), uses public email when present, no out-of-band fetch`() {
+        val token = tokenWith(
+            mapOf(
+                "id" to 123_456,
+                "login" to "octocat",
+                "name" to "Mona Lisa Octocat",
+                "email" to "mona@example.com",
+            ),
+        )
+
+        val resolved = adapter().resolve(token)
+
+        assertThat(resolved.subject).isEqualTo("123456")
+        assertThat(resolved.email).isEqualTo("mona@example.com")
+        assertThat(resolved.displayName).isEqualTo("Mona Lisa Octocat")
+        assertThat(resolved.upstreamIdToken).isNull()
+        // Public email present → /user/emails not called.
+        verify(emailFetcher, never()).fetchPrimaryVerified(any())
+    }
+
+    @Test
+    fun `falls back to login when name is blank`() {
+        val token = tokenWith(
+            mapOf(
+                "id" to 1L,
+                "login" to "octocat",
+                "name" to "",
+                "email" to "x@y.z",
+            ),
+        )
+
+        assertThat(adapter().resolve(token).displayName).isEqualTo("octocat")
+    }
+
+    @Test
+    fun `fetches primary verified email out of band when public email is missing`() {
+        val token = tokenWith(
+            mapOf<String, Any>(
+                "id" to 999L,
+                "login" to "private-user",
+                "name" to "Private User",
+                // GitHub returns "email": null for users with no public email — we
+                // simulate that by leaving the key out (DefaultOAuth2User attributes
+                // is Map<String, Any>, no nulls allowed).
+            ),
+        )
+        val authorizedClient = stubAuthorizedClient(accessToken = "gho_FAKE")
+        whenever(
+            authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(
+                eq("gh-registration"),
+                eq(token.name),
+            ),
+        ).thenReturn(authorizedClient)
+        whenever(emailFetcher.fetchPrimaryVerified("gho_FAKE")).thenReturn("private@example.com")
+
+        val resolved = adapter().resolve(token)
+
+        assertThat(resolved.email).isEqualTo("private@example.com")
+        verify(emailFetcher).fetchPrimaryVerified("gho_FAKE")
+    }
+
+    @Test
+    fun `returns null email when out-of-band fetch yields nothing (downstream raises OidcEmailMissingException)`() {
+        val token = tokenWith(
+            mapOf("id" to 1L, "login" to "u", "name" to "U"),
+        )
+        val authorizedClient = stubAuthorizedClient(accessToken = "gho_FAKE")
+        whenever(
+            authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(
+                eq("gh-registration"),
+                eq(token.name),
+            ),
+        ).thenReturn(authorizedClient)
+        whenever(emailFetcher.fetchPrimaryVerified("gho_FAKE")).thenReturn(null)
+
+        assertThat(adapter().resolve(token).email).isNull()
+    }
+
+    @Test
+    fun `returns null email when no authorized client is loaded (no access token to use)`() {
+        val token = tokenWith(
+            mapOf("id" to 1L, "login" to "u"),
+        )
+        whenever(
+            authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(any(), any()),
+        ).thenReturn(null)
+
+        assertThat(adapter().resolve(token).email).isNull()
+        verify(emailFetcher, never()).fetchPrimaryVerified(any())
+    }
+
+    // Note: a "no id attribute" branch lives in the adapter as a defensive
+    // wiring check, but Spring's DefaultOAuth2User constructor already throws
+    // IllegalArgumentException when the supplied nameAttributeKey is absent
+    // from the attributes map. The check therefore cannot be reached via the
+    // public OAuth2AuthenticationToken path in practice. Kept in code for
+    // explicit-failure-mode documentation, dropped from the test suite as
+    // unreachable.
+
+    private fun stubAuthorizedClient(accessToken: String): OAuth2AuthorizedClient {
+        val now = Instant.now()
+        val token = OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            accessToken,
+            now,
+            now.plusSeconds(3600),
+        )
+        val registration = ClientRegistration.withRegistrationId("gh-registration")
+            .clientId("client-id")
+            .clientSecret("secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("https://example/callback")
+            .authorizationUri("https://github.com/login/oauth/authorize")
+            .tokenUri("https://github.com/login/oauth/access_token")
+            .build()
+        return OAuth2AuthorizedClient(registration, "principal", token)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
@@ -35,11 +35,12 @@ class ProviderPrincipalAdapterRegistryTest {
 
     @Test
     fun `fails with actionable message for unconfigured provider type`() {
+        // After #357 phase 3, FACEBOOK is the remaining unconfigured type.
         val registry = ProviderPrincipalAdapterRegistry(listOf(OidcPrincipalAdapter()))
 
-        assertThatThrownBy { registry.forProviderType(OidcProviderType.GITHUB) }
+        assertThatThrownBy { registry.forProviderType(OidcProviderType.FACEBOOK) }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("GITHUB")
+            .hasMessageContaining("FACEBOOK")
             .hasMessageContaining("#357")
     }
 


### PR DESCRIPTION
## Summary

Closes the OAuth2-only branch of the multi-provider rollout from #357. After this PR the only remaining unsupported provider type is `FACEBOOK` (Phase 4). Spring's `CommonOAuth2Provider.GITHUB` template handles the endpoints; this PR adds the GitHub-specific quirks that the OIDC happy-path does not have.

## What this PR adds

### 1. `GitHubPrincipalAdapter`

Claims `OidcProviderType.GITHUB`. Differences from `OidcPrincipalAdapter`:

- **subject** = `attributes["id"]` (numeric, stringified for storage in `oidc_identity.subject`) instead of the OIDC `sub` claim that GitHub does not emit
- **displayName** falls back to `login` (the @handle) when `name` is blank
- **upstreamIdToken** is always `null` — there is no ID token to capture for RP-Initiated Logout, the existing fallback in `/auth/logout` handles that gracefully (#352)
- **email** handling: try the public email first; if absent, fetch `/user/emails` out of band to recover private-but-verified primary emails

### 2. `GitHubEmailFetcher`

`RestClient`-based wrapper for `GET https://api.github.com/user/emails`. Returns the first row whose `primary && verified` are both true, `null` otherwise. Failures (5xx, 401, transport) resolve to `null` rather than throwing — the adapter then surfaces the absence as `OidcEmailMissingException`, which since #357 Phase 2 carries a GitHub-specific user-actionable message ("Settings → Emails → uncheck 'Keep my email addresses private'").

### 3. `DbClientRegistrationRepository` GITHUB branch

Uses `CommonOAuth2Provider.GITHUB.getBuilder()`. The operator-supplied scope string is **intentionally ignored** for this provider type and replaced with the hardcoded set `{ read:user, user:email }` via a new `effectiveScopes()` helper. Reason: the admin form defaults the scope to OIDC vocabulary (`openid profile email`) which GitHub does not understand, so honouring it would silently break the user-info call.

## Test plan

- [x] `GitHubPrincipalAdapterTest` — 6 cases: provider-type claim, public-email happy path (no out-of-band call), name→login fallback, out-of-band fetch on missing public email, null-email when fetch yields nothing, null-email when no authorized client is loaded
- [x] `GitHubEmailFetcherTest` — 5 cases via MockWebServer: primary verified picked, no-such-row null, empty list null, 401 null (no throw), correct Bearer + Accept headers
- [x] `DbClientRegistrationRepositoryTest` — GITHUB branch produces a registration with the right token endpoint and hardcoded scope set; FACEBOOK still skipped (now solo); GOOGLE + failure-isolation tests unchanged
- [x] `ProviderPrincipalAdapterRegistryTest` — unconfigured-type test now asserts on FACEBOOK
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green
- [ ] CI green
- [ ] Manual smoke test against a real GitHub OAuth app (operator-side)

## Operator instructions for new GitHub providers

1. **GitHub Settings → Developer settings → OAuth Apps → New OAuth App**
   - Homepage URL: `http://localhost:8080` (or your deployed origin)
   - Authorization callback URL: `http://localhost:8080/login/oauth2/code/<provider-uuid>` — the UUID is generated when you create the provider in Plugwerk; circle back to update this field after step 2
2. In Plugwerk admin → OIDC Providers → Add Provider → type **GitHub**, paste `clientId` + `clientSecret`. The scope and issuer URI fields are ignored for this provider type
3. Update the GitHub OAuth App's callback URL with the freshly generated UUID
4. Toggle the provider Enabled. **Login with GitHub** appears on the login page

If the user has no public email and your OAuth app does not have the `user:email` scope (Plugwerk requests it automatically; the operator only needs to make sure the user accepts it on the consent screen), the login fails with a user-actionable 400 message — see `OidcEmailMissingException` from #357 Phase 2 for the exact wording.

## Closes (partial)

Phase 3 of #357. Phase 4 (Facebook) and Phase 5 (cleanup + ADR) follow as separate PRs.