### PR TITLE
fix(client): thread PluginManager through connect() to avoid PF4J wrapper deprecation (#426)

### DIFF
--- a/docs/adrs/0005-client-sdk-design.md
+++ b/docs/adrs/0005-client-sdk-design.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Accepted, with two later refinements documented inline:
+Accepted, with three later refinements documented inline:
 - the original `configure()` + `marketplace()` two-step flow on `PlugwerkPlugin` was collapsed into a single JDBC-style `connect(config)` factory — see [SPI shape update](#spi-shape-update-2026-04-28),
-- `PlugwerkInstaller` was rewired to drive PF4J's `PluginManager` lifecycle directly — see [Installer lifecycle update](#installer-lifecycle-update-2026-05-02).
+- `PlugwerkInstaller` was rewired to drive PF4J's `PluginManager` lifecycle directly — see [Installer lifecycle update](#installer-lifecycle-update-2026-05-02),
+- `connect()` gained an explicit `pluginManager` parameter so the SDK does not depend on PF4J's deprecated `Plugin#wrapper` injection — see [Installer connect-signature update](#installer-connect-signature-update-2026-05-02).
 
 ## Context
 
@@ -229,9 +230,16 @@ The SPI was reshaped (#424) so the method names match what they do:
   the empty-string-version code smell is gone).
 
 **Wire-up:** `PlugwerkInstallerImpl` now requires a `PluginManager`
-constructor parameter. `PlugwerkPluginImpl.connect()` reads it from the
-PF4J wrapper; embedders calling `PlugwerkMarketplaceImpl.create(config,
-pluginManager)` programmatically must supply one.
+constructor parameter. The host passes its `PluginManager` explicitly to
+`PlugwerkPlugin.connect(config, pluginManager)` — the same instance it
+just used to resolve the SDK plugin via `getPlugin(PLUGIN_ID)`. The SDK
+deliberately does NOT read it from `wrapper.pluginManager`: PF4J 3.15
+deprecates `Plugin#wrapper`, the `(PluginWrapper)` constructor and
+`getWrapper()`, and recommends host-defined context injection instead.
+Threading `pluginManager` through the SPI signature keeps the SDK off the
+deprecated API surface and makes the dependency explicit at the call site.
+See [Installer connect-signature update](#installer-connect-signature-update-2026-05-02)
+below for the post-#426 follow-up that landed this approach.
 
 **Why the change:**
 
@@ -254,3 +262,47 @@ small, and the honest naming is worth more than the version-agnostic
 flexibility we lose.
 
 The change landed in plugwerk/plugwerk#425.
+
+## Installer connect-signature update (2026-05-02)
+
+#425 originally read the host's `PluginManager` from `wrapper.pluginManager`
+inside `PlugwerkPluginImpl.connect()`. Two problems surfaced quickly:
+
+1. **NPE under the canonical PF4J load path (#426).** PF4J's
+   `DefaultPluginFactory` looks for `Constructor(PluginWrapper)` first and
+   falls back to no-arg only if absent. Because we exposed only no-arg + a
+   test-only `(PluginManager)` constructor, PF4J chose no-arg and never
+   set the inherited `Plugin#wrapper` field. The first `wrapper.pluginManager`
+   read NPEd. Documented host pattern (Spring example) was broken.
+2. **PF4J 3.15 deprecates the entire `Plugin#wrapper` injection path.**
+   `Plugin(PluginWrapper)`, `Plugin#wrapper` field, and `getWrapper()`
+   are all marked `@Deprecated` with the recommendation to use
+   "application custom `PluginContext` instead of `PluginWrapper`."
+   Adding a `(PluginWrapper)` constructor would have fixed #426 today
+   but tied us to a deprecated API forever.
+
+The fix collapses both problems by **threading `pluginManager` through
+the `connect()` signature**:
+
+```kotlin
+// Before
+fun connect(config: PlugwerkConfig): PlugwerkMarketplace
+
+// After (#426 / PR #427)
+fun connect(config: PlugwerkConfig, pluginManager: PluginManager): PlugwerkMarketplace
+```
+
+The host always has a `PluginManager` reference in scope at the call
+site — it's the same instance it just used to resolve the SDK plugin
+via `pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID)`. Passing it
+costs one extra parameter and:
+
+- removes every read from `Plugin#wrapper` in our code,
+- removes the (now-unnecessary) test-only `(PluginManager)` constructor
+  and the `explicitPluginManager` field,
+- makes the dependency on PF4J's lifecycle explicit at the call site,
+- keeps `PlugwerkPluginImpl` on the canonical no-arg `Plugin()`
+  constructor — exactly what the deprecation note recommends moving
+  toward.
+
+The change landed in plugwerk/plugwerk#427.

--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -56,6 +56,7 @@ plugin.connect(
         .accessToken("eyJhbG...")
         .pluginDirectory(Path.of("/var/app/plugins"))
         .build(),
+    pluginManager,
 ).use { marketplace ->
     marketplace.catalog().listPlugins()
 }
@@ -64,7 +65,7 @@ plugin.connect(
 For long-lived references, store the marketplace and close it explicitly when the host shuts down:
 
 ```kotlin
-val marketplace = plugin.connect(config)
+val marketplace = plugin.connect(config, pluginManager)
 // ... use it across the app's lifetime
 marketplace.close()
 ```
@@ -75,7 +76,10 @@ The plugin is a stateless factory — every `connect()` call returns a fresh mar
 
 ```kotlin
 @Configuration
-class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
+class PlugwerkBeans(
+    private val plugin: PlugwerkPlugin,
+    private val pluginManager: PluginManager,
+) {
 
     @Bean(destroyMethod = "close")
     fun productionMarketplace(): PlugwerkMarketplace = plugin.connect(
@@ -83,6 +87,7 @@ class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
             .accessToken("prod-token")
             .pluginDirectory(Path.of("/var/app/plugins"))
             .build(),
+        pluginManager,
     )
 
     @Bean(destroyMethod = "close")
@@ -91,6 +96,7 @@ class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
             .accessToken("staging-token")
             .pluginDirectory(Path.of("/var/app/plugins"))
             .build(),
+        pluginManager,
     )
 }
 ```
@@ -108,7 +114,7 @@ plugwerk.pluginDirectory=/var/app/plugins
 
 ```kotlin
 val config = PlugwerkConfig.fromProperties(Path.of("plugwerk-client.properties"))
-val marketplace = plugin.connect(config)
+val marketplace = plugin.connect(config, pluginManager)
 ```
 
 > **Security:** Never pass access tokens as JVM system properties (`-Dplugwerk.accessToken=…`) —

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/PlugwerkPluginImpl.kt
@@ -27,8 +27,9 @@ import java.util.concurrent.CopyOnWriteArrayList
  * PF4J plugin entry point for the Plugwerk Client SDK.
  *
  * This class is referenced in `MANIFEST.MF` via `Plugin-Class`. PF4J instantiates it
- * when the SDK JAR is loaded as a plugin; hosts then access it through the
- * [PlugwerkPlugin] interface and call [connect] to open marketplaces.
+ * via the no-arg `Plugin()` constructor — the deprecated `(PluginWrapper)` path is
+ * intentionally not used (#426 / PF4J 3.15 deprecates `Plugin#wrapper`). The host
+ * passes the live `PluginManager` to [connect] explicitly instead.
  *
  * ### Lifecycle
  *
@@ -43,31 +44,13 @@ import java.util.concurrent.CopyOnWriteArrayList
  *
  * @see PlugwerkPlugin
  */
-class PlugwerkPluginImpl() :
+class PlugwerkPluginImpl :
     Plugin(),
     PlugwerkPlugin {
 
     private val openMarketplaces = CopyOnWriteArrayList<WeakReference<PlugwerkMarketplaceImpl>>()
 
-    /**
-     * Test-only constructor bypassing PF4J's wrapper injection. Lets tests pass
-     * a mock [PluginManager] without first running a real PF4J load cycle.
-     * Production code uses the no-arg constructor and reads the wrapper-supplied
-     * `PluginManager` at [connect] time.
-     */
-    private var explicitPluginManager: PluginManager? = null
-
-    internal constructor(pluginManager: PluginManager) : this() {
-        this.explicitPluginManager = pluginManager
-    }
-
-    override fun connect(config: PlugwerkConfig): PlugwerkMarketplace {
-        // PF4J injects the wrapper after construction; reading it here is safe
-        // because `connect` is host-driven and only callable once the plugin is
-        // fully loaded. The PluginManager from the wrapper is the same one the
-        // host used to load us — that is the one the installer must drive.
-        @Suppress("DEPRECATION")
-        val pluginManager = explicitPluginManager ?: wrapper.pluginManager
+    override fun connect(config: PlugwerkConfig, pluginManager: PluginManager): PlugwerkMarketplace {
         val marketplace = PlugwerkMarketplaceImpl.create(config, pluginManager)
         openMarketplaces.add(WeakReference(marketplace))
         return marketplace

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -182,7 +182,7 @@ class PlugwerkMarketplaceIntegrationTest {
         serverB.start()
 
         try {
-            val plugin = PlugwerkPluginImpl(pluginManager)
+            val plugin = PlugwerkPluginImpl()
             val marketplaceA = plugin.connect(
                 PlugwerkConfig(
                     serverUrl = server.url("/").toString().trimEnd('/'),
@@ -190,6 +190,7 @@ class PlugwerkMarketplaceIntegrationTest {
                     accessToken = "token-a",
                     pluginDirectory = pluginDir,
                 ),
+                pluginManager,
             )
             val marketplaceB = plugin.connect(
                 PlugwerkConfig(
@@ -198,6 +199,7 @@ class PlugwerkMarketplaceIntegrationTest {
                     accessToken = "token-b",
                     pluginDirectory = pluginDir,
                 ),
+                pluginManager,
             )
 
             val emptyPage = """{"content":[],"totalElements":0,"page":0,"size":20,"totalPages":0}"""

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkPluginImplTest.kt
@@ -31,6 +31,7 @@ class PlugwerkPluginImplTest {
     lateinit var tempDir: Path
 
     private lateinit var plugin: PlugwerkPluginImpl
+    private lateinit var pluginManager: PluginManager
 
     private fun config(serverUrl: String = "http://localhost:8080", namespace: String = "acme") =
         PlugwerkConfig.Builder(serverUrl, namespace)
@@ -39,14 +40,20 @@ class PlugwerkPluginImplTest {
 
     @BeforeEach
     fun setUp() {
-        // Test-only constructor: bypasses PF4J's wrapper injection so we can
-        // exercise connect() without a real PluginManager load cycle.
-        plugin = PlugwerkPluginImpl(mock<PluginManager>())
+        // PF4J would call the no-arg constructor at load time. We mirror that
+        // here exactly — the (PluginWrapper) deprecated path is intentionally
+        // not exercised. PluginManager arrives via connect()'s parameter
+        // instead, the same way real hosts pass it after #426.
+        plugin = PlugwerkPluginImpl()
+        pluginManager = mock()
     }
 
     @Test
     fun `connect returns a fresh marketplace bound to the given config`() {
-        val marketplace = plugin.connect(config("http://server-a:8080", "ns-a")) as PlugwerkMarketplaceImpl
+        val marketplace = plugin.connect(
+            config("http://server-a:8080", "ns-a"),
+            pluginManager,
+        ) as PlugwerkMarketplaceImpl
 
         assertEquals("http://server-a:8080", marketplace.client.config.serverUrl)
         assertEquals("ns-a", marketplace.client.config.namespace)
@@ -56,16 +63,16 @@ class PlugwerkPluginImplTest {
     fun `connect returns a new instance on every call`() {
         // No internal cache by design — each call yields its own HTTP client. Hosts
         // that want to reuse a marketplace are expected to store the reference.
-        val first = plugin.connect(config())
-        val second = plugin.connect(config())
+        val first = plugin.connect(config(), pluginManager)
+        val second = plugin.connect(config(), pluginManager)
 
         assertNotSame(first, second)
     }
 
     @Test
     fun `multiple connects with different configs produce isolated marketplaces`() {
-        val a = plugin.connect(config("http://server-a:8080", "ns-a")) as PlugwerkMarketplaceImpl
-        val b = plugin.connect(config("http://server-b:8080", "ns-b")) as PlugwerkMarketplaceImpl
+        val a = plugin.connect(config("http://server-a:8080", "ns-a"), pluginManager) as PlugwerkMarketplaceImpl
+        val b = plugin.connect(config("http://server-b:8080", "ns-b"), pluginManager) as PlugwerkMarketplaceImpl
 
         assertEquals("http://server-a:8080", a.client.config.serverUrl)
         assertEquals("ns-a", a.client.config.namespace)
@@ -78,8 +85,8 @@ class PlugwerkPluginImplTest {
         // Hosts that forget to call close() leave us with HTTP clients to reclaim.
         // Stop must close those rather than leaking dispatcher threads on plugin
         // unload.
-        val a = plugin.connect(config()) as PlugwerkMarketplaceImpl
-        val b = plugin.connect(config()) as PlugwerkMarketplaceImpl
+        val a = plugin.connect(config(), pluginManager) as PlugwerkMarketplaceImpl
+        val b = plugin.connect(config(), pluginManager) as PlugwerkMarketplaceImpl
 
         plugin.stop()
 
@@ -94,7 +101,7 @@ class PlugwerkPluginImplTest {
 
     @Test
     fun `close on the marketplace is idempotent`() {
-        val marketplace = plugin.connect(config())
+        val marketplace = plugin.connect(config(), pluginManager)
 
         marketplace.close()
         // Second close is a no-op; if it threw or double-closed the underlying

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/PlugwerkPlugin.kt
@@ -16,6 +16,7 @@
 package io.plugwerk.spi
 
 import io.plugwerk.spi.extension.PlugwerkMarketplace
+import org.pf4j.PluginManager
 
 /**
  * Host-facing entry point for the Plugwerk Client SDK — a JDBC-style **factory** for
@@ -28,7 +29,7 @@ import io.plugwerk.spi.extension.PlugwerkMarketplace
  * **Single server:**
  * ```kotlin
  * val plugin = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).plugin as PlugwerkPlugin
- * plugin.connect(config).use { marketplace ->
+ * plugin.connect(config, pluginManager).use { marketplace ->
  *     marketplace.catalog().listPlugins()
  * }
  * ```
@@ -36,17 +37,23 @@ import io.plugwerk.spi.extension.PlugwerkMarketplace
  * **Long-lived connections (typical Spring host):**
  * ```kotlin
  * @Configuration
- * class PlugwerkBeans(private val plugin: PlugwerkPlugin) {
+ * class PlugwerkBeans(
+ *     private val plugin: PlugwerkPlugin,
+ *     private val pluginManager: PluginManager,
+ * ) {
  *     @Bean(destroyMethod = "close")
- *     fun marketplace() = plugin.connect(config)
+ *     fun marketplace() = plugin.connect(config, pluginManager)
  * }
  * ```
  *
  * **Multiple servers — host owns composition:**
  * ```kotlin
- * class PlugwerkServers(plugin: PlugwerkPlugin) : AutoCloseable {
- *     val production = plugin.connect(prodConfig)
- *     val staging = plugin.connect(stagingConfig)
+ * class PlugwerkServers(
+ *     plugin: PlugwerkPlugin,
+ *     pluginManager: PluginManager,
+ * ) : AutoCloseable {
+ *     val production = plugin.connect(prodConfig, pluginManager)
+ *     val staging = plugin.connect(stagingConfig, pluginManager)
  *     override fun close() { production.close(); staging.close() }
  * }
  * ```
@@ -55,10 +62,21 @@ import io.plugwerk.spi.extension.PlugwerkMarketplace
  * ```java
  * PlugwerkPlugin plugin = (PlugwerkPlugin)
  *     pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID).getPlugin();
- * try (PlugwerkMarketplace mp = plugin.connect(config)) {
+ * try (PlugwerkMarketplace mp = plugin.connect(config, pluginManager)) {
  *     mp.catalog().listPlugins();
  * }
  * ```
+ *
+ * ### Why the host passes the PluginManager explicitly
+ *
+ * After #424 the installer drives PF4J's `PluginManager` (load + start /
+ * stop + unload). The SDK could read it from `wrapper.pluginManager`, but
+ * PF4J 3.15 deprecates the `Plugin#wrapper` field and its `(PluginWrapper)`
+ * constructor in favour of host-defined context injection. Threading
+ * `pluginManager` through [connect] keeps the SDK off the deprecated API
+ * surface and makes the dependency explicit at the call site — the host
+ * always has a `pluginManager` reference in scope (it just used it to
+ * resolve the SDK plugin), so passing it costs one parameter (#426).
  *
  * ### Why no internal registry
  *
@@ -97,7 +115,14 @@ interface PlugwerkPlugin {
      * should store the reference (a property, a DI bean, a small map) — see the
      * class-level KDoc for typical patterns.
      *
+     * @param config         server, namespace, and plugin directory configuration
+     * @param pluginManager  the host's PF4J [PluginManager] — required so the
+     *                       installer can drive `loadPlugin` / `startPlugin` /
+     *                       `stopPlugin` / `unloadPlugin`. The host already has
+     *                       a reference (it used it to resolve this SDK plugin
+     *                       via `getPlugin(PLUGIN_ID)`); pass the same instance.
+     *
      * @throws IllegalStateException if [PlugwerkConfig.pluginDirectory] is not set.
      */
-    fun connect(config: PlugwerkConfig): PlugwerkMarketplace
+    fun connect(config: PlugwerkConfig, pluginManager: PluginManager): PlugwerkMarketplace
 }


### PR DESCRIPTION
## Summary

Closes #426. Bug introduced by #425.

## The bug

PF4J's `DefaultPluginFactory` looks for `Constructor(PluginWrapper)` first and falls back to no-arg only if absent. After #425 `PlugwerkPluginImpl` exposed only `()` and a test-only `(PluginManager)` — PF4J chose no-arg and never set the inherited `Plugin#wrapper` field. Calling `connect()` then NPEd on `wrapper.pluginManager`. Documented host pattern (Spring Boot example in `plugwerk/examples`) was broken.

## Why not just add `(PluginWrapper)` constructor

PF4J 3.15 deprecates the entire wrapper-injection path:

- `Plugin(PluginWrapper)` → `@Deprecated`
- `Plugin#wrapper` field → `@Deprecated`
- `Plugin#getWrapper()` → `@Deprecated`

with the recommendation *"Use application custom PluginContext instead of PluginWrapper"* — `PluginContext` being a concept the host application defines, not a PF4J class. Adding a `(PluginWrapper)` constructor would have fixed #426 today but tied the SDK to a deprecated API forever.

## The fix

Thread `PluginManager` through the `connect()` signature explicitly:

```kotlin
// Before
fun connect(config: PlugwerkConfig): PlugwerkMarketplace

// After
fun connect(config: PlugwerkConfig, pluginManager: PluginManager): PlugwerkMarketplace
```

Host call site (one parameter more — host already has the `pluginManager` in scope):

```java
PluginWrapper wrapper = pluginManager.getPlugin(PlugwerkPlugin.PLUGIN_ID);
return ((PlugwerkPlugin) wrapper.getPlugin()).connect(plugwerkConfig, pluginManager);
//                                                                    ^^^^^^^^^^^^^ new
```

This:
- removes every read from `Plugin#wrapper` in our code
- removes the test-only `(PluginManager)` constructor and the `explicitPluginManager` field
- keeps `PlugwerkPluginImpl` on the canonical no-arg `Plugin()` constructor — exactly what the deprecation note recommends moving toward
- makes the dependency on PF4J's lifecycle explicit at the call site

## Test plan

- [x] All 5 existing `PlugwerkPluginImplTest` cases pass with `setUp()` migrated to the production no-arg constructor + `PluginManager` mock passed via `connect()`
- [x] `PlugwerkMarketplaceIntegrationTest` multi-server isolation case migrated to the same pattern
- [x] `./gradlew :plugwerk-spi:build :plugwerk-client-plugin:build -x integrationTest` — green (compile + spotless + tests)

## Documentation

- ADR-0005 gains an "Installer connect-signature update (2026-05-02)" section spelling out both reasons (#426 NPE + deprecation) and the rejected alternative (suppressing the deprecation with a `(PluginWrapper)` constructor).
- `plugwerk-client-plugin/README.md`: every `connect()` snippet updated to take the `pluginManager` parameter (single-server, Spring multi-bean, properties-loading examples).

## Breaking change

`PlugwerkPlugin.connect(config)` → `PlugwerkPlugin.connect(config, pluginManager)`. Pre-1.0 (currently `1.0.0-beta.2`), so acceptable. Follow-up issues `plugwerk/examples#32` and `plugwerk/website#83` (already filed for the #424 SPI adaptation) gain one extra small change — the `connect()` call now takes two args.

## Related

- plugwerk/plugwerk#424 (parent — installer SPI refactor)
- plugwerk/plugwerk#425 (PR that introduced the regression)
- plugwerk/examples#32 (host-side adaptation, blocked at runtime by this bug — unblocked once this lands)
- plugwerk/website#83 (docs adaptation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)