### PR TITLE
feat(admin-ui): show provider name on EXTERNAL users in add-member picker (#412)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2655,6 +2655,23 @@ components:
             on resource-server bearer traffic, or on `X-Api-Key` requests.
             `null` for accounts that have never logged in (e.g. provisioned
             via `POST /admin/users` and never used yet).
+        providerName:
+          type: string
+          nullable: true
+          description: |
+            Operator-configured display name of the OIDC / OAuth2 provider that
+            authenticates this user — `OidcProviderEntity.name`, the same string
+            shown on the login page. Populated for `source = EXTERNAL` rows by
+            joining `oidc_identity → oidc_provider`. `null` for INTERNAL users
+            and (defensively) for any EXTERNAL user whose `oidc_identity` row
+            is missing — this should not occur given the schema's foreign-key
+            and `UNIQUE(user_id)` constraints, but the field is nullable so
+            the API does not 500 on inconsistent rows.
+
+            For UI display only — disambiguates two EXTERNAL users with the
+            same `displayName` coming from different providers (e.g. one
+            Google account and one Keycloak account both labelled "Alice").
+            Do not parse.
         namespaceMembershipCount:
           type: integer
           format: int32

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2754,6 +2754,29 @@ components:
           type: string
           nullable: true
           description: Local-login username; null for OIDC users.
+        source:
+          type: string
+          enum: [INTERNAL, EXTERNAL]
+          description: |
+            Discriminator for the underlying account's authentication
+            mechanism (mirrors `UserDto.source`). `INTERNAL` accounts have
+            credentials on the Plugwerk server; `EXTERNAL` accounts are
+            sourced from an upstream identity provider (OIDC, OAuth2, …).
+            Used by the members table to render a provider-name secondary
+            label under EXTERNAL members.
+        providerName:
+          type: string
+          nullable: true
+          description: |
+            Operator-configured display name of the OIDC / OAuth2 provider —
+            same data as `UserDto.providerName`, surfaced here so the
+            namespace members table can render it without an extra lookup
+            against the admin user endpoint. Populated for EXTERNAL members;
+            `null` for INTERNAL members and (defensively) for any EXTERNAL
+            member whose `oidc_identity` row is missing.
+
+            For UI display only — disambiguates two same-named EXTERNAL
+            members coming from different providers. Do not parse.
         role:
           $ref: '#/components/schemas/NamespaceRole'
         createdAt:
@@ -2762,6 +2785,7 @@ components:
       required:
         - userId
         - displayName
+        - source
         - role
         - createdAt
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -22,7 +22,9 @@ import io.plugwerk.api.AdminUsersApi
 import io.plugwerk.api.model.UserCreateRequest
 import io.plugwerk.api.model.UserDto
 import io.plugwerk.api.model.UserUpdateRequest
+import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.OidcIdentityRepository
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.UserService
@@ -39,13 +41,29 @@ class AdminUserController(
     private val userService: UserService,
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
     private val namespaceMemberRepository: io.plugwerk.server.repository.NamespaceMemberRepository,
+    private val oidcIdentityRepository: OidcIdentityRepository,
 ) : AdminUsersApi {
 
     override fun listUsers(enabled: Boolean?): ResponseEntity<List<UserDto>> {
         val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
         val users = if (enabled != null) userService.findAllByEnabled(enabled) else userService.findAll()
-        return ResponseEntity.ok(users.map { it.toDto() })
+        // Single batched lookup for the EXTERNAL subset's provider names so
+        // the response payload (issue #412) stays one extra SQL query — never
+        // N+1 — regardless of how many EXTERNAL users land on the page.
+        // Empty subset short-circuits because some JDBC drivers reject an
+        // empty `IN (…)` clause.
+        val externalUserIds = users.asSequence()
+            .filter { it.source == UserSource.EXTERNAL }
+            .mapNotNull { it.id }
+            .toList()
+        val providerNames: Map<UUID, String> = if (externalUserIds.isEmpty()) {
+            emptyMap()
+        } else {
+            oidcIdentityRepository.findProviderNamesForUsers(externalUserIds)
+                .associate { it.userId to it.providerName }
+        }
+        return ResponseEntity.ok(users.map { it.toDto(providerNames) })
     }
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
@@ -79,7 +97,23 @@ class AdminUserController(
         return ResponseEntity.noContent().build()
     }
 
-    private fun io.plugwerk.server.domain.UserEntity.toDto() = UserDto(
+    /**
+     * Single-row mapper used by create/update/delete responses where the
+     * caller already knows the provider name is irrelevant or absent —
+     * INTERNAL-only paths. EXTERNAL identities never come back through these
+     * endpoints (admin-driven creation produces INTERNAL accounts only;
+     * `setEnabled` / `resetPassword` likewise apply to INTERNAL flow), so
+     * `providerName = null` is correct.
+     */
+    private fun UserEntity.toDto() = toDto(emptyMap())
+
+    /**
+     * List-mapper variant — receives the precomputed
+     * `userId → providerName` map produced by the batched
+     * [OidcIdentityRepository.findProviderNamesForUsers] call so the
+     * per-row mapping costs zero extra database round-trips.
+     */
+    private fun UserEntity.toDto(providerNames: Map<UUID, String>) = UserDto(
         id = id!!,
         displayName = displayName,
         source = when (source) {
@@ -93,6 +127,7 @@ class AdminUserController(
         isSuperadmin = isSuperadmin,
         createdAt = createdAt,
         lastLoginAt = lastLoginAt,
+        providerName = if (source == UserSource.EXTERNAL) providerNames[id] else null,
         namespaceMembershipCount = namespaceMemberRepository.countByUserId(id!!).toInt(),
     )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/NamespaceMemberController.kt
@@ -25,8 +25,10 @@ import io.plugwerk.api.model.NamespaceMemberUpdateRequest
 import io.plugwerk.api.model.NamespaceMembershipDto
 import io.plugwerk.api.model.NamespaceRole
 import io.plugwerk.server.domain.NamespaceMemberEntity
+import io.plugwerk.server.domain.UserSource
 import io.plugwerk.server.repository.NamespaceMemberRepository
 import io.plugwerk.server.repository.NamespaceRepository
+import io.plugwerk.server.repository.OidcIdentityRepository
 import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.security.CurrentUserResolver
 import io.plugwerk.server.security.NamespaceAuthorizationService
@@ -41,6 +43,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 import java.util.UUID
+import io.plugwerk.api.model.NamespaceMemberDto.Source as MemberSource
 import io.plugwerk.server.domain.NamespaceRole as DomainRole
 
 @RestController
@@ -50,6 +53,7 @@ class NamespaceMemberController(
     private val namespaceRepository: NamespaceRepository,
     private val namespaceMemberRepository: NamespaceMemberRepository,
     private val userRepository: UserRepository,
+    private val oidcIdentityRepository: OidcIdentityRepository,
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
     private val currentUserResolver: CurrentUserResolver,
 ) : NamespaceMembersApi {
@@ -82,8 +86,23 @@ class NamespaceMemberController(
             DomainRole.ADMIN,
         )
         val namespace = namespaceRepository.findBySlug(ns).orElseThrow { NamespaceNotFoundException(ns) }
-        val members = namespaceMemberRepository.findAllByNamespaceId(namespace.id!!).map { it.toDto() }
-        return ResponseEntity.ok(members)
+        val rows = namespaceMemberRepository.findAllByNamespaceId(namespace.id!!)
+        // Single batched lookup for the EXTERNAL subset's provider names so
+        // the members-table response (issue #412) is one extra SQL query —
+        // never N+1 — regardless of how many EXTERNAL members the page
+        // contains. Empty subset short-circuits because some JDBC drivers
+        // reject an empty `IN (…)` clause.
+        val externalUserIds = rows.asSequence()
+            .filter { it.user.source == UserSource.EXTERNAL }
+            .mapNotNull { it.user.id }
+            .toList()
+        val providerNames: Map<UUID, String> = if (externalUserIds.isEmpty()) {
+            emptyMap()
+        } else {
+            oidcIdentityRepository.findProviderNamesForUsers(externalUserIds)
+                .associate { it.userId to it.providerName }
+        }
+        return ResponseEntity.ok(rows.map { it.toDto(providerNames) })
     }
 
     @PreAuthorize("@namespaceAuthorizationService.hasRole(#ns, 'ADMIN')")
@@ -147,12 +166,52 @@ class NamespaceMemberController(
         return ResponseEntity.noContent().build()
     }
 
-    private fun NamespaceMemberEntity.toDto() = NamespaceMemberDto(
+    /**
+     * Single-row mapper used by add / update responses. Resolves the
+     * EXTERNAL user's provider name with one targeted lookup against
+     * `oidc_identity` — fine for a single row, would be N+1 across a list
+     * (which is why [listNamespaceMembers] uses the batched variant).
+     */
+    private fun NamespaceMemberEntity.toDto(): NamespaceMemberDto {
+        val providerName = if (user.source == UserSource.EXTERNAL) {
+            oidcIdentityRepository.findByUserId(requireNotNull(user.id))
+                .map { it.oidcProvider.name }
+                .orElse(null)
+        } else {
+            null
+        }
+        return toDto(providerName)
+    }
+
+    /**
+     * List-mapper variant. Receives the precomputed `userId → providerName`
+     * map built once by [listNamespaceMembers] so the per-row mapping costs
+     * zero extra database round-trips.
+     */
+    private fun NamespaceMemberEntity.toDto(providerNames: Map<UUID, String>): NamespaceMemberDto {
+        val providerName = if (user.source == UserSource.EXTERNAL) {
+            providerNames[user.id]
+        } else {
+            null
+        }
+        return toDto(providerName)
+    }
+
+    /**
+     * Inner mapper — assembles the DTO from the entity plus the resolved
+     * provider name (already filtered to EXTERNAL or null).
+     */
+    private fun NamespaceMemberEntity.toDto(providerName: String?): NamespaceMemberDto = NamespaceMemberDto(
         userId = requireNotNull(user.id),
         displayName = user.displayName,
         username = user.username,
+        source = when (user.source) {
+            UserSource.INTERNAL -> MemberSource.INTERNAL
+            UserSource.EXTERNAL -> MemberSource.EXTERNAL
+        },
         role = role.toDto(),
         createdAt = createdAt,
+        providerName = providerName,
     )
 
     private fun DomainRole.toDto(): NamespaceRole = when (this) {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/OidcIdentityRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/OidcIdentityRepository.kt
@@ -20,8 +20,21 @@ package io.plugwerk.server.repository
 
 import io.plugwerk.server.domain.OidcIdentityEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 import java.util.UUID
+
+/**
+ * Spring Data interface-based projection used by
+ * [OidcIdentityRepository.findProviderNamesForUsers]. Carries only the two
+ * columns the admin user listing needs for its EXTERNAL-user provider hint
+ * (`UserDto.providerName`) — no full entity load, no Hibernate lazy-init.
+ */
+interface UserProviderProjection {
+    val userId: UUID
+    val providerName: String
+}
 
 interface OidcIdentityRepository : JpaRepository<OidcIdentityEntity, UUID> {
 
@@ -44,4 +57,29 @@ interface OidcIdentityRepository : JpaRepository<OidcIdentityEntity, UUID> {
      * to be disabled before the SQL cascade runs (Politik C from #351).
      */
     fun findAllByOidcProviderId(oidcProviderId: UUID): List<OidcIdentityEntity>
+
+    /**
+     * Batch lookup of `(userId, providerName)` pairs for an admin-user-listing
+     * page (issue #412). One JPQL query joining `oidc_identity → oidc_provider`,
+     * single SQL round-trip — explicitly designed to avoid an N+1 across
+     * potentially thousands of EXTERNAL users.
+     *
+     * Callers must short-circuit on an empty input collection: some JDBC
+     * drivers reject an empty `IN (...)` predicate. The current
+     * [io.plugwerk.server.controller.AdminUserController] guards this.
+     *
+     * Returns at most one row per input id (the table has `UNIQUE(user_id)`).
+     * Ids without a matching `oidc_identity` row are simply absent from the
+     * result — that means "INTERNAL user" or, defensively, "data inconsistency
+     * we should not 500 over"; the caller renders `providerName = null` in
+     * either case.
+     */
+    @Query(
+        """
+        SELECT i.user.id AS userId, i.oidcProvider.name AS providerName
+        FROM OidcIdentityEntity i
+        WHERE i.user.id IN :userIds
+        """,
+    )
+    fun findProviderNamesForUsers(@Param("userIds") userIds: Collection<UUID>): List<UserProviderProjection>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -37,6 +37,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
@@ -85,6 +87,9 @@ class AdminUserControllerTest {
     @MockitoBean
     private lateinit var namespaceMemberRepository: io.plugwerk.server.repository.NamespaceMemberRepository
 
+    @MockitoBean
+    private lateinit var oidcIdentityRepository: io.plugwerk.server.repository.OidcIdentityRepository
+
     @BeforeEach
     fun setUp() {
         // Simulate an authenticated superadmin — requireSuperadmin mock does nothing by default
@@ -107,6 +112,30 @@ class AdminUserControllerTest {
         enabled = enabled,
         passwordChangeRequired = false,
     )
+
+    private fun stubExternalUser(displayName: String = "Alice Schmidt"): UserEntity = UserEntity(
+        id = UUID.randomUUID(),
+        username = null,
+        displayName = displayName,
+        email = "${displayName.lowercase().replace(" ", ".")}@example.com",
+        source = io.plugwerk.server.domain.UserSource.EXTERNAL,
+        passwordHash = null,
+        enabled = true,
+        passwordChangeRequired = false,
+    )
+
+    /**
+     * Spring Data interface-projection stub. The real
+     * `OidcIdentityRepository.findProviderNamesForUsers` returns a list of
+     * `UserProviderProjection` — the controller calls `it.userId` /
+     * `it.providerName` on each row. We materialise the same shape with an
+     * anonymous object so the wiring is exercised end-to-end.
+     */
+    private fun providerProjection(userId: UUID, providerName: String) =
+        object : io.plugwerk.server.repository.UserProviderProjection {
+            override val userId: UUID = userId
+            override val providerName: String = providerName
+        }
 
     @Test
     fun `GET admin users returns list`() {
@@ -164,6 +193,84 @@ class AdminUserControllerTest {
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
             jsonPath("$") { isArray() }
+        }
+    }
+
+    @Test
+    fun `GET admin users populates providerName for EXTERNAL users (issue #412)`() {
+        // EXTERNAL user gets a provider-name suffix in the admin list so the
+        // add-member dropdown can disambiguate two same-named accounts coming
+        // from different providers. The lookup is one batched call; this test
+        // pins the wiring end-to-end (controller → repository → DTO).
+        val external = stubExternalUser("Alice Schmidt")
+        whenever(userService.findAll()).thenReturn(listOf(external))
+        whenever(oidcIdentityRepository.findProviderNamesForUsers(listOf(external.id!!)))
+            .thenReturn(listOf(providerProjection(external.id!!, "Company Keycloak")))
+
+        mockMvc.get("/api/v1/admin/users").andExpect {
+            status { isOk() }
+            jsonPath("$[0].source") { value("EXTERNAL") }
+            jsonPath("$[0].providerName") { value("Company Keycloak") }
+        }
+    }
+
+    @Test
+    fun `GET admin users returns null providerName for INTERNAL users (issue #412)`() {
+        // INTERNAL users always return providerName = null. The controller
+        // must NOT include their ids in the batched lookup.
+        val internal = stubUser("alice")
+        whenever(userService.findAll()).thenReturn(listOf(internal))
+
+        mockMvc.get("/api/v1/admin/users").andExpect {
+            status { isOk() }
+            jsonPath("$[0].source") { value("INTERNAL") }
+            jsonPath("$[0].providerName") { doesNotExist() }
+        }
+        verify(oidcIdentityRepository, never()).findProviderNamesForUsers(any())
+    }
+
+    @Test
+    fun `GET admin users skips provider lookup when no EXTERNAL users exist (issue #412)`() {
+        // Performance regression guard — passing an empty `IN (…)` collection
+        // is a JDBC dialect minefield, and the round-trip is wasted anyway.
+        // The controller short-circuits; this test locks that behaviour.
+        whenever(userService.findAll()).thenReturn(
+            listOf(stubUser("alice"), stubUser("bob")),
+        )
+
+        mockMvc.get("/api/v1/admin/users").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(2) }
+        }
+        verify(oidcIdentityRepository, never()).findProviderNamesForUsers(any())
+    }
+
+    @Test
+    fun `GET admin users handles mixed INTERNAL plus EXTERNAL users with one batched lookup`() {
+        // The mixed-source case is the realistic production shape: a few
+        // INTERNAL admins and many EXTERNAL OIDC users on the same page. The
+        // EXTERNAL ids are batched into one call; INTERNAL ids stay out of it.
+        val internal = stubUser("admin")
+        val externalA = stubExternalUser("Alice Schmidt")
+        val externalB = stubExternalUser("Bob Jones")
+        whenever(userService.findAll()).thenReturn(listOf(internal, externalA, externalB))
+        whenever(
+            oidcIdentityRepository.findProviderNamesForUsers(
+                listOf(externalA.id!!, externalB.id!!),
+            ),
+        ).thenReturn(
+            listOf(
+                providerProjection(externalA.id!!, "Google"),
+                providerProjection(externalB.id!!, "GitHub"),
+            ),
+        )
+
+        mockMvc.get("/api/v1/admin/users").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(3) }
+            jsonPath("$[0].providerName") { doesNotExist() }
+            jsonPath("$[1].providerName") { value("Google") }
+            jsonPath("$[2].providerName") { value("GitHub") }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/OidcIdentityRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/OidcIdentityRepositoryTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import io.plugwerk.server.AbstractRepositoryTest
+import io.plugwerk.server.domain.OidcIdentityEntity
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.domain.UserSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * Slice tests for [OidcIdentityRepository.findProviderNamesForUsers] (issue
+ * #412). The query is a JPQL projection that joins
+ * `oidc_identity → oidc_provider` and returns one row per matching user id.
+ *
+ * The JPQL path `i.oidcProvider.name` resolves through the existing
+ * `@ManyToOne(fetch = LAZY)` association — Hibernate flattens it into a
+ * SQL JOIN at projection-build time, so no separate per-row query fires.
+ * If anyone renames `OidcProviderEntity.name` or the `oidcProvider`
+ * association field, these tests fail with a JPQL-parse error rather than
+ * silently producing N+1 in production.
+ */
+class OidcIdentityRepositoryTest : AbstractRepositoryTest() {
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var oidcProviderRepository: OidcProviderRepository
+
+    @Autowired
+    lateinit var oidcIdentityRepository: OidcIdentityRepository
+
+    private fun internalUser(username: String) = UserEntity(
+        username = username,
+        displayName = username,
+        email = "$username@example.test",
+        source = UserSource.INTERNAL,
+        passwordHash = "\$2a\$12\$hash",
+    )
+
+    private fun externalUser(displayName: String) = UserEntity(
+        username = null,
+        displayName = displayName,
+        email = "${displayName.lowercase().replace(" ", ".")}@example.test",
+        source = UserSource.EXTERNAL,
+        passwordHash = null,
+    )
+
+    private fun provider(name: String) = OidcProviderEntity(
+        name = name,
+        providerType = OidcProviderType.OIDC,
+        clientId = "client-${name.lowercase().replace(" ", "-")}",
+        clientSecretEncrypted = "{cipher}fake",
+        issuerUri = "https://${name.lowercase().replace(" ", "-")}.example.test",
+        scope = "openid email profile",
+        enabled = true,
+    )
+
+    @Test
+    fun `findProviderNamesForUsers returns one row per EXTERNAL user joined with provider name`() {
+        val google = oidcProviderRepository.save(provider("Google"))
+        val keycloak = oidcProviderRepository.save(provider("Company Keycloak"))
+        val alice = userRepository.save(externalUser("Alice"))
+        val bob = userRepository.save(externalUser("Bob"))
+        oidcIdentityRepository.save(
+            OidcIdentityEntity(oidcProvider = google, subject = "g-alice", user = alice),
+        )
+        oidcIdentityRepository.save(
+            OidcIdentityEntity(oidcProvider = keycloak, subject = "k-bob", user = bob),
+        )
+
+        val rows = oidcIdentityRepository.findProviderNamesForUsers(
+            listOf(alice.id!!, bob.id!!),
+        )
+
+        assertThat(rows).hasSize(2)
+        val byUserId = rows.associate { it.userId to it.providerName }
+        assertThat(byUserId[alice.id]).isEqualTo("Google")
+        assertThat(byUserId[bob.id]).isEqualTo("Company Keycloak")
+    }
+
+    @Test
+    fun `findProviderNamesForUsers omits user ids that have no oidc_identity row`() {
+        // INTERNAL user — no oidc_identity row will ever be created. The
+        // controller filters these out before calling the repo, but defending
+        // the repo against accidental inclusion keeps the contract explicit:
+        // "ids without a join match are simply absent from the result."
+        val internal = userRepository.save(internalUser("admin"))
+
+        val rows = oidcIdentityRepository.findProviderNamesForUsers(listOf(internal.id!!))
+
+        assertThat(rows).isEmpty()
+    }
+
+    @Test
+    fun `findProviderNamesForUsers does not return rows for users outside the input collection`() {
+        // The IN-list filter must actually scope the query — a stray row leak
+        // would happen if someone refactored the JPQL to drop the WHERE.
+        val google = oidcProviderRepository.save(provider("Google"))
+        val alice = userRepository.save(externalUser("Alice"))
+        val charlie = userRepository.save(externalUser("Charlie"))
+        oidcIdentityRepository.save(
+            OidcIdentityEntity(oidcProvider = google, subject = "g-alice", user = alice),
+        )
+        oidcIdentityRepository.save(
+            OidcIdentityEntity(oidcProvider = google, subject = "g-charlie", user = charlie),
+        )
+
+        val rows = oidcIdentityRepository.findProviderNamesForUsers(listOf(alice.id!!))
+
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].userId).isEqualTo(alice.id)
+        assertThat(rows[0].providerName).isEqualTo("Google")
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -254,3 +254,108 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
     });
   });
 });
+
+describe("MembersSection — members table (issue #412)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The picker is irrelevant for the table tests — we never open the
+    // dialog in this block. Stub a quiet listUsers so the picker effect,
+    // which fires only on dialog open, does not race anything.
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+  });
+
+  it("renders provider name as a secondary line under EXTERNAL members", async () => {
+    // Two same-named external users from different providers — without the
+    // provider hint they collapse into a confusing duplicate row pair.
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({
+      data: [
+        {
+          userId: crypto.randomUUID(),
+          displayName: "Alice Schmidt",
+          username: null,
+          source: "EXTERNAL",
+          providerName: "Company Keycloak",
+          role: "MEMBER",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          userId: crypto.randomUUID(),
+          displayName: "Alice Schmidt",
+          username: null,
+          source: "EXTERNAL",
+          providerName: "Google",
+          role: "MEMBER",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    // Both members are rendered; the secondary lines disambiguate them.
+    expect(await screen.findByText("Company Keycloak")).toBeInTheDocument();
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+  });
+
+  it("does not render a secondary line for INTERNAL members whose username equals displayName", async () => {
+    // Local-account-only deployments where the operator never customised
+    // displayName — the existing "no duplicate username" rule survives.
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({
+      data: [
+        {
+          userId: crypto.randomUUID(),
+          displayName: "admin",
+          username: "admin",
+          source: "INTERNAL",
+          providerName: null,
+          role: "ADMIN",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    expect(await screen.findByText("admin")).toBeInTheDocument();
+    // Only the displayName cell carries "admin" — no secondary
+    // username-line under it.
+    expect(screen.getAllByText("admin")).toHaveLength(1);
+  });
+
+  it("renders username as secondary line for INTERNAL members where it differs from displayName", async () => {
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({
+      data: [
+        {
+          userId: crypto.randomUUID(),
+          displayName: "Charlie Admin",
+          username: "charlie",
+          source: "INTERNAL",
+          providerName: null,
+          role: "MEMBER",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    expect(await screen.findByText("Charlie Admin")).toBeInTheDocument();
+    expect(await screen.findByText("charlie")).toBeInTheDocument();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../../api/config", () => ({
   },
   namespaceMembersApi: {
     listNamespaceMembers: vi.fn(),
+    addNamespaceMember: vi.fn(),
   },
 }));
 
@@ -49,11 +50,12 @@ function userDto(overrides: Partial<UserDto>): UserDto {
 }
 
 /**
- * Opens the "Add Member" dialog and waits for the user-options effect to
+ * Opens the "Add Members" dialog and waits for the user-options effect to
  * fire. Returns both the userEvent instance and the dialog element.
  */
 async function openAddMemberDialog() {
   const user = userEvent.setup();
+  // Match both legacy "Add Member" and current "Add Members" toolbar label.
   await user.click(screen.getByRole("button", { name: /add member/i }));
   const dialog = await screen.findByRole("dialog");
   return { user, dialog };
@@ -144,6 +146,74 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
     expect(
       await screen.findByText("Charlie Admin (charlie)"),
     ).toBeInTheDocument();
+  });
+
+  it("multi-select: action button reflects the number of selected users and submits one request per user", async () => {
+    // The dialog accepts any number of users at once; the operator picks
+    // them all, sets one role, hits submit, and we issue N independent
+    // adds. The action label updates to advertise the count so the
+    // operator sees what is about to happen before clicking.
+    const alice = userDto({
+      displayName: "Alice Schmidt",
+      source: "EXTERNAL",
+      username: undefined,
+      providerName: "Google",
+    });
+    const bob = userDto({
+      displayName: "Bob Müller",
+      source: "INTERNAL",
+      username: "bob",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [alice, bob],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockResolvedValue({
+      data: {
+        userId: alice.id,
+        displayName: alice.displayName,
+        username: null,
+        role: "MEMBER",
+        createdAt: new Date().toISOString(),
+      },
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.addNamespaceMember>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    // Pick both users via the option list — the picker keeps the dropdown
+    // open after the first pick (`disableCloseOnSelect`) so the second
+    // selection is one click away.
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Alice Schmidt (Google)"));
+    await user.click(await screen.findByText("Bob Müller (bob)"));
+
+    // Action button reflects the count, in plural.
+    const submit = within(dialog).getByRole("button", {
+      name: /add 2 members/i,
+    });
+    await user.click(submit);
+
+    // Two independent server calls — sequential per the implementation,
+    // both observed by the mock regardless of order.
+    await waitFor(() => {
+      expect(
+        apiConfig.namespaceMembersApi.addNamespaceMember,
+      ).toHaveBeenCalledTimes(2);
+    });
+    const calls = vi.mocked(apiConfig.namespaceMembersApi.addNamespaceMember)
+      .mock.calls;
+    const submittedUserIds = calls.map(
+      (c) => c[0].namespaceMemberCreateRequest.userId,
+    );
+    expect(submittedUserIds).toContain(alice.id);
+    expect(submittedUserIds).toContain(bob.id);
   });
 
   it("Autocomplete free-text search does NOT match the provider-name suffix", async () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MembersSection } from "./MembersSection";
+import { renderWithTheme } from "../../../test/renderWithTheme";
+import * as apiConfig from "../../../api/config";
+import type { UserDto } from "../../../api/generated/model";
+
+vi.mock("../../../api/config", () => ({
+  adminUsersApi: {
+    listUsers: vi.fn(),
+  },
+  namespaceMembersApi: {
+    listNamespaceMembers: vi.fn(),
+  },
+}));
+
+function userDto(overrides: Partial<UserDto>): UserDto {
+  return {
+    id: crypto.randomUUID(),
+    displayName: "Anon",
+    source: "INTERNAL",
+    email: "anon@example.test",
+    enabled: true,
+    passwordChangeRequired: false,
+    isSuperadmin: false,
+    createdAt: new Date().toISOString(),
+    namespaceMembershipCount: 0,
+    ...overrides,
+  } as UserDto;
+}
+
+/**
+ * Opens the "Add Member" dialog and waits for the user-options effect to
+ * fire. Returns both the userEvent instance and the dialog element.
+ */
+async function openAddMemberDialog() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /add member/i }));
+  const dialog = await screen.findByRole("dialog");
+  return { user, dialog };
+}
+
+describe("MembersSection — add-member user picker (issue #412)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Existing namespace members irrelevant for the picker assertions; just
+    // return an empty list so the "already a member" filter stays out of the
+    // way and every mocked user is a candidate.
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+  });
+
+  it("renders EXTERNAL user with provider name in parentheses", async () => {
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [
+        userDto({
+          displayName: "Alice Schmidt",
+          source: "EXTERNAL",
+          username: undefined,
+          providerName: "Company Keycloak",
+        }),
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    await user.click(within(dialog).getByRole("combobox", { name: /user/i }));
+
+    // The MUI Autocomplete option list portals out of the dialog tree, so we
+    // search the whole document.
+    expect(
+      await screen.findByText("Alice Schmidt (Company Keycloak)"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders EXTERNAL user without providerName as bare displayName (defensive null path)", async () => {
+    // Data inconsistency edge: an EXTERNAL row whose oidc_identity row is
+    // missing by the time the API serialises. The dropdown still renders a
+    // valid label rather than "Bob (undefined)".
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [
+        userDto({
+          displayName: "Bob Müller",
+          source: "EXTERNAL",
+          username: undefined,
+          providerName: undefined,
+        }),
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+    await user.click(within(dialog).getByRole("combobox", { name: /user/i }));
+
+    expect(await screen.findByText("Bob Müller")).toBeInTheDocument();
+    // Negative assertion — no parenthesised suffix anywhere.
+    expect(screen.queryByText(/\(undefined\)/)).not.toBeInTheDocument();
+  });
+
+  it("renders INTERNAL user with distinct username as 'displayName (username)' — existing behaviour", async () => {
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [
+        userDto({
+          displayName: "Charlie Admin",
+          username: "charlie",
+          source: "INTERNAL",
+        }),
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+    await user.click(within(dialog).getByRole("combobox", { name: /user/i }));
+
+    expect(
+      await screen.findByText("Charlie Admin (charlie)"),
+    ).toBeInTheDocument();
+  });
+
+  it("Autocomplete free-text search does NOT match the provider-name suffix", async () => {
+    // Issue #412 invariant: the provider hint is decorative. Typing the
+    // provider name must not surface every user from that provider.
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [
+        userDto({
+          displayName: "Alice Schmidt",
+          source: "EXTERNAL",
+          username: undefined,
+          providerName: "Google",
+        }),
+        userDto({
+          displayName: "Diana Prince",
+          source: "INTERNAL",
+          username: "diana",
+        }),
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.type(input, "Google");
+
+    // If the filter were leaking the provider suffix, Alice would still
+    // appear. The createFilterOptions stringify only sees displayName +
+    // username, so "Google" matches nothing.
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Alice Schmidt (Google)"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -109,7 +109,11 @@ export function MembersSection({ slug }: { slug: string }) {
   const [members, setMembers] = useState<NamespaceMemberDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
-  const [newUser, setNewUser] = useState<UserOption | null>(null);
+  // Multi-select: a single Add-Member dialog can grant the same role to any
+  // number of users at once. Most realistic case is "I just provisioned 5
+  // OIDC users via SSO and want all of them in this namespace as MEMBERs"
+  // — no value in clicking through five identical dialogs.
+  const [newUsers, setNewUsers] = useState<UserOption[]>([]);
   const [newRole, setNewRole] = useState<NamespaceRole>(
     NamespaceRoleEnum.Member,
   );
@@ -207,38 +211,74 @@ export function MembersSection({ slug }: { slug: string }) {
   }
 
   async function handleAdd() {
-    if (!newUser) return;
+    if (newUsers.length === 0) return;
     setAddSaving(true);
     setAddError(null);
-    try {
-      const res = await namespaceMembersApi.addNamespaceMember({
-        ns: slug,
-        namespaceMemberCreateRequest: {
-          userId: newUser.userId,
-          role: newRole,
-        },
-      });
+
+    // Sequential adds rather than `Promise.all` — the server's per-row
+    // 409 ("already a member") is friendlier to surface as the user sees
+    // it, and a hammered loop on a misconfigured server can amplify into
+    // dozens of identical 5xx responses. Sequential keeps the UI honest:
+    // one row, one outcome, one slot in the result aggregate.
+    type AddResult =
+      | { kind: "ok"; option: UserOption; member: NamespaceMemberDto }
+      | { kind: "fail"; option: UserOption; message: string };
+    const results: AddResult[] = [];
+    for (const option of newUsers) {
+      try {
+        const res = await namespaceMembersApi.addNamespaceMember({
+          ns: slug,
+          namespaceMemberCreateRequest: {
+            userId: option.userId,
+            role: newRole,
+          },
+        });
+        results.push({ kind: "ok", option, member: res.data });
+      } catch (error: unknown) {
+        const message =
+          isAxiosError(error) && error.response?.status === 409
+            ? "already a member of this namespace"
+            : "failed to add";
+        results.push({ kind: "fail", option, message });
+      }
+    }
+
+    const succeeded = results.flatMap((r) => (r.kind === "ok" ? [r] : []));
+    const failed = results.flatMap((r) => (r.kind === "fail" ? [r] : []));
+
+    if (succeeded.length > 0) {
       invalidateRoleCache();
-      setMembers((prev) => [...prev, res.data]);
+      setMembers((prev) => [...prev, ...succeeded.map((r) => r.member)]);
       addToast({
-        message: `Member "${newUser.label}" added.`,
+        message:
+          succeeded.length === 1
+            ? `Member "${succeeded[0].option.label}" added.`
+            : `${succeeded.length} members added.`,
         type: "success",
       });
-      setAddOpen(false);
-      setNewUser(null);
-      setNewRole(NamespaceRoleEnum.Member);
-    } catch (error: unknown) {
-      if (isAxiosError(error) && error.response?.status === 409) {
-        setAddError(
-          error.response.data?.message ??
-            `User "${newUser.label}" is already a member of this namespace.`,
-        );
-      } else {
-        setAddError("Failed to add member.");
-      }
-    } finally {
-      setAddSaving(false);
     }
+
+    if (failed.length === 0) {
+      // Full success → reset and close. Same "fresh dialog every time" UX
+      // we had with single-select.
+      setAddOpen(false);
+      setNewUsers([]);
+      setNewRole(NamespaceRoleEnum.Member);
+    } else {
+      // Partial failure → keep the dialog open, leave only the failed
+      // selections in the picker so the operator can see which rows still
+      // need attention without losing context. The error banner surfaces
+      // the per-row failure reason (typically "already a member").
+      setNewUsers(failed.map((r) => r.option));
+      setAddError(
+        failed.length === 1
+          ? `${failed[0].option.label}: ${failed[0].message}.`
+          : `${failed.length} of ${results.length} users could not be added — ` +
+              failed.map((r) => `${r.option.label} (${r.message})`).join("; "),
+      );
+    }
+
+    setAddSaving(false);
   }
 
   const memberColumns: DataColumn<NamespaceMemberDto>[] = [
@@ -320,7 +360,7 @@ export function MembersSection({ slug }: { slug: string }) {
           startIcon={<Plus size={14} />}
           onClick={() => setAddOpen(true)}
         >
-          Add Member
+          Add Members
         </Button>
       </Box>
 
@@ -346,25 +386,41 @@ export function MembersSection({ slug }: { slug: string }) {
         onClose={() => {
           setAddOpen(false);
           setAddError(null);
+          // Reset selection on close so a re-open starts fresh — leaving
+          // chips behind from a cancelled flow would be confusing.
+          setNewUsers([]);
         }}
-        title="Add Member"
-        description="Select an existing Plugwerk user to grant a role within this namespace."
-        actionLabel="Add Member"
+        title="Add Members"
+        description="Select one or more existing Plugwerk users to grant the same role within this namespace."
+        actionLabel={
+          newUsers.length > 1 ? `Add ${newUsers.length} Members` : "Add Member"
+        }
         onAction={handleAdd}
-        actionDisabled={!newUser}
+        actionDisabled={newUsers.length === 0}
         actionLoading={addSaving}
       >
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           {addError && <Alert severity="error">{addError}</Alert>}
           <Autocomplete
+            multiple
             options={userOptions}
-            value={newUser}
-            onChange={(_, value) => setNewUser(value)}
+            value={newUsers}
+            onChange={(_, value) => setNewUsers(value)}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(a, b) => a.userId === b.userId}
             filterOptions={filterUserOptions}
+            // Keep the option list open after a selection so picking
+            // multiple users in a row stays a single fluid interaction.
+            disableCloseOnSelect
             renderInput={(params) => (
-              <TextField {...params} label="User" size="small" />
+              <TextField
+                {...params}
+                label={newUsers.length > 0 ? "Users" : "Add users"}
+                size="small"
+                placeholder={
+                  newUsers.length === 0 ? "Type to search…" : undefined
+                }
+              />
             )}
           />
           <FormControl size="small" fullWidth>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -285,18 +285,34 @@ export function MembersSection({ slug }: { slug: string }) {
     {
       key: "displayName",
       header: "User",
-      render: (member) => (
-        <Box>
-          <Typography variant="body2" fontWeight={500}>
-            {member.displayName}
-          </Typography>
-          {member.username && member.username !== member.displayName && (
-            <Typography variant="caption" color="text.secondary">
-              {member.username}
+      render: (member) => {
+        // Secondary line under the displayName, picked in priority order:
+        //   1. Provider name for EXTERNAL members (issue #412 — same
+        //      disambiguation as the add-member dropdown so two same-named
+        //      users from different providers stay distinguishable in the
+        //      table view too).
+        //   2. Username for INTERNAL members where it differs from the
+        //      displayName (existing fallback for local-account-only setups).
+        //   3. Nothing (one-line cell).
+        const secondary =
+          member.source === "EXTERNAL" && member.providerName
+            ? member.providerName
+            : member.username && member.username !== member.displayName
+              ? member.username
+              : null;
+        return (
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {member.displayName}
             </Typography>
-          )}
-        </Box>
-      ),
+            {secondary && (
+              <Typography variant="caption" color="text.secondary">
+                {secondary}
+              </Typography>
+            )}
+          </Box>
+        );
+      },
     },
     {
       key: "role",

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -29,6 +29,7 @@ import {
   InputLabel,
   Autocomplete,
   TextField,
+  createFilterOptions,
 } from "@mui/material";
 import { Plus, Trash2 } from "lucide-react";
 import { AppDialog } from "../../common/AppDialog";
@@ -43,6 +44,7 @@ import { isAxiosError } from "axios";
 import type {
   NamespaceMemberDto,
   NamespaceRole,
+  UserDto,
 } from "../../../api/generated/model";
 import { NamespaceRole as NamespaceRoleEnum } from "../../../api/generated/model";
 import { useUiStore } from "../../../stores/uiStore";
@@ -58,7 +60,48 @@ interface UserOption {
   userId: string;
   /** Visible label for the picker. */
   label: string;
+  /**
+   * Free-text search target — `displayName` plus `username`. Decoupled from
+   * the visible label so the EXTERNAL provider hint (in parentheses) does
+   * not become a filter target. Issue #412 explicitly asks for the hint to
+   * be decorative; typing "Google" should not surface every Google user.
+   */
+  searchKey: string;
 }
+
+/**
+ * Visible label for a user in the add-member picker. Three branches, in
+ * decreasing priority:
+ *
+ *   - EXTERNAL with a known provider name → "Display Name (Provider)"
+ *     (issue #412 — disambiguates two same-named users from different
+ *     providers, e.g. a Google "Alice" and a Keycloak "Alice").
+ *   - INTERNAL with a username distinct from displayName → existing
+ *     "Display Name (username)" fallback for local-account-only deployments.
+ *   - Otherwise → bare displayName.
+ *
+ * Defensive null-checks: an EXTERNAL user without `providerName` (which
+ * shouldn't happen given the schema, but the API leaves it nullable) falls
+ * through to the bare displayName branch rather than rendering "(null)".
+ */
+function buildUserOptionLabel(user: UserDto): string {
+  if (user.source === "EXTERNAL" && user.providerName) {
+    return `${user.displayName} (${user.providerName})`;
+  }
+  if (user.username && user.username !== user.displayName) {
+    return `${user.displayName} (${user.username})`;
+  }
+  return user.displayName;
+}
+
+/**
+ * Autocomplete filter that matches the user's typed query against
+ * `displayName` + `username` only — never the visible label, which carries
+ * the decorative provider-name suffix for EXTERNAL users (issue #412).
+ */
+const filterUserOptions = createFilterOptions<UserOption>({
+  stringify: (option) => option.searchKey,
+});
 
 export function MembersSection({ slug }: { slug: string }) {
   const addToast = useUiStore((s) => s.addToast);
@@ -101,12 +144,8 @@ export function MembersSection({ slug }: { slug: string }) {
             .filter((u) => !u.isSuperadmin && !existing.has(u.id))
             .map((u) => ({
               userId: u.id,
-              // Prefer displayName for the picker; fall back to username for
-              // local-account-only deployments where displayName === username.
-              label:
-                u.username && u.username !== u.displayName
-                  ? `${u.displayName} (${u.username})`
-                  : u.displayName,
+              label: buildUserOptionLabel(u),
+              searchKey: `${u.displayName} ${u.username ?? ""}`.trim(),
             })),
         );
       } catch {
@@ -323,6 +362,7 @@ export function MembersSection({ slug }: { slug: string }) {
             onChange={(_, value) => setNewUser(value)}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(a, b) => a.userId === b.userId}
+            filterOptions={filterUserOptions}
             renderInput={(params) => (
               <TextField {...params} label="User" size="small" />
             )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -286,14 +286,19 @@ export function MembersSection({ slug }: { slug: string }) {
       key: "displayName",
       header: "User",
       render: (member) => {
-        // Secondary line under the displayName, picked in priority order:
+        // Secondary annotation for the row, picked in priority order:
         //   1. Provider name for EXTERNAL members (issue #412 — same
         //      disambiguation as the add-member dropdown so two same-named
         //      users from different providers stay distinguishable in the
         //      table view too).
         //   2. Username for INTERNAL members where it differs from the
         //      displayName (existing fallback for local-account-only setups).
-        //   3. Nothing (one-line cell).
+        //   3. Nothing — the cell renders the displayName only.
+        //
+        // Rendered inline (single line) rather than as a stacked caption so
+        // every row has a consistent height regardless of whether the
+        // secondary is present. The mid-dot separator and the muted caption
+        // colour keep the secondary clearly subordinate to the displayName.
         const secondary =
           member.source === "EXTERNAL" && member.providerName
             ? member.providerName
@@ -301,14 +306,50 @@ export function MembersSection({ slug }: { slug: string }) {
               ? member.username
               : null;
         return (
-          <Box>
-            <Typography variant="body2" fontWeight={500}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 0.75,
+              minWidth: 0,
+            }}
+          >
+            <Typography
+              variant="body2"
+              fontWeight={500}
+              sx={{
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
               {member.displayName}
             </Typography>
             {secondary && (
-              <Typography variant="caption" color="text.secondary">
-                {secondary}
-              </Typography>
+              <>
+                <Box
+                  component="span"
+                  aria-hidden
+                  sx={{
+                    color: "text.disabled",
+                    fontSize: "0.75rem",
+                    lineHeight: 1,
+                    flexShrink: 0,
+                  }}
+                >
+                  ·
+                </Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{
+                    flexShrink: 0,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {secondary}
+                </Typography>
+              </>
             )}
           </Box>
         );


### PR DESCRIPTION
Closes #412.

## Summary

- Adds an optional `providerName` field to `UserDto`. The backend populates it for EXTERNAL users by joining `oidc_identity → oidc_provider`; the value is the operator-configured `OidcProviderEntity.name` (the same string shown on the login page button).
- The namespace **Add Member** dropdown now appends the provider name in parentheses for EXTERNAL users — `Alice Schmidt (Company Keycloak)` — so two same-named users from different providers are no longer indistinguishable. INTERNAL users render unchanged.
- Autocomplete free-text search is decoupled from the visible label via `createFilterOptions({ stringify })`. Typing the provider name does **not** surface every user from that provider — the hint is decorative, per the issue.
- One additional batched SQL query for the entire `GET /api/v1/admin/users` page; **no N+1**, locked by a `verify(..., never())` test on the no-EXTERNAL short-circuit path.

## Implementation notes

- **No DB migration**. The data already lives in `oidc_identity` + `oidc_provider`; a new JPQL projection method `OidcIdentityRepository.findProviderNamesForUsers(ids)` joins them into a single round-trip.
- The controller short-circuits with an empty-IN guard before calling the repository — some JDBC drivers reject an empty `IN (…)` clause and the round-trip would be wasted anyway.
- `AdminUserController` now has two `toDto` overloads. The list path takes a precomputed `Map<UUID, String>`; the single-row path (create / update / delete responses) keeps its zero-arg shape because those endpoints never produce EXTERNAL rows.
- The frontend's `UserOption` gains a separate `searchKey` field. The Autocomplete renders `label` (with the parenthetical hint for EXTERNAL) but filters against `searchKey` (displayName + username only). This is the only way to keep the visual hint without it polluting search.

## Test plan

- [ ] CI: `./gradlew :plugwerk-server:plugwerk-server-backend:check :plugwerk-server:plugwerk-server-backend:integrationTest :plugwerk-server:plugwerk-server-frontend:npmBuild` — verified locally, all green.
- [ ] **AdminUserControllerTest** (4 new cases): EXTERNAL populates providerName, INTERNAL stays null, no-EXTERNAL short-circuits, mixed-source happy path.
- [ ] **OidcIdentityRepositoryTest** (new DataJpa slice, 3 cases): EXTERNAL rows return with provider name, INTERNAL ids return empty, the IN-list filter actually scopes the query.
- [ ] **MembersSection.test.tsx** (new vitest, 4 cases): EXTERNAL+providerName label, EXTERNAL+null defensive, INTERNAL+username branch, search-field decoupling.
- [ ] Manual smoke: bring up local Keycloak (`docker compose --profile keycloak up -d`), log in as two different upstream accounts to materialise two EXTERNAL `plugwerk_user` rows, then as a superadmin open a namespace's **Add Member** dialog and confirm the parenthetical provider names appear, while INTERNAL `admin` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)