### PR TITLE
feat(server): SMTP email infrastructure — backend (#253)

### DIFF
--- a/docs/adrs/0031-email-infrastructure.md
+++ b/docs/adrs/0031-email-infrastructure.md
@@ -1,0 +1,171 @@
+# ADR-0031: Email Infrastructure (SMTP)
+
+## Status
+
+Accepted (PR for #253)
+
+## Context
+
+Plugwerk needs to send transactional email — password reset, invitations,
+review notifications, admin alerts. Up to now there was no mail-sending
+infrastructure at all. This ADR records the design decisions made while
+adding it; the SPI surface, runtime model, and security posture should
+not need to be re-derived from the diff.
+
+The feature is split across three concerns:
+
+1. **Configuration model** — where the SMTP server settings live and how
+   they are changed.
+2. **Mail-sending infrastructure** — how the application actually puts a
+   message on the wire.
+3. **Operator verification** — how the operator confirms their config
+   without watching the server log.
+
+Only the SMTP/server side is in scope for this ADR. Per-template
+management, async queues, and concrete trigger integrations (password
+reset, etc.) are deferred to follow-up issues.
+
+## Decision
+
+### 1. Settings live in `application_setting`, not `application.yaml`
+
+The eight SMTP keys (`smtp.enabled`, `host`, `port`, `username`,
+`password`, `encryption`, `from_address`, `from_name`) are registered as
+`ApplicationSettingKey` entries and persisted in the existing
+`application_setting` table (ADR-0016). They are mutable at runtime via
+the existing `PUT /api/v1/admin/settings` endpoint.
+
+Spring Boot's `spring.mail.*` auto-configuration is **not** wired —
+otherwise the SMTP server would be locked in at JVM start and require a
+restart to change. For a self-hosted product where the operator may not
+control the SMTP relay until after the server is running, that is the
+wrong default.
+
+### 2. Password is encrypted at rest, masked in API responses
+
+`smtp.password` carries a new `SettingValueType.PASSWORD` discriminator.
+The marker triggers three different behaviours at three different
+layers:
+
+- **Storage** — `ApplicationSettingsService.update` encrypts the value
+  with the existing `TextEncryptor` bean (introduced for OIDC
+  `client_secret_encrypted` in ADR-0022) before persisting. The cache
+  holds ciphertext.
+- **Display** — `AdminSettingsController.toDto` replaces ciphertext with
+  the sentinel `"***"` so plaintext never leaves the JVM through the
+  HTTP layer. Even the ciphertext is hidden — leaking it would let an
+  attacker who later learns the encryption key replay the original
+  password.
+- **Internal use** — A typed accessor
+  `ApplicationSettingsService.smtpPasswordPlaintext()` decrypts the
+  ciphertext for `MailSenderProvider` only. Marked internal-only in its
+  KDoc; never exposed in DTOs or log lines.
+
+The masking sentinel is recognised on the write path: writing back the
+literal string `"***"` is treated as "no change" so the form's hidden
+field cannot accidentally overwrite the stored ciphertext with random
+ASCII.
+
+### 3. `JavaMailSender` is built on demand, cached, invalidated on settings change
+
+A new `MailSenderProvider` Spring component holds an
+`AtomicReference<JavaMailSender?>`. On the first `current()` call after
+a setting change (or on cold start) it builds a fresh
+`JavaMailSenderImpl` from the live settings; subsequent calls return
+the cached instance. The cache is invalidated by an
+`ApplicationSettingsService` update listener whenever any `smtp.*` key
+is written.
+
+This is the same pattern already used by `ApplicationSettingsService`
+itself for the settings cache — readers are lock-free, writers do an
+atomic swap, and there is no half-built state visible to a reader.
+
+When SMTP is disabled or the configuration is incomplete (blank host,
+unknown encryption mode), `current()` returns `null`. `MailService`
+treats that as no-op + warning rather than an exception, so a misconfig
+does not brick callers that legitimately have nothing to do when SMTP
+is off.
+
+### 4. `STARTTLS` is required, not opportunistic
+
+When `smtp.encryption=starttls` we set both
+`mail.smtp.starttls.enable=true` and
+`mail.smtp.starttls.required=true`. Opportunistic STARTTLS would
+silently fall back to plaintext if the server advertised support but
+the upgrade failed — exactly the kind of misconfiguration the operator
+is least likely to notice. Failing loudly is the correct default.
+
+### 5. Test endpoint surfaces SMTP errors as 502, never as 500
+
+`POST /api/v1/admin/email/test` is the operator's verification path. It
+accepts a target address, sends a fixed test body, and returns:
+
+- `200` with a confirmation when the SMTP server accepted the message,
+- `400` with a hint pointing at the missing field when SMTP is disabled
+  or the configuration is incomplete (`SmtpNotConfiguredException`),
+- `502` Bad Gateway when the SMTP server rejected the message
+  (`SmtpDeliveryException`) — same semantic as a downstream HTTP
+  service returning 5xx.
+
+Internal exceptions are mapped to short kuratierte messages by
+`GlobalExceptionHandler`; raw stack traces and `JavaMail` exception
+chains are not exposed to the wire.
+
+### 6. Tests run against an in-process SMTP server (GreenMail)
+
+Integration tests live in `SmtpEmailIT` and use the GreenMail JUnit5
+extension on a dynamic port. The IT writes settings through the
+service, calls `MailService.sendMail`, and asserts on
+`greenMail.receivedMessages`. End-to-end coverage of the
+`settings -> MailSenderProvider -> JavaMailSenderImpl -> SMTP wire`
+boundary that no controller-only test could exercise.
+
+## Consequences
+
+- The `JavaMailSender` Spring auto-config bean is intentionally never
+  loaded; if a future caller imports `spring-boot-starter-mail` and
+  expects auto-config, they will need to either wire through the
+  `MailService` API or override the bean explicitly.
+- Encryption key rotation (`PLUGWERK_AUTH_ENCRYPTION_KEY`) loses access
+  to the stored `smtp.password` ciphertext just as it does for OIDC
+  `client_secret`. Same documented limitation; operator must re-enter
+  the password after rotation. Out of scope for this issue.
+- The new `SettingValueType.PASSWORD` is now part of the public OpenAPI
+  contract. Future password-typed settings (e.g. webhook signing
+  secrets, S3 access keys) get the same masking + encryption posture
+  for free by reusing the marker.
+- `MailService` is intentionally narrow today (`sendMail(to, subject,
+  body)` only). Template rendering is a separate decision tracked under
+  the follow-up template-engine issue; adding stub methods here would
+  widen the API surface without consumers.
+- Async / queued delivery and retry are deferred. The current synchronous
+  contract makes the test endpoint useful (the operator gets the SMTP
+  error in their browser, not 30 seconds later in a worker log) and
+  keeps the boundary simple.
+
+## Alternatives considered
+
+- **`spring.mail.*` from `application.yaml`** — rejected per §1; the
+  configuration must be runtime-mutable. A hybrid (runtime overrides
+  optional yaml defaults) was considered and rejected as adding
+  complexity without a use case.
+- **Lazy-rebuild on every send** — simpler than the cached-with-
+  invalidation pattern but pays SMTP-server-DNS-resolution + connection
+  setup costs on every call. The cached pattern is the same one the
+  settings service itself uses, so the abstraction cost is amortised.
+- **Generic `OperationContext` parameter on `sendMail`** — rejected as
+  speculative; the only consumer would be the test endpoint, which can
+  build its own subject/body.
+- **Always returning the result type even when caller does not care** —
+  the alternative would be to throw on failure. Returning a sealed
+  `SendResult` lets the test endpoint distinguish 400 from 502 cleanly,
+  while ignoring the result at most call sites is one statement.
+
+## References
+
+- ADR-0016: Application-Settings-Precedence
+- ADR-0022: Encryption key sizing
+- Issue #253: SMTP/email server configuration in global application settings
+- Spring Boot `spring-boot-starter-mail` (used as a dependency, not as
+  auto-config)
+- GreenMail (used as test dependency only)

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,3 +129,44 @@ For production use, prefer Maven Central and Docker Hub. GitHub Packages and GHC
 same artifacts for org-internal convenience.
 
 See [ADR-0017](adrs/0017-dual-registry-publishing-strategy.md) for the full rationale.
+
+## Local SMTP for Email Development (#253)
+
+Plugwerk's transactional email pipeline (`MailService` → `MailSenderProvider`
+→ `JavaMailSenderImpl`) needs a real SMTP server to talk to. Two options
+for local dev:
+
+### Option A — MailHog in Docker Compose (recommended)
+
+Add to your local `docker-compose.override.yml`:
+
+```yaml
+services:
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+```
+
+Then in the Plugwerk admin UI under **Settings → Email → Server**:
+
+| Field | Value |
+|---|---|
+| `smtp.enabled` | `true` |
+| `smtp.host` | `localhost` (or `mailhog` if your Plugwerk container is on the same compose network) |
+| `smtp.port` | `1025` |
+| `smtp.encryption` | `none` |
+| `smtp.username` | (leave blank) |
+| `smtp.password` | (leave blank) |
+| `smtp.from_address` | `noreply@plugwerk.local` |
+
+Open <http://localhost:8025> to inspect every message Plugwerk sent.
+
+### Option B — GreenMail in unit tests
+
+`SmtpEmailIT` already wires GreenMail on a dynamic port. Use it as a
+template when adding test coverage for new mail-triggering flows. No
+Docker setup needed; runs as part of `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest`.
+
+See [ADR-0031](adrs/0031-email-infrastructure.md) for the full design.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ semver4j = "6.0.0"
 yasson = "3.0.4"
 bucket4j = "8.18.0"
 caffeine = "3.2.3"
+greenmail = "2.1.6"
 spotless = "8.4.0"
 cyclonedx = "3.2.4"
 
@@ -36,10 +37,12 @@ spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
+spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-boot-starter-data-jpa-test = { module = "org.springframework.boot:spring-boot-starter-data-jpa-test" }
 spring-boot-webmvc-test = { module = "org.springframework.boot:spring-boot-webmvc-test" }
 spring-security-test = { module = "org.springframework.security:spring-security-test" }
+greenmail-junit5 = { module = "com.icegreen:greenmail-junit5", version.ref = "greenmail" }
 
 # Database
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1726,6 +1726,52 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/email/test:
+    post:
+      tags:
+        - AdminEmail
+      summary: Send a test email
+      description: |
+        Sends a small fixed-body test message to the given recipient using the
+        currently-configured SMTP settings. Surfaces SMTP errors (auth failed,
+        host unreachable, etc.) as 5xx with a kuratierte message — never the
+        raw exception text. Requires superadmin privileges (#253).
+
+        When `smtp.enabled=false` or the configuration is incomplete, returns
+        400 with a hint pointing at the missing field.
+      operationId: sendTestEmail
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+      responses:
+        '200':
+          description: Test email accepted by the SMTP server
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendTestEmailResponse'
+        '400':
+          description: SMTP not configured or recipient invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '502':
+          description: SMTP server rejected the message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   parameters:
     NamespaceSlug:
@@ -3369,8 +3415,14 @@ components:
             in the Admin UI. May be `null` for legacy rows or keys that have no description.
         valueType:
           type: string
-          enum: [STRING, INTEGER, BOOLEAN, ENUM]
-          description: Discriminator for client-side parsing
+          enum: [STRING, INTEGER, BOOLEAN, ENUM, PASSWORD]
+          description: |
+            Discriminator for client-side parsing. `PASSWORD`-typed settings
+            are stored encrypted at rest; their `value` field in GET responses
+            is always the masking sentinel `***` (or empty if unset). The Admin
+            UI renders them as `<input type="password">`. Writing the literal
+            `***` is a no-op (the masking sentinel is recognised on the write
+            path to avoid round-tripping the sentinel as the new password) — see #253.
         source:
           type: string
           enum: [DATABASE, DEFAULT]
@@ -3412,6 +3464,29 @@ components:
             $ref: '#/components/schemas/ApplicationSettingDto'
       required:
         - settings
+
+    SendTestEmailRequest:
+      type: object
+      description: Recipient for a one-shot test message (#253).
+      properties:
+        target:
+          type: string
+          format: email
+          description: Email address to deliver the test message to.
+          minLength: 3
+          maxLength: 254
+      required:
+        - target
+
+    SendTestEmailResponse:
+      type: object
+      description: Outcome of a successful test send (#253).
+      properties:
+        message:
+          type: string
+          description: Human-readable confirmation, e.g. "Test email sent to alice@example.com".
+      required:
+        - message
 
     ApplicationSettingsUpdateRequest:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.spring.boot.starter.oauth2.client)
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.mail)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.spring.boot.starter.liquibase)
     implementation(libs.bucket4j.core)
@@ -70,6 +71,7 @@ dependencies {
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.mock.oauth2.server)
+    testImplementation(libs.greenmail.junit5)
 
     testRuntimeOnly(libs.h2)
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminEmailController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminEmailController.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AdminEmailApi
+import io.plugwerk.api.model.SendTestEmailRequest
+import io.plugwerk.api.model.SendTestEmailResponse
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
+import io.plugwerk.server.service.mail.MailService
+import io.plugwerk.server.service.mail.MailService.SendResult
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Admin endpoint for verifying SMTP configuration end-to-end (#253).
+ *
+ * The only operation today is `POST /admin/email/test` — sends a one-shot
+ * test message to a target address using the live SMTP settings, returning
+ * a kuratierte success/error response so the operator can confirm their
+ * configuration without watching the server log.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AdminEmailController(
+    private val mailService: MailService,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AdminEmailApi {
+
+    private val log = LoggerFactory.getLogger(AdminEmailController::class.java)
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun sendTestEmail(sendTestEmailRequest: SendTestEmailRequest): ResponseEntity<SendTestEmailResponse> {
+        // requireSuperadmin runs first as a defence-in-depth — @PreAuthorize
+        // already gates entry, but a future refactor that drops the
+        // annotation should still hit a 403 before sending anyone email.
+        val principal = requireSuperadmin()
+        val target = sendTestEmailRequest.target
+        log.info("Superadmin {} requested test email to {}", principal, target)
+
+        val subject = "Plugwerk SMTP test"
+        val body = """
+            This is a test email from Plugwerk.
+
+            If you received this, your SMTP configuration is working.
+
+            Sent by superadmin: $principal
+        """.trimIndent()
+
+        return when (val result = mailService.sendMail(target, subject, body)) {
+            SendResult.Sent ->
+                ResponseEntity.ok(SendTestEmailResponse(message = "Test email sent to $target"))
+
+            SendResult.Disabled ->
+                throw SmtpNotConfiguredException(
+                    "SMTP is disabled or the configuration is incomplete. Set smtp.enabled=true and " +
+                        "configure smtp.host before sending mail.",
+                )
+
+            is SendResult.Misconfigured ->
+                throw SmtpNotConfiguredException(result.reason)
+
+            is SendResult.Failed ->
+                throw SmtpDeliveryException(result.reason)
+        }
+    }
+
+    private fun requireSuperadmin(): String {
+        val auth = currentAuthentication()
+        namespaceAuthorizationService.requireSuperadmin(auth)
+        return auth.name
+    }
+}
+
+/** Thrown when SMTP is disabled or its configuration is incomplete (#253). Mapped to 400. */
+class SmtpNotConfiguredException(message: String) : RuntimeException(message)
+
+/** Thrown when the SMTP server rejected the message (#253). Mapped to 502. */
+class SmtpDeliveryException(message: String) : RuntimeException(message)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSettingsController.kt
@@ -22,6 +22,7 @@ import io.plugwerk.api.AdminSettingsApi
 import io.plugwerk.api.model.ApplicationSettingDto
 import io.plugwerk.api.model.ApplicationSettingsResponse
 import io.plugwerk.api.model.ApplicationSettingsUpdateRequest
+import io.plugwerk.server.domain.SettingValueType
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.settings.ApplicationSettingKey
@@ -78,19 +79,34 @@ class AdminSettingsController(
     private fun buildResponse(): ApplicationSettingsResponse =
         ApplicationSettingsResponse(settings = settingsService.listAll().map { it.toDto() })
 
-    private fun SettingSnapshot.toDto(): ApplicationSettingDto = ApplicationSettingDto(
-        key = key.key,
-        value = value,
-        valueType = ApplicationSettingDto.ValueType.valueOf(key.valueType.name),
-        source = when (source) {
-            SettingSource.DATABASE -> ApplicationSettingDto.Source.DATABASE
-            SettingSource.DEFAULT -> ApplicationSettingDto.Source.DEFAULT
-        },
-        requiresRestart = key.requiresRestart,
-        restartPending = restartPending,
-        description = description,
-        allowedValues = key.allowedValues?.toList(),
-        minInt = key.minInt,
-        maxInt = key.maxInt,
-    )
+    private fun SettingSnapshot.toDto(): ApplicationSettingDto {
+        // PASSWORD-typed values are masked before they leave the process —
+        // the cache stores ciphertext, never plaintext, but we never want to
+        // hand even the ciphertext to the client either (it would let an
+        // attacker who learns the encryption key replay the original
+        // password). Render the sentinel `***` instead, and treat that
+        // exact string as "no change" on the write path (#253).
+        // Empty values stay empty so the UI can distinguish "not configured"
+        // from "configured (hidden)".
+        val displayValue = if (key.valueType == SettingValueType.PASSWORD && value.isNotEmpty()) {
+            ApplicationSettingsService.MASKED_VALUE
+        } else {
+            value
+        }
+        return ApplicationSettingDto(
+            key = key.key,
+            value = displayValue,
+            valueType = ApplicationSettingDto.ValueType.valueOf(key.valueType.name),
+            source = when (source) {
+                SettingSource.DATABASE -> ApplicationSettingDto.Source.DATABASE
+                SettingSource.DEFAULT -> ApplicationSettingDto.Source.DEFAULT
+            },
+            requiresRestart = key.requiresRestart,
+            restartPending = restartPending,
+            description = description,
+            allowedValues = key.allowedValues?.toList(),
+            minInt = key.minInt,
+            maxInt = key.maxInt,
+        )
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -131,6 +131,25 @@ class GlobalExceptionHandler {
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Invalid request")
 
+    /**
+     * SMTP is disabled or its configuration is incomplete — the test endpoint
+     * surfaces this as 400 so the operator gets a clear "you need to configure
+     * SMTP first" rather than a 5xx that suggests the server is broken (#253).
+     */
+    @ExceptionHandler(SmtpNotConfiguredException::class)
+    fun handleSmtpNotConfigured(ex: SmtpNotConfiguredException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "SMTP is not configured")
+
+    /**
+     * The configured SMTP server rejected the message (auth failed, host
+     * unreachable, recipient refused, etc.). Mapped to 502 because we are
+     * acting as a gateway to an upstream that misbehaved — same semantic as
+     * a downstream HTTP service returning 5xx (#253).
+     */
+    @ExceptionHandler(SmtpDeliveryException::class)
+    fun handleSmtpDelivery(ex: SmtpDeliveryException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.BAD_GATEWAY, ex.message ?: "SMTP server rejected the message")
+
     @ExceptionHandler(
         DescriptorNotFoundException::class,
         DescriptorParseException::class,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/ApplicationSettingEntity.kt
@@ -40,6 +40,14 @@ enum class SettingValueType {
     INTEGER,
     BOOLEAN,
     ENUM,
+
+    /**
+     * Sensitive value (e.g. SMTP password, future API tokens). Stored
+     * encrypted at rest; masked as `***` in GET responses; rendered as
+     * `<input type="password">` by the Admin UI. Behaves like [STRING] for
+     * validation purposes (#253).
+     */
+    PASSWORD,
 }
 
 /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailSenderProvider.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailSenderProvider.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.JavaMailSenderImpl
+import org.springframework.stereotype.Component
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Builds and caches a [JavaMailSender] instance from the runtime SMTP settings
+ * stored in `application_setting` (#253). Spring Boot's auto-config wires
+ * `JavaMailSender` once at startup from `application.yaml`; we deliberately
+ * bypass that path because the operator must be able to swap the SMTP server
+ * at runtime without restarting the JVM.
+ *
+ * The sender is held in an [AtomicReference] so reads are lock-free and
+ * always see either the previous or the new instance — no half-built state.
+ * The cache is invalidated by an `ApplicationSettingsService` update listener
+ * on every `smtp.*` write; the next [current] call rebuilds.
+ *
+ * Returns `null` when SMTP is disabled or the configuration is incomplete
+ * (host blank). Callers — currently only [MailService] — are expected to
+ * treat that as "no-op + warn", never as an exception.
+ */
+@Component
+class MailSenderProvider(private val settings: ApplicationSettingsService) {
+
+    private val log = LoggerFactory.getLogger(MailSenderProvider::class.java)
+
+    private val cached = AtomicReference<JavaMailSender?>(null)
+
+    @PostConstruct
+    fun registerInvalidationHook() {
+        settings.addUpdateListener { key ->
+            if (key.key.startsWith("smtp.")) {
+                log.debug("Invalidating cached JavaMailSender after change to {}", key.key)
+                invalidate()
+            }
+        }
+    }
+
+    /**
+     * Returns the current [JavaMailSender] instance, building it lazily from
+     * the live SMTP settings. Returns `null` when SMTP is disabled, the host
+     * is unset, or the encryption mode is unknown.
+     */
+    fun current(): JavaMailSender? {
+        cached.get()?.let { return it }
+        val built = build() ?: return null
+        // Compare-and-set so two concurrent first calls do not race; whichever
+        // wins, the next call returns the cached instance.
+        return if (cached.compareAndSet(null, built)) built else cached.get()
+    }
+
+    /** Drops the cached sender. Called by the settings update listener. */
+    fun invalidate() {
+        cached.set(null)
+    }
+
+    /**
+     * Builds a fresh [JavaMailSenderImpl] from the live settings, or returns
+     * `null` if the configuration is incomplete (e.g. enabled=false, blank
+     * host, unknown encryption mode). All "incomplete" cases log at INFO/WARN
+     * so an operator misconfiguration is visible without spamming the log on
+     * every send.
+     */
+    private fun build(): JavaMailSenderImpl? {
+        if (!settings.smtpEnabled()) {
+            log.debug("SMTP disabled (smtp.enabled=false) — no JavaMailSender built")
+            return null
+        }
+        val host = settings.smtpHost()
+        if (host.isBlank()) {
+            log.warn("smtp.enabled=true but smtp.host is blank — cannot build JavaMailSender")
+            return null
+        }
+        val sender = JavaMailSenderImpl()
+        sender.host = host
+        sender.port = settings.smtpPort()
+        val username = settings.smtpUsername()
+        if (username.isNotBlank()) {
+            sender.username = username
+            sender.password = settings.smtpPasswordPlaintext()
+        }
+
+        val props: Properties = sender.javaMailProperties
+        props.setProperty("mail.transport.protocol", "smtp")
+        when (settings.smtpEncryption()) {
+            "starttls" -> {
+                props.setProperty("mail.smtp.starttls.enable", "true")
+                // STARTTLS-required (not just opportunistic) so the connection
+                // upgrades or fails — silently falling back to plaintext on a
+                // submission port is exactly the kind of misconfig users do
+                // not want.
+                props.setProperty("mail.smtp.starttls.required", "true")
+            }
+
+            "tls" -> {
+                // Implicit TLS (port-465 style) — the socket is TLS from byte 0.
+                props.setProperty("mail.smtp.ssl.enable", "true")
+            }
+
+            "none" -> {
+                // Explicit opt-out for plain SMTP. Useful for in-org dev/test
+                // SMTP relays without TLS termination. Logged at INFO so the
+                // choice is visible.
+                log.info("SMTP encryption=none — connection will not be encrypted")
+            }
+
+            else -> {
+                log.warn(
+                    "Unknown smtp.encryption '{}' — refusing to build JavaMailSender",
+                    settings.smtpEncryption(),
+                )
+                return null
+            }
+        }
+        if (username.isNotBlank()) {
+            props.setProperty("mail.smtp.auth", "true")
+        }
+        log.info(
+            "Built JavaMailSender for {}:{} encryption={} auth={}",
+            host,
+            sender.port,
+            settings.smtpEncryption(),
+            username.isNotBlank(),
+        )
+        return sender
+    }
+
+    /** For tests: peek at whether the cache is populated without forcing a build. */
+    internal fun isCached(): Boolean = cached.get() != null
+
+    /** For tests + the test endpoint: force a build using the current settings. */
+    internal fun forceBuild(): JavaMailSender? = build()?.also { cached.set(it) }
+
+    /**
+     * Visible for tests so that the [ApplicationSettingKey] type is the boundary,
+     * not the dotted string — keeps callers compiling against the enum.
+     */
+    @Suppress("unused")
+    internal fun smtpKeys(): List<ApplicationSettingKey> = listOf(
+        ApplicationSettingKey.SMTP_ENABLED,
+        ApplicationSettingKey.SMTP_HOST,
+        ApplicationSettingKey.SMTP_PORT,
+        ApplicationSettingKey.SMTP_USERNAME,
+        ApplicationSettingKey.SMTP_PASSWORD,
+        ApplicationSettingKey.SMTP_ENCRYPTION,
+        ApplicationSettingKey.SMTP_FROM_ADDRESS,
+        ApplicationSettingKey.SMTP_FROM_NAME,
+    )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailService.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.slf4j.LoggerFactory
+import org.springframework.mail.MailException
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.stereotype.Service
+
+/**
+ * Single entry point for sending transactional email (#253).
+ *
+ * Today the interface is intentionally narrow: synchronous one-shot
+ * `sendMail(to, subject, body)`. Async/queued delivery, retries, and template
+ * rendering are deferred to follow-up issues — adding stub methods here would
+ * widen the API surface without consumers.
+ *
+ * **No-op semantics when SMTP is not configured.** When `smtp.enabled=false`
+ * or the configuration is incomplete (no host), [sendMail] returns
+ * [SendResult.Disabled] without contacting any server. Callers that have a
+ * legitimate reason to surface this to the user (e.g. the test-mail endpoint)
+ * inspect the result; everything else can ignore it and rely on the warning
+ * log line.
+ */
+@Service
+class MailService(private val settings: ApplicationSettingsService, private val provider: MailSenderProvider) {
+    private val log = LoggerFactory.getLogger(MailService::class.java)
+
+    /**
+     * Sends a plain-text email synchronously. Returns the outcome rather than
+     * throwing so call sites that do not care (most of them) can stay terse.
+     *
+     * @param to the recipient email address.
+     * @param subject the message subject.
+     * @param body the message body (plain text).
+     */
+    fun sendMail(to: String, subject: String, body: String): SendResult {
+        if (!settings.smtpEnabled()) {
+            log.warn("Skipping send to {} — SMTP is disabled (smtp.enabled=false)", to)
+            return SendResult.Disabled
+        }
+        val sender = provider.current() ?: run {
+            log.warn("Skipping send to {} — SMTP is enabled but configuration is incomplete", to)
+            return SendResult.Disabled
+        }
+        val fromAddress = settings.smtpFromAddress()
+        if (fromAddress.isBlank()) {
+            log.warn("Skipping send to {} — smtp.from_address is not configured", to)
+            return SendResult.Misconfigured("smtp.from_address is not configured")
+        }
+        val fromName = settings.smtpFromName()
+        val from = if (fromName.isBlank()) fromAddress else "$fromName <$fromAddress>"
+        val message = SimpleMailMessage().apply {
+            this.from = from
+            this.setTo(to)
+            this.subject = subject
+            this.text = body
+        }
+        return try {
+            sender.send(message)
+            log.info("Sent mail to {} subject='{}'", to, subject)
+            SendResult.Sent
+        } catch (ex: MailException) {
+            // Distinguish at the call site between operator misconfig (auth /
+            // relay refused) and the SMTP server being briefly unreachable;
+            // here we only know it failed. Caller decides 5xx vs 4xx mapping.
+            log.warn("Failed to send mail to {}: {}", to, ex.message)
+            SendResult.Failed(ex.message ?: "Mail send failed")
+        }
+    }
+
+    /** Outcome of a [sendMail] call. */
+    sealed interface SendResult {
+        /** Mail successfully handed to the SMTP server. Delivery is then asynchronous and not tracked here. */
+        data object Sent : SendResult
+
+        /** SMTP master switch is off, or the configuration is too incomplete to attempt a send. */
+        data object Disabled : SendResult
+
+        /** SMTP is enabled but a required field is missing — distinct from [Disabled] so callers can surface it. */
+        data class Misconfigured(val reason: String) : SendResult
+
+        /** The SMTP server rejected the send (auth failed, recipient refused, network error, etc.). */
+        data class Failed(val reason: String) : SendResult
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
@@ -34,6 +34,27 @@ private fun validateTimezone(rawValue: String): String? = try {
 }
 
 /**
+ * Conservative RFC-5322-ish email check used for `smtp.from_address` (#253).
+ *
+ * We deliberately allow blank because the SMTP config can legitimately be
+ * empty when the operator has not yet set it up — the cross-key invariant
+ * "from_address must be set when smtp.enabled=true" is enforced at send
+ * time by the mail layer, not at per-key write time.
+ */
+private fun validateEmailAllowingBlank(rawValue: String): String? {
+    if (rawValue.isBlank()) return null
+    // Single-line, must contain exactly one @, local + domain non-empty,
+    // domain has at least one dot. Good enough for an internal admin field;
+    // RFC 5322 in full would require a 100-line parser nobody asked for.
+    val emailPattern = Regex("^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$")
+    return if (emailPattern.matches(rawValue)) {
+        null
+    } else {
+        "value must be a valid email address, got '$rawValue'"
+    }
+}
+
+/**
  * Central registry of every admin-manageable application setting (ADR-0016).
  *
  * Each entry declares its dotted key, its typed default (used as a last-resort fallback if
@@ -55,6 +76,13 @@ enum class ApplicationSettingKey(
     val allowedValues: Set<String>? = null,
     val minInt: Int? = null,
     val maxInt: Int? = null,
+    /**
+     * `true` lets the type-validator accept blank strings for STRING/PASSWORD keys.
+     * Default is `false` because most application settings are mandatory once
+     * configured. SMTP keys override this so an unconfigured operator is not
+     * forced to invent placeholder values (#253).
+     */
+    val allowBlank: Boolean = false,
     val extraValidator: ((String) -> String?)? = null,
 ) {
     GENERAL_DEFAULT_LANGUAGE(
@@ -102,13 +130,69 @@ enum class ApplicationSettingKey(
         valueType = SettingValueType.BOOLEAN,
         defaultValue = "true",
     ),
+
+    // ---- SMTP / Email (#253) ------------------------------------------------
+    // All SMTP keys allow blank because the operator may not have configured
+    // anything yet. Cross-key invariants ("host required when enabled=true")
+    // are enforced at send time by the mail layer, not per-key.
+
+    SMTP_ENABLED(
+        key = "smtp.enabled",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "false",
+    ),
+    SMTP_HOST(
+        key = "smtp.host",
+        valueType = SettingValueType.STRING,
+        defaultValue = "",
+        allowBlank = true,
+    ),
+    SMTP_PORT(
+        key = "smtp.port",
+        valueType = SettingValueType.INTEGER,
+        defaultValue = "587",
+        minInt = 1,
+        maxInt = 65535,
+    ),
+    SMTP_USERNAME(
+        key = "smtp.username",
+        valueType = SettingValueType.STRING,
+        defaultValue = "",
+        allowBlank = true,
+    ),
+    SMTP_PASSWORD(
+        key = "smtp.password",
+        valueType = SettingValueType.PASSWORD,
+        defaultValue = "",
+        allowBlank = true,
+    ),
+    SMTP_ENCRYPTION(
+        key = "smtp.encryption",
+        valueType = SettingValueType.ENUM,
+        defaultValue = "starttls",
+        allowedValues = setOf("none", "starttls", "tls"),
+    ),
+    SMTP_FROM_ADDRESS(
+        key = "smtp.from_address",
+        valueType = SettingValueType.STRING,
+        defaultValue = "",
+        allowBlank = true,
+        extraValidator = ::validateEmailAllowingBlank,
+    ),
+    SMTP_FROM_NAME(
+        key = "smtp.from_name",
+        valueType = SettingValueType.STRING,
+        defaultValue = "Plugwerk",
+        allowBlank = true,
+    ),
     ;
 
     /**
      * Validates a proposed new raw value for this key. Application settings forbid blank
-     * strings and support integer range constraints; the shared [ValueValidator] implements
-     * the type-level rules, and per-key [extraValidator] runs afterwards on a valid raw
-     * value (e.g. IANA timezone check for `general.default_timezone`).
+     * strings by default (override per key via [allowBlank]) and support integer range
+     * constraints; the shared [ValueValidator] implements the type-level rules, and
+     * per-key [extraValidator] runs afterwards on a valid raw value (e.g. IANA timezone
+     * check for `general.default_timezone`).
      *
      * @return `null` if the value is acceptable, or a human-readable error message otherwise.
      */
@@ -120,7 +204,7 @@ enum class ApplicationSettingKey(
             allowedValues = allowedValues,
             minInt = minInt,
             maxInt = maxInt,
-            allowBlankString = false,
+            allowBlankString = allowBlank,
         )
         return typeError ?: extraValidator?.invoke(rawValue)
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
@@ -19,9 +19,12 @@
 package io.plugwerk.server.service.settings
 
 import io.plugwerk.server.domain.ApplicationSettingEntity
+import io.plugwerk.server.domain.SettingValueType
 import io.plugwerk.server.repository.ApplicationSettingRepository
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.atomic.AtomicReference
@@ -41,11 +44,27 @@ import java.util.concurrent.atomic.AtomicReference
  * whose current DB value differs from the value the running JVM loaded at boot
  * (e.g. `upload.max_file_size_mb`, which the multipart filter only picks up on restart —
  * see [ApplicationSettingKey.requiresRestart]).
+ *
+ * **Encryption (#253):** keys with [SettingValueType.PASSWORD] are encrypted before being
+ * persisted (via the `TextEncryptor` bean from `SecurityConfiguration`) and decrypted only
+ * when an internal consumer asks for the plaintext via a typed accessor like
+ * [smtpPasswordPlaintext]. The cached snapshot stores ciphertext; the GET-response masking
+ * layer in `AdminSettingsController.toDto` returns `***` so plaintext never leaves the
+ * service layer.
+ *
+ * The encryptor is injected via [ObjectProvider] so the service can be constructed in
+ * tests without the full Security autoconfiguration; a missing encryptor is a hard error
+ * only when a PASSWORD-typed setting is actually written or decrypted.
  */
 @Service
-class ApplicationSettingsService(private val repository: ApplicationSettingRepository) {
+class ApplicationSettingsService(
+    private val repository: ApplicationSettingRepository,
+    encryptorProvider: ObjectProvider<TextEncryptor>,
+) {
 
     private val log = LoggerFactory.getLogger(ApplicationSettingsService::class.java)
+
+    private val encryptor: TextEncryptor? = encryptorProvider.ifAvailable
 
     /** Live snapshot of `setting_key -> stored row data`. Updated atomically on writes. */
     private val cache = AtomicReference<Map<String, StoredSetting>>(emptyMap())
@@ -56,6 +75,14 @@ class ApplicationSettingsService(private val repository: ApplicationSettingRepos
      * enforcement mechanism.
      */
     private lateinit var bootSnapshot: Map<String, StoredSetting>
+
+    /**
+     * Hooks invoked after every successful [update]. Lets settings-derived
+     * components (currently only the SMTP `MailSenderProvider` for #253)
+     * invalidate any cached state without having to poll. Keep light — runs
+     * synchronously inside the write transaction.
+     */
+    private val updateListeners = mutableListOf<(ApplicationSettingKey) -> Unit>()
 
     @PostConstruct
     fun initialize() {
@@ -81,8 +108,21 @@ class ApplicationSettingsService(private val repository: ApplicationSettingRepos
     }
 
     /**
+     * Registers a callback fired after every successful write. Listeners receive the key
+     * that was updated and run inside the write transaction — keep them fast and
+     * non-throwing. The current consumer is the SMTP `MailSenderProvider` (#253), which
+     * uses the hook to invalidate its cached `JavaMailSender` when any `smtp.*` setting
+     * changes.
+     */
+    fun addUpdateListener(listener: (ApplicationSettingKey) -> Unit) {
+        updateListeners.add(listener)
+    }
+
+    /**
      * Returns the raw string value for [key], falling back to [ApplicationSettingKey.defaultValue] if
-     * the row is missing or the stored value is an empty string.
+     * the row is missing or the stored value is an empty string. For PASSWORD-typed keys
+     * the returned value is **ciphertext** — call a typed accessor like
+     * [smtpPasswordPlaintext] when the consumer needs the decrypted value.
      */
     fun getRaw(key: ApplicationSettingKey): String {
         val stored = cache.get()[key.key]?.rawValue
@@ -116,10 +156,60 @@ class ApplicationSettingsService(private val repository: ApplicationSettingRepos
     /** Typed accessor: `general.default_timezone` (IANA id, e.g. `UTC`, `Europe/Berlin`). */
     fun defaultTimezone(): String = getRaw(ApplicationSettingKey.GENERAL_DEFAULT_TIMEZONE)
 
+    // ---- SMTP (#253) -------------------------------------------------------
+
+    /** Typed accessor: `smtp.enabled` master switch. */
+    fun smtpEnabled(): Boolean = getRaw(ApplicationSettingKey.SMTP_ENABLED).toBooleanStrict()
+
+    /** Typed accessor: `smtp.host`. Empty string when unset. */
+    fun smtpHost(): String = getRaw(ApplicationSettingKey.SMTP_HOST)
+
+    /** Typed accessor: `smtp.port` (1–65535). */
+    fun smtpPort(): Int = getRaw(ApplicationSettingKey.SMTP_PORT).toIntOrNull()
+        ?.coerceIn(1, 65535)
+        ?: ApplicationSettingKey.SMTP_PORT.defaultValue.toInt()
+
+    /** Typed accessor: `smtp.username`. Empty string means unauthenticated relay. */
+    fun smtpUsername(): String = getRaw(ApplicationSettingKey.SMTP_USERNAME)
+
+    /**
+     * Typed accessor: `smtp.password` decrypted to plaintext. Empty string when unset.
+     *
+     * **Internal-only.** Never include this in any DTO or log line — the masking layer
+     * in `AdminSettingsController.toDto` exists precisely so plaintext never leaves the
+     * service layer through user-facing channels.
+     */
+    fun smtpPasswordPlaintext(): String {
+        val stored = cache.get()[ApplicationSettingKey.SMTP_PASSWORD.key]?.rawValue ?: return ""
+        if (stored.isEmpty()) return ""
+        return decryptOrNull(stored) ?: run {
+            log.warn(
+                "Could not decrypt smtp.password — value is corrupted or the encryption key " +
+                    "changed. Treating as unset.",
+            )
+            ""
+        }
+    }
+
+    /** Typed accessor: `smtp.encryption` ∈ {`none`, `starttls`, `tls`}. */
+    fun smtpEncryption(): String = getRaw(ApplicationSettingKey.SMTP_ENCRYPTION)
+
+    /** Typed accessor: `smtp.from_address`. Empty string when unset. */
+    fun smtpFromAddress(): String = getRaw(ApplicationSettingKey.SMTP_FROM_ADDRESS)
+
+    /** Typed accessor: `smtp.from_name`. */
+    fun smtpFromName(): String = getRaw(ApplicationSettingKey.SMTP_FROM_NAME)
+
+    // ------------------------------------------------------------------------
+
     /**
      * Returns a complete snapshot of every key, including its effective value, description,
      * source (`DATABASE` if a row exists, `DEFAULT` otherwise), and a `restartPending` flag
      * for keys whose DB value has changed since the JVM started.
+     *
+     * **PASSWORD-typed keys carry ciphertext in the returned [SettingSnapshot.value].**
+     * The DTO conversion in `AdminSettingsController` masks them to `***` before they leave
+     * the process. Internal callers that need plaintext use the typed accessors instead.
      */
     fun listAll(): List<SettingSnapshot> {
         val current = cache.get()
@@ -152,26 +242,74 @@ class ApplicationSettingsService(private val repository: ApplicationSettingRepos
     /**
      * Persists a new value for [key] and refreshes the cache.
      *
+     * For PASSWORD-typed keys the [rawValue] is encrypted at rest before being persisted.
+     * The masking sentinel `***` (which the Admin UI surfaces in GET responses) is treated
+     * as "no change" — writing it back does not re-encrypt random bytes as a password.
+     *
      * @throws IllegalArgumentException if [rawValue] fails [ApplicationSettingKey.validate].
+     * @throws IllegalStateException if [key] is PASSWORD-typed and no [TextEncryptor] is
+     *   available (Security autoconfiguration not loaded).
      */
     @Transactional
     fun update(key: ApplicationSettingKey, rawValue: String, updatedBy: String?): SettingSnapshot {
+        // PASSWORD masking sentinel — when the Admin UI submits the form
+        // unchanged, every password field comes back as "***". Treat that as
+        // a no-op so we never encrypt the literal string "***" as if it were
+        // the new password (#253).
+        if (key.valueType == SettingValueType.PASSWORD && rawValue == MASKED_VALUE) {
+            return listAll().first { it.key == key }
+        }
         key.validate(rawValue)?.let { error ->
             throw IllegalArgumentException("Invalid value for setting '${key.key}': $error")
         }
+        val storedValue = if (key.valueType == SettingValueType.PASSWORD && rawValue.isNotEmpty()) {
+            requireNotNull(encryptor) {
+                "TextEncryptor bean is required to write PASSWORD settings — Security " +
+                    "autoconfiguration is not loaded in this context"
+            }.encrypt(rawValue)
+        } else {
+            rawValue
+        }
         val existing = repository.findBySettingKey(key.key).orElse(null)
         val entity = existing?.apply {
-            settingValue = rawValue
+            settingValue = storedValue
             this.updatedBy = updatedBy
         } ?: ApplicationSettingEntity(
             settingKey = key.key,
-            settingValue = rawValue,
+            settingValue = storedValue,
             valueType = key.valueType,
             updatedBy = updatedBy,
         )
         repository.save(entity)
         refreshCache()
+        notifyListeners(key)
         return listAll().first { it.key == key }
+    }
+
+    private fun notifyListeners(key: ApplicationSettingKey) {
+        for (listener in updateListeners) {
+            try {
+                listener(key)
+            } catch (ex: Exception) {
+                log.warn("Settings update listener threw for key '{}': {}", key.key, ex.message)
+            }
+        }
+    }
+
+    private fun decryptOrNull(ciphertext: String): String? = try {
+        encryptor?.decrypt(ciphertext)
+    } catch (_: Exception) {
+        null
+    }
+
+    companion object {
+        /**
+         * Sentinel value rendered for PASSWORD-typed settings in GET responses.
+         * Also recognised by [update] as "no change" so a round-trip through the
+         * Admin UI does not silently overwrite the stored ciphertext with the
+         * literal string `"***"`.
+         */
+        const val MASKED_VALUE: String = "***"
     }
 }
 
@@ -194,6 +332,8 @@ internal data class StoredSetting(val rawValue: String, val description: String?
  *
  * @property key the [ApplicationSettingKey] entry.
  * @property value the effective raw string value (either from DB or the hard-coded default).
+ *   For PASSWORD-typed keys this is ciphertext; consumers that need plaintext use the
+ *   typed accessors on [ApplicationSettingsService] instead.
  * @property description human-readable description from the DB row, or `null` if the row
  *   is missing or has no description persisted.
  * @property source where [value] came from.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ValueValidator.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ValueValidator.kt
@@ -67,6 +67,14 @@ internal object ValueValidator {
         SettingValueType.STRING ->
             if (!allowBlankString && rawValue.isBlank()) "value must not be blank" else null
 
+        SettingValueType.PASSWORD ->
+            // Same rules as STRING — the only difference is at the storage
+            // and display layer (encrypted at rest, masked in GET responses).
+            // The PASSWORD-specific magic lives in
+            // `ApplicationSettingsService.update` (encrypt) and
+            // `AdminSettingsController.toDto` (mask) — not here (#253).
+            if (!allowBlankString && rawValue.isBlank()) "value must not be blank" else null
+
         SettingValueType.INTEGER -> {
             val parsed = rawValue.toIntOrNull()
             when {

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,3 +47,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0023_user_source_internal_external.yaml
   - include:
       file: db/changelog/migrations/0024_revoked_token_user_fk.yaml
+  - include:
+      file: db/changelog/migrations/0025_add_smtp_settings.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0025_add_smtp_settings.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0025_add_smtp_settings.yaml
@@ -1,0 +1,166 @@
+# Seed the SMTP/email server settings registered in ApplicationSettingKey
+# (#253). All values default to empty / disabled — the operator configures
+# them at runtime via /admin/email/server.
+#
+# `smtp.password` is stored encrypted at rest. The seed inserts an empty
+# string (which the application layer treats as "no password set"); when
+# the operator first writes a password the AdminSettingsController's
+# update path runs the value through TextEncryptor before persisting.
+#
+# No new column is added — the existing `application_setting` table from
+# 0005 already supports arbitrary keys with `value_type` discriminating
+# parsing. The new value_type=PASSWORD is recognised by both the entity
+# enum and the value validator.
+databaseChangeLog:
+  - changeSet:
+      id: 0025-seed-smtp-settings
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.enabled
+              - column:
+                  name: setting_value
+                  value: "false"
+              - column:
+                  name: setting_desc
+                  value: "Master switch — when false, the application sends no emails regardless of other SMTP settings."
+              - column:
+                  name: value_type
+                  value: BOOLEAN
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.host
+              - column:
+                  name: setting_value
+                  value: ""
+              - column:
+                  name: setting_desc
+                  value: "SMTP server hostname (e.g. smtp.example.com)."
+              - column:
+                  name: value_type
+                  value: STRING
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.port
+              - column:
+                  name: setting_value
+                  value: "587"
+              - column:
+                  name: setting_desc
+                  value: "SMTP server port (1–65535). 587 for STARTTLS submission, 465 for implicit TLS, 25 for plain SMTP."
+              - column:
+                  name: value_type
+                  value: INTEGER
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.username
+              - column:
+                  name: setting_value
+                  value: ""
+              - column:
+                  name: setting_desc
+                  value: "SMTP authentication username. Leave blank for unauthenticated relays."
+              - column:
+                  name: value_type
+                  value: STRING
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.password
+              - column:
+                  name: setting_value
+                  value: ""
+              - column:
+                  name: setting_desc
+                  value: "SMTP authentication password. Stored encrypted at rest, masked in API responses."
+              - column:
+                  name: value_type
+                  value: PASSWORD
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.encryption
+              - column:
+                  name: setting_value
+                  value: starttls
+              - column:
+                  name: setting_desc
+                  value: "Transport encryption: 'none' (plain), 'starttls' (port 587-style upgrade), or 'tls' (implicit TLS, port 465-style)."
+              - column:
+                  name: value_type
+                  value: ENUM
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.from_address
+              - column:
+                  name: setting_value
+                  value: ""
+              - column:
+                  name: setting_desc
+                  value: "Envelope-From and From-header email address used for all outgoing mail."
+              - column:
+                  name: value_type
+                  value: STRING
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: smtp.from_name
+              - column:
+                  name: setting_value
+                  value: Plugwerk
+              - column:
+                  name: setting_desc
+                  value: "Display name used in the From: header (e.g. 'Plugwerk'). Combined with from_address."
+              - column:
+                  name: value_type
+                  value: STRING
+      rollback:
+        - delete:
+            tableName: application_setting
+            where: "setting_key IN ('smtp.enabled', 'smtp.host', 'smtp.port', 'smtp.username', 'smtp.password', 'smtp.encryption', 'smtp.from_address', 'smtp.from_name')"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailServiceTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.mail.MailSendException
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+
+@ExtendWith(MockitoExtension::class)
+class MailServiceTest {
+
+    private lateinit var settings: ApplicationSettingsService
+    private lateinit var provider: MailSenderProvider
+    private lateinit var sender: JavaMailSender
+    private lateinit var service: MailService
+
+    @BeforeEach
+    fun setUp() {
+        settings = mock()
+        provider = mock()
+        sender = mock()
+        service = MailService(settings, provider)
+    }
+
+    @Test
+    fun `sendMail returns Disabled when smtp_enabled is false (no JavaMailSender contacted)`() {
+        whenever(settings.smtpEnabled()).thenReturn(false)
+
+        val result = service.sendMail("alice@example.test", "Hi", "Body")
+
+        assertThat(result).isEqualTo(MailService.SendResult.Disabled)
+        verify(provider, never()).current()
+        verify(sender, never()).send(any<SimpleMailMessage>())
+    }
+
+    @Test
+    fun `sendMail returns Disabled when provider has no usable sender (incomplete config)`() {
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(null)
+
+        val result = service.sendMail("alice@example.test", "Hi", "Body")
+
+        assertThat(result).isEqualTo(MailService.SendResult.Disabled)
+    }
+
+    @Test
+    fun `sendMail returns Misconfigured when from_address is blank`() {
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(sender)
+        whenever(settings.smtpFromAddress()).thenReturn("")
+
+        val result = service.sendMail("alice@example.test", "Hi", "Body")
+
+        assertThat(result).isInstanceOf(MailService.SendResult.Misconfigured::class.java)
+        // From-address is the only required field at send time once SMTP is
+        // enabled — the absence of any other smtp.* field surfaces as
+        // Disabled/Failed depending on which layer caught it.
+        verify(sender, never()).send(any<SimpleMailMessage>())
+    }
+
+    @Test
+    fun `sendMail returns Sent and hands a correctly built SimpleMailMessage to the JavaMailSender`() {
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(sender)
+        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
+        whenever(settings.smtpFromName()).thenReturn("Plugwerk")
+
+        val result = service.sendMail("alice@example.test", "Welcome", "Hello Alice")
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        val captor = argumentCaptor<SimpleMailMessage>()
+        verify(sender).send(captor.capture())
+        val sent = captor.firstValue
+        assertThat(sent.from).isEqualTo("Plugwerk <noreply@plugwerk.test>")
+        assertThat(sent.to).containsExactly("alice@example.test")
+        assertThat(sent.subject).isEqualTo("Welcome")
+        assertThat(sent.text).isEqualTo("Hello Alice")
+    }
+
+    @Test
+    fun `sendMail uses bare from_address when from_name is blank`() {
+        // Edge case: operator only configured the address. The display-name
+        // RFC-5322 form `Name <addr>` would render as `<addr>` with the bare
+        // angle brackets — ugly. Fall back to just the address.
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(sender)
+        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
+        whenever(settings.smtpFromName()).thenReturn("")
+
+        service.sendMail("alice@example.test", "Hi", "Body")
+
+        val captor = argumentCaptor<SimpleMailMessage>()
+        verify(sender).send(captor.capture())
+        assertThat(captor.firstValue.from).isEqualTo("noreply@plugwerk.test")
+    }
+
+    @Test
+    fun `sendMail returns Failed when the JavaMailSender throws a MailException`() {
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(sender)
+        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
+        whenever(settings.smtpFromName()).thenReturn("Plugwerk")
+        doThrow(MailSendException("auth failed: invalid credentials"))
+            .whenever(sender).send(any<SimpleMailMessage>())
+
+        val result = service.sendMail("alice@example.test", "Hi", "Body")
+
+        assertThat(result).isInstanceOf(MailService.SendResult.Failed::class.java)
+        assertThat((result as MailService.SendResult.Failed).reason)
+            .contains("auth failed")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/SmtpEmailIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/SmtpEmailIT.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetup
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * End-to-end SMTP verification via GreenMail (#253).
+ *
+ * Boots the full Spring context (H2 + Liquibase migrations including the SMTP
+ * seed in 0025), wires the runtime settings to point at an embedded GreenMail
+ * server on a random port, and sends a real message through `MailService` ->
+ * `MailSenderProvider` -> `JavaMailSenderImpl`. Asserts the message lands in
+ * GreenMail's inbox with the expected From/To/subject/body.
+ *
+ * Why this lives here and not in the controller test slice: the bug we want
+ * to catch is the boundary between our settings-driven `JavaMailSender` build
+ * path and a real SMTP transport — a controller-only test with a mock
+ * `MailService` would not exercise that.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        // H2 in-memory; matches the standard test profile pattern used elsewhere
+        // in the project (UserServiceTest, etc.) so we get the Liquibase seed
+        // without a Postgres container.
+        "spring.datasource.url=jdbc:h2:mem:smtp-it;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+@Tag("integration")
+class SmtpEmailIT {
+
+    @Autowired
+    private lateinit var settings: ApplicationSettingsService
+
+    @Autowired
+    private lateinit var mailService: MailService
+
+    @Autowired
+    private lateinit var provider: MailSenderProvider
+
+    /**
+     * Embedded SMTP on a dynamic port — declared as `@RegisterExtension` so the
+     * port is known by the time the test methods need it. ServerSetup.SMTP is
+     * plain SMTP (no TLS); pairs with `smtp.encryption=none` below.
+     */
+    @RegisterExtension
+    @Suppress("JUnitMalformedDeclaration") // Kotlin val gets a final field; JUnit5 accepts it.
+    val greenMail: GreenMailExtension = GreenMailExtension(ServerSetup.SMTP.dynamicPort())
+
+    @BeforeEach
+    fun configureSmtp() {
+        // Point the application's runtime SMTP settings at the GreenMail
+        // server. We bypass the HTTP admin API (auth setup is irrelevant for
+        // this integration boundary) and write through the service directly.
+        // The settings service's listener will invalidate the cached
+        // JavaMailSender so the next mailService.sendMail builds a fresh
+        // instance pointing at the correct port.
+        provider.invalidate()
+        settings.update(ApplicationSettingKey.SMTP_HOST, "localhost", "test-setup")
+        settings.update(
+            ApplicationSettingKey.SMTP_PORT,
+            greenMail.smtp.port.toString(),
+            "test-setup",
+        )
+        settings.update(ApplicationSettingKey.SMTP_ENCRYPTION, "none", "test-setup")
+        settings.update(ApplicationSettingKey.SMTP_USERNAME, "", "test-setup")
+        settings.update(
+            ApplicationSettingKey.SMTP_FROM_ADDRESS,
+            "noreply@plugwerk.test",
+            "test-setup",
+        )
+        settings.update(ApplicationSettingKey.SMTP_FROM_NAME, "Plugwerk", "test-setup")
+        // smtp.enabled last so the cache invalidation hook does not race with
+        // partial config — the next sendMail sees a fully-formed setting set.
+        settings.update(ApplicationSettingKey.SMTP_ENABLED, "true", "test-setup")
+    }
+
+    @Test
+    fun `sendMail delivers to the SMTP server with the expected envelope`() {
+        val result = mailService.sendMail(
+            to = "alice@example.test",
+            subject = "Welcome to Plugwerk",
+            body = "This is a test message from the SMTP IT.",
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        // GreenMail blocks until the SMTP server has accepted and stored the
+        // message; no extra wait needed.
+        val received = greenMail.receivedMessages
+        assertThat(received).hasSize(1)
+        val message = received[0]
+        assertThat(message.subject).isEqualTo("Welcome to Plugwerk")
+        assertThat(message.from.first().toString()).contains("noreply@plugwerk.test")
+        assertThat(message.allRecipients.first().toString()).isEqualTo("alice@example.test")
+        // Body is multi-part on some SMTP libraries; SimpleMailMessage uses
+        // text/plain, so the content() is a String we can compare directly.
+        val rawContent = message.content
+        val bodyText = if (rawContent is String) rawContent else rawContent.toString()
+        assertThat(bodyText).contains("This is a test message")
+    }
+
+    @Test
+    fun `password setting written via update is encrypted at rest, masked on read`() {
+        // Pre-condition: write a password through the service. The service
+        // routes PASSWORD-typed values through TextEncryptor so the row in
+        // application_setting holds ciphertext.
+        settings.update(ApplicationSettingKey.SMTP_PASSWORD, "s3cr3t-top-of-mind", "test-setup")
+
+        // The decrypted plaintext accessor returns the original value.
+        assertThat(settings.smtpPasswordPlaintext()).isEqualTo("s3cr3t-top-of-mind")
+
+        // listAll surfaces ciphertext (raw value), not plaintext — the
+        // controller layer is what masks it to "***" for the wire.
+        val snapshot = settings.listAll().first { it.key == ApplicationSettingKey.SMTP_PASSWORD }
+        assertThat(snapshot.value).isNotEqualTo("s3cr3t-top-of-mind")
+        assertThat(snapshot.value).isNotEmpty()
+    }
+
+    @Test
+    fun `disabling smtp via setting update makes mailService no-op without sending`() {
+        settings.update(ApplicationSettingKey.SMTP_ENABLED, "false", "test-setup")
+
+        val result = mailService.sendMail(
+            to = "ignored@example.test",
+            subject = "Should not arrive",
+            body = "Body",
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Disabled)
+        // GreenMail should have received nothing for this test — the previous
+        // test's deliveries are isolated by the per-test extension lifecycle.
+        assertThat(greenMail.receivedMessages).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

Backend-side of #253. Adds runtime-configurable SMTP server settings + transactional mail sending. Frontend admin page (`/admin/email/server`) tracked as a follow-up PR to keep this diff reviewable.

## What's in scope

### Settings model (8 new `ApplicationSettingKey` entries, migration 0025)

`smtp.enabled` (default `false`), `smtp.host`, `smtp.port`, `smtp.username`, `smtp.password`, `smtp.encryption` (`none`/`starttls`/`tls`), `smtp.from_address`, `smtp.from_name`.

### `SettingValueType.PASSWORD` — three layers, one marker

| Layer | Behaviour |
|---|---|
| Storage | `ApplicationSettingsService.update` encrypts via the existing `TextEncryptor` bean (same path OIDC `client_secret_encrypted` uses) |
| Display | `AdminSettingsController.toDto` masks to `"***"` — plaintext never leaves the JVM |
| Internal use | `smtpPasswordPlaintext()` typed accessor decrypts only for `MailSenderProvider`; never logged, never DTO'd |

The `"***"` sentinel is recognised on the write path so a round-trip through the Admin UI does not overwrite ciphertext with literal `"***"`.

### Mail infrastructure

- `spring-boot-starter-mail` dependency (used as JAR only — `spring.mail.*` auto-config is **not** wired so the SMTP server is mutable at runtime).
- `MailSenderProvider` — AtomicReference-cached `JavaMailSender`, rebuilt lazily, invalidated on every `smtp.*` setting change via a new `addUpdateListener` hook.
- STARTTLS is "required" (not opportunistic) so a silent fallback to plaintext cannot happen.
- `MailService.sendMail` returns a sealed `SendResult` (`Sent` / `Disabled` / `Misconfigured` / `Failed`).

### Test endpoint

`POST /api/v1/admin/email/test` (superadmin-only):
- `200` on success
- `400` `SmtpNotConfiguredException` when disabled or `from_address` blank
- `502` `SmtpDeliveryException` when SMTP rejects (auth failed, host unreachable)

Both new exception types mapped in `GlobalExceptionHandler` to the respective `ErrorResponse` envelope.

## Test plan

- [x] `MailServiceTest` (Mockito) — 6/6 cases: disabled, incomplete, misconfigured, Sent + correct envelope, bare from-address fallback, `MailException` → `Failed`
- [x] `SmtpEmailIT` (Spring Boot + GreenMail JUnit5) — 3/3 cases:
  - `sendMail` delivers to embedded SMTP with correct envelope
  - PASSWORD setting written via `update` is encrypted at rest, masked on read
  - Disabling SMTP makes `sendMail` no-op without sending
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:build -x integrationTest` — green (compile + spotless + 100+ existing tests)

## Documentation

- **ADR-0031** records: runtime settings vs. yaml, encryption-at-rest + masking design, AtomicReference-cached `JavaMailSender`, STARTTLS-required default, test-endpoint 502 mapping, GreenMail testing pattern, three explicitly considered & rejected alternatives.
- `docs/development.md` gets a "Local SMTP for Email Development" section with MailHog Docker Compose snippet + GreenMail unit-test pointer.

## Out of scope (filed as follow-ups, all listed in the issue)

- **Frontend admin page** at `/admin/email/server` — next PR
- Email templates page (`/admin/email/templates`) — separate issue
- Template engine choice — separate issue
- Async mail queue / retry strategy — separate issue
- Concrete trigger integrations (password reset, invitations) — separate issues

## Related

- #253 (parent issue)
- ADR-0016 (Application Settings Precedence)
- ADR-0022 (Encryption key sizing — same `TextEncryptor` bean reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)