### PR TITLE
feat(auth): forgot-password / reset-password flow when enabled by application settings (#421)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -408,6 +408,94 @@ paths:
         '404':
           description: Self-registration is disabled on this server
 
+  /auth/forgot-password:
+    post:
+      tags:
+        - AuthPasswordReset
+      summary: Request a password-reset email (when enabled by the operator)
+      description: |
+        Sends a single-use, time-limited password-reset link to the
+        address registered for the supplied username or email. Available
+        only when the operator has enabled `auth.password_reset_enabled`;
+        returns 404 otherwise so the existence of the endpoint is not
+        advertised on locked-down deployments. Public — no authentication
+        required (#421).
+
+        Always returns **204 No Content** on the success path, regardless
+        of whether the supplied identifier matched anything. The legitimate
+        owner of an in-use address sees an inbox message; an unknown
+        identifier produces no signal at all. EXTERNAL (OIDC) users
+        likewise receive no email — they reset their password upstream
+        with their identity provider.
+
+        Rate-limited per client IP. Returns 503 with an operator-actionable
+        message when SMTP is not configured.
+      operationId: forgotPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ForgotPasswordRequest'
+      responses:
+        '204':
+          description: Request accepted — if the account exists, a reset email is on its way
+        '400':
+          description: Malformed request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Password reset is disabled on this server
+        '429':
+          description: Too many forgot-password attempts — Retry-After header indicates the cool-off
+        '503':
+          description: Password reset requires email infrastructure that is not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/reset-password:
+    post:
+      tags:
+        - AuthPasswordReset
+      summary: Exchange a password-reset token for a new password
+      description: |
+        Validates the single-use token issued by `POST /forgot-password`
+        and, on success, persists the new BCrypt hash and revokes every
+        active session for the user (access tokens via
+        `passwordInvalidatedBefore`, refresh-token family via cookie
+        rotation). The same token cannot be redeemed twice. Returns 404
+        when password reset is disabled (same disguise as
+        `POST /auth/forgot-password`). Returns 400 when the token is
+        unknown, already consumed, or past its expiry. Public — no
+        authentication required (#421).
+
+        Rate-limited per client IP and per token hash to mitigate
+        brute-force attempts on a leaked link.
+      operationId: resetPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordRequest'
+      responses:
+        '204':
+          description: Password updated and existing sessions revoked
+        '400':
+          description: Token is unknown / consumed / expired, or password fails strength rules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Password reset is disabled on this server
+        '429':
+          description: Too many reset attempts — Retry-After header indicates the cool-off
+
   /namespaces:
     get:
       tags:
@@ -2262,6 +2350,48 @@ components:
       required:
         - status
 
+    ForgotPasswordRequest:
+      type: object
+      description: |
+        Self-service password-reset trigger payload (#421). Either a
+        username or an email address is acceptable; the server resolves
+        them against the same user table. EXTERNAL (OIDC) users get no
+        email — they reset upstream with their identity provider.
+      properties:
+        usernameOrEmail:
+          type: string
+          minLength: 1
+          maxLength: 254
+          description: Username or email address of the account whose password should be reset
+      required:
+        - usernameOrEmail
+
+    ResetPasswordRequest:
+      type: object
+      description: |
+        Exchanges a password-reset token (delivered by email) for a new
+        password (#421). The token is single-use; on success every
+        active session for the user is revoked.
+      properties:
+        token:
+          type: string
+          minLength: 8
+          maxLength: 128
+          description: The opaque token from the reset link
+        newPassword:
+          type: string
+          format: password
+          minLength: 12
+          maxLength: 256
+          description: |
+            Plaintext password — same minimum length (12) as the
+            `POST /admin/users` and `POST /auth/register` flows. Future
+            strength checks (zxcvbn, banned-passwords) will land in the
+            shared validation layer.
+      required:
+        - token
+        - newPassword
+
     LoginRequest:
       type: object
       description: Credentials for password-based login
@@ -3608,9 +3738,20 @@ components:
                 backend enforces the gate independently — flipping this on the
                 client cannot bypass the controller check.
               example: false
+            passwordResetEnabled:
+              type: boolean
+              description: |
+                Whether the operator has enabled the public forgot-password
+                flow (#421). The login page conditionally renders the
+                "Forgot password?" link when this is true. The backend
+                enforces the gate independently — flipping this on the
+                client cannot bypass the controller checks on
+                `/auth/forgot-password` and `/auth/reset-password`.
+              example: false
           required:
             - oidcProviders
             - selfRegistrationEnabled
+            - passwordResetEnabled
       required:
         - version
         - upload

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -392,6 +392,7 @@ data class PlugwerkProperties(
             val windowSeconds: Long = 60,
             val changePassword: ChangePasswordRateLimitProperties = ChangePasswordRateLimitProperties(),
             val register: RegisterRateLimitProperties = RegisterRateLimitProperties(),
+            val passwordReset: PasswordResetRateLimitProperties = PasswordResetRateLimitProperties(),
         )
 
         /**
@@ -440,6 +441,41 @@ data class PlugwerkProperties(
             val ipWindowSeconds: Long = 60,
             val emailMaxAttempts: Int = 5,
             val emailWindowSeconds: Long = 3600,
+        )
+
+        /**
+         * Two-bucket rate limiting for the password-reset flow (#421).
+         *
+         * Two attack surfaces with different shapes:
+         *   - `POST /auth/forgot-password` (IP-keyed): mail-bombing a known
+         *     user by repeatedly requesting reset links. We deliberately do
+         *     **not** key by username/email — that would create a timing
+         *     oracle (existing accounts run out faster than non-existing
+         *     ones, leaking enumeration).
+         *   - `POST /auth/reset-password` (token-keyed): brute-forcing a
+         *     leaked link before its TTL elapses. Keyed by SHA-256 of the
+         *     submitted token so the cap follows the link, not the IP.
+         *
+         * @property ipMaxAttempts IP-keyed cap per [ipWindowSeconds] across
+         *   both endpoints. Conservative by default — five attempts is
+         *   plenty for a real user who fat-fingered their email.
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_IP_MAX_ATTEMPTS`
+         * @property ipWindowSeconds IP rate-limit window in seconds.
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_IP_WINDOW_SECONDS`
+         * @property tokenMaxAttempts Cap per token-hash per
+         *   [tokenWindowSeconds]. The default of 10 means an attacker who
+         *   somehow obtained a leaked link cannot iterate ten failed
+         *   reset-password POSTs against it within the hour — long before
+         *   the link's own expiry kicks in.
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_TOKEN_MAX_ATTEMPTS`
+         * @property tokenWindowSeconds Token rate-limit window in seconds.
+         *   Environment variable: `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_TOKEN_WINDOW_SECONDS`
+         */
+        data class PasswordResetRateLimitProperties(
+            val ipMaxAttempts: Int = 5,
+            val ipWindowSeconds: Long = 900,
+            val tokenMaxAttempts: Int = 10,
+            val tokenWindowSeconds: Long = 3600,
         )
 
         /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.OidcLoginSuccessHandler
 import io.plugwerk.server.security.OidcProviderRegistry
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PromptAwareOAuth2AuthorizationRequestResolver
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
@@ -67,6 +68,7 @@ import java.security.MessageDigest
 class SecurityConfiguration(
     private val loginRateLimitFilter: LoginRateLimitFilter,
     private val registerRateLimitFilter: RegisterRateLimitFilter,
+    private val passwordResetRateLimitFilter: PasswordResetRateLimitFilter,
     private val refreshRateLimitFilter: RefreshRateLimitFilter,
     private val changePasswordRateLimitFilter: ChangePasswordRateLimitFilter,
     private val apiKeyAuthFilter: NamespaceAccessKeyAuthFilter,
@@ -402,6 +404,10 @@ class SecurityConfiguration(
             // RegisterRateLimitFilter protects /api/v1/auth/register from bulk account creation (#420).
             // Email-keyed second bucket runs inside the controller after body parsing.
             .addFilterAfter(registerRateLimitFilter, LoginRateLimitFilter::class.java)
+            // PasswordResetRateLimitFilter protects /api/v1/auth/forgot-password and
+            // /api/v1/auth/reset-password from brute-force / mail-bombing (#421).
+            // Token-keyed second bucket runs inside the controller after body parsing.
+            .addFilterAfter(passwordResetRateLimitFilter, RegisterRateLimitFilter::class.java)
             // RefreshRateLimitFilter protects /api/v1/auth/refresh from DoS/spam (ADR-0027).
             .addFilterAfter(refreshRateLimitFilter, LoginRateLimitFilter::class.java)
             // PublicNamespaceFilter runs next — sets AnonymousAuth for public namespace GETs

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthPasswordResetController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthPasswordResetController.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AuthPasswordResetApi
+import io.plugwerk.api.model.ForgotPasswordRequest
+import io.plugwerk.api.model.ResetPasswordRequest
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.PasswordResetRateLimitService
+import io.plugwerk.server.security.RateLimitResult
+import io.plugwerk.server.security.RefreshTokenCookieFactory
+import io.plugwerk.server.service.RefreshTokenService
+import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.auth.PasswordResetTokenService
+import io.plugwerk.server.service.mail.MailService
+import io.plugwerk.server.service.mail.MailTemplate
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Public endpoints for the opt-in self-service password-reset flow (#421).
+ *
+ * Both endpoints share the "feature-flag disguise" pattern from the
+ * registration controller: when `auth.password_reset_enabled` is `false`
+ * they 404, so a locked-down deployment never advertises that the
+ * surface exists. The `/config` flag `passwordResetEnabled` lets the
+ * frontend hide the matching login-page link in the same off state —
+ * the backend gate is independent and authoritative.
+ *
+ * **Anti-enumeration shape.** `forgot-password` always returns 204 on
+ * the success path regardless of whether the supplied identifier
+ * resolves to an INTERNAL user. EXTERNAL users likewise get no email
+ * (they reset upstream); disabled users get no email (no point); a
+ * mail-send failure is logged but does not change the status code,
+ * because a 503 here would create a timing oracle between
+ * "doesn't-exist" and "mail-server-broken".
+ *
+ * **Session revocation.** A successful `reset-password` revokes both
+ * the access-token side (`passwordInvalidatedBefore` via
+ * [UserService.applyPasswordReset]) and the refresh-token family
+ * (`refreshTokenService.revokeAllForUser`). The refresh-cookie is
+ * cleared on the response so a stolen cookie cannot be replayed.
+ * Without the second revocation an attacker holding the refresh
+ * cookie could keep harvesting fresh access tokens because
+ * `/auth/refresh` does not consult `passwordInvalidatedBefore`.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AuthPasswordResetController(
+    private val settings: ApplicationSettingsService,
+    private val userService: UserService,
+    private val userRepository: UserRepository,
+    private val tokenService: PasswordResetTokenService,
+    private val mailService: MailService,
+    private val rateLimitService: PasswordResetRateLimitService,
+    private val refreshTokenService: RefreshTokenService,
+    private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
+    private val plugwerkProperties: PlugwerkProperties,
+) : AuthPasswordResetApi {
+
+    private val log = LoggerFactory.getLogger(AuthPasswordResetController::class.java)
+
+    override fun forgotPassword(forgotPasswordRequest: ForgotPasswordRequest): ResponseEntity<Unit> {
+        if (!settings.passwordResetEnabled()) {
+            // 404 (not 403) so the feature is invisible when off — same
+            // disguise as the registration endpoint.
+            throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        }
+
+        // SMTP unconfigured → 503 even though that leaks "feature is on";
+        // the operator hint outweighs the marginal enumeration risk and
+        // the issue spec explicitly asks for a 503 here.
+        if (!settings.smtpEnabled()) {
+            throw ResponseStatusException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "Self-service password reset requires SMTP infrastructure that is not configured on this server.",
+            )
+        }
+
+        val input = forgotPasswordRequest.usernameOrEmail.trim()
+        val user = userRepository.findByUsernameOrEmailAndSource(input, UserSource.INTERNAL).orElse(null)
+
+        // Three branches that all return 204 silently:
+        //   1. No matching INTERNAL user — could be a typo or an attacker probing.
+        //   2. The user is disabled — admin or registration verification took
+        //      them out; resetting their password would not actually let them
+        //      back in until they're re-enabled, and surfacing that distinction
+        //      would leak account state.
+        //   3. The user IS resolvable but EXTERNAL — that case is filtered out
+        //      by the source predicate above; this fallthrough catches future
+        //      schema additions defensively.
+        if (user == null || !user.enabled || user.source != UserSource.INTERNAL) {
+            log.info(
+                "forgot-password: silenced for input '{}' (matched={}, eligible={})",
+                input,
+                user != null,
+                user?.enabled == true && user?.source == UserSource.INTERNAL,
+            )
+            return ResponseEntity.noContent().build()
+        }
+
+        return runCatching { issueAndSend(user) }.fold(
+            onSuccess = { ResponseEntity.noContent().build() },
+            onFailure = { err ->
+                // Mail-send or token-issue failure: log loud, but return
+                // the same 204 the silenced branches do — otherwise a slow
+                // 503 vs. a fast 204 leaks "this user exists".
+                log.error(
+                    "forgot-password: mail send failed for user {} — returning 204 to preserve anti-enumeration",
+                    user.id,
+                    err,
+                )
+                ResponseEntity.noContent().build()
+            },
+        )
+    }
+
+    override fun resetPassword(resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Unit> {
+        if (!settings.passwordResetEnabled()) {
+            // Stale link after operator turns the feature off → 404, same
+            // disguise as forgot-password. Without this, an attacker
+            // probing /reset-password could discover that the feature
+            // existed at one point.
+            throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        }
+
+        // Token-keyed bucket fires BEFORE consume so brute-force attempts
+        // against a leaked link can't iterate faster than the limit even
+        // if the token's TTL is generous. The IP bucket already fired in
+        // PasswordResetRateLimitFilter.
+        when (val gate = rateLimitService.tryConsumeToken(resetPasswordRequest.token)) {
+            is RateLimitResult.Allowed -> Unit
+
+            is RateLimitResult.Rejected -> throw ResponseStatusException(
+                HttpStatus.TOO_MANY_REQUESTS,
+                "Too many reset attempts for this token. Retry after ${gate.retryAfterSeconds} s.",
+            )
+        }
+
+        val user = tokenService.consume(resetPasswordRequest.token)
+        val userId = requireNotNull(user.id) { "User without id reached reset-password" }
+
+        // Side-effects in order:
+        //   1. Persist the new password (BCrypt) and bump
+        //      passwordInvalidatedBefore to revoke every access token in
+        //      flight. UserService.applyPasswordReset handles both atoms.
+        //   2. Burn the refresh-token family so /auth/refresh can't mint
+        //      new access tokens from a stolen cookie. AuthController.refresh
+        //      does NOT honour passwordInvalidatedBefore (verified for #421);
+        //      this second revocation is mandatory, not an add-on.
+        //   3. Clear the refresh cookie on the response so the browser
+        //      doesn't keep re-presenting it.
+        userService.applyPasswordReset(userId, resetPasswordRequest.newPassword)
+        refreshTokenService.revokeAllForUser(userId, RefreshTokenService.LOGOUT)
+        log.info("Password reset completed for user {} — all sessions revoked", userId)
+
+        return ResponseEntity.noContent()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.clear().toString())
+            .build()
+    }
+
+    private fun issueAndSend(user: UserEntity) {
+        val issued = tokenService.issue(user)
+        val resetLink = buildResetLink(issued.rawToken)
+        val expiresAtHuman = formatExpiry(issued.expiresAt)
+        val send = mailService.sendMailFromTemplate(
+            template = MailTemplate.AUTH_PASSWORD_RESET,
+            to = user.email,
+            vars = mapOf(
+                "username" to user.displayName,
+                "resetLink" to resetLink,
+                "expiresAtHuman" to expiresAtHuman,
+            ),
+        )
+        if (send !is MailService.SendResult.Sent) {
+            // Caller's runCatching turns this into a logged 204. We throw
+            // rather than return a "soft failure" object so the runCatching
+            // path is the only place that decides on the user-facing status.
+            error("MailService returned $send")
+        }
+        log.info("Issued password-reset email for user {}", user.id)
+    }
+
+    private fun buildResetLink(rawToken: String): String {
+        // Browser-facing link: in dev the SPA lives on a different port
+        // than the API (Vite on :5173 vs. backend on :8080), so we use
+        // the dedicated web-base-url which falls back to base-url for
+        // bundled-SPA production deployments.
+        val base = plugwerkProperties.server.effectiveWebBaseUrl().trimEnd('/')
+        return "$base/reset-password?token=$rawToken"
+    }
+
+    /**
+     * "in 30 minutes" / "in 1 hours" for short windows, otherwise the
+     * absolute UTC timestamp. Matches the verification-email tone from
+     * `AuthRegistrationController.formatExpiry`.
+     */
+    private fun formatExpiry(expiresAt: OffsetDateTime): String {
+        val secondsLeft = Duration.between(OffsetDateTime.now(), expiresAt).seconds
+        return when {
+            secondsLeft <= 0 -> "now (link already expired)"
+            secondsLeft < 3600 -> "in ${(secondsLeft / 60).coerceAtLeast(1)} minutes"
+            secondsLeft < 86_400 -> "in ${(secondsLeft / 3600).coerceAtLeast(1)} hours"
+            else -> "on ${expiresAt.format(ABSOLUTE_FMT)}"
+        }
+    }
+
+    private companion object {
+        private val ABSOLUTE_FMT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("d MMM yyyy 'at' HH:mm 'UTC'")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -50,6 +50,7 @@ class ConfigController(
             auth = ServerConfigResponseAuth(
                 oidcProviders = enabledOidcProviderLoginInfo(),
                 selfRegistrationEnabled = settingsService.selfRegistrationEnabled(),
+                passwordResetEnabled = settingsService.passwordResetEnabled(),
             ),
         ),
     )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -36,6 +36,7 @@ import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.ReleaseAlreadyExistsException
 import io.plugwerk.server.service.ReleaseNotFoundException
 import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.service.auth.InvalidPasswordResetTokenException
 import io.plugwerk.server.service.auth.InvalidVerificationTokenException
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
@@ -163,6 +164,18 @@ class GlobalExceptionHandler {
     @ExceptionHandler(InvalidVerificationTokenException::class)
     fun handleInvalidVerificationToken(ex: InvalidVerificationTokenException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Verification token is invalid")
+
+    /**
+     * Password-reset token failed validation (#421). Mapped to 400 with
+     * the specific reason ("invalid", "expired", "already used") so the
+     * reset-password page can show actionable copy. Same shape as the
+     * verification-token handler above — separate Exception type only so
+     * future flow-specific behaviour (different status codes, different
+     * audit hooks) can branch cleanly.
+     */
+    @ExceptionHandler(InvalidPasswordResetTokenException::class)
+    fun handleInvalidPasswordResetToken(ex: InvalidPasswordResetTokenException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Password-reset token is invalid")
 
     /**
      * Honour the status code carried inside any [ResponseStatusException]

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PasswordResetTokenEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/PasswordResetTokenEntity.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UuidGenerator
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * One row per issued self-service password-reset token (#421).
+ *
+ * Storage and lifecycle mirror [EmailVerificationTokenEntity] (#420):
+ * the raw token only ever lives in the reset-link email plus the inbound
+ * POST body on `/auth/reset-password`; only `SHA-256(rawToken)` hex is
+ * persisted here, so a database leak alone cannot impersonate a user.
+ *
+ * `consumed_at` flips when the user successfully exchanges the token for
+ * a new password; the row sticks around for audit until
+ * [io.plugwerk.server.service.auth.PasswordResetTokenService]'s scheduled
+ * sweep removes it after the grace window.
+ */
+@Entity
+@Table(
+    name = "password_reset_token",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_password_reset_token_hash", columnNames = ["token_hash"]),
+    ],
+    indexes = [
+        Index(name = "idx_password_reset_token_user", columnList = "user_id"),
+        Index(name = "idx_password_reset_token_expires", columnList = "expires_at"),
+    ],
+)
+class PasswordResetTokenEntity(
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "id", updatable = false)
+    var id: UUID? = null,
+
+    // EAGER fetch: the reset-password controller reads `user` outside the
+    // service's transaction (to apply the new password via UserService),
+    // so LAZY would blow up with LazyInitializationException — same
+    // reasoning as EmailVerificationTokenEntity.
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    var user: UserEntity,
+
+    @Column(name = "token_hash", nullable = false, length = 64, updatable = false)
+    var tokenHash: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: OffsetDateTime = OffsetDateTime.now(),
+
+    @Column(name = "expires_at", nullable = false)
+    var expiresAt: OffsetDateTime,
+
+    @Column(name = "consumed_at", nullable = true)
+    var consumedAt: OffsetDateTime? = null,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PasswordResetTokenRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PasswordResetTokenRepository.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import io.plugwerk.server.domain.PasswordResetTokenEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.UUID
+
+interface PasswordResetTokenRepository : JpaRepository<PasswordResetTokenEntity, UUID> {
+    fun findByTokenHash(tokenHash: String): Optional<PasswordResetTokenEntity>
+
+    /**
+     * "Any in-flight token for user X" — used by the issue path to
+     * supersede previous tokens before generating a fresh one. A user
+     * who clicks "forgot password" twice should land on the most-recent
+     * link only; the older one stops working immediately.
+     *
+     * Explicit JPQL (rather than the derived `findByUser_Id…` method name)
+     * so the function signature stays valid Kotlin camelCase under ktlint.
+     */
+    @Query("SELECT t FROM PasswordResetTokenEntity t WHERE t.user.id = :userId AND t.consumedAt IS NULL")
+    fun findUnconsumedTokensForUser(@Param("userId") userId: UUID): List<PasswordResetTokenEntity>
+
+    /**
+     * Sweep target: rows whose `expires_at` has passed. The
+     * @Scheduled job in [io.plugwerk.server.service.auth.PasswordResetTokenService]
+     * runs daily so the table doesn't grow unbounded.
+     */
+    @Transactional
+    fun deleteByExpiresAtBefore(cutoff: OffsetDateTime): Long
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
@@ -57,6 +57,24 @@ interface UserRepository : JpaRepository<UserEntity, UUID> {
     fun findAllByEnabled(enabled: Boolean): List<UserEntity>
 
     /**
+     * Username-or-email lookup scoped to a single [source]. Used by the
+     * password-reset flow (#421): the user can submit either their
+     * username or their email and we look both up against the same row,
+     * but only INTERNAL accounts are eligible (EXTERNAL ones reset
+     * upstream with their identity provider). Email match is
+     * case-insensitive to align with the storage normalisation done in
+     * `UserService.normalizeEmail`.
+     */
+    @Query(
+        "SELECT u FROM UserEntity u WHERE u.source = :source AND " +
+            "(u.username = :input OR LOWER(u.email) = LOWER(:input))",
+    )
+    fun findByUsernameOrEmailAndSource(
+        @Param("input") input: String,
+        @Param("source") source: UserSource,
+    ): Optional<UserEntity>
+
+    /**
      * Bulk-disable users. Used by `OidcProviderService.delete` when a provider
      * is being removed (Politik C from issue #351): disable rather than
      * cascade-delete so the audit trail survives.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitFilter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitFilter.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.OffsetDateTime
+
+/**
+ * IP-keyed rate-limit filter for the public password-reset endpoints
+ * (#421). Fires before any body parsing so the cheapest abuse vector
+ * (volume from one source) is dropped immediately.
+ *
+ * The token-keyed bucket fires inside the controller after the body
+ * has been parsed — same split as [RegisterRateLimitFilter].
+ */
+@Component
+class PasswordResetRateLimitFilter(
+    private val rateLimitService: PasswordResetRateLimitService,
+    private val clientIpResolver: HttpClientIpResolver,
+) : OncePerRequestFilter() {
+
+    companion object {
+        private const val FORGOT_PATH = "/api/v1/auth/forgot-password"
+        private const val RESET_PATH = "/api/v1/auth/reset-password"
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        if (request.method != "POST") return true
+        return request.requestURI != FORGOT_PATH && request.requestURI != RESET_PATH
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val clientIp = clientIpResolver.resolve(request)
+        when (val result = rateLimitService.tryConsumeIp(clientIp)) {
+            is RateLimitResult.Allowed -> filterChain.doFilter(request, response)
+
+            is RateLimitResult.Rejected -> {
+                response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+                response.setHeader("Retry-After", result.retryAfterSeconds.toString())
+                response.contentType = MediaType.APPLICATION_JSON_VALUE
+                response.writer.write(
+                    """{"status":429,"error":"Too Many Requests","message":"Too many password-reset attempts. Please try again later.","timestamp":"${OffsetDateTime.now()}"}""",
+                )
+            }
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitService.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.PlugwerkProperties
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+
+/**
+ * Two-bucket rate limiter for the password-reset flow (#421).
+ *
+ * Mirrors [RegisterRateLimitService] but keyed differently: the
+ * `forgot-password` endpoint uses the **IP** bucket (no email-keyed
+ * bucket here, because that would leak enumeration via timing — an
+ * existing-account bucket would empty faster than a non-existing one),
+ * and the `reset-password` endpoint additionally consults a **token**
+ * bucket so a leaked link cannot be brute-forced for its TTL window.
+ */
+@Component
+class PasswordResetRateLimitService(
+    private val bucketService: BucketRateLimitService,
+    props: PlugwerkProperties,
+) {
+    private val ipMaxAttempts = props.auth.rateLimit.passwordReset.ipMaxAttempts
+    private val ipWindowSeconds = props.auth.rateLimit.passwordReset.ipWindowSeconds
+    private val tokenMaxAttempts = props.auth.rateLimit.passwordReset.tokenMaxAttempts
+    private val tokenWindowSeconds = props.auth.rateLimit.passwordReset.tokenWindowSeconds
+
+    fun tryConsumeIp(ipAddress: String): RateLimitResult =
+        bucketService.tryConsume(IP_SCOPE, ipAddress, ipMaxAttempts, ipWindowSeconds)
+
+    /**
+     * Token-keyed consumption. The submitted plaintext token is hashed so
+     * the bucket map never holds it verbatim — same posture as the
+     * `password_reset_token` table itself.
+     */
+    fun tryConsumeToken(rawToken: String): RateLimitResult {
+        val key = sha256Hex(rawToken)
+        return bucketService.tryConsume(TOKEN_SCOPE, key, tokenMaxAttempts, tokenWindowSeconds)
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { "%02x".format(it) }
+    }
+
+    private companion object {
+        const val IP_SCOPE = "password-reset:ip"
+        const val TOKEN_SCOPE = "password-reset:token"
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PasswordResetRateLimitService.kt
@@ -33,10 +33,7 @@ import java.security.MessageDigest
  * bucket so a leaked link cannot be brute-forced for its TTL window.
  */
 @Component
-class PasswordResetRateLimitService(
-    private val bucketService: BucketRateLimitService,
-    props: PlugwerkProperties,
-) {
+class PasswordResetRateLimitService(private val bucketService: BucketRateLimitService, props: PlugwerkProperties) {
     private val ipMaxAttempts = props.auth.rateLimit.passwordReset.ipMaxAttempts
     private val ipWindowSeconds = props.auth.rateLimit.passwordReset.ipWindowSeconds
     private val tokenMaxAttempts = props.auth.rateLimit.passwordReset.tokenMaxAttempts

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
@@ -162,6 +162,31 @@ class UserService(
         return saved
     }
 
+    /**
+     * Self-service variant of [resetPassword] for the forgot-password flow (#421).
+     *
+     * The user has just chosen a new password themselves via the reset link in
+     * their email, so unlike the admin-driven [resetPassword] we **do not** flip
+     * `passwordChangeRequired` — forcing them to change it again at next login
+     * would be nonsensical.
+     *
+     * `revokeAllForUser` is still called so any sessions an attacker might have
+     * obtained from the old password go dead immediately. The caller is
+     * additionally expected to revoke the refresh-token family — see issue #421
+     * for the full session-invalidation contract.
+     */
+    fun applyPasswordReset(id: UUID, newPassword: String): UserEntity {
+        val user = findById(id)
+        require(user.isInternal()) {
+            "Cannot reset password on OIDC-sourced user — credentials live with the upstream provider"
+        }
+        user.passwordHash = hashPassword(newPassword)
+        user.passwordChangeRequired = false
+        val saved = userRepository.save(user)
+        tokenRevocationService.revokeAllForUser(id)
+        return saved
+    }
+
     fun delete(id: UUID) {
         val user = findById(id)
         if (user.isSuperadmin) throw ForbiddenException("The superadmin account cannot be deleted")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import io.plugwerk.server.domain.PasswordResetTokenEntity
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.repository.PasswordResetTokenRepository
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.Base64
+
+/**
+ * Issues and consumes single-use password-reset tokens for the opt-in
+ * forgot-password flow (#421).
+ *
+ * Mirrors [EmailVerificationTokenService] (#420) almost line-for-line —
+ * same SecureRandom + base64url + SHA-256-hash-at-rest posture, same
+ * supersede-previous semantics on issue, same expired/consumed/unknown
+ * branches in consume, same daily sweep. The only behavioural difference
+ * is that the TTL is **operator-tunable** at runtime (not a code
+ * constant): the value is read from `auth.password_reset_token_ttl_minutes`
+ * each time `issue` is called, so admins can shrink the window from the
+ * settings UI without a redeploy.
+ */
+@Service
+class PasswordResetTokenService(
+    private val repository: PasswordResetTokenRepository,
+    private val settings: ApplicationSettingsService,
+) {
+    private val log = LoggerFactory.getLogger(PasswordResetTokenService::class.java)
+    private val secureRandom = SecureRandom()
+
+    /**
+     * Issues a fresh token for [user] and invalidates any earlier in-flight
+     * tokens (resend semantics — only the most recent reset link works).
+     *
+     * @return the raw token string (caller emails it; never log it) and
+     *   the absolute expiry timestamp (caller renders into the email
+     *   body's "valid until X" line).
+     */
+    @Transactional
+    fun issue(user: UserEntity): IssuedResetToken {
+        val userId = requireNotNull(user.id) { "user.id must be set before issuing a password-reset token" }
+
+        // Invalidate any previous unconsumed tokens for this user. Mark
+        // them consumed (rather than deleting) so the audit trail
+        // survives — same posture as the verification-token service.
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        val previous = repository.findUnconsumedTokensForUser(userId)
+        if (previous.isNotEmpty()) {
+            previous.forEach { it.consumedAt = now }
+            repository.saveAll(previous)
+            log.debug("Invalidated {} previous password-reset token(s) for user {}", previous.size, userId)
+        }
+
+        val rawBytes = ByteArray(TOKEN_BYTES)
+        secureRandom.nextBytes(rawBytes)
+        val rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(rawBytes)
+        val ttl = Duration.ofMinutes(settings.passwordResetTokenTtlMinutes().toLong())
+        val expiresAt = now.plus(ttl)
+        val entity = PasswordResetTokenEntity(
+            user = user,
+            tokenHash = sha256Hex(rawToken),
+            expiresAt = expiresAt,
+        )
+        repository.save(entity)
+        // Only log the hash prefix — the raw token must never appear in logs.
+        log.info(
+            "Issued password-reset token for user {} (hash prefix={}, expires at {})",
+            userId,
+            entity.tokenHash.substring(0, 8),
+            expiresAt,
+        )
+        return IssuedResetToken(rawToken = rawToken, expiresAt = expiresAt)
+    }
+
+    /**
+     * Consumes [rawToken] and returns the linked user. Marks the row
+     * `consumed_at = now` so the same link cannot reset a second time.
+     *
+     * @throws InvalidPasswordResetTokenException if the token is unknown,
+     *   already consumed, or past its expiry.
+     */
+    @Transactional
+    fun consume(rawToken: String): UserEntity {
+        val hash = sha256Hex(rawToken)
+        val entity = repository.findByTokenHash(hash).orElseThrow {
+            InvalidPasswordResetTokenException("Password-reset token is invalid")
+        }
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        if (entity.consumedAt != null) {
+            throw InvalidPasswordResetTokenException("Password-reset token has already been used")
+        }
+        if (entity.expiresAt.isBefore(now)) {
+            throw InvalidPasswordResetTokenException("Password-reset token has expired")
+        }
+        entity.consumedAt = now
+        repository.save(entity)
+        return entity.user
+    }
+
+    /**
+     * Daily sweep: removes rows whose grace window has elapsed. Consumed
+     * rows hang around for a week so a support engineer can correlate a
+     * "the link said expired" complaint to the actual timestamp;
+     * expired-unconsumed rows go straight away.
+     *
+     * Runs five minutes after the email-verification sweep so the two
+     * jobs don't fight for the same DB connection on a small instance.
+     */
+    @Scheduled(cron = "0 35 3 * * *")
+    @Transactional
+    fun sweep() {
+        val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)
+        val removed = repository.deleteByExpiresAtBefore(cutoff)
+        if (removed > 0) {
+            log.info("Password-reset token sweep removed {} expired row(s) older than {}", removed, cutoff)
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { "%02x".format(it) }
+    }
+
+    companion object {
+        /** 32 bytes ≈ 256 bits of entropy, encoded as 43 base64url chars. */
+        const val TOKEN_BYTES = 32
+
+        /** Consumed tokens stick around for 7 days for audit before sweep. */
+        val SWEEP_GRACE: Duration = Duration.ofDays(7)
+    }
+}
+
+/** Raw token (only ever in the email body) + absolute expiry timestamp. */
+data class IssuedResetToken(val rawToken: String, val expiresAt: OffsetDateTime)
+
+/** Mapped to HTTP 400 by [io.plugwerk.server.controller.GlobalExceptionHandler]. */
+class InvalidPasswordResetTokenException(message: String) : RuntimeException(message)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
@@ -203,6 +203,28 @@ enum class ApplicationSettingKey(
         valueType = SettingValueType.BOOLEAN,
         defaultValue = "true",
     ),
+
+    // ---- Password reset (#421) ---------------------------------------------
+    // Off by default — operators of private deployments never see the
+    // /forgot-password and /reset-password endpoints, both 404 with the
+    // same disguise as registration. The TTL-minutes setting controls
+    // how long an issued reset link stays valid; shorter narrows the
+    // window in which a stolen email can be replayed against the
+    // account, longer is more forgiving for users who don't check
+    // their inbox right away.
+
+    AUTH_PASSWORD_RESET_ENABLED(
+        key = "auth.password_reset_enabled",
+        valueType = SettingValueType.BOOLEAN,
+        defaultValue = "false",
+    ),
+    AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES(
+        key = "auth.password_reset_token_ttl_minutes",
+        valueType = SettingValueType.INTEGER,
+        defaultValue = "60",
+        minInt = 5,
+        maxInt = 1440,
+    ),
     ;
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
@@ -217,8 +217,7 @@ class ApplicationSettingsService(
     // ---- Password reset (#421) ---------------------------------------------
 
     /** Master switch: surface the public forgot-password / reset-password endpoints at all? */
-    fun passwordResetEnabled(): Boolean =
-        getRaw(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED).toBooleanStrict()
+    fun passwordResetEnabled(): Boolean = getRaw(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED).toBooleanStrict()
 
     /**
      * How long an issued reset link stays valid, in minutes. Operator-tunable

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
@@ -214,6 +214,21 @@ class ApplicationSettingsService(
     fun selfRegistrationEmailVerificationRequired(): Boolean =
         getRaw(ApplicationSettingKey.AUTH_SELF_REGISTRATION_EMAIL_VERIFICATION_REQUIRED).toBooleanStrict()
 
+    // ---- Password reset (#421) ---------------------------------------------
+
+    /** Master switch: surface the public forgot-password / reset-password endpoints at all? */
+    fun passwordResetEnabled(): Boolean =
+        getRaw(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED).toBooleanStrict()
+
+    /**
+     * How long an issued reset link stays valid, in minutes. Operator-tunable
+     * 5..1440 (enforced by the enum's minInt/maxInt) — defaults to 60.
+     */
+    fun passwordResetTokenTtlMinutes(): Int =
+        getRaw(ApplicationSettingKey.AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES).toIntOrNull()
+            ?.coerceIn(5, 1440)
+            ?: ApplicationSettingKey.AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES.defaultValue.toInt()
+
     // ------------------------------------------------------------------------
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,7 @@ databaseChangeLog:
       file: db/changelog/migrations/0027_add_self_registration_settings.yaml
   - include:
       file: db/changelog/migrations/0028_email_verification_token.yaml
+  - include:
+      file: db/changelog/migrations/0029_password_reset_token.yaml
+  - include:
+      file: db/changelog/migrations/0030_add_password_reset_settings.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0029_password_reset_token.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0029_password_reset_token.yaml
@@ -1,0 +1,83 @@
+# Single-use, time-limited tokens for the opt-in self-service password
+# reset flow (#421). Mirrors the email_verification_token shape (#420)
+# bit-for-bit so the same hash-at-rest, FK-cascade, and sweep machinery
+# applies — only the table name and index prefixes differ.
+#
+# Storage shape:
+#   - token_hash holds SHA-256(rawToken) hex (64 chars). The raw token is
+#     only ever in flight in the reset email + the inbound POST body on
+#     /auth/reset-password; it is never persisted. Same posture as
+#     namespace_access_key / revoked_token / email_verification_token.
+#   - user_id FK with ON DELETE CASCADE so /admin/users delete fans out
+#     automatically — no explicit token sweep needed in UserService.
+#   - consumed_at nullable: a successfully redeemed token sticks around
+#     for audit until the @Scheduled sweep removes expired+consumed rows
+#     after a grace period (handled in PasswordResetTokenService).
+#
+# Indexes:
+#   - uq_password_reset_token_hash → fast hash lookup on the reset POST
+#   - idx_password_reset_token_user → "any in-flight token for user X"
+#     query supports the resend / supersede-previous logic without a scan
+#   - idx_password_reset_token_expires → @Scheduled sweep
+databaseChangeLog:
+  - changeSet:
+      id: 0029-create-password-reset-token
+      author: plugwerk
+      changes:
+        - createTable:
+            tableName: password_reset_token
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_password_reset_token_user
+                    references: plugwerk_user(id)
+                    deleteCascade: true
+              - column:
+                  name: token_hash
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamptz
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: consumed_at
+                  type: timestamptz
+                  constraints:
+                    nullable: true
+        - addUniqueConstraint:
+            tableName: password_reset_token
+            columnNames: token_hash
+            constraintName: uq_password_reset_token_hash
+        - createIndex:
+            tableName: password_reset_token
+            indexName: idx_password_reset_token_user
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            tableName: password_reset_token
+            indexName: idx_password_reset_token_expires
+            columns:
+              - column:
+                  name: expires_at
+      rollback:
+        - dropTable:
+            tableName: password_reset_token

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0030_add_password_reset_settings.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0030_add_password_reset_settings.yaml
@@ -1,0 +1,54 @@
+# Seed the password-reset settings registered in ApplicationSettingKey
+# (#421). Both default to safe values:
+#   - auth.password_reset_enabled = false → /auth/forgot-password and
+#     /auth/reset-password are hidden behind a 404 disguise on every
+#     existing deployment until the operator flips this on.
+#   - auth.password_reset_token_ttl_minutes = 60 → reset links expire
+#     after one hour, balancing usability with the issue's threat model
+#     (the link sits in an inbox; shorter is safer). Range 5..1440 is
+#     enforced by the enum's minInt/maxInt validators.
+databaseChangeLog:
+  - changeSet:
+      id: 0030-seed-password-reset-settings
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: auth.password_reset_enabled
+              - column:
+                  name: setting_value
+                  value: "false"
+              - column:
+                  name: setting_desc
+                  value: "Master switch for the public /auth/forgot-password and /auth/reset-password endpoints. When false the endpoints and the corresponding 'Forgot password?' link on the login page are hidden (404)."
+              - column:
+                  name: value_type
+                  value: BOOLEAN
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: auth.password_reset_token_ttl_minutes
+              - column:
+                  name: setting_value
+                  value: "60"
+              - column:
+                  name: setting_desc
+                  value: "How long a password-reset link stays valid, in minutes. Shorter values reduce the window in which a stolen email lets an attacker take over the account; longer values forgive users who don't check their inbox right away. Range 5..1440 (1 day)."
+              - column:
+                  name: value_type
+                  value: INTEGER
+      rollback:
+        - delete:
+            tableName: application_setting
+            where: "setting_key IN ('auth.password_reset_enabled', 'auth.password_reset_token_ttl_minutes')"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityConfigurationTextEncryptorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityConfigurationTextEncryptorTest.kt
@@ -50,6 +50,7 @@ class SecurityConfigurationTextEncryptorTest {
         return SecurityConfiguration(
             loginRateLimitFilter = mock(),
             registerRateLimitFilter = mock(),
+            passwordResetRateLimitFilter = mock(),
             refreshRateLimitFilter = mock(),
             changePasswordRateLimitFilter = mock(),
             apiKeyAuthFilter = mock(),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
@@ -23,10 +23,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.mail.MailTemplate
 import io.plugwerk.server.service.mail.MailTemplateService
 import io.plugwerk.server.service.mail.MailTemplateView

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.mail.MailTemplate
 import io.plugwerk.server.service.mail.MailTemplateService
 import io.plugwerk.server.service.mail.MailTemplateView
@@ -69,6 +70,7 @@ import java.time.OffsetDateTime
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -24,10 +24,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.ForbiddenException

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -27,6 +27,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.ForbiddenException
@@ -66,6 +67,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RefreshTokenCookieFactory
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.UserCredentialValidator
 import io.plugwerk.server.service.JwtTokenService
 import io.plugwerk.server.service.RefreshTokenService
@@ -65,6 +66,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthControllerTest.kt
@@ -25,11 +25,11 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.OidcEndSessionUrlResolver
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RefreshTokenCookieFactory
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.UserCredentialValidator
 import io.plugwerk.server.service.JwtTokenService
 import io.plugwerk.server.service.RefreshTokenService

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthPasswordResetControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthPasswordResetControllerTest.kt
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.LoginRateLimitFilter
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitService
+import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.security.RateLimitResult
+import io.plugwerk.server.security.RefreshRateLimitFilter
+import io.plugwerk.server.security.RefreshTokenCookieFactory
+import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.RefreshTokenService
+import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.auth.InvalidPasswordResetTokenException
+import io.plugwerk.server.service.auth.IssuedResetToken
+import io.plugwerk.server.service.auth.PasswordResetTokenService
+import io.plugwerk.server.service.mail.MailService
+import io.plugwerk.server.service.mail.MailTemplate
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseCookie
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.UUID
+
+@WebMvcTest(
+    AuthPasswordResetController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class AuthPasswordResetControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @MockitoBean private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean private lateinit var settings: ApplicationSettingsService
+
+    @MockitoBean private lateinit var userService: UserService
+
+    @MockitoBean private lateinit var userRepository: UserRepository
+
+    @MockitoBean private lateinit var tokenService: PasswordResetTokenService
+
+    @MockitoBean private lateinit var mailService: MailService
+
+    @MockitoBean private lateinit var rateLimitService: PasswordResetRateLimitService
+
+    @MockitoBean private lateinit var refreshTokenService: RefreshTokenService
+
+    @MockitoBean private lateinit var refreshTokenCookieFactory: RefreshTokenCookieFactory
+
+    @MockitoBean private lateinit var plugwerkProperties: PlugwerkProperties
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("anon", null, emptyList())
+        // Defaults: feature on, SMTP on, IP+token buckets allow.
+        whenever(settings.passwordResetEnabled()).thenReturn(true)
+        whenever(settings.smtpEnabled()).thenReturn(true)
+        whenever(rateLimitService.tryConsumeToken(any()))
+            .thenReturn(RateLimitResult.Allowed(remainingTokens = 5))
+        whenever(plugwerkProperties.server).thenReturn(
+            PlugwerkProperties.ServerProperties(baseUrl = "https://plugwerk.test"),
+        )
+        whenever(refreshTokenCookieFactory.clear()).thenReturn(
+            ResponseCookie.from("refresh_token", "").maxAge(0).path("/").build(),
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun stubUser(): UserEntity = UserEntity(
+        id = UUID.randomUUID(),
+        username = "alice",
+        email = "alice@example.com",
+        displayName = "Alice",
+        source = UserSource.INTERNAL,
+        passwordHash = "\$2a\$12\$hash",
+        enabled = true,
+        passwordChangeRequired = false,
+    )
+
+    private val forgotBody = """{"usernameOrEmail":"alice@example.com"}"""
+
+    private val resetBody = """{"token":"abc-token","newPassword":"correct-horse-battery-staple"}"""
+
+    @Test
+    fun `POST forgot-password returns 404 when password reset is disabled — does not advertise the endpoint`() {
+        whenever(settings.passwordResetEnabled()).thenReturn(false)
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isNotFound() }
+        }
+        verify(tokenService, never()).issue(any())
+        verify(mailService, never()).sendMailFromTemplate(any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `POST forgot-password returns 503 when SMTP is disabled (operator-actionable)`() {
+        whenever(settings.smtpEnabled()).thenReturn(false)
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isServiceUnavailable() }
+        }
+        verify(tokenService, never()).issue(any())
+    }
+
+    @Test
+    fun `POST forgot-password returns 204 silently when no INTERNAL user matches (anti-enumeration)`() {
+        whenever(userRepository.findByUsernameOrEmailAndSource(any(), eq(UserSource.INTERNAL)))
+            .thenReturn(Optional.empty())
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isNoContent() }
+        }
+        verify(tokenService, never()).issue(any())
+        verify(mailService, never()).sendMailFromTemplate(any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `POST forgot-password returns 204 silently for a disabled user (no email sent)`() {
+        val disabled = stubUser().also { it.enabled = false }
+        whenever(userRepository.findByUsernameOrEmailAndSource(any(), eq(UserSource.INTERNAL)))
+            .thenReturn(Optional.of(disabled))
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isNoContent() }
+        }
+        verify(tokenService, never()).issue(any())
+    }
+
+    @Test
+    fun `POST forgot-password happy path issues a token, sends the template email, and returns 204`() {
+        val user = stubUser()
+        whenever(userRepository.findByUsernameOrEmailAndSource(any(), eq(UserSource.INTERNAL)))
+            .thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user)).thenReturn(
+            IssuedResetToken(
+                rawToken = "demo-raw-token",
+                expiresAt = OffsetDateTime.now().plusHours(1),
+            ),
+        )
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenReturn(MailService.SendResult.Sent)
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isNoContent() }
+        }
+        verify(mailService).sendMailFromTemplate(
+            eq(MailTemplate.AUTH_PASSWORD_RESET),
+            eq("alice@example.com"),
+            argThat {
+                this["resetLink"].toString().contains("demo-raw-token") &&
+                    this["username"] == "Alice"
+            },
+            anyOrNull(),
+        )
+    }
+
+    @Test
+    fun `POST forgot-password still returns 204 when mail send fails (no timing oracle)`() {
+        val user = stubUser()
+        whenever(userRepository.findByUsernameOrEmailAndSource(any(), eq(UserSource.INTERNAL)))
+            .thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user)).thenReturn(
+            IssuedResetToken(rawToken = "x", expiresAt = OffsetDateTime.now().plusHours(1)),
+        )
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenReturn(MailService.SendResult.Failed("smtp down"))
+
+        mockMvc.post("/api/v1/auth/forgot-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = forgotBody
+        }.andExpect {
+            status { isNoContent() }
+        }
+    }
+
+    @Test
+    fun `POST reset-password returns 404 when password reset is disabled`() {
+        whenever(settings.passwordResetEnabled()).thenReturn(false)
+
+        mockMvc.post("/api/v1/auth/reset-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = resetBody
+        }.andExpect {
+            status { isNotFound() }
+        }
+        verify(tokenService, never()).consume(any())
+    }
+
+    @Test
+    fun `POST reset-password returns 429 when token bucket is exhausted (brute-force defence)`() {
+        whenever(rateLimitService.tryConsumeToken(any()))
+            .thenReturn(RateLimitResult.Rejected(retryAfterSeconds = 30))
+
+        mockMvc.post("/api/v1/auth/reset-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = resetBody
+        }.andExpect {
+            status { isTooManyRequests() }
+        }
+        verify(tokenService, never()).consume(any())
+    }
+
+    @Test
+    fun `POST reset-password returns 400 with the reason when the token is invalid`() {
+        whenever(tokenService.consume(any()))
+            .doThrow(InvalidPasswordResetTokenException("Password-reset token has already been used"))
+
+        mockMvc.post("/api/v1/auth/reset-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = resetBody
+        }.andExpect {
+            status { isBadRequest() }
+        }
+        verify(userService, never()).applyPasswordReset(any(), any())
+    }
+
+    @Test
+    fun `POST reset-password happy path applies the new password, revokes refresh family, clears cookie`() {
+        val user = stubUser()
+        whenever(tokenService.consume(any())).thenReturn(user)
+        whenever(userService.applyPasswordReset(eq(requireNotNull(user.id)), eq("correct-horse-battery-staple")))
+            .thenReturn(user)
+
+        mockMvc.post("/api/v1/auth/reset-password") {
+            contentType = MediaType.APPLICATION_JSON
+            content = resetBody
+        }.andExpect {
+            status { isNoContent() }
+            // Cookie-Clear header is set so the browser drops the stale refresh
+            // cookie alongside the server-side revocation.
+            header { exists("Set-Cookie") }
+        }
+        verify(userService).applyPasswordReset(requireNotNull(user.id), "correct-horse-battery-staple")
+        verify(refreshTokenService).revokeAllForUser(requireNotNull(user.id), RefreshTokenService.LOGOUT)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthRegistrationControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthRegistrationControllerTest.kt
@@ -25,11 +25,11 @@ import io.plugwerk.server.security.ChangePasswordRateLimitFilter
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RateLimitResult
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitService
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.UserService

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthRegistrationControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AuthRegistrationControllerTest.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RateLimitResult
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitService
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.UserService
@@ -73,6 +74,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -34,6 +34,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.NamespaceNotFoundException
 import io.plugwerk.server.service.Pf4jCompatibilityService
 import io.plugwerk.server.service.PluginNotFoundException
@@ -70,6 +71,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/CatalogControllerTest.kt
@@ -31,10 +31,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.NamespaceNotFoundException
 import io.plugwerk.server.service.Pf4jCompatibilityService
 import io.plugwerk.server.service.PluginNotFoundException

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.junit.jupiter.api.Test
@@ -51,6 +52,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -25,10 +25,10 @@ import io.plugwerk.server.security.ChangePasswordRateLimitFilter
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.VersionProvider
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.junit.jupiter.api.Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -33,6 +33,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.PluginReleaseService
@@ -69,6 +70,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ManagementControllerTest.kt
@@ -30,10 +30,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.FileTooLargeException
 import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.PluginReleaseService

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
@@ -25,10 +25,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.OidcProviderPatch

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/OidcProviderControllerTest.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.EntityNotFoundException
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.OidcProviderPatch
@@ -67,6 +68,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
@@ -27,10 +27,10 @@ import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.server.service.ReleaseNotFoundException
 import io.plugwerk.spi.model.ReleaseStatus

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ReviewsControllerTest.kt
@@ -30,6 +30,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.PluginReleaseService
 import io.plugwerk.server.service.ReleaseNotFoundException
 import io.plugwerk.spi.model.ReleaseStatus
@@ -60,6 +61,7 @@ import java.util.UUID
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
@@ -23,10 +23,10 @@ import io.plugwerk.server.security.ChangePasswordRateLimitFilter
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
 import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
-import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.NamespaceNotFoundException
 import io.plugwerk.server.service.UpdateCheckService
 import org.junit.jupiter.api.Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/UpdateCheckControllerTest.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.security.PasswordChangeRequiredFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.service.NamespaceNotFoundException
 import io.plugwerk.server.service.UpdateCheckService
 import org.junit.jupiter.api.Test
@@ -51,6 +52,7 @@ import org.springframework.test.web.servlet.post
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
         ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PreAuthorizeCoverageTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/PreAuthorizeCoverageTest.kt
@@ -70,6 +70,16 @@ class PreAuthorizeCoverageTest {
         // is invisible on locked-down deployments. Rate-limited per IP and
         // per email (RegisterRateLimitFilter + RegisterRateLimitService).
         "AuthRegistrationController.register",
+        // AuthPasswordResetController.forgotPassword — public forgot-password (#421).
+        // Gated at the controller-body level by ApplicationSettings + 404 disguise;
+        // anti-enumeration response is a uniform 204 across all branches.
+        // IP-keyed rate-limit in PasswordResetRateLimitFilter.
+        "AuthPasswordResetController.forgotPassword",
+        // AuthPasswordResetController.resetPassword — public reset-password (#421).
+        // Gated by the same 404 disguise. Authorization is "presented a valid
+        // single-use token", which is exactly the security model.
+        // Token-keyed rate-limit fires inside the controller, IP-keyed in the filter.
+        "AuthPasswordResetController.resetPassword",
         // UpdateCheckController.checkForUpdates — intentionally public: PF4J client plugins
         // submit their installed-plugin list (no secrets) and the server answers with
         // available updates. Anonymous callers are allowed by design (see

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
@@ -125,4 +125,44 @@ class UserServiceTest {
         assertThatThrownBy { service.bumpLastLogin(java.util.UUID.randomUUID()) }
             .isInstanceOf(EntityNotFoundException::class.java)
     }
+
+    @Test
+    fun `applyPasswordReset rehashes the password and leaves passwordChangeRequired false (#421)`() {
+        val created = service.create("hank", "hank@example.com", "old-password-1234")
+
+        val updated = service.applyPasswordReset(requireNotNull(created.id), "new-password-1234")
+
+        assertThat(updated.passwordChangeRequired).isFalse()
+        // Hash actually changed and is BCrypt-shaped (the format check is what
+        // distinguishes "we ran the encoder" from "we stored plaintext", which
+        // is the security-relevant property here).
+        assertThat(updated.passwordHash).startsWith("\$2a\$")
+        assertThat(updated.passwordHash).isNotEqualTo(created.passwordHash)
+    }
+
+    @Test
+    fun `applyPasswordReset bumps passwordInvalidatedBefore so all existing sessions are revoked (#421)`() {
+        val created = service.create("ivan", "ivan@example.com", "old-password-1234")
+        assertThat(created.passwordInvalidatedBefore).isNull()
+
+        service.applyPasswordReset(requireNotNull(created.id), "new-password-1234")
+
+        val reloaded = userRepository.findById(requireNotNull(created.id)).orElseThrow()
+        assertThat(reloaded.passwordInvalidatedBefore).isNotNull()
+    }
+
+    @Test
+    fun `applyPasswordReset rejects EXTERNAL OIDC users — credentials live with the provider (#421)`() {
+        val internal = service.create("jane", "jane@example.com", "any-password-1234")
+        // Force the row to look EXTERNAL by mutating + re-saving. We don't go
+        // through OidcIdentityService here because the assertion is purely
+        // about UserService's branch on `user.isInternal()`.
+        internal.source = io.plugwerk.server.domain.UserSource.EXTERNAL
+        userRepository.save(internal)
+
+        assertThatThrownBy {
+            service.applyPasswordReset(requireNotNull(internal.id), "new-password-1234")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("OIDC-sourced")
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenServiceTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import io.plugwerk.server.domain.PasswordResetTokenEntity
+import io.plugwerk.server.repository.PasswordResetTokenRepository
+import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * H2-backed integration test for [PasswordResetTokenService] (#421).
+ *
+ * Mirrors [EmailVerificationTokenServiceTest] (#420). The two services
+ * have almost-identical lifecycles; the unique behaviour to nail down
+ * here is that the TTL is **operator-tunable at runtime** (via the
+ * `auth.password_reset_token_ttl_minutes` setting) — flipping the
+ * setting must affect tokens issued from the next call onwards.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:password-reset;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+class PasswordResetTokenServiceTest {
+
+    @Autowired private lateinit var service: PasswordResetTokenService
+
+    @Autowired private lateinit var repository: PasswordResetTokenRepository
+
+    @Autowired private lateinit var userService: UserService
+
+    @Autowired private lateinit var settingsService: ApplicationSettingsService
+
+    @BeforeEach
+    fun reset() {
+        repository.deleteAll()
+        // Restore the seeded default in case a previous test mutated it.
+        settingsService.update(
+            ApplicationSettingKey.AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES,
+            "60",
+            updatedBy = "test-setup",
+        )
+    }
+
+    private fun createUser(): io.plugwerk.server.domain.UserEntity {
+        val tag = UUID.randomUUID().toString().take(8)
+        return userService.createSelfRegistered(
+            username = "alice-$tag",
+            email = "alice-$tag@example.com",
+            password = "correct-horse-battery-staple",
+            displayName = "Alice $tag",
+            enabled = true,
+        )
+    }
+
+    @Test
+    fun `issue stores the token hash, not the raw token, and returns the raw token to the caller`() {
+        val user = createUser()
+        val issued = service.issue(user)
+
+        // 32-byte entropy → base64url with no padding → 43 chars.
+        assertThat(issued.rawToken).hasSize(43)
+        assertThat(issued.rawToken).matches("[A-Za-z0-9_-]+")
+        val rows = repository.findAll()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].tokenHash).hasSize(64)
+        assertThat(rows[0].tokenHash).doesNotContain(issued.rawToken)
+    }
+
+    @Test
+    fun `issue uses the TTL configured in application settings (default 60 minutes)`() {
+        val user = createUser()
+        val issued = service.issue(user)
+
+        val secondsUntilExpiry = java.time.Duration.between(
+            OffsetDateTime.now(),
+            issued.expiresAt,
+        ).seconds
+        assertThat(secondsUntilExpiry).isBetween(60 * 60 - 5, 60 * 60 + 5)
+    }
+
+    @Test
+    fun `changing the TTL setting affects subsequently issued tokens (operator-tunable)`() {
+        settingsService.update(
+            ApplicationSettingKey.AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES,
+            "5",
+            updatedBy = "test",
+        )
+        val user = createUser()
+
+        val issued = service.issue(user)
+
+        val secondsUntilExpiry = java.time.Duration.between(
+            OffsetDateTime.now(),
+            issued.expiresAt,
+        ).seconds
+        // 5 minutes ± a small slack for clock drift across the test boundary.
+        assertThat(secondsUntilExpiry).isBetween(5 * 60 - 5, 5 * 60 + 5)
+    }
+
+    @Test
+    fun `consume returns the linked user and marks the row consumed (single-use)`() {
+        val user = createUser()
+        val issued = service.issue(user)
+
+        val consumed = service.consume(issued.rawToken)
+        assertThat(consumed.id).isEqualTo(user.id)
+
+        val row = repository.findAll().single()
+        assertThat(row.consumedAt).isNotNull
+
+        assertThatThrownBy { service.consume(issued.rawToken) }
+            .isInstanceOf(InvalidPasswordResetTokenException::class.java)
+            .hasMessageContaining("already been used")
+    }
+
+    @Test
+    fun `consume rejects an unknown token`() {
+        assertThatThrownBy { service.consume("never-issued-token") }
+            .isInstanceOf(InvalidPasswordResetTokenException::class.java)
+            .hasMessageContaining("invalid")
+    }
+
+    @Test
+    fun `consume rejects an expired token`() {
+        val user = createUser()
+        val issued = service.issue(user)
+        val row = repository.findAll().single()
+        row.expiresAt = OffsetDateTime.now().minusMinutes(1)
+        repository.save(row)
+
+        assertThatThrownBy { service.consume(issued.rawToken) }
+            .isInstanceOf(InvalidPasswordResetTokenException::class.java)
+            .hasMessageContaining("expired")
+    }
+
+    @Test
+    fun `re-issuing for the same user invalidates the previous token (supersede semantics)`() {
+        val user = createUser()
+        val first = service.issue(user)
+
+        val second = service.issue(user)
+
+        assertThatThrownBy { service.consume(first.rawToken) }
+            .isInstanceOf(InvalidPasswordResetTokenException::class.java)
+        val redeemed = service.consume(second.rawToken)
+        assertThat(redeemed.id).isEqualTo(user.id)
+    }
+
+    @Test
+    fun `sweep removes rows past the grace window and leaves fresh ones intact`() {
+        val user = createUser()
+        val keep = service.issue(user)
+
+        val stale = PasswordResetTokenEntity(
+            user = user,
+            tokenHash = "stale".repeat(13).take(64),
+            expiresAt = OffsetDateTime.now().minusDays(10),
+        )
+        repository.save(stale)
+
+        service.sweep()
+
+        val remaining = repository.findAll()
+        assertThat(remaining).hasSize(1)
+        assertThat(remaining[0].tokenHash).isNotEqualTo(stale.tokenHash)
+        val redeemed = service.consume(keep.rawToken)
+        assertThat(redeemed.id).isEqualTo(user.id)
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -24,6 +24,7 @@ import { AdminEmailTemplatesApi } from "./generated/api/admin-email-templates-ap
 import { AdminSettingsApi } from "./generated/api/admin-settings-api";
 import { AdminUsersApi } from "./generated/api/admin-users-api";
 import { AuthApi } from "./generated/api/auth-api";
+import { AuthPasswordResetApi } from "./generated/api/auth-password-reset-api";
 import { AuthRegistrationApi } from "./generated/api/auth-registration-api";
 import { CatalogApi } from "./generated/api/catalog-api";
 import { ManagementApi } from "./generated/api/management-api";
@@ -150,6 +151,11 @@ export const adminEmailTemplatesApi = new AdminEmailTemplatesApi(
 );
 export const authApi = new AuthApi(apiConfig, BASE_PATH, axiosInstance);
 export const authRegistrationApi = new AuthRegistrationApi(
+  apiConfig,
+  BASE_PATH,
+  axiosInstance,
+);
+export const authPasswordResetApi = new AuthPasswordResetApi(
   apiConfig,
   BASE_PATH,
   axiosInstance,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ChangePasswordPage.tsx
@@ -18,11 +18,52 @@
  */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box, TextField, Button, Alert } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import { Eye, EyeOff } from "lucide-react";
 import axios from "axios";
 import { AuthCard } from "../components/auth/AuthCard";
 import { authApi } from "../api/config";
 import { useAuthStore } from "../stores/authStore";
+
+interface PasswordVisibilityAdornmentProps {
+  visible: boolean;
+  onToggle: () => void;
+}
+
+function PasswordVisibilityAdornment({
+  visible,
+  onToggle,
+}: PasswordVisibilityAdornmentProps) {
+  // Same eye-toggle pattern used by LoginPage / ResetPasswordPage so the
+  // three auth surfaces stay visually consistent (issue #405 follow-up).
+  // onMouseDown.preventDefault keeps the field focused when the button is
+  // clicked — without it, MUI's TextField loses the cursor mid-type.
+  return (
+    <InputAdornment position="end">
+      <Tooltip title={visible ? "Hide password" : "Show password"}>
+        <IconButton
+          onClick={onToggle}
+          onMouseDown={(e) => e.preventDefault()}
+          aria-label={visible ? "Hide password" : "Show password"}
+          aria-pressed={visible}
+          edge="end"
+          size="small"
+        >
+          {visible ? <EyeOff size={16} /> : <Eye size={16} />}
+        </IconButton>
+      </Tooltip>
+    </InputAdornment>
+  );
+}
 
 function parseError(err: unknown): string {
   if (axios.isAxiosError(err) && err.response?.status === 429) {
@@ -43,6 +84,9 @@ export function ChangePasswordPage() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -99,32 +143,62 @@ export function ChangePasswordPage() {
       >
         <TextField
           label="Current Password"
-          type="password"
+          type={showCurrent ? "text" : "password"}
           value={currentPassword}
           onChange={(e) => setCurrentPassword(e.target.value)}
           required
           size="small"
           autoComplete="current-password"
           autoFocus
+          slotProps={{
+            input: {
+              endAdornment: (
+                <PasswordVisibilityAdornment
+                  visible={showCurrent}
+                  onToggle={() => setShowCurrent((v) => !v)}
+                />
+              ),
+            },
+          }}
         />
         <TextField
           label="New Password"
-          type="password"
+          type={showNew ? "text" : "password"}
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
           required
           size="small"
           autoComplete="new-password"
           helperText="At least 12 characters"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <PasswordVisibilityAdornment
+                  visible={showNew}
+                  onToggle={() => setShowNew((v) => !v)}
+                />
+              ),
+            },
+          }}
         />
         <TextField
           label="Confirm New Password"
-          type="password"
+          type={showConfirm ? "text" : "password"}
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
           required
           size="small"
           autoComplete="new-password"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <PasswordVisibilityAdornment
+                  visible={showConfirm}
+                  onToggle={() => setShowConfirm((v) => !v)}
+                />
+              ),
+            },
+          }}
         />
         <Button
           type="submit"
@@ -132,6 +206,11 @@ export function ChangePasswordPage() {
           size="large"
           disabled={loading}
           fullWidth
+          // Reserve the spinner slot in the start position so the button
+          // width does not jitter on click — same pattern as LoginPage.
+          startIcon={
+            loading ? <CircularProgress size={16} color="inherit" /> : undefined
+          }
         >
           {loading ? "Saving…" : "Set New Password"}
         </Button>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithRouter } from "../test/renderWithTheme";
+import { ForgotPasswordPage } from "./ForgotPasswordPage";
+import { useConfigStore } from "../stores/configStore";
+import * as apiConfig from "../api/config";
+
+vi.mock("../api/config", () => ({
+  authPasswordResetApi: {
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+  axiosInstance: { get: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    useConfigStore.setState({
+      passwordResetEnabled: true,
+      loaded: true,
+    } as never);
+    vi.clearAllMocks();
+  });
+
+  it("renders the form when password reset is enabled", () => {
+    renderWithRouter(<ForgotPasswordPage />);
+    expect(screen.getByLabelText("Username or email")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send reset link/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the disabled-on-server card when /config flag is false", () => {
+    useConfigStore.setState({
+      passwordResetEnabled: false,
+      loaded: true,
+    } as never);
+    renderWithRouter(<ForgotPasswordPage />);
+    expect(screen.getByText(/Password reset unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Username or email"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits the form and shows the anti-enumeration confirmation on 204", async () => {
+    vi.mocked(apiConfig.authPasswordResetApi.forgotPassword).mockResolvedValue(
+      // 204 has no body — axios resolves with status 204 and a void payload.
+      // The cast preserves the typed signature without inventing a payload.
+      { status: 204, data: undefined } as Awaited<
+        ReturnType<typeof apiConfig.authPasswordResetApi.forgotPassword>
+      >,
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<ForgotPasswordPage />);
+
+    await user.type(screen.getByLabelText("Username or email"), "alice");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.authPasswordResetApi.forgotPassword,
+      ).toHaveBeenCalledWith({
+        forgotPasswordRequest: { usernameOrEmail: "alice" },
+      });
+    });
+    // The confirmation copy must be true in BOTH the success and the
+    // silenced-on-collision branches; no language that asserts an email
+    // was actually sent.
+    expect(
+      await screen.findByText(/if an account exists/i),
+    ).toBeInTheDocument();
+  });
+
+  it("still shows the same confirmation when the server returns an unexpected error (anti-enumeration)", async () => {
+    vi.mocked(apiConfig.authPasswordResetApi.forgotPassword).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 500, data: {} },
+      message: "boom",
+    });
+    const user = userEvent.setup();
+    renderWithRouter(<ForgotPasswordPage />);
+
+    await user.type(screen.getByLabelText("Username or email"), "alice");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(
+      await screen.findByText(/if an account exists/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a 503 error inline when SMTP is unconfigured server-side", async () => {
+    vi.mocked(apiConfig.authPasswordResetApi.forgotPassword).mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 503,
+        data: { message: "SMTP not configured" },
+      },
+      message: "Request failed with status code 503",
+    });
+    const user = userEvent.setup();
+    renderWithRouter(<ForgotPasswordPage />);
+
+    await user.type(screen.getByLabelText("Username or email"), "alice");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(await screen.findByText(/SMTP not configured/i)).toBeInTheDocument();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
@@ -16,36 +16,223 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect, useState, type FormEvent } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import {
+  Alert,
   Box,
-  TextField,
   Button,
+  CircularProgress,
+  Link,
+  TextField,
   Typography,
-  Link as MuiLink,
 } from "@mui/material";
-import { Link } from "react-router-dom";
+import { Mail } from "lucide-react";
+import axios from "axios";
 import { AuthCard } from "../components/auth/AuthCard";
+import { authPasswordResetApi } from "../api/config";
+import { useConfigStore } from "../stores/configStore";
 
+/**
+ * Public forgot-password entry page (#421).
+ *
+ * Mounted on `/forgot-password`. Visible only when the operator has
+ * flipped `auth.password_reset_enabled` on; the link on the login
+ * page is gated by the same flag, and direct navigation here when
+ * the feature is off renders a NotFound-style copy that mirrors the
+ * backend's 404 disguise.
+ *
+ * Anti-enumeration shape: regardless of whether the supplied
+ * username/email matches an INTERNAL user, the success path renders
+ * the same "if an account exists, we sent a link" confirmation. The
+ * legitimate owner gets the email; an attacker probing addresses
+ * gets nothing distinguishable. Only true infrastructure failures
+ * (SMTP not configured, rate limit hit) surface a different state.
+ */
 export function ForgotPasswordPage() {
+  const fetchConfig = useConfigStore((s) => s.fetchConfig);
+  const passwordResetEnabled = useConfigStore((s) => s.passwordResetEnabled);
+  const configLoaded = useConfigStore((s) => s.loaded);
+
+  const [usernameOrEmail, setUsernameOrEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [topLevelError, setTopLevelError] = useState<string | null>(null);
+  const [disabledOnServer, setDisabledOnServer] = useState(false);
+
+  useEffect(() => {
+    void fetchConfig();
+  }, [fetchConfig]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!usernameOrEmail.trim()) return;
+    setTopLevelError(null);
+    setSubmitting(true);
+    try {
+      await authPasswordResetApi.forgotPassword({
+        forgotPasswordRequest: {
+          usernameOrEmail: usernameOrEmail.trim(),
+        },
+      });
+      setSubmitted(true);
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        if (status === 404) {
+          setDisabledOnServer(true);
+          return;
+        }
+        if (status === 429) {
+          const retry = err.response?.headers["retry-after"];
+          setTopLevelError(
+            retry
+              ? `Too many attempts. Try again in ${retry} seconds.`
+              : "Too many attempts. Please wait a moment.",
+          );
+          return;
+        }
+        if (status === 503) {
+          setTopLevelError(
+            (err.response?.data as { message?: string } | undefined)?.message ??
+              "Password reset is temporarily unavailable. Please try again later.",
+          );
+          return;
+        }
+      }
+      // Anything else: still pretend it worked. The operator sees the real
+      // failure in the server log; the user sees the same neutral
+      // confirmation as the success path.
+      setSubmitted(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Server-off / config-off → render the same not-found-style copy as if
+  // the route never existed. Keeps the UI consistent with the backend's
+  // 404 disguise on /auth/forgot-password.
+  if (disabledOnServer || (configLoaded && !passwordResetEnabled)) {
+    return (
+      <AuthCard
+        title="Password reset unavailable"
+        subtitle="Self-service password reset is not enabled on this server."
+      >
+        <Typography variant="body2" color="text.secondary">
+          Contact your administrator to have your password reset.
+        </Typography>
+        <Box sx={{ textAlign: "center", mt: 1 }}>
+          <Link
+            component={RouterLink}
+            to="/login"
+            underline="hover"
+            fontWeight={600}
+          >
+            Back to login
+          </Link>
+        </Box>
+      </AuthCard>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <AuthCard
+        title="Check your inbox"
+        subtitle="If the account exists, a reset link is on its way"
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 2,
+            textAlign: "center",
+          }}
+        >
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+            }}
+            aria-hidden="true"
+          >
+            <Mail size={28} />
+          </Box>
+          <Typography variant="body1">
+            If an account exists for that username or email, a reset link is on
+            its way.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Click the link in the email to set a new password. The link expires
+            after a short while; request a new one if it's stale.
+          </Typography>
+          <Typography variant="caption" color="text.disabled" sx={{ mt: 1 }}>
+            No email? Check your spam folder. If the address you supplied isn't
+            registered, no message is sent — verify the spelling or contact your
+            administrator.
+          </Typography>
+        </Box>
+        <Box sx={{ textAlign: "center", mt: 2 }}>
+          <Link
+            component={RouterLink}
+            to="/login"
+            underline="hover"
+            fontWeight={600}
+          >
+            Back to login
+          </Link>
+        </Box>
+      </AuthCard>
+    );
+  }
+
   return (
     <AuthCard
       title="Reset password"
-      subtitle="Enter your email to receive a reset link"
+      subtitle="Enter your username or email to receive a reset link"
     >
       <Box
         component="form"
         noValidate
+        onSubmit={handleSubmit}
         sx={{ display: "flex", flexDirection: "column", gap: 2 }}
       >
+        {topLevelError && (
+          <Alert severity="error" role="alert">
+            {topLevelError}
+          </Alert>
+        )}
         <TextField
-          label="Email"
-          type="email"
+          label="Username or email"
           required
           size="small"
-          autoComplete="email"
+          autoFocus
+          autoComplete="username"
+          value={usernameOrEmail}
+          onChange={(e) => setUsernameOrEmail(e.target.value)}
+          disabled={submitting}
+          inputProps={{ "aria-label": "Username or email" }}
         />
-        <Button type="submit" variant="contained" size="large" fullWidth>
-          Send Reset Link
+        <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          disabled={submitting || !usernameOrEmail.trim()}
+          startIcon={
+            submitting ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : undefined
+          }
+        >
+          {submitting ? "Sending…" : "Send reset link"}
         </Button>
       </Box>
       <Typography
@@ -54,9 +241,14 @@ export function ForgotPasswordPage() {
         sx={{ textAlign: "center" }}
       >
         Remember your password?{" "}
-        <MuiLink component={Link} to="/login" sx={{ color: "primary.main" }}>
+        <Link
+          component={RouterLink}
+          to="/login"
+          sx={{ color: "primary.main" }}
+          underline="hover"
+        >
           Back to login
-        </MuiLink>
+        </Link>
       </Typography>
     </AuthCard>
   );

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -45,6 +45,7 @@ export function LoginPage() {
   const selfRegistrationEnabled = useConfigStore(
     (s) => s.selfRegistrationEnabled,
   );
+  const passwordResetEnabled = useConfigStore((s) => s.passwordResetEnabled);
   const navigate = useNavigate();
   const location = useLocation();
   const from = new URLSearchParams(location.search).get("from") ?? "/";
@@ -167,6 +168,23 @@ export function LoginPage() {
             },
           }}
         />
+        {passwordResetEnabled && (
+          // Same gating pattern as the Sign-up link: rendered only when the
+          // operator has switched the feature on (#421). The backend 404s
+          // /auth/forgot-password and /auth/reset-password independently,
+          // so flipping this client-side cannot bypass the gate.
+          <Box sx={{ mt: -1, textAlign: "right" }}>
+            <Link
+              component={RouterLink}
+              to="/forgot-password"
+              underline="hover"
+              variant="body2"
+              color="text.secondary"
+            >
+              Forgot password?
+            </Link>
+          </Box>
+        )}
         <Button
           type="submit"
           variant="contained"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ResetPasswordPage } from "./ResetPasswordPage";
+import { buildTheme } from "../theme/theme";
+import { useConfigStore } from "../stores/configStore";
+import { useUiStore } from "../stores/uiStore";
+import * as apiConfig from "../api/config";
+
+vi.mock("../api/config", () => ({
+  authPasswordResetApi: {
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+  axiosInstance: { get: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+const STRONG_PASSWORD = "correct-horse-battery-staple";
+
+function renderAt(query: string) {
+  const theme = buildTheme("light");
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <MemoryRouter initialEntries={[`/reset-password${query}`]}>
+          <Routes>
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
+            <Route path="/login" element={<div>login page</div>} />
+            <Route path="/forgot-password" element={<div>forgot page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ResetPasswordPage", () => {
+  beforeEach(() => {
+    useConfigStore.setState({
+      passwordResetEnabled: true,
+      loaded: true,
+    } as never);
+    useUiStore.setState({ toasts: [] });
+    vi.clearAllMocks();
+  });
+
+  it("renders the no-token branch when ?token= is absent", () => {
+    renderAt("");
+    expect(screen.getByText(/No reset token/i)).toBeInTheDocument();
+    expect(apiConfig.authPasswordResetApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("renders the disabled-on-server card when the /config flag is false", () => {
+    useConfigStore.setState({
+      passwordResetEnabled: false,
+      loaded: true,
+    } as never);
+    renderAt("?token=abc-123");
+    expect(screen.getByText(/Password reset unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("New Password")).not.toBeInTheDocument();
+  });
+
+  it("blocks submit when the password is shorter than 12 chars (matches backend rule)", async () => {
+    const user = userEvent.setup();
+    renderAt("?token=abc-123");
+
+    await user.type(screen.getByLabelText("New Password"), "short");
+    await user.type(screen.getByLabelText("Confirm Password"), "short");
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    expect(
+      await screen.findByText(/at least 12 characters/i),
+    ).toBeInTheDocument();
+    expect(apiConfig.authPasswordResetApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when the confirmation does not match", async () => {
+    const user = userEvent.setup();
+    renderAt("?token=abc-123");
+
+    await user.type(screen.getByLabelText("New Password"), STRONG_PASSWORD);
+    await user.type(
+      screen.getByLabelText("Confirm Password"),
+      `${STRONG_PASSWORD}-typo`,
+    );
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    expect(
+      await screen.findByText(/passwords do not match/i),
+    ).toBeInTheDocument();
+    expect(apiConfig.authPasswordResetApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("submits the form, calls the API with the URL token, and redirects to /login on success", async () => {
+    vi.mocked(apiConfig.authPasswordResetApi.resetPassword).mockResolvedValue({
+      status: 204,
+      data: undefined,
+    } as Awaited<
+      ReturnType<typeof apiConfig.authPasswordResetApi.resetPassword>
+    >);
+    const user = userEvent.setup();
+    renderAt("?token=abc-123");
+
+    await user.type(screen.getByLabelText("New Password"), STRONG_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm Password"), STRONG_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    await waitFor(() => {
+      expect(apiConfig.authPasswordResetApi.resetPassword).toHaveBeenCalledWith(
+        {
+          resetPasswordRequest: {
+            token: "abc-123",
+            newPassword: STRONG_PASSWORD,
+          },
+        },
+      );
+    });
+    expect(await screen.findByText("login page")).toBeInTheDocument();
+    // Confirmation toast is enqueued for the login page to render.
+    expect(useUiStore.getState().toasts).toHaveLength(1);
+    expect(useUiStore.getState().toasts[0].message).toMatch(
+      /password updated/i,
+    );
+  });
+
+  it("surfaces the server message when the token is invalid (400)", async () => {
+    vi.mocked(apiConfig.authPasswordResetApi.resetPassword).mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { message: "Password-reset token has already been used" },
+      },
+      message: "Bad Request",
+    });
+    const user = userEvent.setup();
+    renderAt("?token=stale");
+
+    await user.type(screen.getByLabelText("New Password"), STRONG_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm Password"), STRONG_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    expect(
+      await screen.findByText(/has already been used/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
@@ -16,17 +16,199 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import {
+  Link as RouterLink,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
+import {
+  Alert,
   Box,
-  TextField,
   Button,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Link,
+  TextField,
+  Tooltip,
   Typography,
-  Link as MuiLink,
 } from "@mui/material";
-import { Link } from "react-router-dom";
+import { Eye, EyeOff } from "lucide-react";
+import axios from "axios";
 import { AuthCard } from "../components/auth/AuthCard";
+import { authPasswordResetApi } from "../api/config";
+import { useConfigStore } from "../stores/configStore";
+import { useUiStore } from "../stores/uiStore";
 
+const PASSWORD_MIN_LENGTH = 12;
+
+interface FieldErrors {
+  newPassword?: string;
+  confirmPassword?: string;
+}
+
+function extractApiError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = (error.response?.data as { message?: string } | undefined)
+      ?.message;
+    if (typeof message === "string" && message.length > 0) return message;
+    return error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return "Password reset failed.";
+}
+
+/**
+ * Token-callback page reached from the reset email (#421).
+ *
+ * Reads `?token=…`, asks the user for a new password, and on success
+ * redirects to `/login` with a success toast. The reset endpoint is
+ * single-use, so a duplicate POST (StrictMode double-fire, browser
+ * back/forth) would surface as "already used" — the form-level
+ * `submitted` guard short-circuits this before the second request
+ * leaves the page.
+ *
+ * Mirrors `ForgotPasswordPage`'s server-off disguise: when the
+ * operator has the feature disabled, the page renders the same
+ * not-found-style copy as if the route never existed.
+ */
 export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const token = params.get("token");
+
+  const fetchConfig = useConfigStore((s) => s.fetchConfig);
+  const passwordResetEnabled = useConfigStore((s) => s.passwordResetEnabled);
+  const configLoaded = useConfigStore((s) => s.loaded);
+  const addToast = useUiStore((s) => s.addToast);
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [topLevelError, setTopLevelError] = useState<string | null>(null);
+  const [disabledOnServer, setDisabledOnServer] = useState(false);
+
+  // Single-fire guard against duplicate submits (StrictMode-safe disciplina,
+  // and prevents the second click from racing the first while the request
+  // is still in flight). Mirrors VerifyEmailCallbackPage's pattern.
+  const submitted = useRef(false);
+
+  useEffect(() => {
+    void fetchConfig();
+  }, [fetchConfig]);
+
+  function validateLocally(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (newPassword.length < PASSWORD_MIN_LENGTH) {
+      errors.newPassword = `Password must be at least ${PASSWORD_MIN_LENGTH} characters.`;
+    }
+    if (confirmPassword !== newPassword) {
+      errors.confirmPassword = "Passwords do not match.";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!token || submitted.current) return;
+    const localErrors = validateLocally();
+    if (Object.keys(localErrors).length > 0) {
+      setFieldErrors(localErrors);
+      return;
+    }
+    setFieldErrors({});
+    setTopLevelError(null);
+    setSubmitting(true);
+    submitted.current = true;
+    try {
+      await authPasswordResetApi.resetPassword({
+        resetPasswordRequest: {
+          token,
+          newPassword,
+        },
+      });
+      addToast({
+        type: "success",
+        message: "Password updated. Please sign in with your new password.",
+      });
+      navigate("/login", { replace: true });
+    } catch (err) {
+      // Reset the guard so the user can retry after fixing the cause
+      // (typed the wrong new password, etc.).
+      submitted.current = false;
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        if (status === 404) {
+          setDisabledOnServer(true);
+          return;
+        }
+        if (status === 429) {
+          const retry = err.response?.headers["retry-after"];
+          setTopLevelError(
+            retry
+              ? `Too many attempts on this link. Try again in ${retry} seconds.`
+              : "Too many attempts on this link. Please wait a moment.",
+          );
+          return;
+        }
+      }
+      setTopLevelError(extractApiError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (disabledOnServer || (configLoaded && !passwordResetEnabled)) {
+    return (
+      <AuthCard
+        title="Password reset unavailable"
+        subtitle="Self-service password reset is not enabled on this server."
+      >
+        <Typography variant="body2" color="text.secondary">
+          Contact your administrator to have your password reset.
+        </Typography>
+        <Box sx={{ textAlign: "center", mt: 1 }}>
+          <Link
+            component={RouterLink}
+            to="/login"
+            underline="hover"
+            fontWeight={600}
+          >
+            Back to login
+          </Link>
+        </Box>
+      </AuthCard>
+    );
+  }
+
+  if (!token) {
+    return (
+      <AuthCard
+        title="No reset token"
+        subtitle="The link is missing the required `?token=…` parameter."
+      >
+        <Typography variant="body2" color="text.secondary">
+          Open the link from your reset email instead. If you no longer have the
+          email, request a new reset link.
+        </Typography>
+        <Box sx={{ textAlign: "center", mt: 2 }}>
+          <Link
+            component={RouterLink}
+            to="/forgot-password"
+            underline="hover"
+            fontWeight={600}
+          >
+            Request a new link
+          </Link>
+        </Box>
+      </AuthCard>
+    );
+  }
+
   return (
     <AuthCard
       title="Set new password"
@@ -35,24 +217,97 @@ export function ResetPasswordPage() {
       <Box
         component="form"
         noValidate
+        onSubmit={handleSubmit}
         sx={{ display: "flex", flexDirection: "column", gap: 2 }}
       >
+        {topLevelError && (
+          <Alert severity="error" role="alert">
+            {topLevelError}
+          </Alert>
+        )}
         <TextField
           label="New Password"
-          type="password"
+          type={showNew ? "text" : "password"}
           required
           size="small"
+          autoFocus
           autoComplete="new-password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          disabled={submitting}
+          error={Boolean(fieldErrors.newPassword)}
+          helperText={
+            fieldErrors.newPassword ??
+            `Minimum ${PASSWORD_MIN_LENGTH} characters.`
+          }
+          inputProps={{ "aria-label": "New Password" }}
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title={showNew ? "Hide password" : "Show password"}>
+                    <IconButton
+                      aria-label={showNew ? "Hide password" : "Show password"}
+                      onClick={() => setShowNew((v) => !v)}
+                      edge="end"
+                      size="small"
+                    >
+                      {showNew ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            },
+          }}
         />
         <TextField
           label="Confirm Password"
-          type="password"
+          type={showConfirm ? "text" : "password"}
           required
           size="small"
           autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          disabled={submitting}
+          error={Boolean(fieldErrors.confirmPassword)}
+          helperText={fieldErrors.confirmPassword}
+          inputProps={{ "aria-label": "Confirm Password" }}
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip
+                    title={showConfirm ? "Hide password" : "Show password"}
+                  >
+                    <IconButton
+                      aria-label={
+                        showConfirm ? "Hide password" : "Show password"
+                      }
+                      onClick={() => setShowConfirm((v) => !v)}
+                      edge="end"
+                      size="small"
+                    >
+                      {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            },
+          }}
         />
-        <Button type="submit" variant="contained" size="large" fullWidth>
-          Set Password
+        <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          disabled={submitting}
+          startIcon={
+            submitting ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : undefined
+          }
+        >
+          {submitting ? "Updating…" : "Set Password"}
         </Button>
       </Box>
       <Typography
@@ -60,9 +315,15 @@ export function ResetPasswordPage() {
         color="text.disabled"
         sx={{ textAlign: "center" }}
       >
-        <MuiLink component={Link} to="/login" sx={{ color: "primary.main" }}>
+        Remembered after all?{" "}
+        <Link
+          component={RouterLink}
+          to="/login"
+          sx={{ color: "primary.main" }}
+          underline="hover"
+        >
           Back to login
-        </MuiLink>
+        </Link>
       </Typography>
     </AuthCard>
   );

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -320,9 +320,7 @@ describe("GeneralSection", () => {
     });
     const enableToggle = screen.getByLabelText("Password Reset Enabled");
     expect(enableToggle).not.toBeChecked();
-    const ttlInput = screen.getByLabelText(
-      "Password Reset Token Ttl Minutes",
-    );
+    const ttlInput = screen.getByLabelText("Password Reset Token Ttl Minutes");
     expect(ttlInput).toHaveValue(60);
   });
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -87,6 +87,22 @@ const SAMPLE_SETTINGS: ApplicationSettingDto[] = [
     description:
       "When true (recommended) the new account stays disabled until the user clicks the link in the verification email.",
   }),
+  dto({
+    key: "auth.password_reset_enabled",
+    value: "false",
+    valueType: "BOOLEAN",
+    description:
+      "Master switch for the public /auth/forgot-password and /auth/reset-password endpoints. When false the endpoints and the corresponding 'Forgot password?' link on the login page are hidden (404).",
+  }),
+  dto({
+    key: "auth.password_reset_token_ttl_minutes",
+    value: "60",
+    valueType: "INTEGER",
+    minInt: 5,
+    maxInt: 1440,
+    description:
+      "How long a password-reset link stays valid, in minutes. Range 5..1440.",
+  }),
 ];
 
 describe("GeneralSection", () => {
@@ -288,6 +304,26 @@ describe("GeneralSection", () => {
         },
       });
     });
+  });
+
+  it("renders both password-reset settings in the dedicated section (#421)", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({
+      data: { settings: SAMPLE_SETTINGS },
+    } as never);
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Password Reset")).toBeInTheDocument();
+    });
+    const enableToggle = screen.getByLabelText("Password Reset Enabled");
+    expect(enableToggle).not.toBeChecked();
+    const ttlInput = screen.getByLabelText(
+      "Password Reset Token Ttl Minutes",
+    );
+    expect(ttlInput).toHaveValue(60);
   });
 
   it("renders a restart-pending alert when any setting has restartPending=true", async () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -33,7 +33,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { Activity, Globe, Upload, UserPlus } from "lucide-react";
+import { Activity, Globe, KeyRound, Upload, UserPlus } from "lucide-react";
 import { TimezoneSelect } from "../../components/common/TimezoneSelect";
 import type { ApplicationSettingDto } from "../../api/generated/model/application-setting-dto";
 import { Section } from "../../components/common/Section";
@@ -422,6 +422,17 @@ export function GeneralSection() {
         >
           {renderField("auth.self_registration_enabled")}
           {renderField("auth.self_registration_email_verification_required")}
+        </Section>
+
+        {/* Password Reset */}
+        <Section
+          contentGap={2.5}
+          icon={<KeyRound size={18} />}
+          title="Password Reset"
+          description="Self-service forgot-password flow at /forgot-password"
+        >
+          {renderField("auth.password_reset_enabled")}
+          {renderField("auth.password_reset_token_ttl_minutes")}
         </Section>
       </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
@@ -98,6 +98,15 @@ interface ConfigState {
    * controller's 404 disguise.
    */
   readonly selfRegistrationEnabled: boolean;
+  /**
+   * Whether the operator has enabled the public forgot-password flow
+   * (#421). The login page renders the "Forgot password?" link only
+   * when this is true; visiting `/forgot-password` or `/reset-password`
+   * directly with the setting off yields a NotFound shell. The backend
+   * 404s both endpoints in that state, so flipping this client-side
+   * cannot bypass the gate.
+   */
+  readonly passwordResetEnabled: boolean;
   readonly loaded: boolean;
   /**
    * Fetches `/api/v1/config`. Skips the request when the store is already
@@ -116,6 +125,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   defaultTimezone: "UTC",
   oidcProviders: [],
   selfRegistrationEnabled: false,
+  passwordResetEnabled: false,
   loaded: false,
 
   async fetchConfig(options) {
@@ -136,6 +146,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         oidcProviders: parseOidcProviders(res.data?.auth?.oidcProviders),
         selfRegistrationEnabled:
           res.data?.auth?.selfRegistrationEnabled === true,
+        passwordResetEnabled: res.data?.auth?.passwordResetEnabled === true,
         loaded: true,
       });
     } catch {
@@ -143,6 +154,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         version: "unknown",
         oidcProviders: [],
         selfRegistrationEnabled: false,
+        passwordResetEnabled: false,
         loaded: true,
       });
     }


### PR DESCRIPTION
## Summary

Implements the opt-in self-service forgot-password / reset-password flow tracked by #421, mirroring the shape of the registration toggle from #420 — feature is invisible until the operator flips a setting, hash-at-rest single-use tokens, anti-enumeration response shapes, IP- and token-keyed rate limits, and a fully gated frontend surface.

Three commits, each atomic and CI-green on its own:

- **Phase 1 — token storage + service.** Migrations 0029/0030, `password_reset_token` table, `PasswordResetTokenService` (TTL operator-tunable via `auth.password_reset_token_ttl_minutes`, default 60, range 5–1440), `UserService.applyPasswordReset` that does **not** force `passwordChangeRequired` since the user just chose the password themselves.
- **Phase 2 — HTTP surface.** `POST /auth/forgot-password` and `POST /auth/reset-password`, both 404-disguised when `auth.password_reset_enabled` is false. Forgot-password returns 204 on every success path (anti-enumeration: doesn't-exist, EXTERNAL, disabled, mail-send-fail all collapse to 204), 503 when SMTP is unconfigured, 429 when the IP bucket is hit. Reset-password revokes both the access-token side via `passwordInvalidatedBefore` AND the refresh-token family via `refreshTokenService.revokeAllForUser`, plus clears the refresh cookie. The dual revocation is mandatory because `AuthController.refresh` does not consult `passwordInvalidatedBefore` — without it a stolen refresh cookie would keep minting fresh access tokens after the reset.
- **Phase 3 — frontend.** `ForgotPasswordPage` (stub → full), new `ResetPasswordPage` with `useRef` single-fire guard, `LoginPage` "Forgot password?" link gated on `serverConfig.auth.passwordResetEnabled`. `configStore` exposes the new flag; `api/config.ts` registers the generated `authPasswordResetApi`. 11 component tests cover the success/disabled/error matrices.

## Security properties

- Tokens: 32-byte SecureRandom → base64url (43 chars) → SHA-256 hex stored. Single-use, TTL-bound, supersede-previous on issue. Mirrors the verification-token posture from #420.
- Anti-enumeration: forgot-password's response shape is independent of whether the username/email exists, whether the user is INTERNAL or EXTERNAL, whether they are enabled, or whether the mail send succeeded. The IP bucket is deliberately not username-keyed — that would reintroduce a timing oracle.
- Session revocation: a successful reset invalidates every active session (access tokens via `passwordInvalidatedBefore`, refresh family via `revokeAllForUser`, browser cookie cleared on the response). Verified that `AuthController.refresh` does NOT honour `passwordInvalidatedBefore`, hence the explicit refresh-family revocation in the controller.
- Operator gate: feature is off by default; the `/config` flag is read-only and the backend re-enforces the gate independently.

## Test plan

### Backend (gradle test, all green)

- [x] `PasswordResetTokenServiceTest` (8 tests): hash-at-rest, single-use consume, expired-token rejection, supersede-previous, TTL respects the operator-tunable setting (default 60 min, override 5 min)
- [x] `UserServiceTest` extension (3 new tests): `applyPasswordReset` re-hashes the password, leaves `passwordChangeRequired=false`, bumps `passwordInvalidatedBefore`, rejects EXTERNAL users
- [x] `AuthPasswordResetControllerTest` (10 tests): 404 when feature off, 503 when SMTP off, anti-enumeration 204 for unknown / EXTERNAL / disabled / mail-failure branches, happy-path mail send with `AUTH_PASSWORD_RESET` template, 429 on token-bucket exhaustion, 400 with server message on invalid-token, happy-path applies password + revokes refresh family + clears cookie
- [x] `PreAuthorizeCoverageTest` allow-list updated for the two new public endpoints
- [x] All sibling `@WebMvcTest` slices updated to exclude the new `PasswordResetRateLimitFilter` from their component scan

### Frontend (vitest, 407 tests passing)

- [x] `ForgotPasswordPage.test.tsx` (5 tests): renders form when enabled, renders disabled card when off, anti-enumeration confirmation on 204, anti-enumeration confirmation on unexpected 5xx, surfaces 503 inline
- [x] `ResetPasswordPage.test.tsx` (6 tests): renders no-token branch, renders disabled card, blocks submit on weak password, blocks submit on confirmation mismatch, happy-path API call + redirect + toast, surfaces 400 server message
- [x] Existing 396 frontend tests still green

### Local end-to-end (Mailpit)

- [ ] `docker-compose up postgres mailpit`, backend with `PLUGWERK_WEB_BASE_URL=http://localhost:5173`, frontend `npm run dev`
- [ ] Admin → General Settings → Self-Registration / Password Reset toggle ON
- [ ] Logout, click "Forgot password?" on /login, enter username/email, submit → confirmation page
- [ ] Mailpit (http://localhost:8025) shows reset email; click link → /reset-password?token=…
- [ ] Enter new password (≥12 chars), confirm, submit → redirect to /login with success toast
- [ ] Login with old password fails; login with new password succeeds
- [ ] Reuse same link → "already used" inline error
- [ ] Forgot-password with a non-existent email → confirmation page identical, no Mailpit message
- [ ] Forgot-password with an EXTERNAL/OIDC user's email → confirmation page identical, no Mailpit message
- [ ] Setting OFF → /login link gone, /forgot-password and /reset-password render "Password reset unavailable"
- [ ] 6× rapid POST to /auth/forgot-password from one IP → 6th returns 429 with Retry-After

🤖 Generated with [Claude Code](https://claude.com/claude-code)