### PR TITLE
fix(server): map @RequestParam ConstraintViolationException to 400 (#430)

### DIFF
--- a/plugwerk-api/plugwerk-api-endpoint/build.gradle.kts
+++ b/plugwerk-api/plugwerk-api-endpoint/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
 
 kotlin {
     jvmToolchain(21)
+    // Preserve parameter names in bytecode so Spring Bean Validation can
+    // produce field-named messages like "size: must be ..." instead of
+    // "arg2: must be ..." for @RequestParam violations (#430).
+    compilerOptions {
+        javaParameters = true
+    }
 }
 
 dependencies {

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -25,6 +25,12 @@ tasks.cyclonedxDirectBom {
 
 kotlin {
     jvmToolchain(21)
+    // Preserve parameter names in bytecode so Spring Bean Validation can
+    // produce field-named messages like "size: must be ..." instead of
+    // "arg2: must be ..." for @RequestParam violations (#430).
+    compilerOptions {
+        javaParameters = true
+    }
 }
 
 springBoot {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -36,6 +36,7 @@ import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.ReleaseAlreadyExistsException
 import io.plugwerk.server.service.ReleaseNotFoundException
 import io.plugwerk.server.service.UnauthorizedException
+import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -93,6 +94,32 @@ class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(ex: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val details = ex.bindingResult.fieldErrors.joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        return errorResponse(HttpStatus.BAD_REQUEST, details.ifBlank { "Validation failed" })
+    }
+
+    /**
+     * Maps `@Validated` class + `@Min` / `@Max` / `@Pattern` / `@Size` violations
+     * on `@RequestParam` and `@PathVariable` arguments to a clean 400 response
+     * with the same `ErrorResponse` envelope as [handleValidation] (#430).
+     *
+     * Without this handler such violations would fall through to
+     * [handleUnexpected] and surface as 500 Internal Server Error — confusing
+     * callers and breaking the API's documented contract that bad input
+     * produces 400.
+     *
+     * `@Valid @RequestBody` violations go through [handleValidation] (different
+     * exception type — `MethodArgumentNotValidException`); the two paths cover
+     * the full Bean Validation surface.
+     */
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolation(ex: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+        val details = ex.constraintViolations
+            .joinToString("; ") { violation ->
+                // propertyPath is "methodName.paramName" (e.g. "listPlugins.size") —
+                // keep only the last segment for a caller-friendly field name.
+                val field = violation.propertyPath.toString().substringAfterLast('.')
+                "$field: ${violation.message}"
+            }
         return errorResponse(HttpStatus.BAD_REQUEST, details.ifBlank { "Validation failed" })
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -250,6 +250,76 @@ class CatalogControllerTest {
         SecurityContextHolder.clearContext()
     }
 
+    // -----------------------------------------------------------------------
+    // Constraint violation handling — #430. Pre-fix these queries fell through
+    // to handleUnexpected(Exception) in GlobalExceptionHandler and surfaced as
+    // 500 Internal Server Error, breaking the API's documented 400 contract
+    // for bad input.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `GET plugins with size above OpenAPI maximum returns 400 with field-named message (#430)`() {
+        mockMvc.get("/api/v1/namespaces/acme/plugins?size=200")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.status") { value(400) }
+                // Field name is the unqualified parameter ("size"), not
+                // "listPlugins.size" — substringAfterLast('.') strips the prefix.
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("size:")) }
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("less than or equal to 100")) }
+            }
+    }
+
+    @Test
+    fun `GET plugins with size below OpenAPI minimum returns 400 (#430)`() {
+        mockMvc.get("/api/v1/namespaces/acme/plugins?size=0")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("size:")) }
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("greater than or equal to 1")) }
+            }
+    }
+
+    @Test
+    fun `GET plugins with negative page returns 400 (#430)`() {
+        mockMvc.get("/api/v1/namespaces/acme/plugins?page=-1")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("page:")) }
+            }
+    }
+
+    @Test
+    fun `GET plugins with malformed sort parameter returns 400 (#430)`() {
+        mockMvc.get("/api/v1/namespaces/acme/plugins?sort=invalid")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("sort:")) }
+            }
+    }
+
+    @Test
+    fun `GET plugins with valid size at maximum returns 200 (regression — boundary)`() {
+        whenever(
+            pluginService.findPagedByNamespace(
+                eq("acme"),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                any<Pageable>(),
+                any(),
+                anyOrNull(),
+            ),
+        )
+            .thenReturn(PluginService.PagedCatalogResult(PageImpl(emptyList()), emptySet()))
+
+        // size=100 is the documented max — must NOT trigger the constraint
+        // violation path. Pinning the boundary so we don't accidentally start
+        // rejecting valid requests after future Bean Validation upgrades.
+        mockMvc.get("/api/v1/namespaces/acme/plugins?size=100")
+            .andExpect { status { isOk() } }
+    }
+
     @Test
     fun `listPlugins surfaces unexpected runtime error from role lookup as 500`() {
         // KT-004 / #287 regression: before the fix, a runtime error thrown by the


### PR DESCRIPTION
## Summary

Closes #430.

`GlobalExceptionHandler` handled `MethodArgumentNotValidException` (Spring throws this for `@Valid @RequestBody` failures) but had **no handler** for `jakarta.validation.ConstraintViolationException` — the type Spring throws when `@Validated`-class controllers fail `@Min` / `@Max` / `@Pattern` / `@Size` on `@RequestParam` or `@PathVariable` arguments.

Without that handler, requests like `?size=200` (above the documented `maximum: 100` in `plugwerk-api.yaml`) fell through to `handleUnexpected` and surfaced as **500 Internal Server Error** — breaking the API's documented 400 contract for bad input. The reporter in #428 saw "0 results" because they ran `jq '.content | length'` on the error envelope, where `.content` is `null` and `null | length` returns 0 — easy to misinterpret as "size is silently ignored".

## Two changes

### 1. `ConstraintViolationException` handler (`GlobalExceptionHandler.kt`)

Maps each violation to `"field: message"` inside the standard `ErrorResponse` envelope. Property-path is collapsed to its last segment so callers see `"size:"` instead of `"listPlugins.size:"` — consistent with how `handleValidation` formats `MethodArgumentNotValidException`.

### 2. `javaParameters = true` (Kotlin compile flag, two modules)

Without it, Bean Validation's reflection-based parameter-name lookup falls back to `arg0`, `arg1`, `arg2` instead of `ns`, `page`, `size`. The handler from #1 would still produce 400, but with confusing field names — completing the fix at the user level required preserving parameter names in bytecode for both `plugwerk-api-endpoint` (where the controller interfaces live) and `plugwerk-server-backend` (where the implementations live).

## Test plan

- [x] `?size=200` → 400, message contains `"size:"` + `"less than or equal to 100"`
- [x] `?size=0` → 400, `"size:"` + `"greater than or equal to 1"`
- [x] `?page=-1` → 400, `"page:"`
- [x] `?sort=invalid` → 400, `"sort:"`
- [x] `?size=100` (boundary) → 200 (regression pin so future Bean Validation upgrades don't start rejecting valid requests)
- [x] All pre-existing 8 `CatalogControllerTest` cases still green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:build -x integrationTest` — green (compile + spotless + tests)

## Scope

The fix is in `GlobalExceptionHandler` so it covers **every** `@Validated` controller in the API, not just `/plugins`. `CatalogControllerTest` carries the test coverage because that is where the bug was originally observed.

## Issue title

Updated from "ignores ?size query parameter" to "@RequestParam constraint violations return 500 instead of 400" — better captures the actual bug surface.

## Related

- plugwerk/plugwerk#428 (SDK silent truncation — reported the symptom; fixed in PR #431)
- plugwerk/plugwerk#429 (paginated SPI variant — was tracked as blocked on this; PR #431 already side-stepped the blocker by always asking for `size=100`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)