### PR TITLE
feat(compose): bundle Mailpit as opt-in profile for local SMTP testing (#253)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,43 @@ services:
       retries: 30
       start_period: 30s
 
+  # Mailpit — local-only SMTP catch-all for developing the email pipeline (#253).
+  # Not started by default; enable via the `mailpit` profile:
+  #   docker compose --profile mailpit up -d mailpit
+  #
+  # Mailpit accepts every message sent to it without ever forwarding anywhere
+  # — exactly what you want for verifying the SMTP wiring without spamming
+  # real recipients. It is the actively-maintained successor to MailHog and
+  # ships native multi-arch images (linux/amd64 + linux/arm64), so Apple
+  # Silicon contributors do not pay the Rosetta tax MailHog forced.
+  #
+  # SMTP settings to enter in the Plugwerk Admin UI (Settings → Email → Server):
+  #   Host:        mailpit        (when Plugwerk runs in this same compose stack)
+  #                localhost      (when Plugwerk runs natively on the host)
+  #   Port:        1025
+  #   Encryption:  None (plain SMTP — Mailpit speaks no TLS by default)
+  #   Username:    (leave blank)
+  #   Password:    (leave blank)
+  #   From addr:   noreply@plugwerk.local
+  #
+  # Mailpit Web UI: http://localhost:8025 — every captured message renders here,
+  # plus a JSON API at the same origin for assertions in scripted tests.
+  mailpit:
+    image: axllent/mailpit:latest
+    profiles: ["mailpit"]
+    ports:
+      - "127.0.0.1:1025:1025"   # SMTP
+      - "127.0.0.1:8025:8025"   # Web UI + REST API
+    healthcheck:
+      # Mailpit exposes /readyz and /livez on the HTTP port; readyz is the
+      # canonical readiness probe and goes 200 once the SMTP listener is
+      # actually accepting connections (not just process-up).
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025/readyz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+
 volumes:
   postgres-data:
   plugwerk-artifacts:

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,40 +133,45 @@ See [ADR-0017](adrs/0017-dual-registry-publishing-strategy.md) for the full rati
 ## Local SMTP for Email Development (#253)
 
 Plugwerk's transactional email pipeline (`MailService` → `MailSenderProvider`
-→ `JavaMailSenderImpl`) needs a real SMTP server to talk to. Two options
-for local dev:
+→ `JavaMailSenderImpl`) needs a real SMTP server to talk to. Two options for
+local dev — pick one:
 
-### Option A — MailHog in Docker Compose (recommended)
+### Option A — Mailpit via the bundled compose profile (recommended)
 
-Add to your local `docker-compose.override.yml`:
+The repo's `docker-compose.yml` ships a `mailpit` profile that is **off by
+default** (same opt-in pattern as `keycloak` for OIDC dev). Bring it up:
 
-```yaml
-services:
-  mailhog:
-    image: mailhog/mailhog:latest
-    ports:
-      - "1025:1025"   # SMTP
-      - "8025:8025"   # Web UI
+```bash
+docker compose --profile mailpit up -d mailpit
 ```
 
-Then in the Plugwerk admin UI under **Settings → Email → Server**:
+This starts [Mailpit](https://github.com/axllent/mailpit) on:
+- `127.0.0.1:1025` — SMTP (catches everything, never forwards)
+- `127.0.0.1:8025` — Web UI + REST API
+
+Mailpit is the actively-maintained successor to MailHog and ships native
+multi-arch images (`linux/amd64` + `linux/arm64`), so Apple Silicon
+contributors do not pay the Rosetta tax.
+
+Then in the Plugwerk Admin UI under **Settings → Email → Server**:
 
 | Field | Value |
 |---|---|
-| `smtp.enabled` | `true` |
-| `smtp.host` | `localhost` (or `mailhog` if your Plugwerk container is on the same compose network) |
-| `smtp.port` | `1025` |
-| `smtp.encryption` | `none` |
-| `smtp.username` | (leave blank) |
-| `smtp.password` | (leave blank) |
-| `smtp.from_address` | `noreply@plugwerk.local` |
+| `SMTP enabled` | ✅ |
+| `Host` | `mailpit` (when Plugwerk runs in the same compose stack) **or** `localhost` (when Plugwerk runs natively on the host) |
+| `Port` | `1025` |
+| `Encryption` | `None (plain SMTP)` — Mailpit speaks no TLS by default |
+| `Username` / `Password` | (leave blank) |
+| `From address` | `noreply@plugwerk.local` |
 
-Open <http://localhost:8025> to inspect every message Plugwerk sent.
+Save, then click **Send Test Email** with any target — it lands in the
+Mailpit inbox at <http://localhost:8025>.
 
 ### Option B — GreenMail in unit tests
 
 `SmtpEmailIT` already wires GreenMail on a dynamic port. Use it as a
 template when adding test coverage for new mail-triggering flows. No
-Docker setup needed; runs as part of `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest`.
+Docker setup needed; runs as part of
+`./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest`.
 
 See [ADR-0031](adrs/0031-email-infrastructure.md) for the full design.


### PR DESCRIPTION
## Summary

Follow-up to PR #433 (the SMTP backend, already merged). Adds Mailpit to `docker-compose.yml` so contributors developing the email pipeline get a one-command catch-all SMTP server + web UI — same opt-in pattern as the existing `keycloak` profile for OIDC dev.

This was originally meant to ride along in PR #433 but the commits were pushed after the merge and got stranded on the deleted branch. Surfacing them as a small standalone PR.

## Why bake it in

Every contributor who touches the email pipeline needs the same SMTP setup with the same ports, the same SMTP-vs-WebUI mapping, and the same caveats (no TLS — `encryption=none`). Inlining it removes per-developer drift and keeps the canonical "what to plug into the Admin UI" snippet next to the service definition.

## Why Mailpit instead of MailHog

| | MailHog | Mailpit |
|---|---|---|
| Maintained | ❌ stagnant | ✅ active |
| Apple Silicon | amd64-only → Rosetta + warning | native arm64 build |
| Web UI port | 8025 | 8025 |
| SMTP port | 1025 | 1025 |
| REST API for assertions | ❌ | ✅ at `:8025/api/v1/...` |

Drop-in port-compatible, plus `axllent/mailpit` ships native multi-arch images so Apple Silicon contributors don't pay the Rosetta tax.

## Usage

```bash
docker compose --profile mailpit up -d mailpit
```

Settings in the Plugwerk Admin UI under **Settings → Email → Server**:

| Field | Value |
|---|---|
| `SMTP enabled` | ✅ |
| `Host` | `mailpit` (in-stack) **or** `localhost` (native Plugwerk) |
| `Port` | `1025` |
| `Encryption` | `None (plain SMTP)` — Mailpit speaks no TLS |
| `From address` | `noreply@plugwerk.local` |

Inbox at <http://localhost:8025>.

## Verification

Tested locally on Apple Silicon:
- `docker port`: `1025/tcp → 127.0.0.1:1025`, `8025/tcp → 127.0.0.1:8025`
- Image architecture: `arm64/linux` (native, not Rosetta)
- SMTP send via Python's `smtplib` followed by `GET /api/v1/messages` confirms the full pipeline lands the message in Mailpit's inbox

## What changed

- `docker-compose.yml`: new `mailpit` service under the `mailpit` profile, OFF by default
- `docs/development.md` "Local SMTP for Email Development" section: rewritten to reference the bundled profile, with `host=mailpit` (in-stack) vs `host=localhost` (native) guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)