### PR TITLE
fix(client): walk every server page in PlugwerkCatalog list/search/releases (#428)

### DIFF
--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
@@ -33,7 +33,7 @@ internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : Plugwer
     private val log = LoggerFactory.getLogger(PlugwerkCatalogImpl::class.java)
 
     override fun listPlugins(): List<PluginInfo> = paginate(
-        fetchPage = { p -> client.get<PluginPagedResponse>("plugins?page=$p") },
+        fetchPage = { p -> client.get<PluginPagedResponse>(pageUrl("plugins", query = "", page = p)) },
         contentOf = { it.content },
         totalPagesOf = { it.totalPages },
     ).map { it.toPluginInfo() }
@@ -55,7 +55,9 @@ internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : Plugwer
     }
 
     override fun getPluginReleases(pluginId: String): List<PluginReleaseInfo> = paginate(
-        fetchPage = { p -> client.get<ReleasePagedResponse>("plugins/$pluginId/releases?page=$p") },
+        fetchPage = { p ->
+            client.get<ReleasePagedResponse>(pageUrl("plugins/$pluginId/releases", query = "", page = p))
+        },
         contentOf = { it.content },
         totalPagesOf = { it.totalPages },
     ).map { it.toReleaseInfo() }
@@ -106,12 +108,26 @@ internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : Plugwer
         return all
     }
 
+    /**
+     * Builds `path?query&page=N&size=PAGE_SIZE`. Always asks for [PAGE_SIZE]
+     * items per page (the OpenAPI-documented maximum) so a 100-plugin catalog
+     * fits in one round-trip instead of five at the server's default of 20.
+     */
     private fun pageUrl(path: String, query: String, page: Int): String = when {
-        query.isBlank() -> "$path?page=$page"
-        else -> "$path?$query&page=$page"
+        query.isBlank() -> "$path?page=$page&size=$PAGE_SIZE"
+        else -> "$path?$query&page=$page&size=$PAGE_SIZE"
     }
 
     private companion object {
+        /**
+         * Items per page requested from the server. OpenAPI-documented maximum
+         * is 100 (`SizeQuery` parameter in `plugwerk-api.yaml`). Picking the
+         * max minimises round-trips for typical catalog sizes — a 99-plugin
+         * namespace becomes one HTTP call instead of five at the server's
+         * default of 20.
+         */
+        const val PAGE_SIZE = 100
+
         /** Defence against a misbehaving server returning inconsistent `totalPages`. */
         const val MAX_PAGES = 100
     }

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImpl.kt
@@ -26,11 +26,17 @@ import io.plugwerk.spi.model.PluginInfo
 import io.plugwerk.spi.model.PluginReleaseInfo
 import io.plugwerk.spi.model.PluginStatus
 import io.plugwerk.spi.model.SearchCriteria
+import org.slf4j.LoggerFactory
 
 /** HTTP-backed implementation of [PlugwerkCatalog]. All requests are scoped to the namespace in [client.config]. */
 internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : PlugwerkCatalog {
-    override fun listPlugins(): List<PluginInfo> =
-        client.get<PluginPagedResponse>("plugins").content.map { it.toPluginInfo() }
+    private val log = LoggerFactory.getLogger(PlugwerkCatalogImpl::class.java)
+
+    override fun listPlugins(): List<PluginInfo> = paginate(
+        fetchPage = { p -> client.get<PluginPagedResponse>("plugins?page=$p") },
+        contentOf = { it.content },
+        totalPagesOf = { it.totalPages },
+    ).map { it.toPluginInfo() }
 
     override fun getPlugin(pluginId: String): PluginInfo? =
         client.getOrNull<PluginDto>("plugins/$pluginId")?.toPluginInfo()
@@ -41,12 +47,18 @@ internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : Plugwer
             criteria.tag?.let { append("tag=${it.urlEncode()}&") }
             criteria.compatibleWith?.let { append("compatibleWith=${it.urlEncode()}&") }
         }.trimEnd('&')
