### PR TITLE
feat(server): email template engine + HTML body support (#436, #437)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ yasson = "3.0.4"
 bucket4j = "8.18.0"
 caffeine = "3.2.3"
 greenmail = "2.1.6"
+jmustache = "1.16"
 spotless = "8.4.0"
 cyclonedx = "3.2.4"
 
@@ -78,6 +79,9 @@ jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api",
 # Rate Limiting
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+
+# Email template rendering (#436) — logic-less Mustache, safe for admin-edited content
+jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
 
 # Logging
 # SemVer

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.boot.starter.mail)
+    implementation(libs.jmustache)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.spring.boot.starter.liquibase)
     implementation(libs.bucket4j.core)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/MailTemplateEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/MailTemplateEntity.kt
@@ -49,8 +49,13 @@ import java.util.UUID
  *   so a row can be missing without breaking sends — see
  *   [io.plugwerk.server.service.mail.MailTemplateService.render].
  * @property subject Mustache-templated subject line (`{{var}}` placeholders allowed).
- * @property body Mustache-templated plaintext body. v1 is plaintext only;
- *   HTML / multipart deferred to a follow-up.
+ * @property bodyPlain Mustache-templated plaintext body. Always required —
+ *   spam filters and accessibility-focused clients still benefit from a
+ *   real plaintext body even when an HTML alternative is present.
+ * @property bodyHtml Optional Mustache-templated HTML body. When set, the
+ *   mail layer assembles a `multipart/alternative` MIME message with both
+ *   parts; when null, the message is single-part `text/plain` with only
+ *   [bodyPlain].
  */
 @Entity
 @Table(
@@ -79,8 +84,11 @@ class MailTemplateEntity(
     @Column(name = "subject", nullable = false, columnDefinition = "text")
     var subject: String,
 
-    @Column(name = "body", nullable = false, columnDefinition = "text")
-    var body: String,
+    @Column(name = "body_plain", nullable = false, columnDefinition = "text")
+    var bodyPlain: String,
+
+    @Column(name = "body_html", nullable = true, columnDefinition = "text")
+    var bodyHtml: String? = null,
 
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/MailTemplateEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/MailTemplateEntity.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * One per-locale email template variant (#436).
+ *
+ * The [templateKey] is the dotted identifier registered in
+ * [io.plugwerk.server.service.mail.MailTemplate]; [locale] is a BCP-47
+ * language tag (e.g. `en`, `de`, `de-CH`). The pair is unique — every
+ * `(key, locale)` has at most one row.
+ *
+ * Storage is locale-explicit from day 1 even though only `en` is seeded
+ * today. The composite-unique design means future i18n work just inserts
+ * additional rows without any schema migration (no NULL-locale row to
+ * backfill, no constraint to retroactively install). See the issue
+ * thread on #436 for the i18n-readiness rationale.
+ *
+ * @property templateKey dotted registry key, e.g. `auth.password_reset`. Unique per [locale].
+ * @property locale BCP-47 language tag. The render-time fallback chain
+ *   walks `requested → language-base → general.default_language → enum-default`,
+ *   so a row can be missing without breaking sends — see
+ *   [io.plugwerk.server.service.mail.MailTemplateService.render].
+ * @property subject Mustache-templated subject line (`{{var}}` placeholders allowed).
+ * @property body Mustache-templated plaintext body. v1 is plaintext only;
+ *   HTML / multipart deferred to a follow-up.
+ */
+@Entity
+@Table(
+    name = "mail_template",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_mail_template_key_locale", columnNames = ["template_key", "locale"]),
+    ],
+    indexes = [
+        // Supports `findByTemplateKey(...)` which lists every locale variant
+        // of a given template — used by the future Templates admin page (#438).
+        Index(name = "idx_mail_template_key", columnList = "template_key"),
+    ],
+)
+class MailTemplateEntity(
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "id", updatable = false)
+    var id: UUID? = null,
+
+    @Column(name = "template_key", nullable = false, length = 128, updatable = false)
+    var templateKey: String,
+
+    @Column(name = "locale", nullable = false, length = 16, updatable = false)
+    var locale: String,
+
+    @Column(name = "subject", nullable = false, columnDefinition = "text")
+    var subject: String,
+
+    @Column(name = "body", nullable = false, columnDefinition = "text")
+    var body: String,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+
+    @Column(name = "updated_by", nullable = true, length = 255)
+    var updatedBy: String? = null,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/MailTemplateRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/MailTemplateRepository.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import io.plugwerk.server.domain.MailTemplateEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+import java.util.UUID
+
+interface MailTemplateRepository : JpaRepository<MailTemplateEntity, UUID> {
+    fun findByTemplateKey(templateKey: String): List<MailTemplateEntity>
+
+    fun findByTemplateKeyAndLocale(templateKey: String, locale: String): Optional<MailTemplateEntity>
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailService.kt
@@ -21,37 +21,61 @@ package io.plugwerk.server.service.mail
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.slf4j.LoggerFactory
 import org.springframework.mail.MailException
-import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.MailParseException
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets
 
 /**
- * Single entry point for sending transactional email (#253).
+ * Single entry point for sending transactional email (#253, #436).
  *
- * Today the interface is intentionally narrow: synchronous one-shot
- * `sendMail(to, subject, body)`. Async/queued delivery, retries, and template
- * rendering are deferred to follow-up issues — adding stub methods here would
- * widen the API surface without consumers.
+ * Two send paths share one outcome contract ([SendResult]):
+ *
+ *   - [sendMail] — caller already has a rendered subject + body. Required:
+ *     plaintext body. Optional: HTML body. Plaintext-only sends become a
+ *     single-part `text/plain` MIME message; sends with both bodies become
+ *     a `multipart/mixed` (Spring's default flexible container when
+ *     `multipart=true`) wrapping a `multipart/alternative` with both parts,
+ *     so HTML-capable clients render the HTML and plaintext-only clients
+ *     (spam filters, accessibility tools, terminal mail readers) still get
+ *     a real body to render.
+ *
+ *   - [sendMailFromTemplate] — caller provides a [MailTemplate] registry
+ *     entry plus the variable map and an optional locale. The
+ *     [MailTemplateService] runs the locale-fallback chain, renders both
+ *     bodies, and forwards to [sendMail].
  *
  * **No-op semantics when SMTP is not configured.** When `smtp.enabled=false`
- * or the configuration is incomplete (no host), [sendMail] returns
+ * or the configuration is incomplete (no host), both methods return
  * [SendResult.Disabled] without contacting any server. Callers that have a
  * legitimate reason to surface this to the user (e.g. the test-mail endpoint)
  * inspect the result; everything else can ignore it and rely on the warning
  * log line.
  */
 @Service
-class MailService(private val settings: ApplicationSettingsService, private val provider: MailSenderProvider) {
+class MailService(
+    private val settings: ApplicationSettingsService,
+    private val provider: MailSenderProvider,
+    private val templates: MailTemplateService,
+) {
     private val log = LoggerFactory.getLogger(MailService::class.java)
 
     /**
-     * Sends a plain-text email synchronously. Returns the outcome rather than
-     * throwing so call sites that do not care (most of them) can stay terse.
+     * Sends an email synchronously. Returns the outcome rather than throwing
+     * so call sites that do not care (most of them) can stay terse.
      *
      * @param to the recipient email address.
      * @param subject the message subject.
-     * @param body the message body (plain text).
+     * @param bodyPlain the plaintext body — always required, even when
+     *   [bodyHtml] is set. Spam filters and accessibility-focused clients
+     *   benefit from a real plaintext alternative.
+     * @param bodyHtml optional HTML body. When set, the message is sent as
+     *   `multipart/mixed` wrapping a `multipart/alternative` (Spring's
+     *   `MULTIPART_MODE_MIXED_RELATED` default) with both parts; when null,
+     *   the message is single-part `text/plain` (cheaper, smaller, no MIME
+     *   boundary).
      */
-    fun sendMail(to: String, subject: String, body: String): SendResult {
+    fun sendMail(to: String, subject: String, bodyPlain: String, bodyHtml: String? = null): SendResult {
         if (!settings.smtpEnabled()) {
             log.warn("Skipping send to {} — SMTP is disabled (smtp.enabled=false)", to)
             return SendResult.Disabled
@@ -66,17 +90,52 @@ class MailService(private val settings: ApplicationSettingsService, private val 
             return SendResult.Misconfigured("smtp.from_address is not configured")
         }
         val fromName = settings.smtpFromName()
-        val from = if (fromName.isBlank()) fromAddress else "$fromName <$fromAddress>"
-        val message = SimpleMailMessage().apply {
-            this.from = from
-            this.setTo(to)
-            this.subject = subject
-            this.text = body
+
+        val mime = sender.createMimeMessage()
+        try {
+            // multipart=true selects MULTIPART_MODE_MIXED_RELATED so the
+            // outer container can carry future attachments / inline images;
+            // cheap when plaintext-only (no MIME boundary added when only
+            // setText(plain) is called).
+            val helper = MimeMessageHelper(
+                mime,
+                /* multipart = */
+                bodyHtml != null,
+                StandardCharsets.UTF_8.name(),
+            )
+            if (fromName.isBlank()) {
+                helper.setFrom(fromAddress)
+            } else {
+                helper.setFrom(fromAddress, fromName)
+            }
+            helper.setTo(to)
+            helper.setSubject(subject)
+            if (bodyHtml != null) {
+                // Two-arg setText assembles `multipart/alternative` with the
+                // plaintext + HTML parts in the order RFC 2046 recommends
+                // (plaintext first, HTML second so HTML-capable clients
+                // pick the last alternative).
+                helper.setText(bodyPlain, bodyHtml)
+            } else {
+                helper.setText(bodyPlain, false)
+            }
+        } catch (ex: Exception) {
+            log.warn("Failed to assemble MIME message for {}: {}", to, ex.message)
+            return SendResult.Failed("Failed to assemble message: ${ex.message}")
         }
+
         return try {
-            sender.send(message)
-            log.info("Sent mail to {} subject='{}'", to, subject)
+            sender.send(mime)
+            log.info(
+                "Sent mail to {} subject='{}' html={}",
+                to,
+                subject,
+                bodyHtml != null,
+            )
             SendResult.Sent
+        } catch (ex: MailParseException) {
+            log.warn("Failed to parse mail to {}: {}", to, ex.message)
+            SendResult.Failed(ex.message ?: "Mail parse failed")
         } catch (ex: MailException) {
             // Distinguish at the call site between operator misconfig (auth /
             // relay refused) and the SMTP server being briefly unreachable;
@@ -86,7 +145,47 @@ class MailService(private val settings: ApplicationSettingsService, private val 
         }
     }
 
-    /** Outcome of a [sendMail] call. */
+    /**
+     * Renders a registered template and sends it (#436 / #437).
+     *
+     * Resolves the template through [MailTemplateService.render] (locale
+     * fallback chain, strict missing-var detection, dual-compiler HTML
+     * escaping), then forwards to [sendMail]. The HTML body part is
+     * automatically wired when the resolved variant has one.
+     *
+     * @param template registry entry to send.
+     * @param to recipient email address.
+     * @param vars Mustache variable map; every `{{key}}` referenced in the
+     *   resolved variant must be present.
+     * @param locale optional BCP-47 tag. `null` uses the application default.
+     */
+    fun sendMailFromTemplate(
+        template: MailTemplate,
+        to: String,
+        vars: Map<String, Any?>,
+        locale: String? = null,
+    ): SendResult {
+        val rendered = try {
+            templates.render(template, vars, locale)
+        } catch (ex: IllegalArgumentException) {
+            // Most likely a missing required placeholder. Surface as
+            // Misconfigured so the test endpoint and other callers can
+            // distinguish "your template is broken" from "the SMTP server
+            // is broken" — the former is a 400, the latter a 502.
+            log.warn(
+                "Cannot render template {} for {}: {}",
+                template.key,
+                to,
+                ex.message,
+            )
+            return SendResult.Misconfigured(
+                "Template '${template.key}' could not be rendered: ${ex.message}",
+            )
+        }
+        return sendMail(to, rendered.subject, rendered.bodyPlain, rendered.bodyHtml)
+    }
+
+    /** Outcome of a [sendMail] / [sendMailFromTemplate] call. */
     sealed interface SendResult {
         /** Mail successfully handed to the SMTP server. Delivery is then asynchronous and not tracked here. */
         data object Sent : SendResult

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
@@ -75,16 +75,26 @@ package io.plugwerk.server.service.mail
  *   the `template_key` column value and as the API path segment in #438.
  * @property defaultSubject hard-coded fallback subject. Mustache-templated
  *   like the DB-stored variant.
- * @property defaultBodyTemplate hard-coded fallback plaintext body.
+ * @property defaultBodyPlainTemplate hard-coded fallback plaintext body.
+ *   Always required — spam filters and accessibility-focused clients still
+ *   benefit from a real plaintext body even when an HTML alternative is
+ *   present.
+ * @property defaultBodyHtmlTemplate optional hard-coded fallback HTML body.
+ *   When non-null, the mail layer assembles a `multipart/alternative` MIME
+ *   message with both parts; when null, the message is single-part
+ *   `text/plain` with only [defaultBodyPlainTemplate]. Templates with no
+ *   meaningful HTML representation (e.g. internal admin alerts) leave this
+ *   `null`.
  * @property placeholders closed set of `{{var}}` names this template
- *   may reference. The service validates both the DB-stored variant and
- *   the enum default at write time — typos surface as 400, not as a
- *   runtime "undefined variable" exception during a live send.
+ *   may reference. The service validates the DB-stored subject + plain +
+ *   html variants at write time — typos surface as 400, not as a runtime
+ *   "undefined variable" exception during a live send.
  */
 enum class MailTemplate(
     val key: String,
     val defaultSubject: String,
-    val defaultBodyTemplate: String,
+    val defaultBodyPlainTemplate: String,
+    val defaultBodyHtmlTemplate: String?,
     val placeholders: Set<String>,
 ) {
     /**
@@ -94,7 +104,7 @@ enum class MailTemplate(
     AUTH_REGISTRATION_VERIFICATION(
         key = "auth.registration_verification",
         defaultSubject = "Verify your Plugwerk account",
-        defaultBodyTemplate = """
+        defaultBodyPlainTemplate = """
             Hello {{username}},
 
             Welcome to Plugwerk! Please verify your email address by visiting the
@@ -103,6 +113,21 @@ enum class MailTemplate(
             {{verificationLink}}
 
             If you did not create an account, you can safely ignore this message.
+        """.trimIndent(),
+        defaultBodyHtmlTemplate = """
+            <!DOCTYPE html>
+            <html>
+              <body>
+                <p>Hello {{username}},</p>
+                <p>Welcome to Plugwerk! Please verify your email address by clicking
+                  the link below — it is valid {{expiresAtHuman}}.</p>
+                <p><a href="{{verificationLink}}">Verify my email</a></p>
+                <p>If the button does not work, paste this URL into your browser:<br>
+                  <a href="{{verificationLink}}">{{verificationLink}}</a></p>
+                <p style="color: #666; font-size: 0.9em;">If you did not create an account,
+                  you can safely ignore this message.</p>
+              </body>
+            </html>
         """.trimIndent(),
         placeholders = setOf("username", "verificationLink", "expiresAtHuman"),
     ),
@@ -114,7 +139,7 @@ enum class MailTemplate(
     AUTH_PASSWORD_RESET(
         key = "auth.password_reset",
         defaultSubject = "Reset your Plugwerk password",
-        defaultBodyTemplate = """
+        defaultBodyPlainTemplate = """
             Hello {{username}},
 
             We received a request to reset the password for your Plugwerk account.
@@ -124,6 +149,23 @@ enum class MailTemplate(
 
             If you did not request a password reset, you can safely ignore this
             message — your existing password remains active.
+        """.trimIndent(),
+        defaultBodyHtmlTemplate = """
+            <!DOCTYPE html>
+            <html>
+              <body>
+                <p>Hello {{username}},</p>
+                <p>We received a request to reset the password for your Plugwerk
+                  account. Click the link below to set a new password — it is valid
+                  {{expiresAtHuman}}.</p>
+                <p><a href="{{resetLink}}">Reset my password</a></p>
+                <p>If the button does not work, paste this URL into your browser:<br>
+                  <a href="{{resetLink}}">{{resetLink}}</a></p>
+                <p style="color: #666; font-size: 0.9em;">If you did not request a
+                  password reset, you can safely ignore this message — your existing
+                  password remains active.</p>
+              </body>
+            </html>
         """.trimIndent(),
         placeholders = setOf("username", "resetLink", "expiresAtHuman"),
     ),

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+/**
+ * Central registry of every email template the application can send (#436).
+ *
+ * Each entry declares its dotted [key], the hard-coded [defaultSubject] /
+ * [defaultBodyTemplate] used as the last-resort fallback when no DB row
+ * exists, and the closed set of [placeholders] valid in this template.
+ *
+ * Adding a new template:
+ *   1. Add an entry here with sensible defaults + the placeholder set.
+ *   2. Add an INSERT for `(key, locale='en')` to the next mail-template
+ *      Liquibase migration so a fresh install ships with a usable subject
+ *      and body.
+ *   3. Send via `MailService.sendMailFromTemplate(MailTemplate.X, …)`
+ *      (issue #437 — adds that overload on top of `sendMail`).
+ *
+ * ## Engine choice — Mustache (jmustache)
+ *
+ * Templates are admin-editable at runtime through the Templates page in
+ * the Email admin area (#438). That makes the template-engine choice a
+ * security decision, not just an ergonomics one:
+ *
+ *   - **Mustache** is logic-less by design. The expression syntax is
+ *     `{{name}}`, `{{#section}}…{{/section}}`, and that's roughly it.
+ *     An admin who edits a template cannot accidentally open a remote-
+ *     code-execution surface — there is no expression language to abuse.
+ *
+ *   - **Thymeleaf**, **FreeMarker**, **Velocity** all have full
+ *     expression languages with method-call escape hatches. Safe to use
+ *     when templates are checked into source control; risky when they
+ *     are operator-edited at runtime.
+ *
+ * jmustache (`com.samskivert:jmustache`) is the lightweight, zero-
+ * Spring-dependency choice. It runs in strict mode in this project —
+ * a `{{var}}` reference whose key is missing from the render-time map
+ * raises an exception rather than silently substituting an empty
+ * string. An auth email going out without `{{verificationLink}}` is a
+ * bug, not a feature.
+ *
+ * ## i18n readiness (Issue #436 design discussion)
+ *
+ * The `mail_template` schema carries a `locale` column from day 1.
+ * v1 only seeds `en`, but the storage shape is the i18n-ready one so
+ * that adding language variants later is purely additive — no schema
+ * migration, no row backfill. The render-time fallback chain is:
+ *
+ *   1. requested locale exact match  (e.g. `de-CH`)
+ *   2. language-base                  (`de-CH` → `de`)
+ *   3. application default            (`general.default_language`)
+ *   4. enum-default below             ([defaultSubject] / [defaultBodyTemplate])
+ *
+ * Stage 4 guarantees a render never throws because no row was found —
+ * critical for auth flows (registration, password reset).
+ *
+ * @property key dotted identifier, unique across the registry; used as
+ *   the `template_key` column value and as the API path segment in #438.
+ * @property defaultSubject hard-coded fallback subject. Mustache-templated
+ *   like the DB-stored variant.
+ * @property defaultBodyTemplate hard-coded fallback plaintext body.
+ * @property placeholders closed set of `{{var}}` names this template
+ *   may reference. The service validates both the DB-stored variant and
+ *   the enum default at write time — typos surface as 400, not as a
+ *   runtime "undefined variable" exception during a live send.
+ */
+enum class MailTemplate(
+    val key: String,
+    val defaultSubject: String,
+    val defaultBodyTemplate: String,
+    val placeholders: Set<String>,
+) {
+    /**
+     * Verification email sent during opt-in self-registration (#420).
+     * The recipient clicks `verificationLink` to activate their account.
+     */
+    AUTH_REGISTRATION_VERIFICATION(
+        key = "auth.registration_verification",
+        defaultSubject = "Verify your Plugwerk account",
+        defaultBodyTemplate = """
+            Hello {{username}},
+
+            Welcome to Plugwerk! Please verify your email address by visiting the
+            link below — the link is valid {{expiresAtHuman}}.
+
+            {{verificationLink}}
+
+            If you did not create an account, you can safely ignore this message.
+        """.trimIndent(),
+        placeholders = setOf("username", "verificationLink", "expiresAtHuman"),
+    ),
+
+    /**
+     * Password-reset email triggered by the forgot-password flow (#421).
+     * The recipient clicks `resetLink` to set a new password.
+     */
+    AUTH_PASSWORD_RESET(
+        key = "auth.password_reset",
+        defaultSubject = "Reset your Plugwerk password",
+        defaultBodyTemplate = """
+            Hello {{username}},
+
+            We received a request to reset the password for your Plugwerk account.
+            Click the link below to set a new password — it is valid {{expiresAtHuman}}.
+
+            {{resetLink}}
+
+            If you did not request a password reset, you can safely ignore this
+            message — your existing password remains active.
+        """.trimIndent(),
+        placeholders = setOf("username", "resetLink", "expiresAtHuman"),
+    ),
+    ;
+
+    companion object {
+        private val BY_KEY: Map<String, MailTemplate> = entries.associateBy { it.key }
+
+        /** Looks up a [MailTemplate] by its dotted identifier; null on unknown key. */
+        fun byKey(key: String): MailTemplate? = BY_KEY[key]
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplateService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplateService.kt
@@ -45,19 +45,30 @@ import java.util.concurrent.atomic.AtomicReference
  *   1. **Requested locale exact** — `(key, requestedLocale)` row
  *   2. **Language base** — `de-CH` falls back to `de`
  *   3. **Application default** — `general.default_language` (today: `en`)
- *   4. **Enum default** — [MailTemplate.defaultSubject] / [defaultBodyTemplate],
- *      hard-coded fallback that always exists
+ *   4. **Enum default** — [MailTemplate.defaultSubject] / [defaultBodyPlainTemplate]
+ *      / [defaultBodyHtmlTemplate], hard-coded fallback that always exists.
  *
  * The locale parameter is optional; `null` means "use the application default
  * directly" and skips stages 1–2.
  *
- * ### Strict Mustache
+ * ### Strict Mustache + dual compilers
  *
- * The renderer is configured with `strictSections=true` so unknown section
- * tags fail loudly. Variable lookups are wrapped to throw on missing keys —
- * a `{{verificationLink}}` reference in the template plus a render-time map
- * without that key produces an [IllegalArgumentException], not a silently
- * empty placeholder. Auth emails without their action link are bugs.
+ * Two compilers are used because subject/plaintext-body must NOT be HTML-
+ * escaped (they're plaintext) but the HTML body should auto-escape `{{var}}`
+ * substitutions to prevent stored-XSS-style injection through user-controlled
+ * vars (e.g. a username with `<script>` in it):
+ *
+ *   - [mustachePlain]: `escapeHTML=false` — for subject + plaintext body
+ *   - [mustacheHtml]:  `escapeHTML=true`  — for HTML body
+ *
+ * In the HTML body, admins who genuinely want raw HTML in a substitution
+ * use Mustache's triple-mustache `{{{var}}}` to opt out per reference.
+ *
+ * Both compilers run with `strictSections=true`, and the variable map
+ * wrapper throws on missing keys — a `{{verificationLink}}` reference plus
+ * a render-time map without that key produces an [IllegalArgumentException],
+ * not a silently empty placeholder. Auth emails without their action link
+ * are bugs.
  */
 @Service
 class MailTemplateService(
@@ -71,13 +82,35 @@ class MailTemplateService(
     private val cache = AtomicReference<Map<CacheKey, StoredTemplate>>(emptyMap())
 
     /**
-     * Strict-mode Mustache compiler. `strictSections(true)` rejects unknown
-     * section tags; the missing-key behaviour is enforced at the render-time
-     * variable map level, see [render].
+     * Strict-mode compiler for subject + plaintext body.
+     *
+     * - `strictSections=true` rejects unknown section tags
+     * - missing variable references throw [MustacheException] by default
+     *   (`No method or field with name 'X'`) — strict-on-missing is the
+     *   built-in behaviour
+     * - `nullValue("")` makes intentional null values render as empty
+     *   strings (so callers can pass `mapOf("optional" to null)` without
+     *   blowing up)
+     * - `escapeHTML=false` because the consumer is a `text/plain` MIME
+     *   part, not a browser
      */
-    private val mustache: Mustache.Compiler = Mustache.compiler()
+    private val mustachePlain: Mustache.Compiler = Mustache.compiler()
         .strictSections(true)
-        .escapeHTML(false) // plaintext bodies — HTML escaping would mangle special chars in subjects/bodies
+        .nullValue("")
+        .escapeHTML(false)
+
+    /**
+     * Strict-mode compiler for HTML body. Same strict-on-missing semantics
+     * as [mustachePlain]; differs in that `escapeHTML=true` so admin-edited
+     * templates that interpolate user-controlled vars (e.g.
+     * `<p>Hello {{username}}</p>`) are not a stored-XSS surface. Templates
+     * that genuinely need raw HTML in a substitution opt out per reference
+     * with the triple-mustache form `{{{var}}}`.
+     */
+    private val mustacheHtml: Mustache.Compiler = Mustache.compiler()
+        .strictSections(true)
+        .nullValue("")
+        .escapeHTML(true)
 
     @PostConstruct
     fun initialize() {
@@ -90,7 +123,8 @@ class MailTemplateService(
         val snapshot = rows.associate { row ->
             CacheKey(row.templateKey, row.locale) to StoredTemplate(
                 subject = row.subject,
-                body = row.body,
+                bodyPlain = row.bodyPlain,
+                bodyHtml = row.bodyHtml,
                 updatedAt = row.updatedAt,
                 updatedBy = row.updatedBy,
             )
@@ -126,31 +160,41 @@ class MailTemplateService(
     /**
      * Inserts or updates a per-locale template variant.
      *
-     * Validates that every `{{var}}` referenced in [subject] or [body] is
-     * declared in [MailTemplate.placeholders] — typos surface as 400, not as
-     * a runtime exception during a live send.
+     * Validates that every `{{var}}` referenced in [subject], [bodyPlain],
+     * or [bodyHtml] is declared in [MailTemplate.placeholders] — typos
+     * surface as 400, not as a runtime exception during a live send.
+     *
+     * @param bodyHtml optional HTML alternative. `null` (the default) keeps
+     *   the variant plaintext-only; a non-null value enables `multipart/alternative`
+     *   delivery for sends that resolve to this variant.
      *
      * @throws IllegalArgumentException if a referenced variable is not in
-     *   the template's documented placeholders, or if [subject]/[body] are
-     *   blank, or if Mustache cannot parse the template at all.
+     *   the template's documented placeholders, if [subject]/[bodyPlain] are
+     *   blank, or if Mustache cannot parse a template at all.
      */
     @Transactional
     fun update(
         template: MailTemplate,
         locale: String,
         subject: String,
-        body: String,
+        bodyPlain: String,
+        bodyHtml: String? = null,
         updatedBy: String?,
     ): MailTemplateView {
         require(locale.isNotBlank()) { "locale must not be blank" }
         require(subject.isNotBlank()) { "subject must not be blank" }
-        require(body.isNotBlank()) { "body must not be blank" }
+        require(bodyPlain.isNotBlank()) { "bodyPlain must not be blank" }
 
-        // Compile both halves so a malformed template (`{{#unclosed`) fails
-        // here, not at send time. The errors-on-unknown-vars check is below.
-        val subjectErrors = validateReferences(template, "subject", subject)
-        val bodyErrors = validateReferences(template, "body", body)
-        val errors = subjectErrors + bodyErrors
+        val errors = buildList {
+            addAll(validateReferences(template, "subject", subject, mustachePlain))
+            addAll(validateReferences(template, "bodyPlain", bodyPlain, mustachePlain))
+            if (bodyHtml != null) {
+                require(bodyHtml.isNotBlank()) {
+                    "bodyHtml must not be blank when provided (use null for plaintext-only)"
+                }
+                addAll(validateReferences(template, "bodyHtml", bodyHtml, mustacheHtml))
+            }
+        }
         if (errors.isNotEmpty()) {
             throw IllegalArgumentException(
                 "Template '${template.key}' references undocumented variables: " +
@@ -161,13 +205,15 @@ class MailTemplateService(
         val existing = repository.findByTemplateKeyAndLocale(template.key, locale).orElse(null)
         val entity = existing?.apply {
             this.subject = subject
-            this.body = body
+            this.bodyPlain = bodyPlain
+            this.bodyHtml = bodyHtml
             this.updatedBy = updatedBy
         } ?: MailTemplateEntity(
             templateKey = template.key,
             locale = locale,
             subject = subject,
-            body = body,
+            bodyPlain = bodyPlain,
+            bodyHtml = bodyHtml,
             updatedBy = updatedBy,
         )
         repository.save(entity)
@@ -179,6 +225,12 @@ class MailTemplateService(
     /**
      * Renders a template against [vars] using the locale-fallback chain.
      *
+     * Returns both the plaintext and (optionally) the HTML body. The HTML
+     * body is `null` iff the resolved template variant has no `body_html`
+     * row column AND the enum default's [MailTemplate.defaultBodyHtmlTemplate]
+     * is also `null` — the mail layer then sends a single-part `text/plain`
+     * message instead of `multipart/alternative`.
+     *
      * @param template registry entry to render.
      * @param vars variable map; every key referenced in the chosen variant
      *   must be present, otherwise [IllegalArgumentException] is thrown.
@@ -186,16 +238,31 @@ class MailTemplateService(
      *   uses the application-default variant or the enum default.
      */
     fun render(template: MailTemplate, vars: Map<String, Any?>, locale: String? = null): RenderedMail {
+        // Per-row fallback: a DB row is treated as the complete definition.
+        // If a stored variant exists for this (key, locale) chain but its
+        // bodyHtml is null, the message is plaintext-only — we do NOT mix
+        // the operator's plaintext with the enum's HTML default. Operators
+        // who deliberately leave HTML blank get plaintext-only, as expected.
         val stored = resolveStored(template, locale)
         val source = if (stored != null) "DATABASE($locale)" else "ENUM_DEFAULT"
-        val subjectTpl = stored?.subject ?: template.defaultSubject
-        val bodyTpl = stored?.body ?: template.defaultBodyTemplate
+        val subjectTpl: String
+        val plainTpl: String
+        val htmlTpl: String?
+        if (stored != null) {
+            subjectTpl = stored.subject
+            plainTpl = stored.bodyPlain
+            htmlTpl = stored.bodyHtml
+        } else {
+            subjectTpl = template.defaultSubject
+            plainTpl = template.defaultBodyPlainTemplate
+            htmlTpl = template.defaultBodyHtmlTemplate
+        }
 
-        val safeVars = StrictVarMap(template.key, vars)
         val rendered = try {
             RenderedMail(
-                subject = mustache.compile(subjectTpl).execute(safeVars),
-                body = mustache.compile(bodyTpl).execute(safeVars),
+                subject = mustachePlain.compile(subjectTpl).execute(vars),
+                bodyPlain = mustachePlain.compile(plainTpl).execute(vars),
+                bodyHtml = htmlTpl?.let { mustacheHtml.compile(it).execute(vars) },
             )
         } catch (ex: MustacheException) {
             throw IllegalArgumentException(
@@ -203,7 +270,12 @@ class MailTemplateService(
                 ex,
             )
         }
-        log.debug("Rendered template {} (source={})", template.key, source)
+        log.debug(
+            "Rendered template {} (source={}, html={})",
+            template.key,
+            source,
+            rendered.bodyHtml != null,
+        )
         return rendered
     }
 
@@ -237,11 +309,21 @@ class MailTemplateService(
      * via a custom Collector, which would mean instantiating an alternate
      * compiler just for validation. Mustache's tag syntax is regular enough
      * that a straight scan is the smaller, more obvious tool.
+     *
+     * @param compiler the strict compiler that will eventually render this
+     *   field — passed in so the syntax-error pre-check uses the same
+     *   parser settings (escapeHTML on/off doesn't affect parsing, but
+     *   keeping the call symmetric removes a gotcha).
      */
-    private fun validateReferences(template: MailTemplate, fieldName: String, source: String): List<String> {
+    private fun validateReferences(
+        template: MailTemplate,
+        fieldName: String,
+        source: String,
+        compiler: Mustache.Compiler,
+    ): List<String> {
         // Compile once to surface syntax errors at write time, not at send time.
         try {
-            mustache.compile(source)
+            compiler.compile(source)
         } catch (ex: MustacheException) {
             throw IllegalArgumentException(
                 "Template '${template.key}' $fieldName has malformed Mustache syntax: ${ex.message}",
@@ -288,7 +370,8 @@ class MailTemplateService(
 
     private data class StoredTemplate(
         val subject: String,
-        val body: String,
+        val bodyPlain: String,
+        val bodyHtml: String?,
         val updatedAt: OffsetDateTime,
         val updatedBy: String?,
     ) {
@@ -296,40 +379,23 @@ class MailTemplateService(
             key = template,
             locale = locale,
             subject = subject,
-            body = body,
+            bodyPlain = bodyPlain,
+            bodyHtml = bodyHtml,
             source = source,
             updatedAt = updatedAt,
             updatedBy = updatedBy,
         )
     }
-
-    /**
-     * Strict variable map wrapper — Mustache lookups for keys not present
-     * in the underlying map throw, so a missing `{{var}}` is a render-time
-     * error rather than a silent empty string.
-     */
-    private class StrictVarMap(private val templateKey: String, private val backing: Map<String, Any?>) :
-        AbstractMap<String, Any?>() {
-        override val entries: Set<Map.Entry<String, Any?>> get() = backing.entries
-
-        override fun containsKey(key: String): Boolean = backing.containsKey(key)
-
-        override fun get(key: String): Any? {
-            if (!backing.containsKey(key)) {
-                throw IllegalArgumentException(
-                    "Template '$templateKey' references {{$key}} but it was not provided in the render vars",
-                )
-            }
-            // jmustache can't render `null`; treat null as "intentionally absent"
-            // and substitute an empty string. Callers wanting "show this is
-            // missing" should pass a placeholder string explicitly.
-            return backing[key] ?: ""
-        }
-    }
 }
 
-/** Outcome of [MailTemplateService.render] — the materialised subject + body. */
-data class RenderedMail(val subject: String, val body: String)
+/**
+ * Outcome of [MailTemplateService.render].
+ *
+ * @property bodyHtml `null` when the resolved template variant has no HTML
+ *   alternative — the mail layer then sends a single-part `text/plain`
+ *   message instead of `multipart/alternative`.
+ */
+data class RenderedMail(val subject: String, val bodyPlain: String, val bodyHtml: String?)
 
 /** Origin of the variant returned by `findAll` / `findByKey` / `findByKeyAndLocale`. */
 enum class TemplateSource {
@@ -338,9 +404,10 @@ enum class TemplateSource {
 
     /**
      * No row exists; the value would come from [MailTemplate.defaultSubject]
-     * / [MailTemplate.defaultBodyTemplate]. Currently surfaced only by the
-     * render path; the find-* methods return `null` / empty list for missing
-     * rows so the caller can decide whether to materialise the enum default.
+     * / [MailTemplate.defaultBodyPlainTemplate] / [MailTemplate.defaultBodyHtmlTemplate].
+     * Currently surfaced only by the render path; the find-* methods return
+     * `null` / empty list for missing rows so the caller can decide whether
+     * to materialise the enum default.
      */
     DEFAULT,
 }
@@ -349,12 +416,15 @@ enum class TemplateSource {
  * A point-in-time view of one template variant. Mirrors `SettingSnapshot`
  * in shape so the Templates admin page (#438) can build on the same patterns
  * the General settings page already uses.
+ *
+ * @property bodyHtml `null` when the variant is plaintext-only.
  */
 data class MailTemplateView(
     val key: MailTemplate,
     val locale: String,
     val subject: String,
-    val body: String,
+    val bodyPlain: String,
+    val bodyHtml: String?,
     val source: TemplateSource,
     val updatedAt: OffsetDateTime?,
     val updatedBy: String?,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplateService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplateService.kt
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import com.samskivert.mustache.Mustache
+import com.samskivert.mustache.MustacheException
+import io.plugwerk.server.domain.MailTemplateEntity
+import io.plugwerk.server.repository.MailTemplateRepository
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Single source of truth for email-template content (#436).
+ *
+ * Reads the `mail_template` table into an in-memory snapshot at startup and
+ * after every successful write. The snapshot is held in an [AtomicReference]
+ * so reads are lock-free and consistent with the most recent write — same
+ * pattern as [ApplicationSettingsService].
+ *
+ * ### Render-time fallback chain
+ *
+ * [render] walks four stages so a missing row can never crash an auth flow:
+ *
+ *   1. **Requested locale exact** — `(key, requestedLocale)` row
+ *   2. **Language base** — `de-CH` falls back to `de`
+ *   3. **Application default** — `general.default_language` (today: `en`)
+ *   4. **Enum default** — [MailTemplate.defaultSubject] / [defaultBodyTemplate],
+ *      hard-coded fallback that always exists
+ *
+ * The locale parameter is optional; `null` means "use the application default
+ * directly" and skips stages 1–2.
+ *
+ * ### Strict Mustache
+ *
+ * The renderer is configured with `strictSections=true` so unknown section
+ * tags fail loudly. Variable lookups are wrapped to throw on missing keys —
+ * a `{{verificationLink}}` reference in the template plus a render-time map
+ * without that key produces an [IllegalArgumentException], not a silently
+ * empty placeholder. Auth emails without their action link are bugs.
+ */
+@Service
+class MailTemplateService(
+    private val repository: MailTemplateRepository,
+    private val settings: ApplicationSettingsService,
+) {
+
+    private val log = LoggerFactory.getLogger(MailTemplateService::class.java)
+
+    /** Live snapshot of `(template_key, locale) -> stored row`. Updated atomically on writes. */
+    private val cache = AtomicReference<Map<CacheKey, StoredTemplate>>(emptyMap())
+
+    /**
+     * Strict-mode Mustache compiler. `strictSections(true)` rejects unknown
+     * section tags; the missing-key behaviour is enforced at the render-time
+     * variable map level, see [render].
+     */
+    private val mustache: Mustache.Compiler = Mustache.compiler()
+        .strictSections(true)
+        .escapeHTML(false) // plaintext bodies — HTML escaping would mangle special chars in subjects/bodies
+
+    @PostConstruct
+    fun initialize() {
+        refreshCache()
+        log.info("MailTemplateService initialized with {} stored template variant(s)", cache.get().size)
+    }
+
+    private fun refreshCache() {
+        val rows = repository.findAll()
+        val snapshot = rows.associate { row ->
+            CacheKey(row.templateKey, row.locale) to StoredTemplate(
+                subject = row.subject,
+                body = row.body,
+                updatedAt = row.updatedAt,
+                updatedBy = row.updatedBy,
+            )
+        }
+        cache.set(snapshot)
+    }
+
+    /** Returns every stored template variant across every locale. */
+    fun findAll(): List<MailTemplateView> {
+        val current = cache.get()
+        return current.entries.mapNotNull { (cacheKey, stored) ->
+            val template = MailTemplate.byKey(cacheKey.templateKey) ?: return@mapNotNull null
+            stored.toView(template, cacheKey.locale, source = TemplateSource.DATABASE)
+        }
+    }
+
+    /** Returns every locale variant of a single template. Empty list when no row exists. */
+    fun findByKey(template: MailTemplate): List<MailTemplateView> {
+        val current = cache.get()
+        return current.entries
+            .filter { it.key.templateKey == template.key }
+            .map { (cacheKey, stored) ->
+                stored.toView(template, cacheKey.locale, source = TemplateSource.DATABASE)
+            }
+    }
+
+    /** Returns the variant for a specific locale, or `null` if no row exists. */
+    fun findByKeyAndLocale(template: MailTemplate, locale: String): MailTemplateView? {
+        val stored = cache.get()[CacheKey(template.key, locale)] ?: return null
+        return stored.toView(template, locale, source = TemplateSource.DATABASE)
+    }
+
+    /**
+     * Inserts or updates a per-locale template variant.
+     *
+     * Validates that every `{{var}}` referenced in [subject] or [body] is
+     * declared in [MailTemplate.placeholders] — typos surface as 400, not as
+     * a runtime exception during a live send.
+     *
+     * @throws IllegalArgumentException if a referenced variable is not in
+     *   the template's documented placeholders, or if [subject]/[body] are
+     *   blank, or if Mustache cannot parse the template at all.
+     */
+    @Transactional
+    fun update(
+        template: MailTemplate,
+        locale: String,
+        subject: String,
+        body: String,
+        updatedBy: String?,
+    ): MailTemplateView {
+        require(locale.isNotBlank()) { "locale must not be blank" }
+        require(subject.isNotBlank()) { "subject must not be blank" }
+        require(body.isNotBlank()) { "body must not be blank" }
+
+        // Compile both halves so a malformed template (`{{#unclosed`) fails
+        // here, not at send time. The errors-on-unknown-vars check is below.
+        val subjectErrors = validateReferences(template, "subject", subject)
+        val bodyErrors = validateReferences(template, "body", body)
+        val errors = subjectErrors + bodyErrors
+        if (errors.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "Template '${template.key}' references undocumented variables: " +
+                    "${errors.joinToString("; ")}. Allowed: ${template.placeholders}",
+            )
+        }
+
+        val existing = repository.findByTemplateKeyAndLocale(template.key, locale).orElse(null)
+        val entity = existing?.apply {
+            this.subject = subject
+            this.body = body
+            this.updatedBy = updatedBy
+        } ?: MailTemplateEntity(
+            templateKey = template.key,
+            locale = locale,
+            subject = subject,
+            body = body,
+            updatedBy = updatedBy,
+        )
+        repository.save(entity)
+        refreshCache()
+        return findByKeyAndLocale(template, locale)
+            ?: error("Template ${template.key}/$locale missing immediately after save — refreshCache bug?")
+    }
+
+    /**
+     * Renders a template against [vars] using the locale-fallback chain.
+     *
+     * @param template registry entry to render.
+     * @param vars variable map; every key referenced in the chosen variant
+     *   must be present, otherwise [IllegalArgumentException] is thrown.
+     * @param locale optional BCP-47 tag. `null` skips per-locale lookup and
+     *   uses the application-default variant or the enum default.
+     */
+    fun render(template: MailTemplate, vars: Map<String, Any?>, locale: String? = null): RenderedMail {
+        val stored = resolveStored(template, locale)
+        val source = if (stored != null) "DATABASE($locale)" else "ENUM_DEFAULT"
+        val subjectTpl = stored?.subject ?: template.defaultSubject
+        val bodyTpl = stored?.body ?: template.defaultBodyTemplate
+
+        val safeVars = StrictVarMap(template.key, vars)
+        val rendered = try {
+            RenderedMail(
+                subject = mustache.compile(subjectTpl).execute(safeVars),
+                body = mustache.compile(bodyTpl).execute(safeVars),
+            )
+        } catch (ex: MustacheException) {
+            throw IllegalArgumentException(
+                "Mustache failed to render template '${template.key}' (source=$source): ${ex.message}",
+                ex,
+            )
+        }
+        log.debug("Rendered template {} (source={})", template.key, source)
+        return rendered
+    }
+
+    /**
+     * Walks the locale-fallback chain (stages 1–3 of the render contract).
+     * Returns `null` when no row matches — the caller falls back to the
+     * enum-default values (stage 4).
+     */
+    private fun resolveStored(template: MailTemplate, locale: String?): StoredTemplate? {
+        val current = cache.get()
+        if (locale != null) {
+            // Stage 1: exact match
+            current[CacheKey(template.key, locale)]?.let { return it }
+            // Stage 2: language-base — `de-CH` → `de`
+            val base = locale.substringBefore('-')
+            if (base != locale) {
+                current[CacheKey(template.key, base)]?.let { return it }
+            }
+        }
+        // Stage 3: application default language
+        val appDefault = settings.defaultLanguage()
+        return current[CacheKey(template.key, appDefault)]
+    }
+
+    /**
+     * Walks every `{{ref}}` Mustache tag in [source] and returns the names
+     * of any references that are NOT in the template's documented placeholders.
+     *
+     * Uses a small string scanner rather than hooking jmustache's
+     * VariableFetcher API — the fetcher protocol only fires per render call
+     * via a custom Collector, which would mean instantiating an alternate
+     * compiler just for validation. Mustache's tag syntax is regular enough
+     * that a straight scan is the smaller, more obvious tool.
+     */
+    private fun validateReferences(template: MailTemplate, fieldName: String, source: String): List<String> {
+        // Compile once to surface syntax errors at write time, not at send time.
+        try {
+            mustache.compile(source)
+        } catch (ex: MustacheException) {
+            throw IllegalArgumentException(
+                "Template '${template.key}' $fieldName has malformed Mustache syntax: ${ex.message}",
+                ex,
+            )
+        }
+
+        val unknown = sortedSetOf<String>()
+        var i = 0
+        while (i < source.length) {
+            val open = source.indexOf("{{", i)
+            if (open < 0) break
+            val close = source.indexOf("}}", open + 2)
+            if (close < 0) break
+            val inner = source.substring(open + 2, close).trim()
+            // Skip comments `{{!…}}`, partials `{{>…}}`, and section closers
+            // `{{/…}}` — none of them are variable references.
+            val first = inner.firstOrNull()
+            if (first == '!' || first == '>' || first == '/') {
+                i = close + 2
+                continue
+            }
+            // Strip optional section openers `#` / `^` and unescape marker `&`;
+            // triple-mustache `{{{name}}}` is naturally handled because the inner
+            // string then starts with `{name` after our `{{` skip — drop the leading `{`.
+            val payload = inner
+                .removePrefix("#").removePrefix("^").removePrefix("&").removePrefix("{")
+                .trim()
+            // A reference name is the leading run of identifier characters.
+            // Dots are allowed for nested context (e.g. `{{user.email}}`) but
+            // we only validate the top-level segment against placeholders.
+            val name = payload.takeWhile { it.isLetterOrDigit() || it == '_' }
+            if (name.isNotEmpty() && name !in template.placeholders) {
+                unknown.add(name)
+            }
+            i = close + 2
+            // Triple-mustache `{{{name}}}` ends with `}}}` — skip the trailing `}`.
+            if (i < source.length && source[i] == '}') i++
+        }
+        return unknown.map { "$fieldName references {{$it}}" }
+    }
+
+    private data class CacheKey(val templateKey: String, val locale: String)
+
+    private data class StoredTemplate(
+        val subject: String,
+        val body: String,
+        val updatedAt: OffsetDateTime,
+        val updatedBy: String?,
+    ) {
+        fun toView(template: MailTemplate, locale: String, source: TemplateSource): MailTemplateView = MailTemplateView(
+            key = template,
+            locale = locale,
+            subject = subject,
+            body = body,
+            source = source,
+            updatedAt = updatedAt,
+            updatedBy = updatedBy,
+        )
+    }
+
+    /**
+     * Strict variable map wrapper — Mustache lookups for keys not present
+     * in the underlying map throw, so a missing `{{var}}` is a render-time
+     * error rather than a silent empty string.
+     */
+    private class StrictVarMap(private val templateKey: String, private val backing: Map<String, Any?>) :
+        AbstractMap<String, Any?>() {
+        override val entries: Set<Map.Entry<String, Any?>> get() = backing.entries
+
+        override fun containsKey(key: String): Boolean = backing.containsKey(key)
+
+        override fun get(key: String): Any? {
+            if (!backing.containsKey(key)) {
+                throw IllegalArgumentException(
+                    "Template '$templateKey' references {{$key}} but it was not provided in the render vars",
+                )
+            }
+            // jmustache can't render `null`; treat null as "intentionally absent"
+            // and substitute an empty string. Callers wanting "show this is
+            // missing" should pass a placeholder string explicitly.
+            return backing[key] ?: ""
+        }
+    }
+}
+
+/** Outcome of [MailTemplateService.render] — the materialised subject + body. */
+data class RenderedMail(val subject: String, val body: String)
+
+/** Origin of the variant returned by `findAll` / `findByKey` / `findByKeyAndLocale`. */
+enum class TemplateSource {
+    /** A row exists in `mail_template` for this `(key, locale)`. */
+    DATABASE,
+
+    /**
+     * No row exists; the value would come from [MailTemplate.defaultSubject]
+     * / [MailTemplate.defaultBodyTemplate]. Currently surfaced only by the
+     * render path; the find-* methods return `null` / empty list for missing
+     * rows so the caller can decide whether to materialise the enum default.
+     */
+    DEFAULT,
+}
+
+/**
+ * A point-in-time view of one template variant. Mirrors `SettingSnapshot`
+ * in shape so the Templates admin page (#438) can build on the same patterns
+ * the General settings page already uses.
+ */
+data class MailTemplateView(
+    val key: MailTemplate,
+    val locale: String,
+    val subject: String,
+    val body: String,
+    val source: TemplateSource,
+    val updatedAt: OffsetDateTime?,
+    val updatedBy: String?,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -49,3 +49,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0024_revoked_token_user_fk.yaml
   - include:
       file: db/changelog/migrations/0025_add_smtp_settings.yaml
+  - include:
+      file: db/changelog/migrations/0026_mail_template.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0026_mail_template.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0026_mail_template.yaml
@@ -4,11 +4,20 @@
 # touching this schema. See MailTemplate.kt KDoc for the full design
 # rationale.
 #
-# Seed values mirror the hard-coded MailTemplate.defaultSubject /
-# defaultBodyTemplate strings so a fresh install ships with usable
+# Two body columns:
+#
+#   body_plain (NOT NULL) — plaintext body, always required. Spam filters
+#     and accessibility-focused clients still benefit from a real plaintext
+#     body even when an HTML alternative is present.
+#   body_html  (NULL)     — optional HTML alternative. When set, the mail
+#     layer assembles a multipart/alternative MIME message with both parts;
+#     when null, the message is single-part text/plain.
+#
+# Seed values mirror the hard-coded MailTemplate.defaultBodyPlainTemplate /
+# defaultBodyHtmlTemplate strings so a fresh install ships with usable
 # emails out of the box. Operators can override per template via the
-# Templates admin page (#438) — overrides survive every deployment
-# because Liquibase only INSERTs once per checksum.
+# Templates admin page (#438) — overrides survive every deployment because
+# Liquibase only INSERTs once per checksum.
 databaseChangeLog:
   - changeSet:
       id: 0026-create-mail-template
@@ -39,10 +48,15 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  name: body
+                  name: body_plain
                   type: text
                   constraints:
                     nullable: false
+              - column:
+                  name: body_html
+                  type: text
+                  constraints:
+                    nullable: true
               - column:
                   name: updated_at
                   type: timestamptz
@@ -86,7 +100,7 @@ databaseChangeLog:
                   name: subject
                   value: "Verify your Plugwerk account"
               - column:
-                  name: body
+                  name: body_plain
                   value: |
                     Hello {{username}},
 
@@ -96,6 +110,22 @@ databaseChangeLog:
                     {{verificationLink}}
 
                     If you did not create an account, you can safely ignore this message.
+              - column:
+                  name: body_html
+                  value: |
+                    <!DOCTYPE html>
+                    <html>
+                      <body>
+                        <p>Hello {{username}},</p>
+                        <p>Welcome to Plugwerk! Please verify your email address by clicking
+                          the link below — it is valid {{expiresAtHuman}}.</p>
+                        <p><a href="{{verificationLink}}">Verify my email</a></p>
+                        <p>If the button does not work, paste this URL into your browser:<br>
+                          <a href="{{verificationLink}}">{{verificationLink}}</a></p>
+                        <p style="color: #666; font-size: 0.9em;">If you did not create an account,
+                          you can safely ignore this message.</p>
+                      </body>
+                    </html>
       rollback:
         - delete:
             tableName: mail_template
@@ -121,7 +151,7 @@ databaseChangeLog:
                   name: subject
                   value: "Reset your Plugwerk password"
               - column:
-                  name: body
+                  name: body_plain
                   value: |
                     Hello {{username}},
 
@@ -132,6 +162,24 @@ databaseChangeLog:
 
                     If you did not request a password reset, you can safely ignore this
                     message — your existing password remains active.
+              - column:
+                  name: body_html
+                  value: |
+                    <!DOCTYPE html>
+                    <html>
+                      <body>
+                        <p>Hello {{username}},</p>
+                        <p>We received a request to reset the password for your Plugwerk
+                          account. Click the link below to set a new password — it is valid
+                          {{expiresAtHuman}}.</p>
+                        <p><a href="{{resetLink}}">Reset my password</a></p>
+                        <p>If the button does not work, paste this URL into your browser:<br>
+                          <a href="{{resetLink}}">{{resetLink}}</a></p>
+                        <p style="color: #666; font-size: 0.9em;">If you did not request a
+                          password reset, you can safely ignore this message — your existing
+                          password remains active.</p>
+                      </body>
+                    </html>
       rollback:
         - delete:
             tableName: mail_template

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0026_mail_template.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0026_mail_template.yaml
@@ -1,0 +1,138 @@
+# Email template storage (#436). Per-locale variants from day 1 even
+# though only `en` is seeded today — composite-unique on (template_key,
+# locale) means future i18n work just inserts additional rows without
+# touching this schema. See MailTemplate.kt KDoc for the full design
+# rationale.
+#
+# Seed values mirror the hard-coded MailTemplate.defaultSubject /
+# defaultBodyTemplate strings so a fresh install ships with usable
+# emails out of the box. Operators can override per template via the
+# Templates admin page (#438) — overrides survive every deployment
+# because Liquibase only INSERTs once per checksum.
+databaseChangeLog:
+  - changeSet:
+      id: 0026-create-mail-template
+      author: plugwerk
+      changes:
+        - createTable:
+            tableName: mail_template
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: template_key
+                  type: varchar(128)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locale
+                  type: varchar(16)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: subject
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: body
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+                  defaultValueComputed: now()
+              - column:
+                  name: updated_by
+                  type: varchar(255)
+        - addUniqueConstraint:
+            tableName: mail_template
+            constraintName: uq_mail_template_key_locale
+            columnNames: template_key, locale
+        - createIndex:
+            tableName: mail_template
+            indexName: idx_mail_template_key
+            columns:
+              - column:
+                  name: template_key
+      rollback:
+        - dropTable:
+            tableName: mail_template
+
+  - changeSet:
+      id: 0026-seed-auth-registration-verification-en
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: template_key
+                  value: auth.registration_verification
+              - column:
+                  name: locale
+                  value: en
+              - column:
+                  name: subject
+                  value: "Verify your Plugwerk account"
+              - column:
+                  name: body
+                  value: |
+                    Hello {{username}},
+
+                    Welcome to Plugwerk! Please verify your email address by visiting the
+                    link below — the link is valid {{expiresAtHuman}}.
+
+                    {{verificationLink}}
+
+                    If you did not create an account, you can safely ignore this message.
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.registration_verification' AND locale = 'en'"
+
+  - changeSet:
+      id: 0026-seed-auth-password-reset-en
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: template_key
+                  value: auth.password_reset
+              - column:
+                  name: locale
+                  value: en
+              - column:
+                  name: subject
+                  value: "Reset your Plugwerk password"
+              - column:
+                  name: body
+                  value: |
+                    Hello {{username}},
+
+                    We received a request to reset the password for your Plugwerk account.
+                    Click the link below to set a new password — it is valid {{expiresAtHuman}}.
+
+                    {{resetLink}}
+
+                    If you did not request a password reset, you can safely ignore this
+                    message — your existing password remains active.
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.password_reset' AND locale = 'en'"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/IdentityHubSplitMigrationIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/IdentityHubSplitMigrationIT.kt
@@ -93,8 +93,14 @@ class IdentityHubSplitMigrationIT {
      *
      * Liquibase has no first-class "run up to but not including this changeset"
      * primitive, so we use the rollback-on-update-to-target pattern: apply
-     * EVERYTHING, then rollback all changesets defined in 0017's file. The
-     * resulting state is identical to "applied through 0016".
+     * EVERYTHING, then roll back every changeset from [stopBeforeFile] onward
+     * (the target file plus all later migrations). The resulting state is
+     * identical to "applied through the file just before [stopBeforeFile]".
+     *
+     * Note: `liquibase.rollback(N, "")` rolls back the last N applied
+     * changesets *globally*, not the last N from the target file. So we
+     * compute N as `(total changesets) - (index of first target changeset)`,
+     * which stays correct as new migrations are added after the target.
      */
     private fun runLiquibaseUpTo(conn: Connection, stopBeforeFile: String) {
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
@@ -104,15 +110,11 @@ class IdentityHubSplitMigrationIT {
             database,
         ).use { liquibase ->
             liquibase.update(Contexts(), LabelExpression())
-            // Roll back everything declared in the file we want to "skip".
-            // Counting the changesets and using rollbackCount keeps the test
-            // resilient if more 0017 changesets are added later — count is
-            // computed from the parsed changelog.
-            val changesetCount = liquibase.databaseChangeLog
-                .changeSets
-                .count { it.filePath.endsWith(stopBeforeFile) }
-            check(changesetCount > 0) { "no changesets found in $stopBeforeFile" }
-            liquibase.rollback(changesetCount, "")
+            val changesets = liquibase.databaseChangeLog.changeSets
+            val firstIdx = changesets.indexOfFirst { it.filePath.endsWith(stopBeforeFile) }
+            check(firstIdx >= 0) { "no changesets found in $stopBeforeFile" }
+            val rollbackCount = changesets.size - firstIdx
+            liquibase.rollback(rollbackCount, "")
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/RevokedTokenUserFkMigrationIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/RevokedTokenUserFkMigrationIT.kt
@@ -88,6 +88,17 @@ class RevokedTokenUserFkMigrationIT {
         postgres.stop()
     }
 
+    /**
+     * Apply EVERYTHING then roll back every changeset from [stopBeforeFile]
+     * onward (the target file plus all later migrations).
+     *
+     * Note: `liquibase.rollback(N, "")` rolls back the last N changesets
+     * *globally*, not the last N from the target file. So we compute N as
+     * `(total changesets) - (index of first target changeset)` to stay
+     * correct as new migrations are added after the target — without this,
+     * adding 0025/0026 caused this test to roll back into 0026 and leave
+     * 0024 partially applied.
+     */
     private fun runLiquibaseUpTo(conn: Connection, stopBeforeFile: String) {
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
         Liquibase(
@@ -96,11 +107,11 @@ class RevokedTokenUserFkMigrationIT {
             database,
         ).use { liquibase ->
             liquibase.update(Contexts(), LabelExpression())
-            val changesetCount = liquibase.databaseChangeLog
-                .changeSets
-                .count { it.filePath.endsWith(stopBeforeFile) }
-            check(changesetCount > 0) { "no changesets found in $stopBeforeFile" }
-            liquibase.rollback(changesetCount, "")
+            val changesets = liquibase.databaseChangeLog.changeSets
+            val firstIdx = changesets.indexOfFirst { it.filePath.endsWith(stopBeforeFile) }
+            check(firstIdx >= 0) { "no changesets found in $stopBeforeFile" }
+            val rollbackCount = changesets.size - firstIdx
+            liquibase.rollback(rollbackCount, "")
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/UserSettingUserIdFkMigrationIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/UserSettingUserIdFkMigrationIT.kt
@@ -78,19 +78,25 @@ class UserSettingUserIdFkMigrationIT {
     }
 
     /**
-     * Apply EVERYTHING then roll back the changesets in [stopBeforeFile] —
-     * mirrors the pattern from `IdentityHubSplitMigrationIT` and is safe
-     * because 0019 only touches `user_setting`, which `runLiquibaseUpdate`
+     * Apply EVERYTHING then roll back every changeset from [stopBeforeFile]
+     * onward — mirrors the pattern from `IdentityHubSplitMigrationIT` and is
+     * safe because 0019 only touches `user_setting`, which `runLiquibaseUpdate`
      * later re-applies cleanly.
+     *
+     * Note: `liquibase.rollback(N, "")` rolls back the last N changesets
+     * *globally*, not the last N from the target file. So we compute N as
+     * `(total changesets) - (index of first target changeset)` to stay
+     * correct as new migrations are added after the target.
      */
     private fun runLiquibaseUpTo(conn: Connection, stopBeforeFile: String) {
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
         Liquibase("db/changelog/db.changelog-master.yaml", ClassLoaderResourceAccessor(), database).use { liquibase ->
             liquibase.update(Contexts(), LabelExpression())
-            val changesetCount = liquibase.databaseChangeLog.changeSets
-                .count { it.filePath.endsWith(stopBeforeFile) }
-            check(changesetCount > 0) { "no changesets found in $stopBeforeFile" }
-            liquibase.rollback(changesetCount, "")
+            val changesets = liquibase.databaseChangeLog.changeSets
+            val firstIdx = changesets.indexOfFirst { it.filePath.endsWith(stopBeforeFile) }
+            check(firstIdx >= 0) { "no changesets found in $stopBeforeFile" }
+            val rollbackCount = changesets.size - firstIdx
+            liquibase.rollback(rollbackCount, "")
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailServiceTest.kt
@@ -19,12 +19,15 @@
 package io.plugwerk.server.service.mail
 
 import io.plugwerk.server.service.settings.ApplicationSettingsService
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
@@ -32,14 +35,15 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.mail.MailSendException
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import java.util.Properties
 
 @ExtendWith(MockitoExtension::class)
 class MailServiceTest {
 
     private lateinit var settings: ApplicationSettingsService
     private lateinit var provider: MailSenderProvider
+    private lateinit var templates: MailTemplateService
     private lateinit var sender: JavaMailSender
     private lateinit var service: MailService
 
@@ -47,8 +51,25 @@ class MailServiceTest {
     fun setUp() {
         settings = mock()
         provider = mock()
+        templates = mock()
         sender = mock()
-        service = MailService(settings, provider)
+        // The service uses sender.createMimeMessage() to assemble its message,
+        // then sender.send(message). Wire createMimeMessage() to return a real
+        // MimeMessage backed by a default Session — both calls become observable
+        // through the captor below. lenient() because the early-return tests
+        // (Disabled / Misconfigured) never reach createMimeMessage and Mockito
+        // strict mode would otherwise flag the unused stub.
+        org.mockito.Mockito.lenient().`when`(sender.createMimeMessage()).thenAnswer {
+            MimeMessage(Session.getDefaultInstance(Properties()))
+        }
+        service = MailService(settings, provider, templates)
+    }
+
+    private fun configureSmtpEnabled() {
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(provider.current()).thenReturn(sender)
+        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
+        whenever(settings.smtpFromName()).thenReturn("Plugwerk")
     }
 
     @Test
@@ -59,7 +80,7 @@ class MailServiceTest {
 
         assertThat(result).isEqualTo(MailService.SendResult.Disabled)
         verify(provider, never()).current()
-        verify(sender, never()).send(any<SimpleMailMessage>())
+        verify(sender, never()).send(any<MimeMessage>())
     }
 
     @Test
@@ -81,36 +102,65 @@ class MailServiceTest {
         val result = service.sendMail("alice@example.test", "Hi", "Body")
 
         assertThat(result).isInstanceOf(MailService.SendResult.Misconfigured::class.java)
-        // From-address is the only required field at send time once SMTP is
-        // enabled — the absence of any other smtp.* field surfaces as
-        // Disabled/Failed depending on which layer caught it.
-        verify(sender, never()).send(any<SimpleMailMessage>())
+        verify(sender, never()).send(any<MimeMessage>())
     }
 
     @Test
-    fun `sendMail returns Sent and hands a correctly built SimpleMailMessage to the JavaMailSender`() {
-        whenever(settings.smtpEnabled()).thenReturn(true)
-        whenever(provider.current()).thenReturn(sender)
-        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
-        whenever(settings.smtpFromName()).thenReturn("Plugwerk")
+    fun `sendMail with plaintext body only sends a single-part text-plain message`() {
+        configureSmtpEnabled()
 
         val result = service.sendMail("alice@example.test", "Welcome", "Hello Alice")
 
         assertThat(result).isEqualTo(MailService.SendResult.Sent)
-        val captor = argumentCaptor<SimpleMailMessage>()
+        val captor = argumentCaptor<MimeMessage>()
         verify(sender).send(captor.capture())
         val sent = captor.firstValue
-        assertThat(sent.from).isEqualTo("Plugwerk <noreply@plugwerk.test>")
-        assertThat(sent.to).containsExactly("alice@example.test")
         assertThat(sent.subject).isEqualTo("Welcome")
-        assertThat(sent.text).isEqualTo("Hello Alice")
+        assertThat(sent.from.first().toString()).contains("noreply@plugwerk.test")
+        assertThat(sent.allRecipients.first().toString()).isEqualTo("alice@example.test")
+        // Plaintext-only branch: content-type is text/plain (not multipart)
+        assertThat(sent.contentType).startsWith("text/plain")
+        assertThat(sent.content).isEqualTo("Hello Alice")
+    }
+
+    @Test
+    fun `sendMail with bodyHtml sends a multipart-alternative MIME message containing both parts`() {
+        configureSmtpEnabled()
+
+        val result = service.sendMail(
+            to = "alice@example.test",
+            subject = "Welcome",
+            bodyPlain = "Hello Alice (plain)",
+            bodyHtml = "<p>Hello <b>Alice</b> (html)</p>",
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        val captor = argumentCaptor<MimeMessage>()
+        verify(sender).send(captor.capture())
+        val sent = captor.firstValue
+        // saveChanges() materialises the MIME headers from the in-memory
+        // Multipart — without this, getContentType() reports the placeholder
+        // "text/plain" set during the empty-message bootstrap. JavaMailSenderImpl
+        // does this internally before transport; the mock does not, so we
+        // do it here to match production semantics.
+        sent.saveChanges()
+        // Spring's MimeMessageHelper(multipart=true) defaults to MIXED_RELATED,
+        // so the outer content-type is `multipart/mixed`. The plain+html
+        // `multipart/alternative` part is nested inside — assert against the
+        // raw MIME stream rather than the top-level header.
+        assertThat(sent.contentType).startsWith("multipart/")
+        val baos = java.io.ByteArrayOutputStream()
+        sent.writeTo(baos)
+        val mimeText = baos.toString()
+        assertThat(mimeText).contains("multipart/alternative")
+        assertThat(mimeText).contains("Hello Alice (plain)")
+        assertThat(mimeText).contains("<p>Hello <b>Alice</b> (html)</p>")
+        assertThat(mimeText).contains("text/plain")
+        assertThat(mimeText).contains("text/html")
     }
 
     @Test
     fun `sendMail uses bare from_address when from_name is blank`() {
-        // Edge case: operator only configured the address. The display-name
-        // RFC-5322 form `Name <addr>` would render as `<addr>` with the bare
-        // angle brackets — ugly. Fall back to just the address.
         whenever(settings.smtpEnabled()).thenReturn(true)
         whenever(provider.current()).thenReturn(sender)
         whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
@@ -118,19 +168,17 @@ class MailServiceTest {
 
         service.sendMail("alice@example.test", "Hi", "Body")
 
-        val captor = argumentCaptor<SimpleMailMessage>()
+        val captor = argumentCaptor<MimeMessage>()
         verify(sender).send(captor.capture())
-        assertThat(captor.firstValue.from).isEqualTo("noreply@plugwerk.test")
+        // No display name → bare address only, no `Name <addr>` form.
+        assertThat(captor.firstValue.from.first().toString()).isEqualTo("noreply@plugwerk.test")
     }
 
     @Test
     fun `sendMail returns Failed when the JavaMailSender throws a MailException`() {
-        whenever(settings.smtpEnabled()).thenReturn(true)
-        whenever(provider.current()).thenReturn(sender)
-        whenever(settings.smtpFromAddress()).thenReturn("noreply@plugwerk.test")
-        whenever(settings.smtpFromName()).thenReturn("Plugwerk")
+        configureSmtpEnabled()
         doThrow(MailSendException("auth failed: invalid credentials"))
-            .whenever(sender).send(any<SimpleMailMessage>())
+            .whenever(sender).send(any<MimeMessage>())
 
         val result = service.sendMail("alice@example.test", "Hi", "Body")
 
@@ -138,4 +186,67 @@ class MailServiceTest {
         assertThat((result as MailService.SendResult.Failed).reason)
             .contains("auth failed")
     }
+
+    @Test
+    fun `sendMailFromTemplate forwards rendered subject + bodies to sendMail`() {
+        configureSmtpEnabled()
+        whenever(
+            templates.render(
+                eq(MailTemplate.AUTH_PASSWORD_RESET),
+                any(),
+                anyOrNull<String>(),
+            ),
+        ).thenReturn(
+            RenderedMail(
+                subject = "Rendered subject",
+                bodyPlain = "Plain body",
+                bodyHtml = "<p>HTML body</p>",
+            ),
+        )
+
+        val result = service.sendMailFromTemplate(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            to = "alice@example.test",
+            vars = mapOf("username" to "alice"),
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        val captor = argumentCaptor<MimeMessage>()
+        verify(sender).send(captor.capture())
+        val sent = captor.firstValue
+        sent.saveChanges()
+        assertThat(sent.subject).isEqualTo("Rendered subject")
+        // Both bodies present → multipart/alternative.
+        assertThat(sent.contentType).startsWith("multipart/")
+    }
+
+    @Test
+    fun `sendMailFromTemplate returns Misconfigured when render throws missing-var`() {
+        // Deliberately do NOT call configureSmtpEnabled — render fails before
+        // the SMTP path is touched, so the SMTP enabled-check should also not
+        // matter. Mirrors how a typo in the var map would surface in
+        // production.
+        whenever(
+            templates.render(
+                eq(MailTemplate.AUTH_PASSWORD_RESET),
+                any(),
+                anyOrNull<String>(),
+            ),
+        ).thenThrow(IllegalArgumentException("Template references {{resetLink}} but it was not provided"))
+
+        val result = service.sendMailFromTemplate(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            to = "alice@example.test",
+            vars = mapOf("username" to "alice"),
+        )
+
+        assertThat(result).isInstanceOf(MailService.SendResult.Misconfigured::class.java)
+        assertThat((result as MailService.SendResult.Misconfigured).reason)
+            .contains("auth.password_reset")
+            .contains("resetLink")
+        verify(sender, never()).send(any<MimeMessage>())
+    }
 }
+
+// Tiny eq-helper alias to keep the test bodies above readable.
+private inline fun <reified T : Any> eq(value: T): T = org.mockito.kotlin.eq(value)

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailTemplateServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailTemplateServiceTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.mail
+
+import io.plugwerk.server.repository.MailTemplateRepository
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * H2-backed integration test for [MailTemplateService] (#436).
+ *
+ * @SpringBootTest gives us the real Liquibase migration (so the seeded
+ * `(auth.*, en)` rows are present), the wired-up TextEncryptor, and the
+ * settings cache that `render` reads its default-language fallback from.
+ *
+ * The test class deletes every row in the cache between tests so each case
+ * controls its own seed state — without that, the migration's `en` rows
+ * leak across tests and silently mask "no row exists" assertions.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:mail-template-svc;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+class MailTemplateServiceTest {
+
+    @Autowired private lateinit var service: MailTemplateService
+
+    @Autowired private lateinit var repository: MailTemplateRepository
+
+    @Autowired private lateinit var settings: ApplicationSettingsService
+
+    @BeforeEach
+    fun reset() {
+        repository.deleteAll()
+        // Force the service cache to reflect the empty state — without this,
+        // the @PostConstruct snapshot from a previous test leaks in.
+        service.initialize()
+    }
+
+    @Test
+    fun `render falls through enum default when no row exists for any locale`() {
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf("username" to "alice", "resetLink" to "https://x", "expiresAtHuman" to "in 30 minutes"),
+        )
+
+        assertThat(rendered.subject).isEqualTo("Reset your Plugwerk password")
+        assertThat(rendered.body).contains("Hello alice,")
+        assertThat(rendered.body).contains("https://x")
+        assertThat(rendered.body).contains("in 30 minutes")
+    }
+
+    @Test
+    fun `render uses exact-locale row when present (stage 1 of fallback chain)`() {
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "de",
+            subject = "Passwort zurücksetzen",
+            body = "Hallo {{username}}, klicke {{resetLink}} ({{expiresAtHuman}})",
+            updatedBy = "test",
+        )
+
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf("username" to "alice", "resetLink" to "https://x", "expiresAtHuman" to "in 30 Minuten"),
+            locale = "de",
+        )
+
+        assertThat(rendered.subject).isEqualTo("Passwort zurücksetzen")
+        assertThat(rendered.body).isEqualTo("Hallo alice, klicke https://x (in 30 Minuten)")
+    }
+
+    @Test
+    fun `render falls back to language-base (stage 2) — de-CH falls through to de`() {
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "de",
+            subject = "Passwort",
+            body = "Hi {{username}}",
+            updatedBy = "test",
+        )
+
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf("username" to "fritz", "resetLink" to "x", "expiresAtHuman" to "y"),
+            locale = "de-CH",
+        )
+
+        assertThat(rendered.subject).isEqualTo("Passwort")
+        assertThat(rendered.body).isEqualTo("Hi fritz")
+    }
+
+    @Test
+    fun `render falls back to application default language (stage 3) when requested locale not present`() {
+        // Seed an `en` row only. Request `de` → stage 1 misses (no de),
+        // stage 2 misses (de has no language-base), stage 3 hits the en row
+        // because general.default_language=en in this test profile.
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "en",
+            subject = "Reset",
+            body = "Hi {{username}}",
+            updatedBy = "test",
+        )
+
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf("username" to "alice", "resetLink" to "x", "expiresAtHuman" to "y"),
+            locale = "de",
+        )
+
+        assertThat(rendered.subject).isEqualTo("Reset")
+        assertThat(rendered.body).isEqualTo("Hi alice")
+        // Sanity check — stage 3 only resolves because settings.defaultLanguage() is `en`.
+        assertThat(settings.defaultLanguage()).isEqualTo("en")
+    }
+
+    @Test
+    fun `render strict mode throws on missing variable rather than silently emitting empty string`() {
+        // Vars include `username` but not `resetLink` — the template's
+        // default body references {{resetLink}}, so render must throw.
+        assertThatThrownBy {
+            service.render(
+                MailTemplate.AUTH_PASSWORD_RESET,
+                mapOf("username" to "alice", "expiresAtHuman" to "in 30 minutes"),
+                // No locale → falls through to enum default, which references {{resetLink}}.
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("resetLink")
+    }
+
+    @Test
+    fun `update rejects undocumented placeholder references`() {
+        assertThatThrownBy {
+            service.update(
+                MailTemplate.AUTH_PASSWORD_RESET,
+                locale = "en",
+                subject = "Reset",
+                body = "Hi {{username}}, click {{badPlaceholder}} now",
+                updatedBy = "test",
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("badPlaceholder")
+            .hasMessageContaining(MailTemplate.AUTH_PASSWORD_RESET.placeholders.toString())
+    }
+
+    @Test
+    fun `update accepts a subset of declared placeholders (not every var must be referenced)`() {
+        // The template declares username + resetLink + expiresAtHuman, but
+        // a custom variant might only need username — that is allowed. The
+        // validator catches typos (extra refs), not missing refs.
+        val view = service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "en",
+            subject = "Reset",
+            body = "Hello {{username}}",
+            updatedBy = "test",
+        )
+
+        assertThat(view.body).isEqualTo("Hello {{username}}")
+        // And render against this minimal variant — only username needs to be in vars.
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf("username" to "alice"),
+            locale = "en",
+        )
+        assertThat(rendered.body).isEqualTo("Hello alice")
+    }
+
+    @Test
+    fun `update is idempotent — second update overwrites the first row, no duplicate`() {
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "en",
+            subject = "v1",
+            body = "Body {{username}}",
+            updatedBy = "test",
+        )
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "en",
+            subject = "v2",
+            body = "Body {{username}}",
+            updatedBy = "test",
+        )
+
+        val variants = service.findByKey(MailTemplate.AUTH_PASSWORD_RESET)
+        assertThat(variants).hasSize(1)
+        assertThat(variants.first().subject).isEqualTo("v2")
+    }
+
+    @Test
+    fun `findByKeyAndLocale returns null when no row exists — caller falls through to render's enum default`() {
+        val view = service.findByKeyAndLocale(MailTemplate.AUTH_PASSWORD_RESET, "fr")
+
+        assertThat(view).isNull()
+    }
+
+    @Test
+    fun `findByKey lists every locale variant of a template`() {
+        service.update(MailTemplate.AUTH_PASSWORD_RESET, "en", "EN", "Hi {{username}}", "test")
+        service.update(MailTemplate.AUTH_PASSWORD_RESET, "de", "DE", "Hallo {{username}}", "test")
+
+        val variants = service.findByKey(MailTemplate.AUTH_PASSWORD_RESET)
+
+        assertThat(variants).hasSize(2)
+        assertThat(variants.map { it.locale }).containsExactlyInAnyOrder("en", "de")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailTemplateServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/MailTemplateServiceTest.kt
@@ -72,9 +72,13 @@ class MailTemplateServiceTest {
         )
 
         assertThat(rendered.subject).isEqualTo("Reset your Plugwerk password")
-        assertThat(rendered.body).contains("Hello alice,")
-        assertThat(rendered.body).contains("https://x")
-        assertThat(rendered.body).contains("in 30 minutes")
+        assertThat(rendered.bodyPlain).contains("Hello alice,")
+        assertThat(rendered.bodyPlain).contains("https://x")
+        assertThat(rendered.bodyPlain).contains("in 30 minutes")
+        // Enum default for AUTH_PASSWORD_RESET ships an HTML body too —
+        // render must materialise it.
+        assertThat(rendered.bodyHtml).isNotNull()
+        assertThat(rendered.bodyHtml).contains("<a href=\"https://x\">Reset my password</a>")
     }
 
     @Test
@@ -83,7 +87,8 @@ class MailTemplateServiceTest {
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "de",
             subject = "Passwort zurücksetzen",
-            body = "Hallo {{username}}, klicke {{resetLink}} ({{expiresAtHuman}})",
+            bodyPlain = "Hallo {{username}}, klicke {{resetLink}} ({{expiresAtHuman}})",
+            bodyHtml = "<p>Hallo {{username}}, <a href=\"{{resetLink}}\">klicke hier</a></p>",
             updatedBy = "test",
         )
 
@@ -94,7 +99,8 @@ class MailTemplateServiceTest {
         )
 
         assertThat(rendered.subject).isEqualTo("Passwort zurücksetzen")
-        assertThat(rendered.body).isEqualTo("Hallo alice, klicke https://x (in 30 Minuten)")
+        assertThat(rendered.bodyPlain).isEqualTo("Hallo alice, klicke https://x (in 30 Minuten)")
+        assertThat(rendered.bodyHtml).isEqualTo("<p>Hallo alice, <a href=\"https://x\">klicke hier</a></p>")
     }
 
     @Test
@@ -103,54 +109,51 @@ class MailTemplateServiceTest {
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "de",
             subject = "Passwort",
-            body = "Hi {{username}}",
+            bodyPlain = "Hi {{username}}",
             updatedBy = "test",
         )
 
         val rendered = service.render(
             MailTemplate.AUTH_PASSWORD_RESET,
-            mapOf("username" to "fritz", "resetLink" to "x", "expiresAtHuman" to "y"),
+            mapOf("username" to "fritz"),
             locale = "de-CH",
         )
 
         assertThat(rendered.subject).isEqualTo("Passwort")
-        assertThat(rendered.body).isEqualTo("Hi fritz")
+        assertThat(rendered.bodyPlain).isEqualTo("Hi fritz")
+        // Per-row fallback: the `de` row exists and explicitly has no HTML
+        // body, so render returns null instead of mixing in the enum's
+        // English HTML default. Operator-set plaintext-only stays plaintext-only.
+        assertThat(rendered.bodyHtml).isNull()
     }
 
     @Test
     fun `render falls back to application default language (stage 3) when requested locale not present`() {
-        // Seed an `en` row only. Request `de` → stage 1 misses (no de),
-        // stage 2 misses (de has no language-base), stage 3 hits the en row
-        // because general.default_language=en in this test profile.
         service.update(
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "en",
             subject = "Reset",
-            body = "Hi {{username}}",
+            bodyPlain = "Hi {{username}}",
             updatedBy = "test",
         )
 
         val rendered = service.render(
             MailTemplate.AUTH_PASSWORD_RESET,
-            mapOf("username" to "alice", "resetLink" to "x", "expiresAtHuman" to "y"),
+            mapOf("username" to "alice"),
             locale = "de",
         )
 
         assertThat(rendered.subject).isEqualTo("Reset")
-        assertThat(rendered.body).isEqualTo("Hi alice")
-        // Sanity check — stage 3 only resolves because settings.defaultLanguage() is `en`.
+        assertThat(rendered.bodyPlain).isEqualTo("Hi alice")
         assertThat(settings.defaultLanguage()).isEqualTo("en")
     }
 
     @Test
     fun `render strict mode throws on missing variable rather than silently emitting empty string`() {
-        // Vars include `username` but not `resetLink` — the template's
-        // default body references {{resetLink}}, so render must throw.
         assertThatThrownBy {
             service.render(
                 MailTemplate.AUTH_PASSWORD_RESET,
                 mapOf("username" to "alice", "expiresAtHuman" to "in 30 minutes"),
-                // No locale → falls through to enum default, which references {{resetLink}}.
             )
         }
             .isInstanceOf(IllegalArgumentException::class.java)
@@ -158,42 +161,91 @@ class MailTemplateServiceTest {
     }
 
     @Test
-    fun `update rejects undocumented placeholder references`() {
+    fun `render auto-escapes HTML in vars to prevent stored-XSS through user-controlled placeholders`() {
+        service.update(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            locale = "en",
+            subject = "Reset",
+            bodyPlain = "Hi {{username}}",
+            bodyHtml = "<p>Hi {{username}}, click <a href=\"{{resetLink}}\">here</a></p>",
+            updatedBy = "test",
+        )
+
+        val rendered = service.render(
+            MailTemplate.AUTH_PASSWORD_RESET,
+            mapOf(
+                "username" to "<script>alert('xss')</script>",
+                "resetLink" to "https://app/reset?token=abc&user=alice",
+                "expiresAtHuman" to "in 30 minutes",
+            ),
+            locale = "en",
+        )
+
+        // Plaintext body keeps `<` `>` `&` intact — no HTML rendering happens.
+        assertThat(rendered.bodyPlain).contains("<script>alert('xss')</script>")
+        // HTML body escapes the dangerous characters — &lt;script&gt; renders
+        // as visible text in the browser, not an executable element.
+        assertThat(rendered.bodyHtml).contains("&lt;script&gt;alert")
+        assertThat(rendered.bodyHtml).doesNotContain("<script>")
+        // The `&` in the URL is escaped to `&amp;`. jmustache's escaper is
+        // aggressive and additionally hex-escapes `=` (-> `&#x3D;`) and `'`
+        // (-> `&#39;`); browsers decode all of those back to the original
+        // characters when rendering the attribute value, so the link still
+        // works at click time. The assertion below pins the safety property
+        // (no raw `&` outside the entity form, no executable script).
+        assertThat(rendered.bodyHtml).contains("&amp;")
+        assertThat(rendered.bodyHtml).doesNotContain("?token=abc&user")
+    }
+
+    @Test
+    fun `update rejects undocumented placeholder references in any of subject, plaintext, html`() {
         assertThatThrownBy {
             service.update(
                 MailTemplate.AUTH_PASSWORD_RESET,
                 locale = "en",
                 subject = "Reset",
-                body = "Hi {{username}}, click {{badPlaceholder}} now",
+                bodyPlain = "Hi {{username}}, click {{badPlaceholder}} now",
                 updatedBy = "test",
             )
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("badPlaceholder")
-            .hasMessageContaining(MailTemplate.AUTH_PASSWORD_RESET.placeholders.toString())
+
+        // Same check for the HTML body — plain is fine but html has a typo.
+        assertThatThrownBy {
+            service.update(
+                MailTemplate.AUTH_PASSWORD_RESET,
+                locale = "en",
+                subject = "Reset",
+                bodyPlain = "Hi {{username}}",
+                bodyHtml = "<p>Hi {{username}}, <a href=\"{{notARealVar}}\">click</a></p>",
+                updatedBy = "test",
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("notARealVar")
     }
 
     @Test
     fun `update accepts a subset of declared placeholders (not every var must be referenced)`() {
-        // The template declares username + resetLink + expiresAtHuman, but
-        // a custom variant might only need username — that is allowed. The
-        // validator catches typos (extra refs), not missing refs.
         val view = service.update(
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "en",
             subject = "Reset",
-            body = "Hello {{username}}",
+            bodyPlain = "Hello {{username}}",
             updatedBy = "test",
         )
 
-        assertThat(view.body).isEqualTo("Hello {{username}}")
-        // And render against this minimal variant — only username needs to be in vars.
+        assertThat(view.bodyPlain).isEqualTo("Hello {{username}}")
+        assertThat(view.bodyHtml).isNull()
+
         val rendered = service.render(
             MailTemplate.AUTH_PASSWORD_RESET,
             mapOf("username" to "alice"),
             locale = "en",
         )
-        assertThat(rendered.body).isEqualTo("Hello alice")
+        assertThat(rendered.bodyPlain).isEqualTo("Hello alice")
+        assertThat(rendered.bodyHtml).isNull()
     }
 
     @Test
@@ -202,20 +254,38 @@ class MailTemplateServiceTest {
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "en",
             subject = "v1",
-            body = "Body {{username}}",
+            bodyPlain = "Body {{username}}",
             updatedBy = "test",
         )
         service.update(
             MailTemplate.AUTH_PASSWORD_RESET,
             locale = "en",
             subject = "v2",
-            body = "Body {{username}}",
+            bodyPlain = "Body {{username}}",
+            bodyHtml = "<p>HTML body {{username}}</p>",
             updatedBy = "test",
         )
 
         val variants = service.findByKey(MailTemplate.AUTH_PASSWORD_RESET)
         assertThat(variants).hasSize(1)
         assertThat(variants.first().subject).isEqualTo("v2")
+        assertThat(variants.first().bodyHtml).isEqualTo("<p>HTML body {{username}}</p>")
+    }
+
+    @Test
+    fun `update with explicit blank bodyHtml is rejected — null is the no-html marker, blank is invalid`() {
+        assertThatThrownBy {
+            service.update(
+                MailTemplate.AUTH_PASSWORD_RESET,
+                locale = "en",
+                subject = "Reset",
+                bodyPlain = "Hi {{username}}",
+                bodyHtml = "   ",
+                updatedBy = "test",
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("bodyHtml")
     }
 
     @Test
@@ -227,8 +297,8 @@ class MailTemplateServiceTest {
 
     @Test
     fun `findByKey lists every locale variant of a template`() {
-        service.update(MailTemplate.AUTH_PASSWORD_RESET, "en", "EN", "Hi {{username}}", "test")
-        service.update(MailTemplate.AUTH_PASSWORD_RESET, "de", "DE", "Hallo {{username}}", "test")
+        service.update(MailTemplate.AUTH_PASSWORD_RESET, "en", "EN", "Hi {{username}}", null, "test")
+        service.update(MailTemplate.AUTH_PASSWORD_RESET, "de", "DE", "Hallo {{username}}", null, "test")
 
         val variants = service.findByKey(MailTemplate.AUTH_PASSWORD_RESET)
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/SmtpEmailIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/mail/SmtpEmailIT.kt
@@ -107,27 +107,86 @@ class SmtpEmailIT {
     }
 
     @Test
-    fun `sendMail delivers to the SMTP server with the expected envelope`() {
+    fun `sendMail with plaintext body delivers a single-part text-plain message`() {
         val result = mailService.sendMail(
             to = "alice@example.test",
             subject = "Welcome to Plugwerk",
-            body = "This is a test message from the SMTP IT.",
+            bodyPlain = "This is a test message from the SMTP IT.",
         )
 
         assertThat(result).isEqualTo(MailService.SendResult.Sent)
-        // GreenMail blocks until the SMTP server has accepted and stored the
-        // message; no extra wait needed.
         val received = greenMail.receivedMessages
         assertThat(received).hasSize(1)
         val message = received[0]
         assertThat(message.subject).isEqualTo("Welcome to Plugwerk")
         assertThat(message.from.first().toString()).contains("noreply@plugwerk.test")
         assertThat(message.allRecipients.first().toString()).isEqualTo("alice@example.test")
-        // Body is multi-part on some SMTP libraries; SimpleMailMessage uses
-        // text/plain, so the content() is a String we can compare directly.
+        assertThat(message.contentType).startsWith("text/plain")
         val rawContent = message.content
         val bodyText = if (rawContent is String) rawContent else rawContent.toString()
         assertThat(bodyText).contains("This is a test message")
+    }
+
+    @Test
+    fun `sendMail with bodyHtml delivers a multipart-alternative message containing both parts`() {
+        val result = mailService.sendMail(
+            to = "alice@example.test",
+            subject = "Multipart test",
+            bodyPlain = "Plain text fallback for HTML clients.",
+            bodyHtml = "<p>HTML <b>preferred</b> view.</p>",
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        val received = greenMail.receivedMessages
+        assertThat(received).hasSize(1)
+        val message = received[0]
+        assertThat(message.contentType).startsWith("multipart/")
+        // Spring's MimeMessageHelper(multipart=true) wraps in MIXED_RELATED;
+        // the outer content-type is `multipart/mixed`, the alternative is
+        // nested inside. Verify the structure end-to-end via the raw stream.
+        val baos = java.io.ByteArrayOutputStream()
+        message.writeTo(baos)
+        val raw = baos.toString()
+        assertThat(raw).contains("multipart/alternative")
+        assertThat(raw).contains("text/plain")
+        assertThat(raw).contains("text/html")
+        assertThat(raw).contains("Plain text fallback")
+        assertThat(raw).contains("<p>HTML <b>preferred</b> view.</p>")
+    }
+
+    @Test
+    fun `sendMailFromTemplate renders the password-reset template and delivers it`() {
+        val result = mailService.sendMailFromTemplate(
+            template = MailTemplate.AUTH_PASSWORD_RESET,
+            to = "alice@example.test",
+            vars = mapOf(
+                "username" to "alice",
+                "resetLink" to "https://app.plugwerk.test/reset?token=abc",
+                "expiresAtHuman" to "in 30 minutes",
+            ),
+        )
+
+        assertThat(result).isEqualTo(MailService.SendResult.Sent)
+        val received = greenMail.receivedMessages
+        assertThat(received).hasSize(1)
+        val message = received[0]
+        assertThat(message.subject).isEqualTo("Reset your Plugwerk password")
+        // Seeded en row carries both bodies → multipart/alternative.
+        assertThat(message.contentType).startsWith("multipart/")
+        val baos = java.io.ByteArrayOutputStream()
+        message.writeTo(baos)
+        val raw = baos.toString()
+        // Plaintext body. Note: MIME transports plaintext bodies as
+        // quoted-printable, which escapes `=` to `=3D`. So the URL appears
+        // as `?token=3Dabc` in the raw stream — assert on the prefix that
+        // sidesteps this encoding wart.
+        assertThat(raw).contains("Hello alice,")
+        assertThat(raw).contains("https://app.plugwerk.test/reset?token")
+        // HTML body anchor text from the seeded en variant. Quoted-printable
+        // soft-wraps lines at column ~76 (`Reset my =\r\npassword`), so test
+        // for a fragment that survives any line-wrap position.
+        assertThat(raw).contains("Reset my")
+        assertThat(raw).contains("multipart/alternative")
     }
 
     @Test
@@ -154,7 +213,7 @@ class SmtpEmailIT {
         val result = mailService.sendMail(
             to = "ignored@example.test",
             subject = "Should not arrive",
-            body = "Body",
+            bodyPlain = "Body",
         )
 
         assertThat(result).isEqualTo(MailService.SendResult.Disabled)


### PR DESCRIPTION
## Summary

Closes #436. Closes #437.

Foundation for templated email sending — the rendering pipeline + send API
that #438 (Templates admin page) edits, and that #420 / #421 ultimately
consume.

**Scope expanded mid-PR:** the original draft shipped plaintext-only
templates and deferred HTML to a follow-up. Per discussion, this PR now
ships full HTML support (option C) and folds in #437's
`MailService.sendMailFromTemplate` API — "alles bauen" requires the actual
send path to work end-to-end.

## Key design decisions

### 1. i18n-ready schema from day 1

`mail_template` carries a `locale varchar(16)` column with composite-unique
`(template_key, locale)`. Today only `en` is seeded; adding `de`/`fr`/etc.
later is purely additive — no migration, no row backfill, no constraint to
retroactively install.

> **Why now and not later:** the cost today is one extra column. The cost
> later would be a backfill + NOT-NULL + composite-unique migration on a
> populated table. Pre-1.0, baking in the right shape is the cheaper path.

### 2. Dual body columns: `body_plain` (NOT NULL) + `body_html` (NULL)

`body_plain` is always required — it's the accessibility floor (terminal
mail readers, screen readers, spam-filter signal) and a dependable
fallback when the HTML body fails to render. `body_html` is optional;
**null means "no HTML for this row"**, not "use the enum HTML default".

> **Per-row fallback semantics:** when an operator explicitly seeds a
> plaintext-only `de` row, render returns `bodyHtml = null` rather than
> mixing in the enum's English HTML default. The DB row is the complete
> definition for its locale.

### 3. Engine: **jmustache**, two compilers

Logic-less by design — operator-edited templates cannot expose RCE via
expression language. Two compiler instances:

- **plain compiler** — `escapeHTML=false`, no escaping (would mangle
  plaintext bodies)
- **html compiler** — `escapeHTML=true`, double-mustache `{{var}}` escapes
  `<`, `>`, `&`, `'`, `=`; triple-mustache `{{{var}}}` opts out for
  pre-trusted markup (use sparingly)

Both compilers run with `strictSections=true` and default missing-key
throws — an auth email without `{{verificationLink}}` is a bug, not a
feature.

### 4. 4-stage render fallback chain

`render(template, vars, locale = null)`:

1. **Requested locale exact** — `(key, requestedLocale)` row
2. **Language base** — `de-CH` falls back to `de`
3. **Application default** — `general.default_language` (today `en`)
4. **Enum default** — hard-coded `MailTemplate.defaultSubject` /
   `defaultBodyPlainTemplate` / `defaultBodyHtmlTemplate`, always present

Stage 4 guarantees a render never throws because no row exists — critical
for auth flows.

### 5. Validation at write time, not send time

`update()` scans subject + bodyPlain + bodyHtml for `{{var}}` references
and rejects any name not in `MailTemplate.placeholders`. Typos surface as
400 at admin-edit time, not as a runtime exception when an email actually
goes out. Blank `bodyHtml` is also rejected — null is the no-html marker.

### 6. MailService: MimeMessage + multipart

`MailService.sendMail(to, subject, bodyPlain, bodyHtml = null)` switches
from `SimpleMailMessage` to `MimeMessage` via `MimeMessageHelper`.
Plaintext-only sends remain single-part `text/plain`; sends with both
bodies become `multipart/mixed → multipart/related → multipart/alternative`
(`MULTIPART_MODE_MIXED_RELATED`) — the outer container leaves room for
future inline images and attachments without another schema change.

### 7. Same cache pattern as `ApplicationSettingsService`

`AtomicReference<Map<(key,locale), StoredTemplate>>`. Lock-free reads,
atomic swap on every write inside the `@Transactional update` method.
Readers see either the old or new snapshot in full.

## What landed

| File | Purpose |
|---|---|
| `MailTemplate.kt` | Registry enum: `AUTH_REGISTRATION_VERIFICATION` + `AUTH_PASSWORD_RESET` with default subject + plain + html + placeholders |
| `MailTemplateEntity.kt` | JPA entity: `body_plain` (NOT NULL) + `body_html` (NULL), composite-unique `(template_key, locale)` |
| `MailTemplateRepository.kt` | `findByTemplateKey` + `findByTemplateKeyAndLocale` |
| `0026_mail_template.yaml` | CREATE TABLE + UNIQUE + index + seed both `auth.*` templates with `locale='en'` (plain + html) |
| `MailTemplateService.kt` | `findAll` / `findByKey` / `findByKeyAndLocale` / `update` / `render` with dual-compiler + per-row fallback |
| `MailService.kt` | `sendMail` (MimeMessage) + `sendMailFromTemplate` (#437) — Disabled / Sent / Misconfigured / Failed result type |

## Test plan

- [x] `MailTemplateServiceTest` (`@SpringBootTest` + H2) — 12/12:
  - Enum-default fallback when no row exists for any locale (incl. HTML)
  - Exact-locale hit (stage 1)
  - Language-base fallback `de-CH → de` (stage 2) — verifies per-row HTML
    fallback (no enum mix-in)
  - Application-default fallback (stage 3)
  - Strict-mode missing-var → `IllegalArgumentException`
  - Auto-escape of HTML-special chars in placeholder values (`<script>` →
    `&lt;script&gt;`, `&` → `&amp;`)
  - Undocumented-placeholder rejection in subject + plain + html
  - Subset of placeholders allowed
  - `update` idempotency
  - Blank `bodyHtml` rejected (null is the no-html marker)
  - `findByKeyAndLocale` returns null when absent
  - `findByKey` lists every locale variant
- [x] `MailServiceTest` (Mockito) — 9/9:
  - Disabled paths (smtp.enabled=false, no usable sender)
  - Misconfigured (blank from_address)
  - Plaintext-only → single-part `text/plain`
  - bodyHtml present → `multipart/mixed` wrapping `multipart/alternative`
  - Bare from_address when from_name blank
  - `MailException` → `Failed`
  - `sendMailFromTemplate` forwards rendered subject + both bodies
  - `sendMailFromTemplate` returns `Misconfigured` on render failure
- [x] `SmtpEmailIT` (GreenMail) — 5/5:
  - Plaintext-only delivery
  - Multipart-alternative delivery (verified via raw MIME stream)
  - `sendMailFromTemplate` end-to-end render + deliver
  - Password ciphertext at rest, plaintext via accessor
  - SMTP disabled → no-op
- [x] All existing backend tests still pass (`./gradlew :plugwerk-server:plugwerk-server-backend:test` green)
- [x] Spotless / ktlint clean

## Out of scope

- **#438** Templates admin page (`/admin/email/templates`)
- Actual i18n locale picker UI — `locale` column is wired, picker lands
  with the i18n issue

## Related

- #253 (parent — SMTP infrastructure)
- #438 (next: Templates frontend)
- #420 / #421 (eventual consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)