### PR TITLE
fix(ci): skip CLA action on Issue comments (was crashing on every issue thread)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,6 +43,18 @@ jobs:
   cla-check:
     runs-on: ubuntu-latest
 
+    # GitHub fires `issue_comment` for both Issue AND PR comments — they
+    # share the same event payload. Without this filter, every comment on
+    # a regular Issue (e.g. design discussion threads) triggers the CLA
+    # action, which then tries to GraphQL-resolve a PR with the issue's
+    # number and crashes with "Could not resolve to a PullRequest". The
+    # `issue.pull_request` field is set only when the parent is a PR, so
+    # this is the canonical filter for "PR comment only". Uses `event_name`
+    # and a presence check — no untrusted user input is interpolated.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+
     # Match the action's documented permission requirements. Scoped to this
     # job only so future jobs in this file do not inherit write access.
     permissions:


### PR DESCRIPTION
## Summary

Closes the recurring CLA workflow failures visible at e.g. https://github.com/plugwerk/plugwerk/actions/runs/25262802938.

## Root cause

GitHub fires `issue_comment` for **both Issue AND PR comments** — they share the same event payload. The CLA workflow's trigger:

```yaml
on:
  issue_comment:
    types: [created]
  pull_request_target:
    types: [opened, closed, synchronize]
```

…fires on every Issue comment too. The `contributor-assistant/github-action` then assumes the comment's parent number is a PR and runs a GraphQL query for that PR, which 404s with:

```
GraphqlError: Could not resolve to a PullRequest with the number of 421.
```

Every design-discussion or planning comment we leave on an Issue (recently: the heads-up cross-references on #420 and #421 about the new template-infrastructure issues) trips this. Visible in the Actions tab as a recurring red CLA workflow.

## Fix

A job-level `if:` clause that only runs the job when:

- the trigger is `pull_request_target` (always a PR, no ambiguity), **OR**
- the trigger is `issue_comment` AND the comment's parent is a PR

The presence-of-`pull_request`-key trick is the canonical filter for this exact foot-gun — `github.event.issue.pull_request` is a non-null object only when the parent is a PR. It's the pattern in [GitHub's own docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment).

## Security envelope

Per ADR-0019, this workflow uses `pull_request_target` and is the highest-risk file in the repo. The `if:` expression only references:
- `github.event_name` (a constant set by GitHub)
- `github.event.issue.pull_request` (a presence check, not interpolated into any shell command)

No untrusted user input flows into a `run:` block. The `pull_request_target` + no-checkout-of-PR-code envelope from ADR-0019 is unchanged.

## Verification plan

After merge:
1. Comment on any Issue (e.g. #436) — the CLA workflow should NOT run (visible in the Actions tab).
2. Open or comment on any PR — the CLA workflow runs as before.
3. The recurring red runs in the Actions tab stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)