-        val path = if (query.isBlank()) "plugins" else "plugins?$query"
-        return client.get<PluginPagedResponse>(path).content.map { it.toPluginInfo() }
+        return paginate(
+            fetchPage = { p -> client.get<PluginPagedResponse>(pageUrl("plugins", query, p)) },
+            contentOf = { it.content },
+            totalPagesOf = { it.totalPages },
+        ).map { it.toPluginInfo() }
     }
 
-    override fun getPluginReleases(pluginId: String): List<PluginReleaseInfo> =
-        client.get<ReleasePagedResponse>("plugins/$pluginId/releases").content.map { it.toReleaseInfo() }
+    override fun getPluginReleases(pluginId: String): List<PluginReleaseInfo> = paginate(
+        fetchPage = { p -> client.get<ReleasePagedResponse>("plugins/$pluginId/releases?page=$p") },
+        contentOf = { it.content },
+        totalPagesOf = { it.totalPages },
+    ).map { it.toReleaseInfo() }
 
     override fun getPluginRelease(pluginId: String, version: String): PluginReleaseInfo? =
         client.getOrNull<PluginReleaseDto>("plugins/$pluginId/releases/$version")?.toReleaseInfo()
@@ -54,6 +66,55 @@ internal class PlugwerkCatalogImpl(private val client: PlugwerkClient) : Plugwer
     /** Returns the artifact download URL for the given plugin release. */
     fun downloadUrl(pluginId: String, version: String): String =
         client.url("plugins/$pluginId/releases/$version/download")
