### PR TITLE
feat(auth): "Use a different account" link for OIDC providers (#410)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -3221,6 +3221,46 @@ components:
             client; never an absolute URL — keeps the same-origin guarantees
             of the open-redirect guard from issue #274 trivially satisfied.
           example: "/oauth2/authorization/keycloak-local"
+        accountPickerLoginUrl:
+          type: string
+          nullable: true
+          description: |
+            Relative URL the frontend navigates the browser to when the user
+            wants to pick a *different* upstream account (issue #410). Same
+            shape as `loginUrl` but with the OIDC `prompt` query parameter
+            appended so the upstream provider re-displays its account-picker
+            / re-auth screen instead of silently re-using the existing IdP
+            session.
+
+            Per provider type:
+
+            - `OIDC`, `GOOGLE`, `FACEBOOK` → `?prompt=select_account`
+            - `OAUTH2` (generic) → `?prompt=login` (best-effort — many but
+              not all OAuth2 providers honour this)
+            - `GITHUB` → `null` (no `prompt` support; see `accountSwitchHintUrl`
+              below for the textual fallback the frontend renders instead)
+
+            The backend whitelists the value strictly via
+            [PromptAwareOAuth2AuthorizationRequestResolver] — only
+            `select_account` and `login` are forwarded upstream.
+          example: "/oauth2/authorization/keycloak-local?prompt=select_account"
+        accountSwitchHintUrl:
+          type: string
+          nullable: true
+          description: |
+            Absolute upstream URL the user can follow to terminate their
+            session at the IdP when the provider does not support OIDC
+            `prompt` (issue #410). Today only set for `GITHUB`
+            (`https://github.com/logout`); `null` for every other provider
+            type because they all surface their account-switch affordance
+            through `accountPickerLoginUrl` instead.
+
+            The frontend renders this as a small inline hint underneath
+            the primary button — never a clickable button. The link only
+            terminates the GitHub session; the user still has to come
+            back to Plugwerk and click the primary button to actually
+            sign in with a different account.
+          example: "https://github.com/logout"
       required:
         - id
         - name

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.OidcLoginSuccessHandler
 import io.plugwerk.server.security.OidcProviderRegistry
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PromptAwareOAuth2AuthorizationRequestResolver
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import org.springframework.context.annotation.Bean
@@ -256,6 +257,7 @@ class SecurityConfiguration(
         http: HttpSecurity,
         dbClientRegistrationRepository: DbClientRegistrationRepository,
         oidcLoginSuccessHandler: OidcLoginSuccessHandler,
+        promptAwareAuthorizationRequestResolver: PromptAwareOAuth2AuthorizationRequestResolver,
     ): SecurityFilterChain {
         http
             // CORS is configured via the corsConfigurationSource() bean above.
@@ -346,6 +348,12 @@ class SecurityConfiguration(
                 oauth2
                     .clientRegistrationRepository(dbClientRegistrationRepository)
                     .successHandler(oidcLoginSuccessHandler)
+                    // Issue #410: lets the login page's "Use a different
+                    // account" link inject `prompt=select_account` (OIDC) /
+                    // `prompt=login` (generic OAuth2) into the upstream
+                    // authorize request. The resolver enforces a strict
+                    // allow-list — see PromptAwareOAuth2AuthorizationRequestResolver.
+                    .authorizationEndpoint { it.authorizationRequestResolver(promptAwareAuthorizationRequestResolver) }
             }
             .authorizeHttpRequests { auth ->
                 auth

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -24,6 +24,8 @@ import io.plugwerk.api.model.ServerConfigResponse
 import io.plugwerk.api.model.ServerConfigResponseAuth
 import io.plugwerk.api.model.ServerConfigResponseGeneral
 import io.plugwerk.api.model.ServerConfigResponseUpload
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
 import io.plugwerk.server.security.OidcRegistrationIds
 import io.plugwerk.server.service.VersionProvider
@@ -67,10 +69,58 @@ class ConfigController(
     private fun enabledOidcProviderLoginInfo(): List<OidcProviderLoginInfo> =
         oidcProviderRepository.findAllByEnabledTrue().map { provider ->
             val registrationId = OidcRegistrationIds.of(provider)
+            val loginUrl = "/oauth2/authorization/$registrationId"
             OidcProviderLoginInfo(
                 id = registrationId,
                 name = provider.name,
-                loginUrl = "/oauth2/authorization/$registrationId",
+                loginUrl = loginUrl,
+                accountPickerLoginUrl = accountPickerLoginUrlFor(provider, loginUrl),
+                accountSwitchHintUrl = accountSwitchHintUrlFor(provider),
             )
         }
+
+    /**
+     * Per-provider-type "use a different account" URL (issue #410).
+     *
+     * The OIDC `prompt` query parameter the upstream accepts is not
+     * uniform across the provider types Plugwerk supports:
+     *
+     *   - OIDC / Google / Facebook → `select_account` (OIDC standard
+     *     for "show the account picker"). Google uses the same value
+     *     in its specific dialect.
+     *   - Generic OAuth2 → `login` (OIDC standard for "force a fresh
+     *     login"). Best-effort hint; not all OAuth2 providers honour it
+     *     but the well-behaved ones do.
+     *   - GitHub → `null`. GitHub's authorize endpoint does not implement
+     *     `prompt`; the frontend renders a textual "sign out at
+     *     github.com" hint instead of a clickable link.
+     *
+     * The value forwarded upstream is allow-listed by
+     * [PromptAwareOAuth2AuthorizationRequestResolver] so this mapping
+     * stays the single source of truth — operators cannot inject
+     * arbitrary `prompt` values via crafted query strings.
+     */
+    private fun accountPickerLoginUrlFor(provider: OidcProviderEntity, loginUrl: String): String? =
+        when (provider.providerType) {
+            OidcProviderType.OIDC,
+            OidcProviderType.GOOGLE,
+            OidcProviderType.FACEBOOK,
+            -> "$loginUrl?prompt=select_account"
+
+            OidcProviderType.OAUTH2 -> "$loginUrl?prompt=login"
+
+            OidcProviderType.GITHUB -> null
+        }
+
+    /**
+     * Upstream sign-out URL for providers that do not honour `prompt`,
+     * surfaced by the frontend as a textual hint instead of an in-product
+     * picker (issue #410). Today only GitHub, where session termination
+     * happens at github.com/logout — the user then comes back and clicks
+     * the primary button to actually sign in with a different account.
+     */
+    private fun accountSwitchHintUrlFor(provider: OidcProviderEntity): String? = when (provider.providerType) {
+        OidcProviderType.GITHUB -> "https://github.com/logout"
+        else -> null
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolver.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolver.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Adds the OIDC `prompt` query parameter to the upstream authorization
+ * request when the operator requested an account-picker / re-auth screen
+ * from the Plugwerk login page (issue #410).
+ *
+ * ## Why
+ *
+ * Spring's default `OAuth2AuthorizationRequestResolver` sends no `prompt`
+ * hint, so a logged-out Plugwerk user clicking the "Sign in with Google"
+ * button gets silently re-authenticated as the same upstream account —
+ * the IdP's session cookie is still valid. There is no built-in way for
+ * the user to switch to a different account without a private window.
+ *
+ * The Plugwerk login page now renders a small "Use a different account"
+ * link below each provider button. That link points at
+ * `/oauth2/authorization/{registrationId}?prompt=…`. This resolver
+ * intercepts the request, validates the `prompt` value strictly, and
+ * passes it to the upstream as `additionalParameters["prompt"]`.
+ *
+ * ## Allow-list
+ *
+ * Only two `prompt` values reach the upstream — anything else is dropped
+ * silently (no echo, no error, no upstream forwarding):
+ *
+ *   - `select_account` — OIDC (and Google's specific dialect): show the
+ *     account picker. Used for `OIDC`, `GOOGLE`, `FACEBOOK` providers.
+ *   - `login` — OIDC standard: force re-authentication. Used for the
+ *     `OAUTH2` (generic OAuth2) provider type as a best-effort hint.
+ *
+ * Anything else — `consent`, `none`, arbitrary strings, multiple values
+ * — is dropped. This is the only line of defence against a malicious
+ * caller trying to inject upstream-side parameters via the query string.
+ *
+ * ## GitHub carve-out
+ *
+ * GitHub's OAuth2 implementation does not honour the `prompt` parameter
+ * — it is silently ignored at GitHub's authorize endpoint today, but
+ * passing it is misleading to the operator (suggests something will
+ * happen) and may break with future strictness changes at GitHub. For
+ * `OidcProviderType.GITHUB` this resolver passes the request through
+ * unchanged regardless of the inbound `prompt` value. The frontend
+ * mirrors this — no clickable link is rendered for GitHub providers.
+ *
+ * ## PKCE / state preservation
+ *
+ * Adding `prompt` rebuilds the `OAuth2AuthorizationRequest` via the
+ * builder's `from(...)` constructor and `additionalParameters { mutator }`
+ * setter, both of which copy every other field — including the PKCE
+ * `code_verifier` (lives in `attributes`), the `state`, the resolved
+ * redirect URI, and the scope set. A regression here would be the most
+ * dangerous failure mode; the unit test pins it.
+ */
+@Component
+class PromptAwareOAuth2AuthorizationRequestResolver(
+    clientRegistrationRepository: ClientRegistrationRepository,
+    private val oidcProviderRepository: OidcProviderRepository,
+) : OAuth2AuthorizationRequestResolver {
+
+    private val delegate = DefaultOAuth2AuthorizationRequestResolver(
+        clientRegistrationRepository,
+        DEFAULT_AUTHORIZATION_REQUEST_BASE_URI,
+    )
+
+    override fun resolve(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        val resolved = delegate.resolve(request) ?: return null
+        return maybeAddPrompt(request, resolved)
+    }
+
+    override fun resolve(request: HttpServletRequest, clientRegistrationId: String?): OAuth2AuthorizationRequest? {
+        val resolved = delegate.resolve(request, clientRegistrationId) ?: return null
+        return maybeAddPrompt(request, resolved)
+    }
+
+    private fun maybeAddPrompt(
+        request: HttpServletRequest,
+        resolved: OAuth2AuthorizationRequest,
+    ): OAuth2AuthorizationRequest {
+        val promptValue = readWhitelistedPrompt(request) ?: return resolved
+        val registrationId = resolved.attributes[REGISTRATION_ID_ATTR] as? String ?: return resolved
+        val providerType = providerTypeFor(registrationId) ?: return resolved
+        // GitHub does not honour `prompt`. Drop it silently rather than
+        // forwarding a parameter the upstream will ignore — keeps the
+        // resolver's contract honest with what actually happens.
+        if (providerType == OidcProviderType.GITHUB) return resolved
+        return OAuth2AuthorizationRequest.from(resolved)
+            .additionalParameters { params -> params["prompt"] = promptValue }
+            .build()
+    }
+
+    /**
+     * Reads `?prompt=…` from the inbound query string and returns the
+     * value only if it is exactly one of the allow-listed strings.
+     * Returns `null` for: missing parameter, unknown value, multiple
+     * values (parameter pollution defence), empty value.
+     */
+    private fun readWhitelistedPrompt(request: HttpServletRequest): String? {
+        val values = request.getParameterValues("prompt") ?: return null
+        if (values.size != 1) return null
+        val candidate = values[0]
+        return if (candidate in ALLOWED_PROMPT_VALUES) candidate else null
+    }
+
+    /**
+     * Resolves the [OidcProviderType] for a Spring `registrationId`. The
+     * registrationId is the entity UUID (see [OidcRegistrationIds.of]),
+     * so this is a single PK lookup against `oidc_provider`. Authorize
+     * requests are not high-frequency (one per user-initiated login
+     * click), so we accept the per-request roundtrip rather than
+     * mirroring the in-memory map of [DbClientRegistrationRepository].
+     *
+     * Returns `null` for malformed registration IDs (treated as
+     * "skip the prompt addition" — the underlying request will fail
+     * downstream when Spring cannot find the registration anyway).
+     */
+    private fun providerTypeFor(registrationId: String): OidcProviderType? {
+        val uuid = runCatching { UUID.fromString(registrationId) }.getOrNull() ?: return null
+        return oidcProviderRepository.findById(uuid).map { it.providerType }.orElse(null)
+    }
+
+    companion object {
+        const val DEFAULT_AUTHORIZATION_REQUEST_BASE_URI = "/oauth2/authorization"
+
+        /**
+         * The OIDC standard attribute key Spring uses to carry the
+         * registration id on the resolved request. Re-declared here as
+         * a constant so a typo cannot silently break the GitHub
+         * carve-out.
+         */
+        const val REGISTRATION_ID_ATTR = "registration_id"
+
+        /**
+         * The closed set of `prompt` values we forward upstream.
+         *   - `select_account` is the OIDC (and Google) value to pop
+         *     the account picker.
+         *   - `login` is the OIDC value to force a fresh upstream
+         *     authentication; sent for generic OAuth2 providers.
+         */
+        val ALLOWED_PROMPT_VALUES: Set<String> = setOf("select_account", "login")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -180,4 +180,100 @@ class ConfigControllerTest {
                 jsonPath("$.auth.oidcProviders[0].clientSecret") { doesNotExist() }
             }
     }
+
+    @Test
+    fun `GET config exposes accountPickerLoginUrl=prompt=select_account for OIDC, GOOGLE, FACEBOOK (#410)`() {
+        // The four OIDC-shaped provider types use the OIDC standard
+        // `select_account` prompt to pop the account picker; all three
+        // get the same shape of accountPickerLoginUrl.
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        val oidcId = UUID.fromString("11111111-0000-0000-0000-000000000001")
+        val googleId = UUID.fromString("11111111-0000-0000-0000-000000000002")
+        val facebookId = UUID.fromString("11111111-0000-0000-0000-000000000003")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(
+            listOf(
+                providerOf(oidcId, OidcProviderType.OIDC),
+                providerOf(googleId, OidcProviderType.GOOGLE),
+                providerOf(facebookId, OidcProviderType.FACEBOOK),
+            ),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.auth.oidcProviders.length()") { value(3) }
+                jsonPath("$.auth.oidcProviders[0].accountPickerLoginUrl") {
+                    value("/oauth2/authorization/$oidcId?prompt=select_account")
+                }
+                jsonPath("$.auth.oidcProviders[1].accountPickerLoginUrl") {
+                    value("/oauth2/authorization/$googleId?prompt=select_account")
+                }
+                jsonPath("$.auth.oidcProviders[2].accountPickerLoginUrl") {
+                    value("/oauth2/authorization/$facebookId?prompt=select_account")
+                }
+            }
+    }
+
+    @Test
+    fun `GET config exposes accountPickerLoginUrl=prompt=login for OAUTH2 generic providers (#410)`() {
+        // Generic OAuth2 (post-#409) is best-effort — many but not all
+        // OAuth2 providers honour `prompt=login`. The frontend renders
+        // the link unconditionally; if the upstream ignores the value
+        // the user sees a silent re-login (no harm).
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        val oauth2Id = UUID.fromString("22222222-0000-0000-0000-000000000001")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(
+            listOf(providerOf(oauth2Id, OidcProviderType.OAUTH2)),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.auth.oidcProviders[0].accountPickerLoginUrl") {
+                    value("/oauth2/authorization/$oauth2Id?prompt=login")
+                }
+            }
+    }
+
+    @Test
+    fun `GET config returns null accountPickerLoginUrl for GITHUB providers (#410)`() {
+        // GitHub does not implement OIDC `prompt`. We must surface this
+        // as null so the frontend can render the textual hint instead of
+        // a clickable link that would do nothing useful.
+        whenever(settingsService.maxUploadSizeMb()).thenReturn(100)
+        whenever(settingsService.defaultTimezone()).thenReturn("UTC")
+        whenever(versionProvider.getVersion()).thenReturn("1.0.0")
+        val githubId = UUID.fromString("33333333-0000-0000-0000-000000000001")
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(
+            listOf(providerOf(githubId, OidcProviderType.GITHUB)),
+        )
+
+        mockMvc.get("/api/v1/config")
+            .andExpect {
+                status { isOk() }
+                // OpenAPI generates `accountPickerLoginUrl` as a nullable
+                // optional field; serialised as either `null` or absent
+                // depending on Jackson defaults. Either is correct from
+                // the schema's perspective; assert "not present as a
+                // string value".
+                jsonPath("$.auth.oidcProviders[0].id") { value(githubId.toString()) }
+                jsonPath("$.auth.oidcProviders[0].accountPickerLoginUrl") {
+                    value(null as String?)
+                }
+            }
+    }
+
+    private fun providerOf(id: UUID, type: OidcProviderType) = OidcProviderEntity(
+        id = id,
+        name = "Test ${type.name}",
+        providerType = type,
+        enabled = true,
+        clientId = "test-client",
+        clientSecretEncrypted = "{cipher}ignored",
+        issuerUri = "https://example.test/realms/x",
+    )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolverTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolverTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.repository.OidcProviderRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PromptAwareOAuth2AuthorizationRequestResolverTest {
+
+    @Mock lateinit var oidcProviderRepository: OidcProviderRepository
+
+    private val providerId: UUID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    /**
+     * The Spring `ClientRegistrationRepository` the resolver is constructed
+     * over. We register one in-memory `ClientRegistration` keyed by the test
+     * provider's UUID-as-string so the underlying
+     * `DefaultOAuth2AuthorizationRequestResolver` can resolve `/oauth2/authorization/{id}`
+     * to a real authorization request.
+     */
+    private fun stubClientRegistrationRepository(): ClientRegistrationRepository {
+        val registration = ClientRegistration.withRegistrationId(providerId.toString())
+            .clientId("test-client")
+            .clientSecret("test-secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/login/oauth2/code/{registrationId}")
+            .authorizationUri("https://idp.example/authorize")
+            .tokenUri("https://idp.example/token")
+            .userInfoUri("https://idp.example/userinfo")
+            .userNameAttributeName("sub")
+            .scope("openid", "email")
+            .clientName("Test")
+            .build()
+        return ClientRegistrationRepository { id -> if (id == providerId.toString()) registration else null }
+    }
+
+    private fun resolver() = PromptAwareOAuth2AuthorizationRequestResolver(
+        stubClientRegistrationRepository(),
+        oidcProviderRepository,
+    )
+
+    /**
+     * Class-level `Strictness.LENIENT` because some test cases never reach
+     * `findById` — when the inbound `prompt` is invalid the resolver
+     * short-circuits before the provider-type lookup. Strict Mockito would
+     * flag those stubs as unused, which is technically true but masks the
+     * *important* check (does the resolver still strip `prompt` for those
+     * cases).
+     */
+    private fun stubProvider(type: OidcProviderType) {
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(
+            Optional.of(
+                OidcProviderEntity(
+                    id = providerId,
+                    name = "Test",
+                    providerType = type,
+                    enabled = true,
+                    clientId = "test-client",
+                    clientSecretEncrypted = "{cipher}ignored",
+                    issuerUri = "https://idp.example/realms/x",
+                ),
+            ),
+        )
+    }
+
+    private fun authorizeRequest(promptParam: String? = null, multiplePrompts: List<String>? = null) =
+        MockHttpServletRequest("GET", "/oauth2/authorization/$providerId").apply {
+            servletPath = "/oauth2/authorization/$providerId"
+            when {
+                multiplePrompts != null -> setParameter("prompt", *multiplePrompts.toTypedArray())
+                promptParam != null -> setParameter("prompt", promptParam)
+            }
+        }
+
+    @Test
+    fun `prompt=select_account is added to additionalParameters for OIDC provider`() {
+        stubProvider(OidcProviderType.OIDC)
+        val resolved = resolver().resolve(authorizeRequest(promptParam = "select_account"))
+
+        assertThat(resolved).isNotNull
+        assertThat(resolved!!.additionalParameters).containsEntry("prompt", "select_account")
+    }
+
+    @Test
+    fun `prompt=login is added to additionalParameters for OAUTH2 generic provider`() {
+        stubProvider(OidcProviderType.OAUTH2)
+        val resolved = resolver().resolve(authorizeRequest(promptParam = "login"))
+
+        assertThat(resolved!!.additionalParameters).containsEntry("prompt", "login")
+    }
+
+    @Test
+    fun `prompt is dropped for GitHub provider regardless of inbound value`() {
+        // GitHub silently ignores `prompt` upstream — passing it would
+        // mislead operators about what is happening. The resolver must
+        // strip it for GitHub no matter what the caller sent.
+        stubProvider(OidcProviderType.GITHUB)
+        val resolved = resolver().resolve(authorizeRequest(promptParam = "select_account"))
+
+        assertThat(resolved!!.additionalParameters).doesNotContainKey("prompt")
+    }
+
+    @Test
+    fun `unknown prompt values are dropped silently (no inject vector)`() {
+        stubProvider(OidcProviderType.OIDC)
+        for (rogueValue in listOf("consent", "none", "arbitrary-junk", "")) {
+            val resolved = resolver().resolve(authorizeRequest(promptParam = rogueValue))
+            assertThat(resolved!!.additionalParameters)
+                .`as`("rogue prompt value '$rogueValue' must be dropped")
+                .doesNotContainKey("prompt")
+        }
+    }
+
+    @Test
+    fun `parameter pollution (multiple prompt values) is dropped`() {
+        // ?prompt=login&prompt=select_account — naive `getParameter` would
+        // pick the first; we explicitly require exactly one value via
+        // `getParameterValues(...).size == 1`.
+        stubProvider(OidcProviderType.OIDC)
+        val resolved = resolver().resolve(
+            authorizeRequest(multiplePrompts = listOf("login", "select_account")),
+        )
+
+        assertThat(resolved!!.additionalParameters).doesNotContainKey("prompt")
+    }
+
+    @Test
+    fun `missing prompt query parameter leaves the request unchanged (silent SSO default)`() {
+        stubProvider(OidcProviderType.OIDC)
+        val resolved = resolver().resolve(authorizeRequest())
+
+        assertThat(resolved!!.additionalParameters).doesNotContainKey("prompt")
+    }
+
+    @Test
+    fun `state, scope, redirect_uri, and PKCE attributes are preserved when prompt is added`() {
+        // The most dangerous failure mode: rebuilding the authorization
+        // request via `from(...)` could in principle drop fields. Pin
+        // every piece the upstream needs to round-trip the flow.
+        stubProvider(OidcProviderType.OIDC)
+        val resolved = resolver().resolve(authorizeRequest(promptParam = "select_account"))!!
+
+        assertThat(resolved.state).isNotBlank
+        assertThat(resolved.scopes).contains("openid")
+        assertThat(resolved.redirectUri).isEqualTo("http://localhost/login/oauth2/code/$providerId")
+        // PKCE pieces sit on the `attributes` and `additionalParameters` of
+        // the resolved request — Spring sets `code_verifier` on attributes
+        // and the derived `code_challenge` + `code_challenge_method` on
+        // additionalParameters.
+        assertThat(resolved.attributes).containsKey("code_verifier")
+        assertThat(resolved.additionalParameters).containsKey("code_challenge")
+        assertThat(resolved.additionalParameters).containsEntry("code_challenge_method", "S256")
+        // And of course the prompt we just added.
+        assertThat(resolved.additionalParameters).containsEntry("prompt", "select_account")
+    }
+
+    @Test
+    fun `unresolvable registration id returns null without contacting the provider repository`() {
+        // The DefaultOAuth2AuthorizationRequestResolver returns null when
+        // the path does not match an `/oauth2/authorization/{id}` URL —
+        // our wrapper must propagate that without crashing.
+        val request = MockHttpServletRequest("GET", "/some/other/path").apply {
+            servletPath = "/some/other/path"
+        }
+        val resolved = resolver().resolve(request)
+
+        assertThat(resolved).isNull()
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { OidcProviderButton } from "./OidcProviderButton";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import type { OidcProviderLoginInfo } from "../../stores/configStore";
+
+function provider(
+  overrides: Partial<OidcProviderLoginInfo> = {},
+): OidcProviderLoginInfo {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Test Provider",
+    loginUrl: "/oauth2/authorization/11111111-1111-1111-1111-111111111111",
+    accountPickerLoginUrl: null,
+    accountSwitchHintUrl: null,
+    ...overrides,
+  };
+}
+
+describe("OidcProviderButton (issue #410)", () => {
+  it("renders the primary login button with the loginUrl as href", () => {
+    renderWithTheme(
+      <OidcProviderButton provider={provider({ name: "Google" })} />,
+    );
+
+    const primary = screen.getByRole("link", { name: /login with google/i });
+    expect(primary).toHaveAttribute(
+      "href",
+      "/oauth2/authorization/11111111-1111-1111-1111-111111111111",
+    );
+  });
+
+  it("renders the 'Use a different account' link when accountPickerLoginUrl is set", () => {
+    renderWithTheme(
+      <OidcProviderButton
+        provider={provider({
+          name: "Google",
+          accountPickerLoginUrl:
+            "/oauth2/authorization/11111111-1111-1111-1111-111111111111?prompt=select_account",
+        })}
+      />,
+    );
+
+    const switchLink = screen.getByRole("link", {
+      name: /sign in with a different google account/i,
+    });
+    expect(switchLink).toHaveAttribute(
+      "href",
+      "/oauth2/authorization/11111111-1111-1111-1111-111111111111?prompt=select_account",
+    );
+  });
+
+  it("renders the GitHub-style hint with hostname when accountSwitchHintUrl is set", () => {
+    renderWithTheme(
+      <OidcProviderButton
+        provider={provider({
+          name: "GitHub",
+          accountPickerLoginUrl: null,
+          accountSwitchHintUrl: "https://github.com/logout",
+        })}
+      />,
+    );
+
+    // Hint copy is split across DOM nodes ("To switch accounts, sign out
+    // at <link>github.com</link> first.") — assert the host link by role
+    // + the surrounding text by partial match.
+    const hostLink = screen.getByRole("link", { name: /github\.com/i });
+    expect(hostLink).toHaveAttribute("href", "https://github.com/logout");
+    expect(hostLink).toHaveAttribute("target", "_blank");
+    expect(
+      screen.getByText(/to switch accounts, sign out at/i),
+    ).toBeInTheDocument();
+    // No "Use a different account" link in this branch.
+    expect(
+      screen.queryByRole("link", { name: /sign in with a different/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders neither secondary affordance when both fields are null", () => {
+    // Defensive shape — backend never sends both null today, but the
+    // component must not crash if a future provider type lands without
+    // either capability. Primary button still renders.
+    renderWithTheme(
+      <OidcProviderButton provider={provider({ name: "Mystery" })} />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /login with mystery/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /sign in with a different/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/to switch accounts/i)).not.toBeInTheDocument();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
@@ -98,11 +98,12 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
         color="text.secondary"
         aria-label={`Sign in with a different ${provider.name} account`}
         sx={{
-          // Match the surrounding caption rhythm — gentle hover into the
-          // primary palette so the link feels like an offer rather than a
-          // demand.
+          // Same `text.secondary` colour as the GitHub-hint host link
+          // below, including on hover — keeps both affordances visually
+          // identical so the difference between "click me" and "this is
+          // here for context" lives in the wording, not the colour.
           fontWeight: 500,
-          "&:hover": { color: "primary.main" },
+          "&:hover": { color: "text.secondary" },
         }}
       >
         Use a different account

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Box, Button, Link, Typography } from "@mui/material";
+import type { OidcProviderLoginInfo } from "../../stores/configStore";
+
+interface OidcProviderButtonProps {
+  provider: OidcProviderLoginInfo;
+}
+
+/**
+ * One provider button on the login page (issue #79) plus an optional
+ * "Use a different account" affordance underneath (issue #410).
+ *
+ * Composition:
+ *
+ *   1. Primary `<Button component="a">` — silent SSO. Single click, the
+ *      browser navigates to `/oauth2/authorization/{id}`, Spring's
+ *      OAuth2 filter takes over. If the upstream session is still valid
+ *      this re-uses the same account (the desired default for ~99 % of
+ *      logins).
+ *
+ *   2. Secondary affordance: depends on `accountPickerLoginUrl`.
+ *      - String → small "Use a different account" link that points at
+ *        the same `/oauth2/authorization/{id}` URL but with `?prompt=…`
+ *        appended. Clicking it pops the upstream account picker.
+ *      - `null` → small textual hint pointing the operator at the
+ *        upstream's logout URL (today only GitHub, which has no
+ *        standard `prompt` parameter). Honest about the limitation
+ *        instead of rendering a clickable link that does nothing.
+ *
+ * Both clickables are plain anchors (no XHR) so Spring Security can
+ * intercept them — same model as the original login button.
+ */
+export function OidcProviderButton({ provider }: OidcProviderButtonProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 0.5,
+      }}
+    >
+      <Button
+        component="a"
+        href={provider.loginUrl}
+        variant="outlined"
+        size="large"
+        fullWidth
+      >
+        {`Login with ${provider.name}`}
+      </Button>
+      <ProviderAccountSwitchAffordance provider={provider} />
+    </Box>
+  );
+}
+
+interface AffordanceProps {
+  provider: OidcProviderLoginInfo;
+}
+
+/**
+ * Renders the small caption underneath the primary button. Two branches:
+ *
+ *  - Provider supports OIDC `prompt` → clickable "Use a different account"
+ *    link with `aria-label` carrying the provider name so screen readers
+ *    have context outside the button group.
+ *  - Provider does not (today only GitHub) → muted textual hint pointing
+ *    at the upstream logout URL.
+ *
+ * The component renders nothing for an unknown / future shape — defensive
+ * fallback so a backend that omits both fields cannot break the layout.
+ */
+function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
+  if (provider.accountPickerLoginUrl) {
+    return (
+      <Link
+        component="a"
+        href={provider.accountPickerLoginUrl}
+        variant="caption"
+        underline="hover"
+        color="text.secondary"
+        aria-label={`Sign in with a different ${provider.name} account`}
+        sx={{
+          // Match the surrounding caption rhythm — gentle hover into the
+          // primary palette so the link feels like an offer rather than a
+          // demand.
+          fontWeight: 500,
+          "&:hover": { color: "primary.main" },
+        }}
+      >
+        Use a different account
+      </Link>
+    );
+  }
+  if (provider.accountSwitchHintUrl) {
+    // Backend gave us an upstream sign-out URL but no in-product picker
+    // (today only GitHub). Render an honest textual hint with the
+    // hostname inline — clicking the host link only terminates the
+    // upstream session; the user still has to come back and use the
+    // primary button afterwards.
+    const hintHost = safeHostname(provider.accountSwitchHintUrl);
+    return (
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textAlign: "center", lineHeight: 1.4 }}
+      >
+        To switch accounts, sign out at{" "}
+        <Link
+          component="a"
+          href={provider.accountSwitchHintUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+          color="inherit"
+          sx={{ fontFamily: "monospace" }}
+        >
+          {hintHost}
+        </Link>{" "}
+        first.
+      </Typography>
+    );
+  }
+  return null;
+}
+
+/**
+ * Pulls the hostname out of an absolute URL for inline display. Returns
+ * the original string if the URL fails to parse — defensive against a
+ * misconfigured backend value rather than crashing the login page.
+ */
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -27,6 +27,7 @@ import {
   Typography,
 } from "@mui/material";
 import { AuthCard } from "../components/auth/AuthCard";
+import { OidcProviderButton } from "../components/auth/OidcProviderButton";
 import { useAuthStore } from "../stores/authStore";
 import { useConfigStore } from "../stores/configStore";
 import { safeRedirectPath } from "../utils/safeRedirectPath";
@@ -142,28 +143,14 @@ export function LoginPage() {
       </Box>
 
       {oidcProviders.length > 0 && (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 1 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
           <Divider>
             <Typography variant="caption" color="text.secondary">
               or
             </Typography>
           </Divider>
           {oidcProviders.map((provider) => (
-            // Plain anchor — Spring Security's OAuth2 client filter intercepts
-            // the navigation server-side; an XHR-driven button would not start
-            // the redirect dance. The loginUrl is always relative
-            // (`/oauth2/authorization/{id}`), so the open-redirect guard from
-            // #274 is trivially satisfied.
-            <Button
-              key={provider.id}
-              component="a"
-              href={provider.loginUrl}
-              variant="outlined"
-              size="large"
-              fullWidth
-            >
-              {`Login with ${provider.name}`}
-            </Button>
+            <OidcProviderButton key={provider.id} provider={provider} />
           ))}
         </Box>
       )}

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
@@ -32,6 +32,28 @@ export interface OidcProviderLoginInfo {
   readonly id: string;
   readonly name: string;
   readonly loginUrl: string;
+  /**
+   * Same shape as `loginUrl` but with the OIDC `prompt` query parameter
+   * appended so the upstream re-displays its account-picker / re-auth
+   * screen instead of silently re-using the existing IdP session
+   * (issue #410).
+   *
+   * `null` for provider types that do not honour `prompt` (today only
+   * GitHub) — see `accountSwitchHintUrl` for the textual fallback.
+   */
+  readonly accountPickerLoginUrl: string | null;
+  /**
+   * Absolute upstream URL the user follows to terminate their session
+   * at the IdP, when the provider does not honour OIDC `prompt`. Today
+   * only set for GitHub (`https://github.com/logout`); `null` for every
+   * other provider type.
+   *
+   * Frontend renders this as a small textual hint underneath the
+   * primary button — never as a clickable button — and the user still
+   * has to come back to Plugwerk and click the primary button to
+   * actually sign in with a different account.
+   */
+  readonly accountSwitchHintUrl: string | null;
 }
 
 interface ConfigState {
@@ -100,6 +122,26 @@ function parseOidcProviders(raw: unknown): readonly OidcProviderLoginInfo[] {
     ) {
       return [];
     }
-    return [{ id: e.id, name: e.name, loginUrl: e.loginUrl }];
+    // Defensive null on unexpected shapes — a missing field is treated
+    // as "provider does not support account-switching" rather than
+    // crashing. Backend always sends the field (string or null) per
+    // OpenAPI, but the runtime narrowing keeps the store honest.
+    const accountPickerLoginUrl =
+      typeof e.accountPickerLoginUrl === "string"
+        ? e.accountPickerLoginUrl
+        : null;
+    const accountSwitchHintUrl =
+      typeof e.accountSwitchHintUrl === "string"
+        ? e.accountSwitchHintUrl
+        : null;
+    return [
+      {
+        id: e.id,
+        name: e.name,
+        loginUrl: e.loginUrl,
+        accountPickerLoginUrl,
+        accountSwitchHintUrl,
+      },
+    ];
   });
 }


### PR DESCRIPTION
Closes #410.

## Summary

After logging out of Plugwerk and clicking "Sign in with Google" again, the user was silently re-authenticated as their last upstream account — the IdP session cookie is still valid and Spring's default authorization-request resolver sends no `prompt` hint. Switching to a different account required a private window.

This PR adds a small "Use a different account" link underneath each provider button (primary silent-SSO behaviour preserved), with a per-provider mapping that lands the right `prompt` value upstream. GitHub gets a textual hint instead of a clickable link because it does not implement OIDC `prompt`.

## UX

```
┌──────────────────────────┐
│   Sign in with Google    │   ← OIDC: silent SSO (unchanged)
└──────────────────────────┘
       Use a different account     ← clicks ?prompt=select_account

┌──────────────────────────┐
│   Sign in with GitHub    │
└──────────────────────────┘
 To switch accounts, sign out at github.com first.   ← github.com is a link to /logout (target=_blank)
```

Per provider type:

| Provider | accountPickerLoginUrl | Affordance |
|---|---|---|
| `OIDC` (Generic OIDC) | `?prompt=select_account` | Link |
| `GOOGLE` | `?prompt=select_account` | Link |
| `FACEBOOK` | `?prompt=select_account` | Link |
| `OAUTH2` (Generic OAuth2) | `?prompt=login` | Link (best-effort) |
| `GITHUB` | `null` | Hint with link to `github.com/logout` |

## Backend

- New `PromptAwareOAuth2AuthorizationRequestResolver` wraps Spring's `DefaultOAuth2AuthorizationRequestResolver`. Reads `?prompt=…` from the inbound request, validates strictly against the allow-list `{ select_account, login }`, looks up the provider type, and adds the value to `additionalParameters` only for non-GitHub providers. Anything else (unknown values, parameter pollution, GitHub) is dropped silently.
- Wired into `SecurityConfiguration`'s `oauth2Login` block via `.authorizationEndpoint { it.authorizationRequestResolver(…) }`.
- Rebuilds the authorization request via `OAuth2AuthorizationRequest.from(...).additionalParameters {…}.build()` — preserves PKCE `code_verifier`, state, scope, redirect URI. The unit test pins this.

## API contract

`OidcProviderLoginInfo` gains two nullable fields:

- `accountPickerLoginUrl: string | null` — the `?prompt=…` URL the primary "Use a different account" link points at.
- `accountSwitchHintUrl: string | null` — the upstream sign-out URL for providers that do not honour `prompt` (today only GitHub: `https://github.com/logout`).

Per-provider mapping lives in `ConfigController` — single source of truth, frontend never has to know which `prompt` value goes with which type.

## Tests

- **`PromptAwareOAuth2AuthorizationRequestResolverTest`** (new, 8 cases): prompt forwarding for OIDC + OAUTH2, GitHub strip, unknown values dropped, parameter-pollution dropped, missing prompt no-op, PKCE + state + scope preservation, unresolvable registration null.
- **`ConfigControllerTest`** extended with three cases: select_account for OIDC/GOOGLE/FACEBOOK, login for OAUTH2, null for GITHUB.
- **`OidcProviderButton.test.tsx`** (new, 4 cases): primary link href, picker link rendering + aria-label, GitHub hint with host link + target=_blank, defensive both-null branch.

## Test plan

- [ ] CI: `./gradlew :plugwerk-server:plugwerk-server-backend:check :plugwerk-server:plugwerk-server-backend:integrationTest :plugwerk-server:plugwerk-server-frontend:npmBuild` — verified locally, all green.
- [ ] Manual smoke (local Keycloak): sign in as `alice`, sign out, click "Sign in with Keycloak" → silently signed back in as Alice. Sign out again, click **Use a different account** → Keycloak login form / picker → sign in as `bob`.
- [ ] Manual smoke (security): with the dev tools open, navigate `/oauth2/authorization/{id}?prompt=consent` (rogue value), confirm via the network tab that the upstream request does not carry `prompt` (allow-list dropped it).
- [ ] Manual smoke (GitHub provider): confirm the "Use a different account" link is **not** rendered; the textual hint with the `github.com` host link is rendered instead, opens in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)