### PR TITLE
fix(deps): bump postcss >=8.5.10 (CVE-2026-41305, code-scanning #14)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -9357,9 +9357,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/plugwerk-server/plugwerk-server-frontend/package.json
+++ b/plugwerk-server/plugwerk-server-frontend/package.json
@@ -61,6 +61,7 @@
   },
   "overrides": {
     "dompurify": "^3.4.0",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Closes code-scanning alert [#14](https://github.com/plugwerk/plugwerk/security/code-scanning/14): postcss 8.5.8 → ≥ 8.5.10 (npm install resolved 8.5.14).

CVE-2026-41305 is a medium-severity XSS via improper escaping of style closing tags. PostCSS is a transitive dependency reached through two paths:

- vite 8.0.8 → postcss
- @scalar/api-reference-react → @scalar/api-reference → vue → @vue/compiler-sfc → postcss

Neither parent has a release out yet that pins 8.5.10+, so an npm `overrides` entry is the cleanest patch — surgical, removable the moment one of those parents catches up.

## What changed

- `package.json` — added `\"postcss\": \"^8.5.10\"` to the existing `overrides` block (alongside the dompurify and follow-redirects pins already there for similar reasons).
- `package-lock.json` — `npm install` regenerated.

Practical impact on Plugwerk is minimal: PostCSS only runs at build time (Vite + Tailwind pipelines), no user input is fed into a CSS string at runtime. The bump is here to keep the security dashboard clean and to dodge the case where a future feature does start pushing untrusted strings through PostCSS.

## Test plan

- [x] `npm install` produces a deterministic lockfile with postcss@8.5.14 in both dep trees
- [x] `npm run build` clean
- [x] `npm run test:run` — 46 files / 396 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)