### PR TITLE
feat(auth): add Facebook OAuth2 browser-login support (#357 phase 4)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -56,19 +56,22 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * ## Provider type support
  *
- * Browser login is wired for [OidcProviderType.OIDC] (relies on RFC-8414 /
- * OIDC discovery via `issuerUri`), [OidcProviderType.GOOGLE] (same
- * machinery, hardcoded issuer URI — operators only configure clientId +
- * clientSecret, see #357 Phase 1), and [OidcProviderType.GITHUB] (pure
- * OAuth2 via Spring's `CommonOAuth2Provider.GITHUB` template, with the
- * `read:user` and `user:email` scopes hardcoded for this provider type
- * because the operator-supplied scope string from the admin UI defaults to
- * the OIDC vocabulary which GitHub does not understand, see #357 Phase 3).
- * The remaining vendor provider [OidcProviderType.FACEBOOK] has sufficient
- * metadata in [OidcProviderRegistry] to validate incoming bearer tokens
- * but the browser-flow wiring is tracked in #357 Phase 4. It is silently
- * skipped here and emits a single warning at refresh time so operators
- * know the row will not appear on the login page.
+ * Browser login is wired for all four [OidcProviderType] values:
+ *
+ *   - [OidcProviderType.OIDC] — relies on RFC-8414 / OIDC discovery via
+ *     the operator-supplied `issuerUri`.
+ *   - [OidcProviderType.GOOGLE] — same machinery as OIDC, but the issuer
+ *     URI is hardcoded so operators only configure clientId + clientSecret
+ *     (#357 Phase 1).
+ *   - [OidcProviderType.GITHUB] — pure OAuth2 via Spring's
+ *     `CommonOAuth2Provider.GITHUB` template. Scopes are hardcoded to
+ *     `read:user user:email`; the email-recovery path runs out of band via
+ *     [GitHubPrincipalAdapter] / [GitHubEmailFetcher] (#357 Phase 3).
+ *   - [OidcProviderType.FACEBOOK] — pure OAuth2 via Spring's
+ *     `CommonOAuth2Provider.FACEBOOK` template. Scopes are hardcoded to
+ *     `email public_profile`; the userinfo response carries `email`
+ *     directly when Facebook App Review has approved the `email`
+ *     permission (#357 Phase 4).
  *
  * ## Failure isolation
  *
@@ -152,10 +155,15 @@ class DbClientRegistrationRepository(
                 CommonOAuth2Provider.GITHUB.getBuilder(registrationId)
             }
 
-            OidcProviderType.FACEBOOK -> error(
-                "Browser login flow not yet implemented for provider type ${provider.providerType} " +
-                    "(see #357 phase 4). The provider remains usable as a resource-server token issuer.",
-            )
+            // Facebook follows the same shape as GitHub (pure OAuth2, no ID
+            // token, numeric `id` as subject) but its userinfo response
+            // carries `email` directly when the `email` permission was
+            // granted — no out-of-band fetch needed. Spring's
+            // CommonOAuth2Provider.FACEBOOK template carries the right
+            // endpoints. Issue #357 Phase 4.
+            OidcProviderType.FACEBOOK -> {
+                CommonOAuth2Provider.FACEBOOK.getBuilder(registrationId)
+            }
         }
         return builder
             .registrationId(registrationId)
@@ -172,17 +180,27 @@ class DbClientRegistrationRepository(
      * verbatim — both providers share the OIDC vocabulary the admin form
      * defaults to (`openid profile email`).
      *
-     * For GitHub the OIDC default is meaningless (GitHub ignores `openid` and
-     * `profile`), so we ALWAYS hardcode `read:user user:email`. `read:user`
-     * is what powers the `/user` response Spring's user-info call relies on;
-     * `user:email` is what makes `/user/emails` fetchable for the
-     * private-primary-email recovery path in [GitHubPrincipalAdapter]. If a
-     * future operator needs custom GitHub scopes (e.g. `repo` for an app),
-     * the override path is to remove this hardcoded branch and accept that
-     * the admin UI scope hint must then be GitHub-specific.
+     * For GitHub and Facebook the OIDC default is meaningless (GitHub ignores
+     * `openid` and `profile`; Facebook expects its own `email public_profile`
+     * permission set), so we hardcode the right scope for each:
+     *
+     *   - GitHub → `read:user user:email`. `read:user` powers Spring's
+     *     `/user` user-info call; `user:email` makes `/user/emails` fetchable
+     *     for the private-primary-email recovery path in
+     *     [GitHubPrincipalAdapter].
+     *   - Facebook → `email public_profile`. `public_profile` is granted
+     *     implicitly on every Facebook OAuth flow and powers `/me`'s `name`
+     *     attribute; `email` is the permission Facebook App Review approves
+     *     and is what makes `/me`'s `email` attribute populated.
+     *
+     * If a future operator needs custom scopes (GitHub `repo`, Facebook
+     * page-management permissions etc.), the override path is to remove the
+     * hardcoded branch for that provider type and accept that the admin UI
+     * scope hint must then become provider-specific.
      */
     private fun effectiveScopes(provider: OidcProviderEntity): Set<String> = when (provider.providerType) {
         OidcProviderType.GITHUB -> setOf("read:user", "user:email")
+        OidcProviderType.FACEBOOK -> setOf("email", "public_profile")
         else -> provider.scope.split(" ").filter { it.isNotBlank() }.toSet()
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/FacebookPrincipalAdapter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/FacebookPrincipalAdapter.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.stereotype.Component
+
+/**
+ * Adapter for the pure-OAuth2 Facebook provider type (#357 phase 4).
+ *
+ * Facebook's shape sits between OIDC and GitHub:
+ *
+ *   - Like GitHub, there is no `/.well-known/openid-configuration`, no ID
+ *     token, and the stable subject is `attributes["id"]` rather than the
+ *     OIDC `sub` claim.
+ *   - Unlike GitHub, the userinfo response (`/me`) carries `email` directly
+ *     when the app has been granted the `email` permission. There is no
+ *     out-of-band fetch endpoint to recover a hidden primary email — if
+ *     `email` is missing here, the only path forward is for the operator
+ *     to complete Facebook App Review for the `email` permission (apps
+ *     in Development mode can authenticate developer/tester accounts only).
+ *
+ * The `Facebook App Review`-shaped error message lives in
+ * [io.plugwerk.server.service.OidcEmailMissingException] (#357 phase 2);
+ * this adapter just returns `email = null` when the userinfo response did
+ * not surface one and lets the downstream raise the exception.
+ *
+ * `upstreamIdToken` is always `null` — there is no ID token. The
+ * `/auth/logout` RP-Initiated Logout fallback (#352) handles that path
+ * gracefully.
+ */
+@Component
+class FacebookPrincipalAdapter : ProviderPrincipalAdapter {
+
+    override val providerTypes: Set<OidcProviderType> = setOf(OidcProviderType.FACEBOOK)
+
+    override fun resolve(authentication: OAuth2AuthenticationToken): ResolvedPrincipal {
+        val registrationId = authentication.authorizedClientRegistrationId
+        val principal = requireNotNull(authentication.principal) {
+            "OAuth2AuthenticationToken for $registrationId has no principal"
+        }
+
+        // Facebook's user-id is a numeric string already (returned as a String,
+        // unlike GitHub which returns an Integer/Long). `toString()` is a
+        // safety net for either shape.
+        val rawId = principal.attributes["id"]
+            ?: error(
+                "Facebook provider $registrationId returned a userinfo response without an `id` attribute — " +
+                    "cannot map to a Plugwerk user.",
+            )
+        val subject = rawId.toString()
+
+        // `name` is Facebook's canonical display label (full name). It is
+        // present whenever the `public_profile` permission is granted, which
+        // is implicit in every Facebook OAuth flow.
+        val displayName = (principal.attributes["name"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+
+        // `email` is present when the `email` permission was granted. Apps in
+        // Development mode can request it for developer/tester accounts;
+        // production apps need Facebook App Review approval. When absent we
+        // surface null and the caller raises OidcEmailMissingException with
+        // the App-Review-shaped message from #357 phase 2.
+        val email = (principal.attributes["email"] as? String)?.trim()?.takeIf { it.isNotBlank() }
+
+        return ResolvedPrincipal(
+            subject = subject,
+            email = email,
+            displayName = displayName,
+            upstreamIdToken = null,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -116,23 +116,33 @@ class DbClientRegistrationRepositoryTest {
     }
 
     @Test
-    fun `Facebook provider type still skipped (tracked in #357 phase 4)`() {
+    fun `Facebook provider type now produces a registration via CommonOAuth2Provider (#357 phase 4)`() {
+        whenever(textEncryptor.decrypt("{cipher}fb-secret")).thenReturn("plain-fb-secret")
         val facebook = OidcProviderEntity(
             id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
             name = "Facebook",
             providerType = OidcProviderType.FACEBOOK,
             enabled = true,
             clientId = "fb-client",
-            clientSecretEncrypted = "{cipher}ignored",
+            clientSecretEncrypted = "{cipher}fb-secret",
             issuerUri = null,
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(facebook))
 
         val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val registration = repo.findByRegistrationId(facebook.id.toString())
 
-        // Logged-and-skipped — registry is empty, lookup returns null.
-        assertThat(repo.iterator().hasNext()).isFalse()
-        assertThat(repo.findByRegistrationId(facebook.id.toString())).isNull()
+        assertThat(registration).isNotNull()
+        assertThat(registration!!.clientId).isEqualTo("fb-client")
+        assertThat(registration.clientSecret).isEqualTo("plain-fb-secret")
+        // Hardcoded Facebook scopes — operator-supplied OIDC scopes are
+        // intentionally ignored for this provider type because Facebook
+        // expects its own permission set.
+        assertThat(registration.scopes).containsExactlyInAnyOrder("email", "public_profile")
+        // Spring's CommonOAuth2Provider.FACEBOOK template carries the right
+        // endpoints — pin the token endpoint to confirm.
+        assertThat(registration.providerDetails.tokenUri)
+            .isEqualTo("https://graph.facebook.com/v2.8/oauth/access_token")
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/FacebookPrincipalAdapterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/FacebookPrincipalAdapterTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+
+class FacebookPrincipalAdapterTest {
+
+    private val adapter = FacebookPrincipalAdapter()
+
+    private fun tokenWith(attributes: Map<String, Any>): OAuth2AuthenticationToken {
+        val user = DefaultOAuth2User(emptyList(), attributes, "id")
+        return OAuth2AuthenticationToken(user, emptyList(), "fb-registration")
+    }
+
+    @Test
+    fun `claims only the FACEBOOK provider type`() {
+        assertThat(adapter.providerTypes).containsExactly(OidcProviderType.FACEBOOK)
+    }
+
+    @Test
+    fun `extracts numeric id as subject string, email and name from the userinfo response`() {
+        // Facebook's `/me?fields=id,name,email` returns these fields as strings.
+        val token = tokenWith(
+            mapOf(
+                "id" to "1234567890",
+                "name" to "Mona Lisa",
+                "email" to "mona@example.com",
+            ),
+        )
+
+        val resolved = adapter.resolve(token)
+
+        assertThat(resolved.subject).isEqualTo("1234567890")
+        assertThat(resolved.email).isEqualTo("mona@example.com")
+        assertThat(resolved.displayName).isEqualTo("Mona Lisa")
+        assertThat(resolved.upstreamIdToken).isNull()
+    }
+
+    @Test
+    fun `stringifies a numeric id (defensive — Facebook usually returns String, but be safe)`() {
+        val token = tokenWith(
+            mapOf(
+                "id" to 9_876_543_210L,
+                "name" to "Numeric",
+                "email" to "n@example.com",
+            ),
+        )
+
+        assertThat(adapter.resolve(token).subject).isEqualTo("9876543210")
+    }
+
+    @Test
+    fun `returns null email when the userinfo response did not surface email`() {
+        // Apps without Facebook App Review approval for `email` get a userinfo
+        // response without the field — adapter must surface that as null so the
+        // downstream raises OidcEmailMissingException with the App-Review
+        // remediation message (#357 phase 2).
+        val token = tokenWith(
+            mapOf(
+                "id" to "42",
+                "name" to "App-Review-Pending",
+            ),
+        )
+
+        assertThat(adapter.resolve(token).email).isNull()
+    }
+
+    @Test
+    fun `returns null email when the email attribute is blank`() {
+        val token = tokenWith(
+            mapOf(
+                "id" to "42",
+                "name" to "X",
+                "email" to "   ",
+            ),
+        )
+
+        assertThat(adapter.resolve(token).email).isNull()
+    }
+
+    @Test
+    fun `returns null displayName when name is blank (caller falls back to subject)`() {
+        val token = tokenWith(
+            mapOf(
+                "id" to "42",
+                "email" to "x@y.z",
+            ),
+        )
+
+        assertThat(adapter.resolve(token).displayName).isNull()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/ProviderPrincipalAdapterRegistryTest.kt
@@ -34,8 +34,12 @@ class ProviderPrincipalAdapterRegistryTest {
     }
 
     @Test
-    fun `fails with actionable message for unconfigured provider type`() {
-        // After #357 phase 3, FACEBOOK is the remaining unconfigured type.
+    fun `fails with actionable message when no adapter is registered for a provider type`() {
+        // Build a registry with only the OIDC adapter — Facebook is therefore
+        // an unconfigured branch from this registry's point of view, even
+        // though a real FacebookPrincipalAdapter exists in the application
+        // context. The error must point at #357 so any future addition to
+        // OidcProviderType lands on a discoverable signal.
         val registry = ProviderPrincipalAdapterRegistry(listOf(OidcPrincipalAdapter()))
 
         assertThatThrownBy { registry.forProviderType(OidcProviderType.FACEBOOK) }


### PR DESCRIPTION
## Summary

Closes the multi-provider rollout of #357. After this PR every `OidcProviderType` value has a working browser-login flow: OIDC + GOOGLE via OIDC discovery; GITHUB + FACEBOOK via Spring's `CommonOAuth2Provider` templates with provider-specific adapters.

## Why Facebook is smaller than GitHub

Facebook's shape sits between OIDC and GitHub:

- **Like GitHub**: no `/.well-known/openid-configuration`, no ID token, stable subject is `attributes["id"]`, not the OIDC `sub` claim.
- **Unlike GitHub**: the userinfo response (`/me`) carries `email` directly when the app has been granted the `email` permission. There is no out-of-band fetch endpoint to recover a hidden email — if `email` is missing here, the operator needs to complete Facebook App Review. The App-Review-shaped error message already lives in `OidcEmailMissingException` (#357 phase 2).

So the adapter is roughly half the size of `GitHubPrincipalAdapter` and there is no `FetcherClient`-style helper.

## What this PR adds

### 1. `FacebookPrincipalAdapter`

Claims `OidcProviderType.FACEBOOK`. Reads subject from `attributes["id"]` (stringified — Facebook usually returns String, the `toString()` is a defensive net), `name` and `email` straight from the userinfo response, `upstreamIdToken` always `null`.

### 2. `DbClientRegistrationRepository` FACEBOOK branch

Uses `CommonOAuth2Provider.FACEBOOK.getBuilder()`. Operator-supplied scope is intentionally ignored and replaced with hardcoded `email public_profile` via the existing `effectiveScopes()` helper. The class-level Javadoc has been refreshed to reflect that all four provider types are now wired.

### 3. Tests

- `FacebookPrincipalAdapterTest` — 6 cases: provider type claim, happy path with id+name+email, defensive `Long → String` for `id`, null email when userinfo did not surface it (App-Review-pending), null email when email is blank, null displayName when name is blank.
- `DbClientRegistrationRepositoryTest` — FACEBOOK branch produces a registration with the right token endpoint (`graph.facebook.com/v2.8/oauth/access_token`) and the hardcoded scope set.
- `ProviderPrincipalAdapterRegistryTest` — comment refreshed: the registry-fail-fast test still uses FACEBOOK as a synthetic example for an unconfigured type (a registry built with only the OIDC adapter rejects FACEBOOK lookups), even though a real `FacebookPrincipalAdapter` exists in the application context.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:check` green.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` green.
- [ ] CI green.
- [ ] Manual smoke test against a real Facebook OAuth app (operator-side; requires Facebook Developer account and App Review for full email-permission validation).

## Operator instructions for new Facebook providers

1. **Facebook for Developers** → My Apps → **Create App** → Type **Consumer** (or **Business** if appropriate).
2. **Settings → Basic**: note the **App ID** (= clientId) and **App Secret** (= clientSecret).
3. **Use cases → Authentication and account creation → Customize**:
   - Add the **email** and **public_profile** permissions.
   - Add the OAuth Redirect URI: `http://localhost:5173/login/oauth2/code/<provider-uuid>` (UUID generated by Plugwerk; see other phases for the pattern).
4. In Plugwerk admin → OIDC Providers → Add Provider → type **Facebook**, paste clientId + clientSecret. The scope and issuer URI fields are ignored for this provider type.
5. Update the Facebook OAuth Redirect URI with the freshly generated UUID.
6. Toggle the provider Enabled. **Login with Facebook** appears on the login page.

In **Development mode** only developer/tester accounts can authenticate. To allow public users, the app needs **Facebook App Review** approval for the `email` permission — the `OidcEmailMissingException` Phase-2 message names that path explicitly when an unapproved app surfaces a missing-email login.

## Closes (partial)

Phase 4 of #357. Phase 5 (cleanup + ADR-0031 documenting the multi-provider architecture) is the last remaining piece.