+
+    /**
+     * Fetches every page of a paginated server response and concatenates the
+     * `content` lists. Closes #428 — the pre-fix code only consumed `.content`
+     * of page 0 and silently dropped everything else.
+     *
+     * Capped at [MAX_PAGES] iterations as a defence against a server that
+     * returns inconsistent `totalPages` (would otherwise loop forever). At the
+     * server's default page size of 20 the cap covers up to 2000 items per
+     * call — far beyond any realistic catalog size today. If the cap is hit
+     * we log a warning and return what we have so far rather than throwing,
+     * because the alternative (throwing) would brick existing callers.
+     */
+    private inline fun <P, T> paginate(
+        fetchPage: (Int) -> P,
+        contentOf: (P) -> List<T>,
+        totalPagesOf: (P) -> Int,
+    ): List<T> {
+        val all = mutableListOf<T>()
+        var page = 0
+        var totalPages: Int
+        do {
+            val response = fetchPage(page)
+            all.addAll(contentOf(response))
+            totalPages = totalPagesOf(response)
+            page++
+            if (page >= MAX_PAGES && page < totalPages) {
+                log.warn(
+                    "Paginated fetch hit the {}-page safety cap (server reported totalPages={}); " +
+                        "returning {} items collected so far. If this is legitimate, paginate explicitly.",
+                    MAX_PAGES,
+                    totalPages,
+                    all.size,
+                )
+                break
+            }
+        } while (page < totalPages)
+        return all
+    }
+
+    private fun pageUrl(path: String, query: String, page: Int): String = when {
+        query.isBlank() -> "$path?page=$page"
+        else -> "$path?$query&page=$page"
+    }
+
+    private companion object {
+        /** Defence against a misbehaving server returning inconsistent `totalPages`. */
+        const val MAX_PAGES = 100
+    }
 }
 
 private fun PluginDto.toPluginInfo(): PluginInfo = PluginInfo(

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
@@ -135,4 +135,128 @@ class PlugwerkCatalogImplTest {
             "Unexpected download URL: $url"
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Pagination — #428 regression coverage. Pre-fix the SDK only consumed
+    // page 0 and silently dropped the rest.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `listPlugins walks every server page (#428)`() {
+        enqueuePluginPage(page = 0, totalPages = 3, ids = listOf("a", "b"))
+        enqueuePluginPage(page = 1, totalPages = 3, ids = listOf("c", "d"))
+        enqueuePluginPage(page = 2, totalPages = 3, ids = listOf("e"))
+
+        val plugins = catalog.listPlugins()
+
+        assertEquals(listOf("a", "b", "c", "d", "e"), plugins.map { it.pluginId })
+        assertEquals(3, server.requestCount)
+        assertPagedRequests(
+            expectedPages = listOf(0, 1, 2),
+            pathPrefix = "/api/v1/namespaces/acme/plugins",
+        )
+    }
+
+    @Test
+    fun `listPlugins returns empty list when totalPages is zero (#428)`() {
+        // totalPages=0 paths still issue exactly one GET so the loop exits
+        // immediately and callers are not surprised by an extra round-trip.
+        server.enqueue(
+            MockResponse()
+                .setBody("""{"content":[],"totalElements":0,"page":0,"size":20,"totalPages":0}""")
+                .setResponseCode(200),
+        )
+
+        val plugins = catalog.listPlugins()
+
+        assertEquals(0, plugins.size)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `searchPlugins walks every server page and preserves query params (#428)`() {
+        enqueuePluginPage(page = 0, totalPages = 2, ids = listOf("a"))
+        enqueuePluginPage(page = 1, totalPages = 2, ids = listOf("b"))
+
+        val plugins = catalog.searchPlugins(SearchCriteria(query = "hello", tag = "ai"))
+
+        assertEquals(listOf("a", "b"), plugins.map { it.pluginId })
+        assertEquals(2, server.requestCount)
+        // Query params survive every page request — `?q=hello&tag=ai&page=N` shape.
+        repeat(2) { i ->
+            val request = server.takeRequest()
+            val path = request.path!!
+            assert(path.contains("q=hello")) { "Page $i lost q= parameter: $path" }
+            assert(path.contains("tag=ai")) { "Page $i lost tag= parameter: $path" }
+            assert(path.contains("page=$i")) { "Page $i missing page=$i: $path" }
+        }
+    }
+
+    @Test
+    fun `getPluginReleases walks every server page (#428)`() {
+        enqueueReleasePage(page = 0, totalPages = 2, versions = listOf("1.0.0"))
+        enqueueReleasePage(page = 1, totalPages = 2, versions = listOf("2.0.0"))
+
+        val releases = catalog.getPluginReleases("my-plugin")
+
+        assertEquals(listOf("1.0.0", "2.0.0"), releases.map { it.version })
+        assertEquals(2, server.requestCount)
+        assertPagedRequests(
+            expectedPages = listOf(0, 1),
+            pathPrefix = "/api/v1/namespaces/acme/plugins/my-plugin/releases",
+        )
+    }
+
+    @Test
+    fun `paginate caps at the safety limit when server reports inconsistent totalPages (#428)`() {
+        // Server lies about totalPages — every page claims totalPages=10000.
+        // The cap should kick in at MAX_PAGES (= 100 today) so we do not
+        // hammer the server in an unbounded loop.
+        repeat(120) { p ->
+            enqueuePluginPage(page = p, totalPages = 10_000, ids = listOf("p$p"))
+        }
+
+        val plugins = catalog.listPlugins()
+
+        assertEquals(100, server.requestCount) {
+            "Expected the safety cap to stop after MAX_PAGES requests, got ${server.requestCount}"
+        }
+        assertEquals(100, plugins.size) {
+            "Items collected before the cap should still be returned"
+        }
+    }
+
+    private fun enqueuePluginPage(page: Int, totalPages: Int, ids: List<String>) {
+        val items = ids.joinToString(",") { id ->
+            """{"id":"00000000-0000-0000-0000-000000000001",""" +
+                """"pluginId":"$id","name":"P-$id","status":"active"}"""
+        }
+        val body = """{"content":[$items],"totalElements":${ids.size},""" +
+            """"page":$page,"size":20,"totalPages":$totalPages}"""
+        server.enqueue(MockResponse().setBody(body).setResponseCode(200))
+    }
+
+    private fun enqueueReleasePage(page: Int, totalPages: Int, versions: List<String>) {
+        val items = versions.joinToString(",") { v ->
+            """{"id":"00000000-0000-0000-0000-000000000002",""" +
+                """"pluginId":"my-plugin","version":"$v","status":"published"}"""
+        }
+        val body = """{"content":[$items],"totalElements":${versions.size},""" +
+            """"page":$page,"size":20,"totalPages":$totalPages}"""
+        server.enqueue(MockResponse().setBody(body).setResponseCode(200))
+    }
+
+    /**
+     * Verifies the SDK issued one request per expected page in order, with
+     * `?page=N` appended to [pathPrefix]. Drains MockWebServer's request
+     * queue in the process.
+     */
+    private fun assertPagedRequests(expectedPages: List<Int>, pathPrefix: String) {
+        expectedPages.forEach { p ->
+            val request = server.takeRequest()
+            val path = request.path!!
+            assert(path.startsWith(pathPrefix)) { "Page $p hit unexpected path: $path" }
+            assert(path.contains("page=$p")) { "Page $p missing page=$p: $path" }
+        }
+    }
 }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
@@ -182,13 +182,14 @@ class PlugwerkCatalogImplTest {
 
         assertEquals(listOf("a", "b"), plugins.map { it.pluginId })
         assertEquals(2, server.requestCount)
-        // Query params survive every page request — `?q=hello&tag=ai&page=N` shape.
+        // Query params survive every page request — `?q=hello&tag=ai&page=N&size=100` shape.
         repeat(2) { i ->
             val request = server.takeRequest()
             val path = request.path!!
             assert(path.contains("q=hello")) { "Page $i lost q= parameter: $path" }
             assert(path.contains("tag=ai")) { "Page $i lost tag= parameter: $path" }
             assert(path.contains("page=$i")) { "Page $i missing page=$i: $path" }
+            assert(path.contains("size=100")) { "Page $i missing size=100: $path" }
         }
     }
 
@@ -248,8 +249,8 @@ class PlugwerkCatalogImplTest {
 
     /**
      * Verifies the SDK issued one request per expected page in order, with
-     * `?page=N` appended to [pathPrefix]. Drains MockWebServer's request
-     * queue in the process.
+     * `?page=N&size=100` appended to [pathPrefix]. Drains MockWebServer's
+     * request queue in the process.
      */
     private fun assertPagedRequests(expectedPages: List<Int>, pathPrefix: String) {
         expectedPages.forEach { p ->
@@ -257,6 +258,7 @@ class PlugwerkCatalogImplTest {
             val path = request.path!!
             assert(path.startsWith(pathPrefix)) { "Page $p hit unexpected path: $path" }
             assert(path.contains("page=$p")) { "Page $p missing page=$p: $path" }
+            assert(path.contains("size=100")) { "Page $p missing size=100: $path" }
         }
     }
 }

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
@@ -52,9 +52,10 @@ interface PlugwerkCatalog : ExtensionPoint {
      * The returned list includes only plugins with status [io.plugwerk.spi.model.PluginStatus.ACTIVE].
      * Suspended or archived plugins are excluded.
      *
-     * **Multiple HTTP round-trips.** The default SDK implementation walks every
-     * server page until the catalog is exhausted (#428) — a 200-plugin namespace
-     * at the server's default page size of 20 will issue 10 GETs. Hosts that
+     * **Multiple HTTP round-trips when the catalog exceeds one page.** The
+     * default SDK implementation walks every server page until the catalog is
+     * exhausted (#428) and asks for the OpenAPI-documented maximum of 100
+     * items per page, so a 250-plugin namespace becomes 3 GETs. Hosts that
      * want to render paginated UIs should keep their own page state and fetch
      * one server page at a time; today they must drop to the lower-level
      * `PlugwerkClient` to do so (paginated SPI variant tracked separately).

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkCatalog.kt
@@ -52,6 +52,13 @@ interface PlugwerkCatalog : ExtensionPoint {
      * The returned list includes only plugins with status [io.plugwerk.spi.model.PluginStatus.ACTIVE].
      * Suspended or archived plugins are excluded.
      *
+     * **Multiple HTTP round-trips.** The default SDK implementation walks every
+     * server page until the catalog is exhausted (#428) — a 200-plugin namespace
+     * at the server's default page size of 20 will issue 10 GETs. Hosts that
+     * want to render paginated UIs should keep their own page state and fetch
+     * one server page at a time; today they must drop to the lower-level
+     * `PlugwerkClient` to do so (paginated SPI variant tracked separately).
+     *
      * @return unordered list of available plugins; empty list if the catalog is empty
      */
     fun listPlugins(): List<PluginInfo>
@@ -70,6 +77,8 @@ interface PlugwerkCatalog : ExtensionPoint {
      * All non-null fields in [criteria] are combined with AND semantics.
      * Passing an empty [SearchCriteria] is equivalent to calling [listPlugins].
      *
+     * Walks every server page like [listPlugins] does (#428).
+     *
      * @param criteria filter criteria; fields left `null` are ignored
      * @return plugins matching all specified criteria; empty list if none match
      */
@@ -80,6 +89,8 @@ interface PlugwerkCatalog : ExtensionPoint {
      *
      * Results are not guaranteed to be version-sorted. Use
      * [io.plugwerk.spi.version.compareSemVer] to sort them if needed.
+     *
+     * Walks every server page like [listPlugins] does (#428).
      *
      * @param pluginId the plugin's unique ID within the namespace
      * @return list of all releases; empty list if the plugin has no releases or does not exist


### PR DESCRIPTION
## Summary

Closes #428.

`PlugwerkCatalogImpl` was reading the paginated server response and only keeping `.content` of page 0 — `totalPages` / `totalElements` were silently dropped. Hosts saw the first 20 plugins (server's default page size) and had no signal that the rest existed. Same bug in **three places** (the reporter only observed `listPlugins`, but `searchPlugins` and `getPluginReleases` had the same pattern).

## Fix

A small `paginate(...)` helper that loops `?page=N&size=100` until `page >= totalPages`, concatenating `content`. All three affected methods now route through it. **No SPI signature change** — the `List<T>` contract still means "everything", and now actually honours that.

### Why `size=100`

Asking for the **OpenAPI-documented maximum** (100) instead of the server's default 20 cuts round-trips by 5x for typical catalog sizes:

| Catalog size | Before (size=20) | After (size=100) |
|---|---|---|
| 99 plugins | 5 GETs | 1 GET |
| 500 plugins | 25 GETs | 5 GETs |
| 2000 plugins (cap) | 100 GETs | 20 GETs |

Verified against the spec (`plugwerk-api.yaml` `SizeQuery.maximum: 100`) and the server controller (`CatalogController.listPlugins` threads `size` to `PageRequest.of(page, size, sort)` — no hard-coded cap below 100).

### Safety cap

100 page-iterations defends against a misbehaving server returning inconsistent `totalPages` (would otherwise loop forever). At `size=100` that covers up to 10 000 items per call. On cap-hit we WARN-log and return what we have so far rather than throwing — throwing would brick existing callers without recourse.

## Test plan

- [x] **`listPlugins` walks every page** — three pages enqueued, all 5 items returned, exactly 3 requests with `page=0/1/2&size=100`
- [x] **`searchPlugins` walks every page and preserves query params** — every paged request still carries `q=hello&tag=ai&size=100`
- [x] **`getPluginReleases` walks every page** — same pattern, scoped to a plugin id
- [x] **Empty catalog** — `totalPages=0` issues exactly one GET, returns empty list
- [x] **Safety cap** — server lies about `totalPages=10000`, paginate stops at 100 requests with WARN log, returns 100 items
- [x] All 6 pre-existing `PlugwerkCatalogImplTest` cases still green
- [x] `./gradlew :plugwerk-client-plugin:build -x integrationTest` — green (compile + spotless + tests)

## Documentation

`PlugwerkCatalog` SPI KDoc on `listPlugins` / `searchPlugins` / `getPluginReleases` now states "Multiple HTTP round-trips when the catalog exceeds one page" with concrete numbers (250-plugin namespace = 3 GETs at size=100).

## Out of scope (filed as follow-ups)

- **#429** — paginated SPI variant (`listPlugins(page, size): PluginPage<T>`) for hosts that render server-paged UIs.
- **#430** — server-side `?size=200` returns empty result instead of 400 Bad Request (out-of-spec value). Independent of this PR; we never exceed `size=100`, so unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)