### PR TITLE
fix(admin-ui): audit admin forms for premature-validation anti-pattern (#405)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import { CreateNamespaceDialog } from "./CreateNamespaceDialog";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import * as apiConfig from "../../api/config";
+
+vi.mock("../../api/config", () => ({
+  namespacesApi: {
+    createNamespace: vi.fn(),
+  },
+}));
+
+function setup(
+  overrides: { onCreated?: () => void; onError?: () => void } = {},
+) {
+  return renderWithTheme(
+    <CreateNamespaceDialog
+      open
+      onClose={() => {}}
+      onCreated={overrides.onCreated ?? (() => {})}
+      onError={overrides.onError ?? (() => {})}
+    />,
+  );
+}
+
+describe("CreateNamespaceDialog — premature-validation gate (issue #405)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens calmly: no aria-invalid fields, no Required text on mount", async () => {
+    setup();
+
+    // Wait for the dialog to be in the document.
+    await screen.findByRole("dialog");
+
+    // Slug + Name are required, but neither should be flagged as invalid
+    // before the operator has interacted with the form.
+    const slug = screen.getByRole("textbox", { name: /slug/i });
+    const name = screen.getByRole("textbox", { name: /^name/i });
+    expect(slug).not.toHaveAttribute("aria-invalid", "true");
+    expect(name).not.toHaveAttribute("aria-invalid", "true");
+    // Helper texts show their informational defaults, never "Required.".
+    expect(screen.queryByText("Required.")).not.toBeInTheDocument();
+  });
+
+  it("blur on empty Slug reveals the format/required error", async () => {
+    const user = userEvent.setup();
+    setup();
+
+    const slug = screen.getByRole("textbox", { name: /slug/i });
+    await user.click(slug);
+    await user.tab(); // blur away from the slug field
+
+    await waitFor(() => {
+      expect(slug).toHaveAttribute("aria-invalid", "true");
+    });
+    expect(screen.getByText("Required.")).toBeInTheDocument();
+  });
+
+  it("submit attempt with empty fields reveals every error and keeps the action button disabled", async () => {
+    const user = userEvent.setup();
+    setup();
+
+    // The Create button stays disabled while errors exist, so we cannot
+    // click it directly. We simulate the submit attempt by clicking it
+    // anyway (userEvent honours the `disabled` attribute and does
+    // nothing) — and then verify that even *without* a click, the
+    // touched-gate is still off until either blur or a real submit.
+    //
+    // Tab from the slug to the name to the create-button to trigger
+    // both blur events; the gate must reveal both errors.
+    const slug = screen.getByRole("textbox", { name: /slug/i });
+    await user.click(slug);
+    await user.tab(); // → name
+    await user.tab(); // → description (blurs name)
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Required.")).toHaveLength(2);
+    });
+    const create = screen.getByRole("button", { name: /create/i });
+    expect(create).toBeDisabled();
+  });
+
+  it("server 409 response surfaces inline below the Slug field even when Slug is untouched", async () => {
+    // This pins the carve-out: the server-side conflict error MUST NOT be
+    // hidden by the touched-gate. The operator just hit Create — they
+    // need to see the conflict message, untouched-state or not.
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.namespacesApi.createNamespace).mockRejectedValue(
+      new AxiosError("Conflict", "ERR_BAD_REQUEST", undefined, undefined, {
+        status: 409,
+        statusText: "Conflict",
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+        data: { message: "Namespace already exists." },
+      }),
+    );
+    setup();
+
+    // Type a *valid* slug so client validation passes — the server-side
+    // 409 is the only error path we want to verify here.
+    await user.type(
+      screen.getByRole("textbox", { name: /slug/i }),
+      "my-namespace",
+    );
+    await user.type(screen.getByRole("textbox", { name: /^name/i }), "My NS");
+
+    const create = screen.getByRole("button", { name: /create/i });
+    await waitFor(() => expect(create).toBeEnabled());
+    await user.click(create);
+
+    // Server 409 message renders unconditionally — even if we hadn't
+    // touched/blurred anything, this message would still appear.
+    expect(
+      await screen.findByText("Namespace already exists."),
+    ).toBeInTheDocument();
+  });
+
+  it("server 409 message clears when the operator edits the slug", async () => {
+    // Once the operator changes the conflicting value, the previous error
+    // is stale and must go — otherwise it would persist across an edit
+    // and confuse them about which value the message actually refers to.
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.namespacesApi.createNamespace).mockRejectedValue(
+      new AxiosError("Conflict", "ERR_BAD_REQUEST", undefined, undefined, {
+        status: 409,
+        statusText: "Conflict",
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+        data: { message: "Namespace already exists." },
+      }),
+    );
+    setup();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /slug/i }),
+      "taken-slug",
+    );
+    await user.type(screen.getByRole("textbox", { name: /^name/i }), "Taken");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+    await screen.findByText("Namespace already exists.");
+
+    // Edit the slug — message should disappear.
+    await user.type(
+      screen.getByRole("textbox", { name: /slug/i }),
+      "-different",
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Namespace already exists."),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Box,
   FormControlLabel,
@@ -38,6 +38,13 @@ interface CreateNamespaceDialogProps {
   onError: (message: string) => void;
 }
 
+type FieldKey = "slug" | "name";
+
+const INITIAL_TOUCHED: Record<FieldKey, boolean> = {
+  slug: false,
+  name: false,
+};
+
 export function CreateNamespaceDialog({
   open,
   onClose,
@@ -50,18 +57,61 @@ export function CreateNamespaceDialog({
   const [publicCatalog, setPublicCatalog] = useState(false);
   const [autoApprove, setAutoApprove] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [slugError, setSlugError] = useState<string | null>(null);
+  // Server-side 409 ("namespace already exists") lives in its own state slot
+  // so the inline error message remains visible regardless of whether the
+  // operator has interacted with the field. The touched/submitAttempted gate
+  // below applies only to client-side format / required validation.
+  const [slugServerError, setSlugServerError] = useState<string | null>(null);
 
-  function handleSlugChange(value: string) {
-    setSlug(value);
-    if (value && !SLUG_PATTERN.test(value)) {
-      setSlugError(
-        "Must be lowercase alphanumeric with hyphens, 2\u201364 characters.",
-      );
-    } else {
-      setSlugError(null);
-    }
-  }
+  // Touched-gate (issue #405). A field's error becomes visible once the
+  // operator has either blurred it or attempted submit — not on mount.
+  // Without this gate every required field would render red the moment the
+  // dialog opens, reading as "validation failed" before the operator typed
+  // anything.
+  const [touched, setTouched] =
+    useState<Record<FieldKey, boolean>>(INITIAL_TOUCHED);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const markTouched = (key: FieldKey) =>
+    setTouched((prev) => (prev[key] ? prev : { ...prev, [key]: true }));
+
+  // Reset interaction state on every (re)open so a freshly-opened dialog is
+  // calm rather than carrying touched flags from a prior cancelled flow.
+  useEffect(() => {
+    if (!open) return;
+    setTouched(INITIAL_TOUCHED);
+    setSubmitAttempted(false);
+    setSlugServerError(null);
+  }, [open]);
+
+  // Pure derived validation — every error is computed from current state, no
+  // imperative side effects in onChange handlers. Output strings are the
+  // text rendered to the operator; visibility is the touched/submit gate's
+  // job, not this layer's.
+  const errors = useMemo(() => {
+    const trimmedSlug = slug.trim();
+    const trimmedName = name.trim();
+    return {
+      slug:
+        trimmedSlug.length === 0
+          ? "Required."
+          : !SLUG_PATTERN.test(trimmedSlug)
+            ? "Must be lowercase alphanumeric with hyphens, 2–64 characters."
+            : null,
+      name: trimmedName.length === 0 ? "Required." : null,
+    };
+  }, [slug, name]);
+
+  /**
+   * Visible-error gate — returns the client validation error only after the
+   * field has been blurred or after a submit attempt. Server-side errors
+   * (e.g. the 409 conflict on `slug`) bypass this gate and render
+   * unconditionally; they are surfaced via their own state slot.
+   */
+  const visibleError = (key: FieldKey): string | null =>
+    touched[key] || submitAttempted ? errors[key] : null;
+
+  const hasErrors = Object.values(errors).some((e) => e !== null);
+  const saveDisabled = hasErrors;
 
   function handleClose() {
     setSlug("");
@@ -69,13 +119,20 @@ export function CreateNamespaceDialog({
     setDescription("");
     setPublicCatalog(false);
     setAutoApprove(false);
-    setSlugError(null);
+    setSlugServerError(null);
+    setTouched(INITIAL_TOUCHED);
+    setSubmitAttempted(false);
     onClose();
   }
 
   async function handleCreate() {
-    if (!slug.trim() || !SLUG_PATTERN.test(slug) || !name.trim()) return;
+    // Promote interaction state so any latent errors become visible — a user
+    // who clicks Create without focusing every field still gets every
+    // relevant red marker.
+    setSubmitAttempted(true);
+    if (saveDisabled) return;
     setSaving(true);
+    setSlugServerError(null);
     try {
       const res = await namespacesApi.createNamespace({
         namespaceCreateRequest: {
@@ -90,7 +147,11 @@ export function CreateNamespaceDialog({
       handleClose();
     } catch (error: unknown) {
       if (isAxiosError(error) && error.response?.status === 409) {
-        setSlugError("Namespace already exists.");
+        // Surfaces inline next to the slug field — that is the conflicting
+        // value the operator can edit immediately. Stays visible even if
+        // the field has not been touched (server-side errors are not
+        // gated by interaction).
+        setSlugServerError("Namespace already exists.");
       } else {
         onError("Failed to create namespace.");
       }
@@ -98,6 +159,13 @@ export function CreateNamespaceDialog({
       setSaving(false);
     }
   }
+
+  // Slug field surfaces server 409 unconditionally (overrides the gated
+  // client error so the conflict message is never hidden by the touched
+  // gate); when no server error is present the visible client error
+  // applies.
+  const slugError = slugServerError ?? visibleError("slug");
+  const nameError = visibleError("name");
 
   return (
     <AppDialog
@@ -107,30 +175,43 @@ export function CreateNamespaceDialog({
       description="A namespace groups plugins, members, and API keys under a shared scope."
       actionLabel="Create"
       onAction={handleCreate}
-      actionDisabled={!slug.trim() || !name.trim() || !!slugError}
+      actionDisabled={saveDisabled}
       actionLoading={saving}
     >
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <TextField
           label="Slug"
           value={slug}
-          onChange={(e) => handleSlugChange(e.target.value)}
+          onChange={(e) => {
+            setSlug(e.target.value);
+            // Clear the server-side error as soon as the operator edits the
+            // slug — they have acknowledged the conflict by changing the
+            // value, the message becomes stale.
+            if (slugServerError) setSlugServerError(null);
+          }}
+          onBlur={() => markTouched("slug")}
           required
           size="small"
-          autoFocus
-          error={!!slugError}
+          // Deliberately no `autoFocus` — MUI Dialog's focus-trap relocates
+          // focus to the dialog container right after a child autoFocus
+          // fires, which counts as a `blur` on the input and would mark
+          // the field user-touched before the operator did anything.
+          error={slugError !== null}
           helperText={
-            slugError ??
-            "Lowercase alphanumeric with hyphens, 2\u201364 characters."
+            slugError ?? "Lowercase alphanumeric with hyphens, 2–64 characters."
           }
         />
         <TextField
           label="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          onBlur={() => markTouched("name")}
           required
           size="small"
-          helperText="Human-readable display name for this namespace."
+          error={nameError !== null}
+          helperText={
+            nameError ?? "Human-readable display name for this namespace."
+          }
         />
         <TextField
           label="Description"

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
@@ -268,7 +268,11 @@ export function ApiKeysSection({ slug }: { slug: string }) {
             }}
             size="small"
             required
-            autoFocus
+            // Deliberately no `autoFocus` (issue #405). MUI Dialog's focus-
+            // trap turns a child autoFocus into an immediate blur on the
+            // input, which would mark the field user-interacted before the
+            // operator typed anything once touched-gated validation is
+            // added.
             helperText="Unique name to identify this key (e.g. 'CI pipeline')."
           />
           <TextField

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
@@ -117,7 +117,19 @@ export function AppDialog({
       </DialogTitle>
 
       {/* ── Content ── */}
-      <DialogContent>
+      <DialogContent
+        sx={{
+          // Mute the MUI default required-asterisk colour for every form
+          // hosted in an AppDialog. The default is `theme.palette.error.main`,
+          // which paints required fields' asterisks bright red on mount —
+          // before the operator has touched anything — and reads as a
+          // validation error rather than a "field is required" hint. See
+          // PR #404 / issue #405 for the original report and full rationale.
+          // Centralising the rule here keeps every existing and future
+          // dialog calm on first open without per-call-site `sx` repetition.
+          "& .MuiFormLabel-asterisk": { color: "text.secondary" },
+        }}
+      >
         {description && (
           <Typography
             variant="body2"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
@@ -85,7 +85,17 @@ export function ChangePasswordPage() {
         component="form"
         onSubmit={handleSubmit}
         noValidate
-        sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          // Mute the MUI default required-asterisk colour (issue #405). The
+          // default `error.main` paints the asterisks bright red on mount,
+          // which reads as "validation failed" before the operator typed
+          // anything. Validation here runs in `handleSubmit` and surfaces
+          // through a top-level Alert, not the field `error` prop.
+          "& .MuiFormLabel-asterisk": { color: "text.secondary" },
+        }}
       >
         <TextField
           label="Current Password"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -100,7 +100,17 @@ export function LoginPage() {
         component="form"
         onSubmit={handleSubmit}
         noValidate
-        sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          // Mute the MUI default required-asterisk colour (issue #405). The
+          // default `error.main` paints the asterisks bright red on mount,
+          // which reads as "validation failed" before the operator typed
+          // anything. Validation here runs in `handleSubmit` and surfaces
+          // through a top-level Alert, not the field `error` prop.
+          "& .MuiFormLabel-asterisk": { color: "text.secondary" },
+        }}
       >
         <TextField
           label="Username"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -311,7 +311,11 @@ export function UsersSection() {
             onChange={(e) => setUsername(e.target.value)}
             required
             size="small"
-            autoFocus
+            // Deliberately no `autoFocus` (issue #405). MUI Dialog's focus-
+            // trap relocates focus to the dialog container right after a
+            // child autoFocus fires, which counts as a `blur` on the input
+            // — any future touched-gated validation would then mark the
+            // field as user-interacted before the operator did anything.
           />
           <TextField
             label="Email"


### PR DESCRIPTION
Closes #405.

## Summary

Audit of every admin/user form listed in #405. After inspection, only **CreateNamespaceDialog** needed the full touched/submitAttempted gate; the other six surfaces are either already calm or only needed cosmetic asterisk-mute and an `autoFocus` removal.

| Surface | Status | Patch |
|---|---|---|
| `CreateNamespaceDialog` | Anti-pattern present | Full touched-gate + visibleError + drop autoFocus |
| `DeleteNamespaceDialog` | Clean (no validation) | Skip — autoFocus kept by exception |
| `ApiKeysSection` (Generate Key) | Half-clean | Drop autoFocus |
| `UsersSection` (Add User) | Half-clean | Drop autoFocus |
| `ProfileSettingsPage` | Clean | Skip — only Selects, no Dialog |
| `ChangePasswordPage` | Half-clean | Asterisk-mute (form-level `sx`) |
| `LoginPage` | Half-clean | Asterisk-mute (form-level `sx`) |

## Implementation notes

- **Centralised asterisk-mute in `AppDialog`** instead of per-call-site `sx`. Replaces what would have been four near-identical patches and protects every future dialog. The two non-dialog forms (Login, ChangePassword) get a one-line `sx` directly on their `<Box component="form">`.
- **CreateNamespaceDialog** carve-out for the server 409: the existing `slugError` state slot doubled as both the client-validation sink and the server-conflict sink. Splitting it into `errors.slug` (client, gated) + `slugServerError` (server, unconditional) keeps "Namespace already exists." visible regardless of touched-state — the operator just hit Create, hiding their actual error behind a touched-gate would be hostile. The server message clears on the next slug edit so it does not go stale.
- **`DeleteNamespaceDialog` keeps `autoFocus`** by exception. The typed-confirmation field has no validation wiring at all, so the MUI focus-trap blur side effect cannot manifest. The "no autoFocus in MUI Dialogs" rule from #404 specifically targets the validation-driven anti-pattern, which does not apply here. Documented in code.
- **Out-of-scope** mention for `NamespaceDetailView`'s General "Name" field — same cosmetic asterisk issue, not in #405's audit list, deferred to a follow-up.

## Test plan

- [ ] CI: `npm run test:run` + `npm run lint` + `npm run format:check` from `plugwerk-server/plugwerk-server-frontend/` — verified locally, all green.
- [ ] **CreateNamespaceDialog.test.tsx** (new vitest, 5 cases):
  - opens calmly: no `aria-invalid`, no \"Required.\" on mount;
  - blur on empty Slug reveals \"Required.\";
  - two-tab tour reveals both errors and keeps Create disabled;
  - server 409 surfaces inline unconditionally even with untouched fields;
  - server 409 clears when the operator edits the slug.
- [ ] Manual visual sweep: open each affected surface, confirm asterisks render in `text.secondary` (subtle grey) and no fields render `aria-invalid` on first paint.
- [ ] Manual focus check: open Add User / Generate Key / Create Namespace dialogs, confirm focus lands on the dialog container (not on the first input), no spurious blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)