### PR TITLE
chore(deps): MUI Material v7 → v9 migration (#456)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,13 +105,6 @@
       "description": "npm major updates — one PR per package (no grouping). Bundling unrelated majors caused PR #394 to ship a broken lockfile because typescript-eslint v8 still pinned eslint <10 while the group already advanced eslint to 10. Per-package PRs let each major be reviewed and merged independently of incompatible peers.",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"]
-    },
-    {
-      "description": "Mute @mui/material major bumps during the v7→v9 migration tracked in #456. The bot opened PR #453 against v9 and produced 62 type errors; the migration is being done deliberately on chore/456-mui-v9 with manual codemods + visual QA. Remove this rule once the migration ships so future v9.x majors flow normally.",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@mui/material"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,6 +105,13 @@
       "description": "npm major updates — one PR per package (no grouping). Bundling unrelated majors caused PR #394 to ship a broken lockfile because typescript-eslint v8 still pinned eslint <10 while the group already advanced eslint to 10. Per-package PRs let each major be reviewed and merged independently of incompatible peers.",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Mute @mui/material major bumps during the v7→v9 migration tracked in #456. The bot opened PR #453 against v9 and produced 62 type errors; the migration is being done deliberately on chore/456-mui-v9 with manual codemods + visual QA. Remove this rule once the migration ships so future v9.x majors flow normally.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@mui/material"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/styled": "^11.14.1",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@mui/material": "^7.3.9",
+        "@mui/material": "^9.0.0",
         "@scalar/api-reference-react": "^0.9.23",
         "@tanstack/react-query": "^5.100.0",
         "@uiw/react-codemirror": "^4.25.9",
@@ -1547,9 +1547,9 @@
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
-      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
+      "integrity": "sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1557,22 +1557,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
-      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
+      "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.9",
-        "@mui/system": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.0",
+        "@mui/system": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.4",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -1585,7 +1585,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.9",
+        "@mui/material-pigment-css": "^9.0.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1606,13 +1606,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
-      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
+      "integrity": "sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1633,12 +1633,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
-      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1667,16 +1667,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
-      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.0.tgz",
+      "integrity": "sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.9",
-        "@mui/styled-engine": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.0",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -1707,12 +1707,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1724,17 +1724,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
-      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
+        "react-is": "^19.2.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9812,9 +9812,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/plugwerk-server/plugwerk-server-frontend/package.json
+++ b/plugwerk-server/plugwerk-server-frontend/package.json
@@ -23,7 +23,7 @@
     "@emotion/styled": "^11.14.1",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@mui/material": "^7.3.9",
+    "@mui/material": "^9.0.0",
     "@scalar/api-reference-react": "^0.9.23",
     "@tanstack/react-query": "^5.100.0",
     "@uiw/react-codemirror": "^4.25.9",

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
@@ -233,7 +233,9 @@ export function CreateNamespaceDialog({
             label={
               <Box>
                 <Typography variant="body2">Public Catalog</Typography>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{
+                  color: "text.secondary"
+                }}>
                   Allow unauthenticated users to browse the plugin catalog.
                 </Typography>
               </Box>
@@ -251,7 +253,9 @@ export function CreateNamespaceDialog({
             label={
               <Box>
                 <Typography variant="body2">Auto-Approve Releases</Typography>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{
+                  color: "text.secondary"
+                }}>
                   Uploaded releases are published immediately without manual
                   review.
                 </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/CreateNamespaceDialog.tsx
@@ -233,9 +233,12 @@ export function CreateNamespaceDialog({
             label={
               <Box>
                 <Typography variant="body2">Public Catalog</Typography>
-                <Typography variant="caption" sx={{
-                  color: "text.secondary"
-                }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: "text.secondary",
+                  }}
+                >
                   Allow unauthenticated users to browse the plugin catalog.
                 </Typography>
               </Box>
@@ -253,9 +256,12 @@ export function CreateNamespaceDialog({
             label={
               <Box>
                 <Typography variant="body2">Auto-Approve Releases</Typography>
-                <Typography variant="caption" sx={{
-                  color: "text.secondary"
-                }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: "text.secondary",
+                  }}
+                >
                   Uploaded releases are published immediately without manual
                   review.
                 </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -143,9 +143,12 @@ export function NamespaceDetailView() {
         <Typography variant="h2" sx={{ mb: 0.5 }}>
           {slug}
         </Typography>
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Manage namespace settings, members, and API keys.
         </Typography>
       </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespaceDetailView.tsx
@@ -143,11 +143,12 @@ export function NamespaceDetailView() {
         <Typography variant="h2" sx={{ mb: 0.5 }}>
           {slug}
         </Typography>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Manage namespace settings, members, and API keys.
         </Typography>
       </Box>
-
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
         <Section
           icon={<Settings size={18} />}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -74,7 +74,9 @@ export function NamespacesSection() {
       key: "slug",
       header: "Slug",
       render: (ns) => (
-        <Typography variant="body2" fontWeight={500}>
+        <Typography variant="body2" sx={{
+          fontWeight: 500
+        }}>
           {ns.slug}
         </Typography>
       ),
@@ -83,7 +85,9 @@ export function NamespacesSection() {
       key: "name",
       header: "Name",
       render: (ns) => (
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" sx={{
+          color: "text.secondary"
+        }}>
           {ns.name || "\u2014"}
         </Typography>
       ),
@@ -134,13 +138,14 @@ export function NamespacesSection() {
           Create Namespace
         </Button>
       </Box>
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : namespaces.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No namespaces found.
         </Typography>
       ) : (
@@ -151,14 +156,12 @@ export function NamespacesSection() {
           columns={namespaceCols}
         />
       )}
-
       <CreateNamespaceDialog
         open={createOpen}
         onClose={() => setCreateOpen(false)}
         onCreated={handleCreated}
         onError={(msg) => addToast({ message: msg, type: "error" })}
       />
-
       <DeleteNamespaceDialog
         namespace={deleteTarget}
         onClose={() => setDeleteTarget(null)}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/NamespacesSection.tsx
@@ -74,9 +74,12 @@ export function NamespacesSection() {
       key: "slug",
       header: "Slug",
       render: (ns) => (
-        <Typography variant="body2" sx={{
-          fontWeight: 500
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 500,
+          }}
+        >
           {ns.slug}
         </Typography>
       ),
@@ -85,9 +88,12 @@ export function NamespacesSection() {
       key: "name",
       header: "Name",
       render: (ns) => (
-        <Typography variant="caption" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           {ns.name || "\u2014"}
         </Typography>
       ),
@@ -143,9 +149,12 @@ export function NamespacesSection() {
           <CircularProgress size={24} />
         </Box>
       ) : namespaces.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No namespaces found.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/mail-template-preview/MailTemplatePreviewPane.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/mail-template-preview/MailTemplatePreviewPane.tsx
@@ -124,25 +124,27 @@ export function MailTemplatePreviewPane({
     >
       <Stack
         direction="row"
-        alignItems="center"
         spacing={1}
         sx={{
+          alignItems: "center",
           px: 1.5,
           py: 0.5,
           minHeight: 36,
           borderBottom: "1px solid",
           borderColor: "divider",
+
           background: isDark
             ? alpha("#ffffff", 0.04)
-            : alpha(tokens.color.gray20, 0.4),
-        }}
-      >
+            : alpha(tokens.color.gray20, 0.4)
+        }}>
         <Stack
           direction="row"
-          alignItems="center"
           spacing={0.75}
-          sx={{ flex: 1, minWidth: 0 }}
-        >
+          sx={{
+            alignItems: "center",
+            flex: 1,
+            minWidth: 0
+          }}>
           <Typography
             variant="caption"
             sx={{
@@ -166,7 +168,9 @@ export function MailTemplatePreviewPane({
               onClick={(e) => setVarsAnchor(e.currentTarget)}
               sx={{ borderRadius: tokens.radius.btn }}
             >
-              <Stack direction="row" alignItems="center" spacing={0.375}>
+              <Stack direction="row" spacing={0.375} sx={{
+                alignItems: "center"
+              }}>
                 <Variable size={13} />
                 <Typography
                   variant="caption"
@@ -197,7 +201,6 @@ export function MailTemplatePreviewPane({
           </span>
         </Tooltip>
       </Stack>
-
       <Popover
         open={Boolean(varsAnchor)}
         anchorEl={varsAnchor}
@@ -217,7 +220,12 @@ export function MailTemplatePreviewPane({
           },
         }}
       >
-        <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1.25 }}>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 600,
+            mb: 1.25
+          }}>
           Sample variables
         </Typography>
         <Stack spacing={1.25}>
@@ -248,13 +256,15 @@ export function MailTemplatePreviewPane({
         </Stack>
         <Typography
           variant="caption"
-          color="text.secondary"
-          sx={{ display: "block", mt: 1.5, fontStyle: "italic" }}
-        >
+          sx={{
+            color: "text.secondary",
+            display: "block",
+            mt: 1.5,
+            fontStyle: "italic"
+          }}>
           Changes apply automatically after a short pause.
         </Typography>
       </Popover>
-
       <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
         {showError ? (
           <Box sx={{ p: 1.5 }}>
@@ -354,9 +364,12 @@ function StatusBadge({ status }: StatusBadgeProps): ReactNode {
   return (
     <Stack
       direction="row"
-      alignItems="center"
       spacing={0.5}
+      role="status"
+      aria-live="polite"
+      aria-label={`Preview status: ${meta.label}`}
       sx={{
+        alignItems: "center",
         px: 0.875,
         py: 0.125,
         borderRadius: 999,
@@ -367,12 +380,8 @@ function StatusBadge({ status }: StatusBadgeProps): ReactNode {
         letterSpacing: 0.5,
         textTransform: "uppercase",
         userSelect: "none",
-        flexShrink: 0,
-      }}
-      role="status"
-      aria-live="polite"
-      aria-label={`Preview status: ${meta.label}`}
-    >
+        flexShrink: 0
+      }}>
       <Box
         sx={{
           display: "flex",

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/mail-template-preview/MailTemplatePreviewPane.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/mail-template-preview/MailTemplatePreviewPane.tsx
@@ -135,16 +135,18 @@ export function MailTemplatePreviewPane({
 
           background: isDark
             ? alpha("#ffffff", 0.04)
-            : alpha(tokens.color.gray20, 0.4)
-        }}>
+            : alpha(tokens.color.gray20, 0.4),
+        }}
+      >
         <Stack
           direction="row"
           spacing={0.75}
           sx={{
             alignItems: "center",
             flex: 1,
-            minWidth: 0
-          }}>
+            minWidth: 0,
+          }}
+        >
           <Typography
             variant="caption"
             sx={{
@@ -168,9 +170,13 @@ export function MailTemplatePreviewPane({
               onClick={(e) => setVarsAnchor(e.currentTarget)}
               sx={{ borderRadius: tokens.radius.btn }}
             >
-              <Stack direction="row" spacing={0.375} sx={{
-                alignItems: "center"
-              }}>
+              <Stack
+                direction="row"
+                spacing={0.375}
+                sx={{
+                  alignItems: "center",
+                }}
+              >
                 <Variable size={13} />
                 <Typography
                   variant="caption"
@@ -224,8 +230,9 @@ export function MailTemplatePreviewPane({
           variant="subtitle2"
           sx={{
             fontWeight: 600,
-            mb: 1.25
-          }}>
+            mb: 1.25,
+          }}
+        >
           Sample variables
         </Typography>
         <Stack spacing={1.25}>
@@ -260,8 +267,9 @@ export function MailTemplatePreviewPane({
             color: "text.secondary",
             display: "block",
             mt: 1.5,
-            fontStyle: "italic"
-          }}>
+            fontStyle: "italic",
+          }}
+        >
           Changes apply automatically after a short pause.
         </Typography>
       </Popover>
@@ -380,8 +388,9 @@ function StatusBadge({ status }: StatusBadgeProps): ReactNode {
         letterSpacing: 0.5,
         textTransform: "uppercase",
         userSelect: "none",
-        flexShrink: 0
-      }}>
+        flexShrink: 0,
+      }}
+    >
       <Box
         sx={{
           display: "flex",

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
@@ -151,15 +151,21 @@ export function ApiKeysSection({ slug }: { slug: string }) {
       header: "Expires",
       render: (key) =>
         key.expiresAt ? (
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             <Timestamp date={key.expiresAt} />
           </Typography>
         ) : (
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             Never
           </Typography>
         ),
@@ -168,9 +174,12 @@ export function ApiKeysSection({ slug }: { slug: string }) {
       key: "created",
       header: "Created",
       render: (key) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={key.createdAt} />
         </Typography>
       ),
@@ -198,8 +207,9 @@ export function ApiKeysSection({ slug }: { slug: string }) {
           variant="caption"
           sx={{
             color: "text.secondary",
-            flex: 1
-          }}>
+            flex: 1,
+          }}
+        >
           API keys provide programmatic access for CI/CD pipelines and the SDK.
           The key is shown only once after creation.
         </Typography>
@@ -240,9 +250,12 @@ export function ApiKeysSection({ slug }: { slug: string }) {
           <CircularProgress size={24} />
         </Box>
       ) : keys.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No API keys configured.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/ApiKeysSection.tsx
@@ -151,11 +151,15 @@ export function ApiKeysSection({ slug }: { slug: string }) {
       header: "Expires",
       render: (key) =>
         key.expiresAt ? (
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             <Timestamp date={key.expiresAt} />
           </Typography>
         ) : (
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             Never
           </Typography>
         ),
@@ -164,7 +168,9 @@ export function ApiKeysSection({ slug }: { slug: string }) {
       key: "created",
       header: "Created",
       render: (key) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={key.createdAt} />
         </Typography>
       ),
@@ -188,7 +194,12 @@ export function ApiKeysSection({ slug }: { slug: string }) {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
-        <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+            flex: 1
+          }}>
           API keys provide programmatic access for CI/CD pipelines and the SDK.
           The key is shown only once after creation.
         </Typography>
@@ -202,7 +213,6 @@ export function ApiKeysSection({ slug }: { slug: string }) {
           Generate Key
         </Button>
       </Box>
-
       {newKey && (
         <Alert
           severity="success"
@@ -225,13 +235,14 @@ export function ApiKeysSection({ slug }: { slug: string }) {
           </Typography>
         </Alert>
       )}
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : keys.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No API keys configured.
         </Typography>
       ) : (
@@ -243,7 +254,6 @@ export function ApiKeysSection({ slug }: { slug: string }) {
           rowSx={(key) => (key.revoked ? { opacity: 0.5 } : undefined)}
         />
       )}
-
       <AppDialog
         open={createOpen}
         onClose={() => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -316,13 +316,12 @@ export function MembersSection({ slug }: { slug: string }) {
           >
             <Typography
               variant="body2"
-              fontWeight={500}
               sx={{
+                fontWeight: 500,
                 whiteSpace: "nowrap",
                 overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
+                textOverflow: "ellipsis"
+              }}>
               {member.displayName}
             </Typography>
             {secondary && (
@@ -341,12 +340,11 @@ export function MembersSection({ slug }: { slug: string }) {
                 </Box>
                 <Typography
                   variant="caption"
-                  color="text.secondary"
                   sx={{
+                    color: "text.secondary",
                     flexShrink: 0,
-                    whiteSpace: "nowrap",
-                  }}
-                >
+                    whiteSpace: "nowrap"
+                  }}>
                   {secondary}
                 </Typography>
               </>
@@ -381,7 +379,9 @@ export function MembersSection({ slug }: { slug: string }) {
       key: "created",
       header: "Created",
       render: (member) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={member.createdAt} />
         </Typography>
       ),
@@ -420,13 +420,14 @@ export function MembersSection({ slug }: { slug: string }) {
           Add Members
         </Button>
       </Box>
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : members.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No members found.
         </Typography>
       ) : (
@@ -437,7 +438,6 @@ export function MembersSection({ slug }: { slug: string }) {
           ariaLabel="Namespace members"
         />
       )}
-
       <AppDialog
         open={addOpen}
         onClose={() => {

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -320,8 +320,9 @@ export function MembersSection({ slug }: { slug: string }) {
                 fontWeight: 500,
                 whiteSpace: "nowrap",
                 overflow: "hidden",
-                textOverflow: "ellipsis"
-              }}>
+                textOverflow: "ellipsis",
+              }}
+            >
               {member.displayName}
             </Typography>
             {secondary && (
@@ -343,8 +344,9 @@ export function MembersSection({ slug }: { slug: string }) {
                   sx={{
                     color: "text.secondary",
                     flexShrink: 0,
-                    whiteSpace: "nowrap"
-                  }}>
+                    whiteSpace: "nowrap",
+                  }}
+                >
                   {secondary}
                 </Typography>
               </>
@@ -379,9 +381,12 @@ export function MembersSection({ slug }: { slug: string }) {
       key: "created",
       header: "Created",
       render: (member) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={member.createdAt} />
         </Typography>
       ),
@@ -425,9 +430,12 @@ export function MembersSection({ slug }: { slug: string }) {
           <CircularProgress size={24} />
         </Box>
       ) : members.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No members found.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
@@ -70,14 +70,15 @@ export function AuthCard({ title, subtitle, children }: AuthCardProps) {
             // `text.secondary` (not `text.disabled`) — the subtitle is
             // information, not a placeholder. Disabled grey reads as
             // "this field is unavailable" on form-heavy surfaces.
-            (<Typography
+            <Typography
               variant="body2"
               sx={{
                 color: "text.secondary",
-                mt: 0.5
-              }}>
+                mt: 0.5,
+              }}
+            >
               {subtitle}
-            </Typography>)
+            </Typography>
           )}
         </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
@@ -70,9 +70,14 @@ export function AuthCard({ title, subtitle, children }: AuthCardProps) {
             // `text.secondary` (not `text.disabled`) — the subtitle is
             // information, not a placeholder. Disabled grey reads as
             // "this field is unavailable" on form-heavy surfaces.
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            (<Typography
+              variant="body2"
+              sx={{
+                color: "text.secondary",
+                mt: 0.5
+              }}>
               {subtitle}
-            </Typography>
+            </Typography>)
           )}
         </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
@@ -97,19 +97,19 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
         href={provider.accountPickerLoginUrl}
         variant="caption"
         underline="hover"
-        color="text.secondary"
         aria-label={`Sign in with a different ${provider.name} account`}
         sx={{
+          color: "text.secondary",
+
           // Same `text.secondary` colour as the GitHub-hint host link
           // below, including on hover — keeps both affordances visually
           // identical so the difference between "click me" and "this is
           // here for context" lives in the wording, not the colour.
           fontWeight: 500,
-          "&:hover": { color: "text.secondary" },
-        }}
-      >
-        Use a different account
-      </Link>
+
+          "&:hover": { color: "text.secondary" }
+        }}>Use a different account
+              </Link>
     );
   }
   if (provider.accountSwitchHintUrl) {
@@ -122,10 +122,11 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
     return (
       <Typography
         variant="caption"
-        color="text.secondary"
-        sx={{ textAlign: "center", lineHeight: 1.4 }}
-      >
-        To switch accounts, sign out at{" "}
+        sx={{
+          color: "text.secondary",
+          textAlign: "center",
+          lineHeight: 1.4
+        }}>To switch accounts, sign out at{" "}
         <Link
           component="a"
           href={provider.accountSwitchHintUrl}
@@ -136,9 +137,8 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
           sx={{ fontFamily: "monospace" }}
         >
           {hintHost}
-        </Link>{" "}
-        first.
-      </Typography>
+        </Link>{" "}first.
+              </Typography>
     );
   }
   return null;

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/OidcProviderButton.tsx
@@ -107,9 +107,11 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
           // here for context" lives in the wording, not the colour.
           fontWeight: 500,
 
-          "&:hover": { color: "text.secondary" }
-        }}>Use a different account
-              </Link>
+          "&:hover": { color: "text.secondary" },
+        }}
+      >
+        Use a different account
+      </Link>
     );
   }
   if (provider.accountSwitchHintUrl) {
@@ -125,8 +127,10 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
         sx={{
           color: "text.secondary",
           textAlign: "center",
-          lineHeight: 1.4
-        }}>To switch accounts, sign out at{" "}
+          lineHeight: 1.4,
+        }}
+      >
+        To switch accounts, sign out at{" "}
         <Link
           component="a"
           href={provider.accountSwitchHintUrl}
@@ -137,8 +141,9 @@ function ProviderAccountSwitchAffordance({ provider }: AffordanceProps) {
           sx={{ fontFamily: "monospace" }}
         >
           {hintHost}
-        </Link>{" "}first.
-              </Typography>
+        </Link>{" "}
+        first.
+      </Typography>
     );
   }
   return null;

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PaginationBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PaginationBar.tsx
@@ -56,7 +56,9 @@ export function PaginationBar({
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-        <Typography variant="caption" color="text.primary">
+        <Typography variant="caption" sx={{
+          color: "text.primary"
+        }}>
           Show:
         </Typography>
         <FilterSelect
@@ -72,7 +74,6 @@ export function PaginationBar({
           ))}
         </FilterSelect>
       </Box>
-
       <Pagination
         count={totalPages}
         page={filters.page + 1}
@@ -81,8 +82,9 @@ export function PaginationBar({
         color="primary"
         aria-label="Pagination"
       />
-
-      <Typography variant="caption" color="text.primary">
+      <Typography variant="caption" sx={{
+        color: "text.primary"
+      }}>
         Showing {start}–{end} of {totalElements}
       </Typography>
     </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PaginationBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PaginationBar.tsx
@@ -56,9 +56,12 @@ export function PaginationBar({
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-        <Typography variant="caption" sx={{
-          color: "text.primary"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.primary",
+          }}
+        >
           Show:
         </Typography>
         <FilterSelect
@@ -82,9 +85,12 @@ export function PaginationBar({
         color="primary"
         aria-label="Pagination"
       />
-      <Typography variant="caption" sx={{
-        color: "text.primary"
-      }}>
+      <Typography
+        variant="caption"
+        sx={{
+          color: "text.primary",
+        }}
+      >
         Showing {start}–{end} of {totalElements}
       </Typography>
     </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -130,8 +130,9 @@ export const PluginCard = memo(function PluginCard({
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
                     flex: 1,
-                    minWidth: 0
-                  }}>
+                    minWidth: 0,
+                  }}
+                >
                   {plugin.name}
                 </Typography>
               </Tooltip>
@@ -161,8 +162,9 @@ export const PluginCard = memo(function PluginCard({
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
-                    minWidth: 0
-                  }}>
+                    minWidth: 0,
+                  }}
+                >
                   {plugin.provider ? `by ${plugin.provider}` : ""}
                 </Typography>
               </Tooltip>
@@ -186,8 +188,9 @@ export const PluginCard = memo(function PluginCard({
                 WebkitLineClamp: 2,
                 WebkitBoxOrient: "vertical",
                 overflow: "hidden",
-                lineHeight: 1.6
-              }}>
+                lineHeight: 1.6,
+              }}
+            >
               {plugin.description}
             </Typography>
           </Tooltip>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginCard.tsx
@@ -124,15 +124,14 @@ export const PluginCard = memo(function PluginCard({
                 <Typography
                   ref={nameRef}
                   variant="body1"
-                  fontWeight={600}
                   sx={{
+                    fontWeight: 600,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
                     flex: 1,
-                    minWidth: 0,
-                  }}
-                >
+                    minWidth: 0
+                  }}>
                   {plugin.name}
                 </Typography>
               </Tooltip>
@@ -157,14 +156,13 @@ export const PluginCard = memo(function PluginCard({
                 <Typography
                   ref={providerRef}
                   variant="caption"
-                  color="text.disabled"
                   sx={{
+                    color: "text.disabled",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
-                    minWidth: 0,
-                  }}
-                >
+                    minWidth: 0
+                  }}>
                   {plugin.provider ? `by ${plugin.provider}` : ""}
                 </Typography>
               </Tooltip>
@@ -182,15 +180,14 @@ export const PluginCard = memo(function PluginCard({
             <Typography
               ref={descRef}
               variant="body2"
-              color="text.secondary"
               sx={{
+                color: "text.secondary",
                 display: "-webkit-box",
                 WebkitLineClamp: 2,
                 WebkitBoxOrient: "vertical",
                 overflow: "hidden",
-                lineHeight: 1.6,
-              }}
-            >
+                lineHeight: 1.6
+              }}>
               {plugin.description}
             </Typography>
           </Tooltip>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -95,10 +95,11 @@ export const PluginListRow = memo(function PluginListRow({
       >
         <Puzzle size={20} />
       </Box>
-
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-          <Typography variant="body2" fontWeight={600} noWrap>
+          <Typography variant="body2" noWrap sx={{
+            fontWeight: 600
+          }}>
             {plugin.name}
           </Typography>
           {isDraftOnly && (
@@ -116,10 +117,14 @@ export const PluginListRow = memo(function PluginListRow({
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
           {plugin.provider && (
             <>
-              <Typography variant="caption" color="text.disabled">
+              <Typography variant="caption" sx={{
+                color: "text.disabled"
+              }}>
                 by {plugin.provider}
               </Typography>
-              <Typography variant="caption" color="text.disabled">
+              <Typography variant="caption" sx={{
+                color: "text.disabled"
+              }}>
                 ·
               </Typography>
             </>
@@ -127,7 +132,6 @@ export const PluginListRow = memo(function PluginListRow({
           <CopyablePluginId pluginId={plugin.pluginId} />
         </Box>
       </Box>
-
       {/* Tags */}
       {plugin.tags && plugin.tags.length > 0 && (
         <Box sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}>
@@ -138,7 +142,6 @@ export const PluginListRow = memo(function PluginListRow({
           ))}
         </Box>
       )}
-
       {/* Quick download */}
       {downloadUrl && (
         <ActionIconButton
@@ -154,7 +157,6 @@ export const PluginListRow = memo(function PluginListRow({
           }}
         />
       )}
-
       <Box
         sx={{ display: "flex", gap: 2, color: "text.disabled", flexShrink: 0 }}
       >

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/PluginListRow.tsx
@@ -97,9 +97,13 @@ export const PluginListRow = memo(function PluginListRow({
       </Box>
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-          <Typography variant="body2" noWrap sx={{
-            fontWeight: 600
-          }}>
+          <Typography
+            variant="body2"
+            noWrap
+            sx={{
+              fontWeight: 600,
+            }}
+          >
             {plugin.name}
           </Typography>
           {isDraftOnly && (
@@ -117,14 +121,20 @@ export const PluginListRow = memo(function PluginListRow({
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
           {plugin.provider && (
             <>
-              <Typography variant="caption" sx={{
-                color: "text.disabled"
-              }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "text.disabled",
+                }}
+              >
                 by {plugin.provider}
               </Typography>
-              <Typography variant="caption" sx={{
-                color: "text.disabled"
-              }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "text.disabled",
+                }}
+              >
                 ·
               </Typography>
             </>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
@@ -115,7 +115,6 @@ export function AppDialog({
           <X size={18} />
         </IconButton>
       </DialogTitle>
-
       {/* ── Content ── */}
       <DialogContent
         sx={{
@@ -133,15 +132,15 @@ export function AppDialog({
         {description && (
           <Typography
             variant="body2"
-            color="text.secondary"
-            sx={{ mb: children ? 2.5 : 0 }}
-          >
+            sx={{
+              color: "text.secondary",
+              mb: children ? 2.5 : 0
+            }}>
             {description}
           </Typography>
         )}
         {children}
       </DialogContent>
-
       {/* ── Footer ── */}
       {!hideActions && (
         <DialogActions>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/AppDialog.tsx
@@ -134,8 +134,9 @@ export function AppDialog({
             variant="body2"
             sx={{
               color: "text.secondary",
-              mb: children ? 2.5 : 0
-            }}>
+              mb: children ? 2.5 : 0,
+            }}
+          >
             {description}
           </Typography>
         )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
@@ -52,8 +52,9 @@ export function DataTable<T>({
         variant="body2"
         sx={{
           color: "text.secondary",
-          py: 3
-        }}>
+          py: 3,
+        }}
+      >
         {emptyMessage}
       </Typography>
     );

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/DataTable.tsx
@@ -48,7 +48,12 @@ export function DataTable<T>({
 }: DataTableProps<T>) {
   if (rows.length === 0 && emptyMessage) {
     return (
-      <Typography variant="body2" color="text.secondary" sx={{ py: 3 }}>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+          py: 3
+        }}>
         {emptyMessage}
       </Typography>
     );

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/EmptyState.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/EmptyState.tsx
@@ -59,17 +59,21 @@ export function EmptyState({
         <path d="M20 26h12M26 20v12" />
         <path d="M44 10 l4-4 M10 44 l-4 4" opacity="0.4" />
       </Box>
-      <Typography variant="h3" sx={{
-        color: "text.primary"
-      }}>
+      <Typography
+        variant="h3"
+        sx={{
+          color: "text.primary",
+        }}
+      >
         {title}
       </Typography>
       <Typography
         variant="body1"
         sx={{
           color: "text.secondary",
-          maxWidth: 400
-        }}>
+          maxWidth: 400,
+        }}
+      >
         {message}
       </Typography>
       {actionLabel && onAction && (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/EmptyState.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/EmptyState.tsx
@@ -59,10 +59,17 @@ export function EmptyState({
         <path d="M20 26h12M26 20v12" />
         <path d="M44 10 l4-4 M10 44 l-4 4" opacity="0.4" />
       </Box>
-      <Typography variant="h3" color="text.primary">
+      <Typography variant="h3" sx={{
+        color: "text.primary"
+      }}>
         {title}
       </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 400 }}>
+      <Typography
+        variant="body1"
+        sx={{
+          color: "text.secondary",
+          maxWidth: 400
+        }}>
         {message}
       </Typography>
       {actionLabel && onAction && (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/FilterAutocomplete.tsx
@@ -53,12 +53,18 @@ export function FilterAutocomplete({
           placeholder={placeholder}
           aria-label={ariaLabel}
           slotProps={{
+            // Preserve every slot Autocomplete injects via params.slotProps —
+            // critically `htmlInput` (carries the input ref + ARIA wiring
+            // from useAutocomplete; v8 routed this through `InputProps`,
+            // v9 split it off into its own slot). Spreading `{...params}`
+            // above does not reach this nested object once we override
+            // `slotProps`, so we rebuild it explicitly here.
             input: {
-              ...params.InputProps,
+              ...params.slotProps.input,
               endAdornment: (
                 <>
                   {loading && <CircularProgress color="inherit" size={16} />}
-                  {params.InputProps.endAdornment}
+                  {params.slotProps.input.endAdornment}
                 </>
               ),
               sx: {
@@ -77,6 +83,8 @@ export function FilterAutocomplete({
                 },
               },
             },
+            htmlInput: params.slotProps.htmlInput,
+            inputLabel: params.slotProps.inputLabel,
           }}
         />
       )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Section.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Section.tsx
@@ -61,15 +61,21 @@ export function Section({
       >
         <Box sx={{ color: "text.secondary", display: "flex" }}>{icon}</Box>
         <Box>
-          <Typography variant="subtitle1" sx={{
-            fontWeight: 600
-          }}>
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 600,
+            }}
+          >
             {title}
           </Typography>
           {description && (
-            <Typography variant="caption" sx={{
-              color: "text.secondary"
-            }}>
+            <Typography
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+              }}
+            >
               {description}
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Section.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Section.tsx
@@ -61,11 +61,15 @@ export function Section({
       >
         <Box sx={{ color: "text.secondary", display: "flex" }}>{icon}</Box>
         <Box>
-          <Typography variant="subtitle1" fontWeight={600}>
+          <Typography variant="subtitle1" sx={{
+            fontWeight: 600
+          }}>
             {title}
           </Typography>
           {description && (
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="caption" sx={{
+              color: "text.secondary"
+            }}>
               {description}
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
@@ -70,8 +70,9 @@ function ToastItem({ toast }: { toast: ToastItem }) {
               variant="body2"
               sx={{
                 fontWeight: 600,
-                lineHeight: 1.4
-              }}>
+                lineHeight: 1.4,
+              }}
+            >
               {toast.title}
             </Typography>
           )}
@@ -81,8 +82,9 @@ function ToastItem({ toast }: { toast: ToastItem }) {
               sx={{
                 color: "text.secondary",
                 lineHeight: 1.4,
-                mt: toast.title ? 0.25 : 0
-              }}>
+                mt: toast.title ? 0.25 : 0,
+              }}
+            >
               {toast.message}
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/Toast.tsx
@@ -68,18 +68,21 @@ function ToastItem({ toast }: { toast: ToastItem }) {
           {toast.title && (
             <Typography
               variant="body2"
-              fontWeight={600}
-              sx={{ lineHeight: 1.4 }}
-            >
+              sx={{
+                fontWeight: 600,
+                lineHeight: 1.4
+              }}>
               {toast.title}
             </Typography>
           )}
           {toast.message && (
             <Typography
               variant="body2"
-              color="text.secondary"
-              sx={{ lineHeight: 1.4, mt: toast.title ? 0.25 : 0 }}
-            >
+              sx={{
+                color: "text.secondary",
+                lineHeight: 1.4,
+                mt: toast.title ? 0.25 : 0
+              }}>
               {toast.message}
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
@@ -51,10 +51,14 @@ export function Footer() {
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Typography variant="body2" fontWeight={700}>
+          <Typography variant="body2" sx={{
+            fontWeight: 700
+          }}>
             Plugwerk
           </Typography>
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             v{version}
           </Typography>
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
@@ -51,14 +51,20 @@ export function Footer() {
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Typography variant="body2" sx={{
-            fontWeight: 700
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 700,
+            }}
+          >
             Plugwerk
           </Typography>
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             v{version}
           </Typography>
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/ChangelogTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/ChangelogTab.tsx
@@ -33,10 +33,14 @@ export function ChangelogTab({ releases }: ChangelogTabProps) {
 
   if (withChangelog.length === 0) {
     return (
-      <Typography variant="body2" sx={{
-        color: "text.secondary"
-      }}>No changelog available. Add release notes when publishing a new version.
-              </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
+        No changelog available. Add release notes when publishing a new version.
+      </Typography>
     );
   }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/ChangelogTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/ChangelogTab.tsx
@@ -33,9 +33,10 @@ export function ChangelogTab({ releases }: ChangelogTabProps) {
 
   if (withChangelog.length === 0) {
     return (
-      <Typography variant="body2" color="text.secondary">
-        No changelog available. Add release notes when publishing a new version.
-      </Typography>
+      <Typography variant="body2" sx={{
+        color: "text.secondary"
+      }}>No changelog available. Add release notes when publishing a new version.
+              </Typography>
     );
   }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
@@ -35,9 +35,10 @@ export function DependenciesTab({ release, namespace }: DependenciesTabProps) {
 
   if (deps.length === 0) {
     return (
-      <Typography variant="body2" color="text.secondary">
-        This plugin has no dependencies.
-      </Typography>
+      <Typography variant="body2" sx={{
+        color: "text.secondary"
+      }}>This plugin has no dependencies.
+              </Typography>
     );
   }
 
@@ -67,7 +68,12 @@ export function DependenciesTab({ release, namespace }: DependenciesTabProps) {
 
   return (
     <Box>
-      <Typography variant="body2" color="text.disabled" sx={{ mb: 2 }}>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.disabled",
+          mb: 2
+        }}>
         Required plugins that must be installed alongside this plugin.
       </Typography>
       <Box sx={{ overflowX: "auto" }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/DependenciesTab.tsx
@@ -35,10 +35,14 @@ export function DependenciesTab({ release, namespace }: DependenciesTabProps) {
 
   if (deps.length === 0) {
     return (
-      <Typography variant="body2" sx={{
-        color: "text.secondary"
-      }}>This plugin has no dependencies.
-              </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
+        This plugin has no dependencies.
+      </Typography>
     );
   }
 
@@ -72,8 +76,9 @@ export function DependenciesTab({ release, namespace }: DependenciesTabProps) {
         variant="body2"
         sx={{
           color: "text.disabled",
-          mb: 2
-        }}>
+          mb: 2,
+        }}
+      >
         Required plugins that must be installed alongside this plugin.
       </Typography>
       <Box sx={{ overflowX: "auto" }}>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -136,7 +136,6 @@ export function PluginHeader({
       >
         <Puzzle size={48} />
       </Box>
-
       {/* Plugin info */}
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Box
@@ -165,7 +164,9 @@ export function PluginHeader({
         </Box>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             by{" "}
             <strong style={{ color: "inherit" }}>
               {plugin.provider ?? namespace}
@@ -251,7 +252,6 @@ export function PluginHeader({
           </Box>
         )}
       </Box>
-
       {/* Actions */}
       <Box
         sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/PluginHeader.tsx
@@ -164,9 +164,12 @@ export function PluginHeader({
         </Box>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             by{" "}
             <strong style={{ color: "inherit" }}>
               {plugin.provider ?? namespace}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -50,9 +50,10 @@ function CopyableSha256({ value }: { value?: string }) {
 
   if (!value)
     return (
-      <Typography variant="caption" color="text.disabled">
-        —
-      </Typography>
+      <Typography variant="caption" sx={{
+        color: "text.disabled"
+      }}>—
+              </Typography>
     );
 
   async function handleCopy() {
@@ -272,7 +273,9 @@ export function VersionsTab({
       key: "uploaded",
       header: "Uploaded",
       render: (rel) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={rel.createdAt} />
         </Typography>
       ),
@@ -290,7 +293,9 @@ export function VersionsTab({
       key: "format",
       header: "Format",
       render: (rel) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           .{rel.fileFormat ?? "jar"}
         </Typography>
       ),
@@ -300,7 +305,9 @@ export function VersionsTab({
       header: "Size",
       align: "right",
       render: (rel) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           {rel.artifactSize ? formatFileSize(rel.artifactSize) : "—"}
         </Typography>
       ),
@@ -316,7 +323,9 @@ export function VersionsTab({
       align: "right",
       render: (rel) => (
         <Tooltip title={formatCountFull(rel.downloadCount)} placement="left">
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             {formatCount(rel.downloadCount)}
           </Typography>
         </Tooltip>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.tsx
@@ -50,10 +50,14 @@ function CopyableSha256({ value }: { value?: string }) {
 
   if (!value)
     return (
-      <Typography variant="caption" sx={{
-        color: "text.disabled"
-      }}>—
-              </Typography>
+      <Typography
+        variant="caption"
+        sx={{
+          color: "text.disabled",
+        }}
+      >
+        —
+      </Typography>
     );
 
   async function handleCopy() {
@@ -273,9 +277,12 @@ export function VersionsTab({
       key: "uploaded",
       header: "Uploaded",
       render: (rel) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={rel.createdAt} />
         </Typography>
       ),
@@ -293,9 +300,12 @@ export function VersionsTab({
       key: "format",
       header: "Format",
       render: (rel) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           .{rel.fileFormat ?? "jar"}
         </Typography>
       ),
@@ -305,9 +315,12 @@ export function VersionsTab({
       header: "Size",
       align: "right",
       render: (rel) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           {rel.artifactSize ? formatFileSize(rel.artifactSize) : "—"}
         </Typography>
       ),
@@ -323,9 +336,12 @@ export function VersionsTab({
       align: "right",
       render: (rel) => (
         <Tooltip title={formatCountFull(rel.downloadCount)} placement="left">
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             {formatCount(rel.downloadCount)}
           </Typography>
         </Tooltip>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/CatalogDropOverlay.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/CatalogDropOverlay.tsx
@@ -68,13 +68,17 @@ export function CatalogDropOverlay({ visible }: CatalogDropOverlayProps) {
             variant="h5"
             sx={{
               fontWeight: 600,
-              color: "text.primary"
-            }}>
+              color: "text.primary",
+            }}
+          >
             Drop .jar or .zip files to upload
           </Typography>
-          <Typography variant="body2" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             Files will be uploaded immediately
           </Typography>
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/CatalogDropOverlay.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/CatalogDropOverlay.tsx
@@ -64,10 +64,17 @@ export function CatalogDropOverlay({ visible }: CatalogDropOverlayProps) {
             color={tokens.color.primary}
             strokeWidth={1.25}
           />
-          <Typography variant="h5" fontWeight={600} color="text.primary">
+          <Typography
+            variant="h5"
+            sx={{
+              fontWeight: 600,
+              color: "text.primary"
+            }}>
             Drop .jar or .zip files to upload
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{
+            color: "text.secondary"
+          }}>
             Files will be uploaded immediately
           </Typography>
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -113,7 +113,6 @@ export function UploadModal() {
           {error}
         </Alert>
       )}
-
       <Box
         {...getRootProps()}
         sx={{
@@ -142,17 +141,20 @@ export function UploadModal() {
           }}
         >
           <UploadCloud size={36} color={tokens.color.gray40} />
-          <Typography variant="body2" fontWeight={600}>
+          <Typography variant="body2" sx={{
+            fontWeight: 600
+          }}>
             {isDragActive
               ? "Drop the files here…"
               : "Drag & drop .jar or .zip files here"}
           </Typography>
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             or click to browse · Max. {maxFileSizeMb} MB per file
           </Typography>
         </Box>
       </Box>
-
       {/* Selected file list */}
       {files.length > 0 && (
         <Box sx={{ mt: 2, display: "flex", flexDirection: "column", gap: 0.5 }}>
@@ -174,21 +176,21 @@ export function UploadModal() {
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography
                   variant="body2"
-                  fontWeight={500}
                   sx={{
+                    fontWeight: 500,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
+                    whiteSpace: "nowrap"
+                  }}>
                   {file.name}
                 </Typography>
               </Box>
               <Typography
                 variant="caption"
-                color="text.disabled"
-                sx={{ flexShrink: 0 }}
-              >
+                sx={{
+                  color: "text.disabled",
+                  flexShrink: 0
+                }}>
                 {(file.size / 1024 / 1024).toFixed(2)} MB
               </Typography>
               <IconButton

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadModal.tsx
@@ -141,16 +141,22 @@ export function UploadModal() {
           }}
         >
           <UploadCloud size={36} color={tokens.color.gray40} />
-          <Typography variant="body2" sx={{
-            fontWeight: 600
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 600,
+            }}
+          >
             {isDragActive
               ? "Drop the files here…"
               : "Drag & drop .jar or .zip files here"}
           </Typography>
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             or click to browse · Max. {maxFileSizeMb} MB per file
           </Typography>
         </Box>
@@ -180,8 +186,9 @@ export function UploadModal() {
                     fontWeight: 500,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
-                    whiteSpace: "nowrap"
-                  }}>
+                    whiteSpace: "nowrap",
+                  }}
+                >
                   {file.name}
                 </Typography>
               </Box>
@@ -189,8 +196,9 @@ export function UploadModal() {
                 variant="caption"
                 sx={{
                   color: "text.disabled",
-                  flexShrink: 0
-                }}>
+                  flexShrink: 0,
+                }}
+              >
                 {(file.size / 1024 / 1024).toFixed(2)} MB
               </Typography>
               <IconButton

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
@@ -102,8 +102,9 @@ function EntryRow({ entry }: { entry: FileUploadEntry }) {
             sx={{
               color: "text.secondary",
               flexShrink: 0,
-              fontVariantNumeric: "tabular-nums"
-            }}>
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
             {entry.progress}%
           </Typography>
         )}
@@ -222,8 +223,9 @@ export function UploadProgressPanel() {
               variant="body2"
               sx={{
                 fontWeight: 600,
-                lineHeight: 1.3
-              }}>
+                lineHeight: 1.3,
+              }}
+            >
               {headerText}
             </Typography>
             {isComplete && failedCount > 0 && (

--- a/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/upload/UploadProgressPanel.tsx
@@ -99,14 +99,15 @@ function EntryRow({ entry }: { entry: FileUploadEntry }) {
         {(entry.status === "uploading" || entry.status === "pending") && (
           <Typography
             variant="caption"
-            color="text.secondary"
-            sx={{ flexShrink: 0, fontVariantNumeric: "tabular-nums" }}
-          >
+            sx={{
+              color: "text.secondary",
+              flexShrink: 0,
+              fontVariantNumeric: "tabular-nums"
+            }}>
             {entry.progress}%
           </Typography>
         )}
       </Box>
-
       {entry.status === "uploading" && (
         <LinearProgress
           variant="determinate"
@@ -114,7 +115,6 @@ function EntryRow({ entry }: { entry: FileUploadEntry }) {
           sx={{ mt: 0.75, height: 3, borderRadius: tokens.radius.btn }}
         />
       )}
-
       {entry.status === "failed" && entry.errorMessage && (
         <Typography
           variant="caption"
@@ -220,9 +220,10 @@ export function UploadProgressPanel() {
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Typography
               variant="body2"
-              fontWeight={600}
-              sx={{ lineHeight: 1.3 }}
-            >
+              sx={{
+                fontWeight: 600,
+                lineHeight: 1.3
+              }}>
               {headerText}
             </Typography>
             {isComplete && failedCount > 0 && (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -176,8 +176,10 @@ export function CatalogPage() {
           {!loading && (
             <Typography
               variant="caption"
-              color="text.primary"
               aria-live="polite"
+              sx={{
+                color: "text.primary"
+              }}
             >
               {totalElements} plugins
             </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.tsx
@@ -178,7 +178,7 @@ export function CatalogPage() {
               variant="caption"
               aria-live="polite"
               sx={{
-                color: "text.primary"
+                color: "text.primary",
               }}
             >
               {totalElements} plugins

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
@@ -231,7 +231,7 @@ export function ForgotPasswordPage() {
           value={usernameOrEmail}
           onChange={(e) => setUsernameOrEmail(e.target.value)}
           disabled={submitting}
-          inputProps={{ "aria-label": "Username or email" }}
+          slotProps={{ htmlInput: { "aria-label": "Username or email" } }}
         />
         <Button
           type="submit"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
@@ -118,9 +118,12 @@ export function ForgotPasswordPage() {
         title="Password reset unavailable"
         subtitle="Self-service password reset is not enabled on this server."
       >
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Contact your administrator to have your password reset.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -129,7 +132,7 @@ export function ForgotPasswordPage() {
             to="/login"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Back to login
@@ -173,9 +176,12 @@ export function ForgotPasswordPage() {
             If an account exists for that username or email, a reset link is on
             its way.
           </Typography>
-          <Typography variant="body2" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             Click the link in the email to set a new password. The link expires
             after a short while; request a new one if it's stale.
           </Typography>
@@ -183,8 +189,9 @@ export function ForgotPasswordPage() {
             variant="caption"
             sx={{
               color: "text.disabled",
-              mt: 1
-            }}>
+              mt: 1,
+            }}
+          >
             No email? Check your spam folder. If the address you supplied isn't
             registered, no message is sent — verify the spelling or contact your
             administrator.
@@ -196,7 +203,7 @@ export function ForgotPasswordPage() {
             to="/login"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Back to login
@@ -252,8 +259,9 @@ export function ForgotPasswordPage() {
         variant="caption"
         sx={{
           color: "text.disabled",
-          textAlign: "center"
-        }}>
+          textAlign: "center",
+        }}
+      >
         Remember your password?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ForgotPasswordPage.tsx
@@ -118,7 +118,9 @@ export function ForgotPasswordPage() {
         title="Password reset unavailable"
         subtitle="Self-service password reset is not enabled on this server."
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Contact your administrator to have your password reset.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -126,7 +128,9 @@ export function ForgotPasswordPage() {
             component={RouterLink}
             to="/login"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Back to login
           </Link>
@@ -169,11 +173,18 @@ export function ForgotPasswordPage() {
             If an account exists for that username or email, a reset link is on
             its way.
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{
+            color: "text.secondary"
+          }}>
             Click the link in the email to set a new password. The link expires
             after a short while; request a new one if it's stale.
           </Typography>
-          <Typography variant="caption" color="text.disabled" sx={{ mt: 1 }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+              mt: 1
+            }}>
             No email? Check your spam folder. If the address you supplied isn't
             registered, no message is sent — verify the spelling or contact your
             administrator.
@@ -184,7 +195,9 @@ export function ForgotPasswordPage() {
             component={RouterLink}
             to="/login"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Back to login
           </Link>
@@ -237,9 +250,10 @@ export function ForgotPasswordPage() {
       </Box>
       <Typography
         variant="caption"
-        color="text.disabled"
-        sx={{ textAlign: "center" }}
-      >
+        sx={{
+          color: "text.disabled",
+          textAlign: "center"
+        }}>
         Remember your password?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -172,19 +172,19 @@ export function LoginPage() {
           // operator has switched the feature on (#421). The backend 404s
           // /auth/forgot-password and /auth/reset-password independently,
           // so flipping this client-side cannot bypass the gate.
-          (<Box sx={{ mt: -1, textAlign: "right" }}>
+          <Box sx={{ mt: -1, textAlign: "right" }}>
             <Link
               component={RouterLink}
               to="/forgot-password"
               underline="hover"
               variant="body2"
               sx={{
-                color: "text.secondary"
+                color: "text.secondary",
               }}
             >
               Forgot password?
             </Link>
-          </Box>)
+          </Box>
         )}
         <Button
           type="submit"
@@ -206,31 +206,36 @@ export function LoginPage() {
           // Rendered conditionally on the public /config flag (#420). The
           // backend independently 404s POST /auth/register when the flag is
           // off, so flipping this client-side cannot bypass the gate.
-          (<Typography
+          <Typography
             variant="body2"
             sx={{
               color: "text.secondary",
-              textAlign: "center"
-            }}>Don't have an account?{" "}
+              textAlign: "center",
+            }}
+          >
+            Don't have an account?{" "}
             <Link
               component={RouterLink}
               to="/register"
               underline="hover"
               sx={{
-                fontWeight: 600
+                fontWeight: 600,
               }}
             >
               Sign up
             </Link>
-          </Typography>)
+          </Typography>
         )}
       </Box>
       {oidcProviders.length > 0 && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
           <Divider>
-            <Typography variant="caption" sx={{
-              color: "text.secondary"
-            }}>
+            <Typography
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+              }}
+            >
               or
             </Typography>
           </Divider>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/LoginPage.tsx
@@ -107,7 +107,6 @@ export function LoginPage() {
           {error}
         </Alert>
       )}
-
       <Box
         component="form"
         onSubmit={handleSubmit}
@@ -173,17 +172,19 @@ export function LoginPage() {
           // operator has switched the feature on (#421). The backend 404s
           // /auth/forgot-password and /auth/reset-password independently,
           // so flipping this client-side cannot bypass the gate.
-          <Box sx={{ mt: -1, textAlign: "right" }}>
+          (<Box sx={{ mt: -1, textAlign: "right" }}>
             <Link
               component={RouterLink}
               to="/forgot-password"
               underline="hover"
               variant="body2"
-              color="text.secondary"
+              sx={{
+                color: "text.secondary"
+              }}
             >
               Forgot password?
             </Link>
-          </Box>
+          </Box>)
         )}
         <Button
           type="submit"
@@ -205,28 +206,31 @@ export function LoginPage() {
           // Rendered conditionally on the public /config flag (#420). The
           // backend independently 404s POST /auth/register when the flag is
           // off, so flipping this client-side cannot bypass the gate.
-          <Typography
+          (<Typography
             variant="body2"
-            color="text.secondary"
-            sx={{ textAlign: "center" }}
-          >
-            Don&apos;t have an account?{" "}
+            sx={{
+              color: "text.secondary",
+              textAlign: "center"
+            }}>Don't have an account?{" "}
             <Link
               component={RouterLink}
               to="/register"
               underline="hover"
-              fontWeight={600}
+              sx={{
+                fontWeight: 600
+              }}
             >
               Sign up
             </Link>
-          </Typography>
+          </Typography>)
         )}
       </Box>
-
       {oidcProviders.length > 0 && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
           <Divider>
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="caption" sx={{
+              color: "text.secondary"
+            }}>
               or
             </Typography>
           </Divider>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
@@ -63,8 +63,9 @@ export function OnboardingPage() {
                 color: "text.secondary",
                 mb: 4,
                 maxWidth: 420,
-                mx: "auto"
-              }}>
+                mx: "auto",
+              }}
+            >
               No namespaces have been created yet. Create your first namespace
               to start publishing and managing plugins.
             </Typography>
@@ -83,8 +84,9 @@ export function OnboardingPage() {
               sx={{
                 color: "text.disabled",
                 display: "block",
-                mt: 3
-              }}>
+                mt: 3,
+              }}
+            >
               A namespace groups your plugins and controls who can access them.
             </Typography>
 
@@ -102,8 +104,9 @@ export function OnboardingPage() {
               color: "text.secondary",
               mb: 4,
               maxWidth: 460,
-              mx: "auto"
-            }}>
+              mx: "auto",
+            }}
+          >
             You don't have access to any namespace yet. Ask a Plugwerk
             administrator to add you to one.
           </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
@@ -59,9 +59,12 @@ export function OnboardingPage() {
           <>
             <Typography
               variant="body1"
-              color="text.secondary"
-              sx={{ mb: 4, maxWidth: 420, mx: "auto" }}
-            >
+              sx={{
+                color: "text.secondary",
+                mb: 4,
+                maxWidth: 420,
+                mx: "auto"
+              }}>
               No namespaces have been created yet. Create your first namespace
               to start publishing and managing plugins.
             </Typography>
@@ -77,9 +80,11 @@ export function OnboardingPage() {
 
             <Typography
               variant="caption"
-              color="text.disabled"
-              sx={{ display: "block", mt: 3 }}
-            >
+              sx={{
+                color: "text.disabled",
+                display: "block",
+                mt: 3
+              }}>
               A namespace groups your plugins and controls who can access them.
             </Typography>
 
@@ -93,9 +98,12 @@ export function OnboardingPage() {
         ) : (
           <Typography
             variant="body1"
-            color="text.secondary"
-            sx={{ mb: 4, maxWidth: 460, mx: "auto" }}
-          >
+            sx={{
+              color: "text.secondary",
+              mb: 4,
+              maxWidth: 460,
+              mx: "auto"
+            }}>
             You don't have access to any namespace yet. Ask a Plugwerk
             administrator to add you to one.
           </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -163,7 +163,9 @@ export function PluginDetailPage() {
             style={{ color: "var(--mui-palette-text-disabled)" }}
             aria-hidden="true"
           />
-          <Typography variant="body2" color="text.primary" aria-current="page">
+          <Typography variant="body2" aria-current="page" sx={{
+            color: "text.primary"
+          }}>
             {plugin.name}
           </Typography>
         </Box>
@@ -278,7 +280,6 @@ export function PluginDetailPage() {
           ))}
         </Box>
       </Container>
-
       <ConfirmDeleteDialog
         open={showDeletePlugin}
         title="Delete Plugin"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/PluginDetailPage.tsx
@@ -163,9 +163,13 @@ export function PluginDetailPage() {
             style={{ color: "var(--mui-palette-text-disabled)" }}
             aria-hidden="true"
           />
-          <Typography variant="body2" aria-current="page" sx={{
-            color: "text.primary"
-          }}>
+          <Typography
+            variant="body2"
+            aria-current="page"
+            sx={{
+              color: "text.primary",
+            }}
+          >
             {plugin.name}
           </Typography>
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
@@ -74,8 +74,9 @@ function InfoRow({ label, value, copyable = false }: InfoRowProps) {
           color: "text.secondary",
           minWidth: 80,
           flexShrink: 0,
-          fontWeight: 500
-        }}>
+          fontWeight: 500,
+        }}
+      >
         {label}
       </Typography>
       <Typography variant="body2">{value}</Typography>
@@ -158,8 +159,9 @@ export function ProfileSettingsPage() {
           variant="body2"
           sx={{
             color: "text.secondary",
-            mb: 4
-          }}>
+            mb: 4,
+          }}
+        >
           Manage your account preferences and workspace configuration.
         </Typography>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ProfileSettingsPage.tsx
@@ -70,9 +70,12 @@ function InfoRow({ label, value, copyable = false }: InfoRowProps) {
     <Box sx={{ display: "flex", alignItems: "center", gap: 2, py: 0.75 }}>
       <Typography
         variant="caption"
-        color="text.secondary"
-        sx={{ minWidth: 80, flexShrink: 0, fontWeight: 500 }}
-      >
+        sx={{
+          color: "text.secondary",
+          minWidth: 80,
+          flexShrink: 0,
+          fontWeight: 500
+        }}>
         {label}
       </Typography>
       <Typography variant="body2">{value}</Typography>
@@ -151,7 +154,12 @@ export function ProfileSettingsPage() {
         <Typography variant="h1" sx={{ mb: 0.5 }}>
           Profile Settings
         </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+            mb: 4
+          }}>
           Manage your account preferences and workspace configuration.
         </Typography>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
@@ -224,7 +224,7 @@ export function RegisterPage() {
           disabled={submitting}
           error={Boolean(fieldErrors.username)}
           helperText={fieldErrors.username}
-          inputProps={{ "aria-label": "Username" }}
+          slotProps={{ htmlInput: { "aria-label": "Username" } }}
         />
         <TextField
           label="Email"
@@ -237,7 +237,7 @@ export function RegisterPage() {
           disabled={submitting}
           error={Boolean(fieldErrors.email)}
           helperText={fieldErrors.email}
-          inputProps={{ "aria-label": "Email" }}
+          slotProps={{ htmlInput: { "aria-label": "Email" } }}
         />
         <TextField
           label="Password"
@@ -252,8 +252,8 @@ export function RegisterPage() {
           helperText={
             fieldErrors.password ?? `Minimum ${PASSWORD_MIN_LENGTH} characters.`
           }
-          inputProps={{ "aria-label": "Password" }}
           slotProps={{
+            htmlInput: { "aria-label": "Password" },
             input: {
               endAdornment: (
                 <InputAdornment position="end">

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
@@ -180,9 +180,12 @@ export function RegisterPage() {
         title="Registration unavailable"
         subtitle="Self-registration is not enabled on this server."
       >
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Contact your administrator to request an account.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -191,7 +194,7 @@ export function RegisterPage() {
             to="/login"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Back to login
@@ -295,8 +298,9 @@ export function RegisterPage() {
         variant="caption"
         sx={{
           color: "text.disabled",
-          textAlign: "center"
-        }}>
+          textAlign: "center",
+        }}
+      >
         Already have an account?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/RegisterPage.tsx
@@ -180,7 +180,9 @@ export function RegisterPage() {
         title="Registration unavailable"
         subtitle="Self-registration is not enabled on this server."
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Contact your administrator to request an account.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -188,7 +190,9 @@ export function RegisterPage() {
             component={RouterLink}
             to="/login"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Back to login
           </Link>
@@ -289,9 +293,10 @@ export function RegisterPage() {
       </Box>
       <Typography
         variant="caption"
-        color="text.disabled"
-        sx={{ textAlign: "center" }}
-      >
+        sx={{
+          color: "text.disabled",
+          textAlign: "center"
+        }}>
         Already have an account?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
@@ -248,8 +248,8 @@ export function ResetPasswordPage() {
             fieldErrors.newPassword ??
             `Minimum ${PASSWORD_MIN_LENGTH} characters.`
           }
-          inputProps={{ "aria-label": "New Password" }}
           slotProps={{
+            htmlInput: { "aria-label": "New Password" },
             input: {
               endAdornment: (
                 <InputAdornment position="end">
@@ -279,8 +279,8 @@ export function ResetPasswordPage() {
           disabled={submitting}
           error={Boolean(fieldErrors.confirmPassword)}
           helperText={fieldErrors.confirmPassword}
-          inputProps={{ "aria-label": "Confirm Password" }}
           slotProps={{
+            htmlInput: { "aria-label": "Confirm Password" },
             input: {
               endAdornment: (
                 <InputAdornment position="end">

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
@@ -168,9 +168,12 @@ export function ResetPasswordPage() {
         title="Password reset unavailable"
         subtitle="Self-service password reset is not enabled on this server."
       >
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Contact your administrator to have your password reset.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -179,7 +182,7 @@ export function ResetPasswordPage() {
             to="/login"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Back to login
@@ -195,9 +198,12 @@ export function ResetPasswordPage() {
         title="No reset token"
         subtitle="The link is missing the required `?token=…` parameter."
       >
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Open the link from your reset email instead. If you no longer have the
           email, request a new reset link.
         </Typography>
@@ -207,7 +213,7 @@ export function ResetPasswordPage() {
             to="/forgot-password"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Request a new link
@@ -322,8 +328,9 @@ export function ResetPasswordPage() {
         variant="caption"
         sx={{
           color: "text.disabled",
-          textAlign: "center"
-        }}>
+          textAlign: "center",
+        }}
+      >
         Remembered after all?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/ResetPasswordPage.tsx
@@ -168,7 +168,9 @@ export function ResetPasswordPage() {
         title="Password reset unavailable"
         subtitle="Self-service password reset is not enabled on this server."
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Contact your administrator to have your password reset.
         </Typography>
         <Box sx={{ textAlign: "center", mt: 1 }}>
@@ -176,7 +178,9 @@ export function ResetPasswordPage() {
             component={RouterLink}
             to="/login"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Back to login
           </Link>
@@ -191,7 +195,9 @@ export function ResetPasswordPage() {
         title="No reset token"
         subtitle="The link is missing the required `?token=…` parameter."
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Open the link from your reset email instead. If you no longer have the
           email, request a new reset link.
         </Typography>
@@ -200,7 +206,9 @@ export function ResetPasswordPage() {
             component={RouterLink}
             to="/forgot-password"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Request a new link
           </Link>
@@ -312,9 +320,10 @@ export function ResetPasswordPage() {
       </Box>
       <Typography
         variant="caption"
-        color="text.disabled"
-        sx={{ textAlign: "center" }}
-      >
+        sx={{
+          color: "text.disabled",
+          textAlign: "center"
+        }}>
         Remembered after all?{" "}
         <Link
           component={RouterLink}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailCallbackPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailCallbackPage.tsx
@@ -101,7 +101,9 @@ export function VerifyEmailCallbackPage() {
         title="No verification token"
         subtitle="The link is missing the required `?token=…` parameter."
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Open the link from your verification email instead. If you no longer
           have the email, register again to receive a new one.
         </Typography>
@@ -110,7 +112,9 @@ export function VerifyEmailCallbackPage() {
             component={RouterLink}
             to="/register"
             underline="hover"
-            fontWeight={600}
+            sx={{
+              fontWeight: 600
+            }}
           >
             Register
           </Link>
@@ -213,11 +217,15 @@ export function VerifyEmailCallbackPage() {
         >
           <AlertCircle size={28} />
         </Box>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           {errorMessage ??
             "The verification link could not be processed. It may have expired or already been used."}
         </Typography>
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           Register again to request a fresh verification email.
         </Typography>
       </Box>
@@ -234,7 +242,9 @@ export function VerifyEmailCallbackPage() {
           component={RouterLink}
           to="/register"
           underline="hover"
-          fontWeight={600}
+          sx={{
+            fontWeight: 600
+          }}
         >
           Register
         </Link>
@@ -242,7 +252,9 @@ export function VerifyEmailCallbackPage() {
           component={RouterLink}
           to="/login"
           underline="hover"
-          color="text.secondary"
+          sx={{
+            color: "text.secondary"
+          }}
         >
           Back to login
         </Link>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailCallbackPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailCallbackPage.tsx
@@ -101,9 +101,12 @@ export function VerifyEmailCallbackPage() {
         title="No verification token"
         subtitle="The link is missing the required `?token=…` parameter."
       >
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Open the link from your verification email instead. If you no longer
           have the email, register again to receive a new one.
         </Typography>
@@ -113,7 +116,7 @@ export function VerifyEmailCallbackPage() {
             to="/register"
             underline="hover"
             sx={{
-              fontWeight: 600
+              fontWeight: 600,
             }}
           >
             Register
@@ -217,15 +220,21 @@ export function VerifyEmailCallbackPage() {
         >
           <AlertCircle size={28} />
         </Box>
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           {errorMessage ??
             "The verification link could not be processed. It may have expired or already been used."}
         </Typography>
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           Register again to request a fresh verification email.
         </Typography>
       </Box>
@@ -243,7 +252,7 @@ export function VerifyEmailCallbackPage() {
           to="/register"
           underline="hover"
           sx={{
-            fontWeight: 600
+            fontWeight: 600,
           }}
         >
           Register
@@ -253,7 +262,7 @@ export function VerifyEmailCallbackPage() {
           to="/login"
           underline="hover"
           sx={{
-            color: "text.secondary"
+            color: "text.secondary",
           }}
         >
           Back to login

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailPendingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailPendingPage.tsx
@@ -80,11 +80,18 @@ export function VerifyEmailPendingPage() {
             "If the address you provided isn't already registered, a verification link is on its way."
           )}
         </Typography>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           Click the link in the email to activate your account. The link expires
           in 24 hours.
         </Typography>
-        <Typography variant="caption" color="text.disabled" sx={{ mt: 1 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+            mt: 1
+          }}>
           No email? Check your spam folder. If the address is already in use, no
           new email is sent — try{" "}
           <Box component="strong" sx={{ fontWeight: 600 }}>
@@ -102,7 +109,9 @@ export function VerifyEmailPendingPage() {
           component={RouterLink}
           to="/login"
           underline="hover"
-          fontWeight={600}
+          sx={{
+            fontWeight: 600
+          }}
         >
           Back to login
         </Link>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailPendingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/VerifyEmailPendingPage.tsx
@@ -80,9 +80,12 @@ export function VerifyEmailPendingPage() {
             "If the address you provided isn't already registered, a verification link is on its way."
           )}
         </Typography>
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           Click the link in the email to activate your account. The link expires
           in 24 hours.
         </Typography>
@@ -90,8 +93,9 @@ export function VerifyEmailPendingPage() {
           variant="caption"
           sx={{
             color: "text.disabled",
-            mt: 1
-          }}>
+            mt: 1,
+          }}
+        >
           No email? Check your spam folder. If the address is already in use, no
           new email is sent — try{" "}
           <Box component="strong" sx={{ fontWeight: 600 }}>
@@ -110,7 +114,7 @@ export function VerifyEmailPendingPage() {
           to="/login"
           underline="hover"
           sx={{
-            fontWeight: 600
+            fontWeight: 600,
           }}
         >
           Back to login

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailLayout.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailLayout.tsx
@@ -46,9 +46,12 @@ export function EmailLayout() {
         <Typography variant="h2" gutterBottom>
           Email
         </Typography>
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           SMTP server and outgoing email configuration. Changes take effect
           immediately — no server restart required.
         </Typography>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailLayout.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailLayout.tsx
@@ -46,12 +46,13 @@ export function EmailLayout() {
         <Typography variant="h2" gutterBottom>
           Email
         </Typography>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           SMTP server and outgoing email configuration. Changes take effect
           immediately — no server restart required.
         </Typography>
       </Box>
-
       <Tabs
         value={activeTab}
         onChange={(_, value: string) => navigate(`/admin/email/${value}`)}
@@ -62,7 +63,6 @@ export function EmailLayout() {
           <Tab key={tab.path} label={tab.label} value={tab.path} />
         ))}
       </Tabs>
-
       <Outlet />
     </Box>
   );

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
@@ -368,7 +368,6 @@ export function EmailServerPage() {
           }}
         />
       </Section>
-
       <Section
         contentGap={2.5}
         icon={<User size={18} />}
@@ -404,7 +403,6 @@ export function EmailServerPage() {
           inputProps={{ "aria-label": "From name" }}
         />
       </Section>
-
       <Section
         contentGap={2.5}
         icon={<Mail size={18} />}
@@ -465,7 +463,9 @@ export function EmailServerPage() {
           </Button>
         </Box>
         {!enabledValue && (
-          <Typography variant="caption" color="text.secondary">
+          <Typography variant="caption" sx={{
+            color: "text.secondary"
+          }}>
             Enable SMTP and save your changes before sending a test message.
           </Typography>
         )}
@@ -479,7 +479,6 @@ export function EmailServerPage() {
           </Alert>
         )}
       </Section>
-
       <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
         <Button
           variant="text"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
@@ -276,7 +276,7 @@ export function EmailServerPage() {
           disabled={saving}
           placeholder="smtp.example.com"
           sx={{ maxWidth: 480 }}
-          inputProps={{ "aria-label": "Host" }}
+          slotProps={{ htmlInput: { "aria-label": "Host" } }}
         />
         <TextField
           label="Port"
@@ -289,7 +289,7 @@ export function EmailServerPage() {
             fieldErrors["smtp.port"] ?? byKey.get("smtp.port")?.description
           }
           disabled={saving}
-          inputProps={{ min: 1, max: 65535, "aria-label": "Port" }}
+          slotProps={{ htmlInput: { min: 1, max: 65535, "aria-label": "Port" } }}
           sx={{ maxWidth: 200 }}
         />
         <FormControl
@@ -337,7 +337,7 @@ export function EmailServerPage() {
           }
           disabled={saving}
           sx={{ maxWidth: 480 }}
-          inputProps={{ "aria-label": "Username" }}
+          slotProps={{ htmlInput: { "aria-label": "Username" } }}
         />
         <TextField
           label="Password"
@@ -351,20 +351,24 @@ export function EmailServerPage() {
           }
           disabled={saving}
           sx={{ maxWidth: 480 }}
-          inputProps={{ "aria-label": "Password" }}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                  onClick={() => setShowPassword((v) => !v)}
-                  edge="end"
-                  size="small"
-                >
-                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                </IconButton>
-              </InputAdornment>
-            ),
+          slotProps={{
+            htmlInput: { "aria-label": "Password" },
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
+                    onClick={() => setShowPassword((v) => !v)}
+                    edge="end"
+                    size="small"
+                  >
+                    {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
           }}
         />
       </Section>
@@ -390,7 +394,7 @@ export function EmailServerPage() {
           disabled={saving}
           placeholder="noreply@example.com"
           sx={{ maxWidth: 480 }}
-          inputProps={{ "aria-label": "From address" }}
+          slotProps={{ htmlInput: { "aria-label": "From address" } }}
         />
         <TextField
           label="From name"
@@ -400,7 +404,7 @@ export function EmailServerPage() {
           helperText={byKey.get("smtp.from_name")?.description}
           disabled={saving}
           sx={{ maxWidth: 480 }}
-          inputProps={{ "aria-label": "From name" }}
+          slotProps={{ htmlInput: { "aria-label": "From name" } }}
         />
       </Section>
       <Section
@@ -421,7 +425,7 @@ export function EmailServerPage() {
                   )
                 }
                 disabled={saving}
-                inputProps={{ "aria-label": "SMTP enabled" }}
+                slotProps={{ input: { "aria-label": "SMTP enabled" } }}
               />
             }
             label="SMTP enabled"
@@ -448,7 +452,7 @@ export function EmailServerPage() {
             onChange={(e) => setTestTarget(e.target.value)}
             disabled={testing}
             sx={{ maxWidth: 360, flex: 1 }}
-            inputProps={{ "aria-label": "Test recipient" }}
+            slotProps={{ htmlInput: { "aria-label": "Test recipient" } }}
           />
           <Button
             variant="outlined"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.tsx
@@ -289,7 +289,9 @@ export function EmailServerPage() {
             fieldErrors["smtp.port"] ?? byKey.get("smtp.port")?.description
           }
           disabled={saving}
-          slotProps={{ htmlInput: { min: 1, max: 65535, "aria-label": "Port" } }}
+          slotProps={{
+            htmlInput: { min: 1, max: 65535, "aria-label": "Port" },
+          }}
           sx={{ maxWidth: 200 }}
         />
         <FormControl
@@ -467,9 +469,12 @@ export function EmailServerPage() {
           </Button>
         </Box>
         {!enabledValue && (
-          <Typography variant="caption" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             Enable SMTP and save your changes before sending a test message.
           </Typography>
         )}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
@@ -347,8 +347,9 @@ export function EmailTemplateEditPage() {
             color: "text.secondary",
             fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             display: "block",
-            mt: 0.5
-          }}>
+            mt: 0.5,
+          }}
+        >
           {template.key} · {template.locale}
         </Typography>
         <EditAttribution
@@ -626,8 +627,9 @@ function PlaceholderReference({
         spacing={1.5}
         sx={{
           alignItems: "flex-start",
-          flexWrap: "wrap"
-        }}>
+          flexWrap: "wrap",
+        }}
+      >
         <Box
           sx={{
             color: isDark
@@ -652,9 +654,12 @@ function PlaceholderReference({
           >
             Available variables
           </Typography>
-          <Typography variant="caption" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             Click a chip to insert{" "}
             <Box
               component="code"
@@ -688,8 +693,9 @@ function PlaceholderReference({
               sx={{
                 flexWrap: "wrap",
                 rowGap: 0.75,
-                mt: 1.5
-              }}>
+                mt: 1.5,
+              }}
+            >
               {placeholders.map((name) => (
                 <Chip
                   key={name}
@@ -726,8 +732,9 @@ function PlaceholderReference({
                 color: "text.secondary",
                 mt: 1.5,
                 display: "block",
-                fontStyle: "italic"
-              }}>
+                fontStyle: "italic",
+              }}
+            >
               This template takes no variables.
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
@@ -343,13 +343,12 @@ export function EmailTemplateEditPage() {
         </Typography>
         <Typography
           variant="caption"
-          color="text.secondary"
           sx={{
+            color: "text.secondary",
             fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             display: "block",
-            mt: 0.5,
-          }}
-        >
+            mt: 0.5
+          }}>
           {template.key} · {template.locale}
         </Typography>
         <EditAttribution
@@ -358,12 +357,10 @@ export function EmailTemplateEditPage() {
           updatedBy={template.updatedBy}
         />
       </Box>
-
       <PlaceholderReference
         placeholders={template.placeholders}
         onInsert={handleInsertPlaceholder}
       />
-
       {/*
        * Each body section pairs its editor with a preview pane in a
        * 2-column row (md+) so what the operator types and what gets sent
@@ -424,7 +421,6 @@ export function EmailTemplateEditPage() {
         </Box>
         <DefaultDiff label="Default subject" value={template.defaultSubject} />
       </Section>
-
       <Section
         contentGap={1.5}
         icon={<FileText size={18} />}
@@ -472,7 +468,6 @@ export function EmailTemplateEditPage() {
           multiline
         />
       </Section>
-
       <Section
         contentGap={1.5}
         icon={<Code2 size={18} />}
@@ -553,7 +548,6 @@ export function EmailTemplateEditPage() {
           </Stack>
         </Collapse>
       </Section>
-
       <Box
         sx={{
           display: "flex",
@@ -592,7 +586,6 @@ export function EmailTemplateEditPage() {
           </Button>
         </Box>
       </Box>
-
       <ResetConfirmDialog
         open={resetDialogOpen}
         templateName={template.friendlyName}
@@ -631,9 +624,10 @@ function PlaceholderReference({
       <Stack
         direction="row"
         spacing={1.5}
-        alignItems="flex-start"
-        flexWrap="wrap"
-      >
+        sx={{
+          alignItems: "flex-start",
+          flexWrap: "wrap"
+        }}>
         <Box
           sx={{
             color: isDark
@@ -658,7 +652,9 @@ function PlaceholderReference({
           >
             Available variables
           </Typography>
-          <Typography variant="caption" color="text.secondary">
+          <Typography variant="caption" sx={{
+            color: "text.secondary"
+          }}>
             Click a chip to insert{" "}
             <Box
               component="code"
@@ -689,10 +685,11 @@ function PlaceholderReference({
             <Stack
               direction="row"
               spacing={0.75}
-              flexWrap="wrap"
-              rowGap={0.75}
-              sx={{ mt: 1.5 }}
-            >
+              sx={{
+                flexWrap: "wrap",
+                rowGap: 0.75,
+                mt: 1.5
+              }}>
               {placeholders.map((name) => (
                 <Chip
                   key={name}
@@ -725,9 +722,12 @@ function PlaceholderReference({
           ) : (
             <Typography
               variant="caption"
-              color="text.secondary"
-              sx={{ mt: 1.5, display: "block", fontStyle: "italic" }}
-            >
+              sx={{
+                color: "text.secondary",
+                mt: 1.5,
+                display: "block",
+                fontStyle: "italic"
+              }}>
               This template takes no variables.
             </Typography>
           )}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.tsx
@@ -396,7 +396,7 @@ export function EmailTemplateEditPage() {
             }}
             inputRef={subjectRef}
             disabled={saving}
-            inputProps={{ "aria-label": "Subject" }}
+            slotProps={{ htmlInput: { "aria-label": "Subject" } }}
             sx={{
               height: "100%",
               "& .MuiOutlinedInput-root": { height: "100%" },
@@ -496,7 +496,7 @@ export function EmailTemplateEditPage() {
                 }
               }}
               disabled={saving}
-              inputProps={{ "aria-label": "Add HTML alternative" }}
+              slotProps={{ input: { "aria-label": "Add HTML alternative" } }}
             />
           }
           label={showHtmlEditor ? "HTML alternative enabled" : "Plaintext only"}
@@ -878,8 +878,10 @@ function ResetConfirmDialog({
       open={open}
       onClose={onClose}
       aria-labelledby="reset-template-title"
-      PaperProps={{
-        sx: { borderRadius: tokens.radius.dialog, maxWidth: 480 },
+      slotProps={{
+        paper: {
+          sx: { borderRadius: tokens.radius.dialog, maxWidth: 480 },
+        },
       }}
     >
       <DialogTitle

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplatesListPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplatesListPage.tsx
@@ -144,43 +144,48 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
       }}
     >
       <Box sx={{ minWidth: 0 }}>
-        <Stack direction="row" spacing={1.5} alignItems="center" mb={0.5}>
+        <Stack
+          direction="row"
+          spacing={1.5}
+          sx={{
+            alignItems: "center",
+            mb: 0.5
+          }}>
           <Box sx={{ color: "text.secondary", display: "flex" }}>
             <FileText size={16} />
           </Box>
           <Typography
             variant="subtitle1"
-            fontWeight={600}
-            sx={{ lineHeight: 1.2 }}
-          >
+            sx={{
+              fontWeight: 600,
+              lineHeight: 1.2
+            }}>
             {template.friendlyName}
           </Typography>
         </Stack>
         <Typography
           variant="caption"
-          color="text.secondary"
           sx={{
+            color: "text.secondary",
             fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             display: "block",
             mb: 0.75,
-            ml: 3.5,
-          }}
-        >
+            ml: 3.5
+          }}>
           {template.key}
         </Typography>
         <Typography
           variant="body2"
-          color="text.secondary"
           sx={{
+            color: "text.secondary",
             ml: 3.5,
             mb: 0.5,
             overflow: "hidden",
             textOverflow: "ellipsis",
             display: "-webkit-box",
             WebkitLineClamp: 1,
-            WebkitBoxOrient: "vertical",
-          }}
-        >
+            WebkitBoxOrient: "vertical"
+          }}>
           {template.subject}
         </Typography>
         <EditAttribution
@@ -189,7 +194,6 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
           updatedBy={template.updatedBy}
         />
       </Box>
-
       <Box
         className="row-arrow"
         sx={{

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplatesListPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplatesListPage.tsx
@@ -149,8 +149,9 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
           spacing={1.5}
           sx={{
             alignItems: "center",
-            mb: 0.5
-          }}>
+            mb: 0.5,
+          }}
+        >
           <Box sx={{ color: "text.secondary", display: "flex" }}>
             <FileText size={16} />
           </Box>
@@ -158,8 +159,9 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
             variant="subtitle1"
             sx={{
               fontWeight: 600,
-              lineHeight: 1.2
-            }}>
+              lineHeight: 1.2,
+            }}
+          >
             {template.friendlyName}
           </Typography>
         </Stack>
@@ -170,8 +172,9 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
             fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
             display: "block",
             mb: 0.75,
-            ml: 3.5
-          }}>
+            ml: 3.5,
+          }}
+        >
           {template.key}
         </Typography>
         <Typography
@@ -184,8 +187,9 @@ function TemplateRow({ template, onClick }: TemplateRowProps) {
             textOverflow: "ellipsis",
             display: "-webkit-box",
             WebkitLineClamp: 1,
-            WebkitBoxOrient: "vertical"
-          }}>
+            WebkitBoxOrient: "vertical",
+          }}
+        >
           {template.subject}
         </Typography>
         <EditAttribution

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -201,7 +201,7 @@ export function GeneralSection() {
                   handleFieldChange(key, e.target.checked ? "true" : "false")
                 }
                 disabled={saving}
-                inputProps={{ "aria-label": label }}
+                slotProps={{ input: { "aria-label": label } }}
               />
             }
             label={label}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -363,11 +363,15 @@ export function GeneralSection() {
         <Typography variant="h2" gutterBottom>
           General Settings
         </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+            mb: 1
+          }}>
           These settings are stored in the database and apply to all users.
         </Typography>
       </Box>
-
       {restartPendingKeys.length > 0 && (
         <Alert severity="warning" role="alert">
           The following setting
@@ -376,7 +380,6 @@ export function GeneralSection() {
           <strong>{restartPendingKeys.join(", ")}</strong>
         </Alert>
       )}
-
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
         {/* General */}
         <Section
@@ -435,7 +438,6 @@ export function GeneralSection() {
           {renderField("auth.password_reset_token_ttl_minutes")}
         </Section>
       </Box>
-
       <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
         <Button
           variant="text"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -306,10 +306,12 @@ export function GeneralSection() {
             error={Boolean(error)}
             helperText={helperText}
             disabled={saving}
-            inputProps={{
-              min: setting.minInt,
-              max: setting.maxInt,
-              "aria-label": label,
+            slotProps={{
+              htmlInput: {
+                min: setting.minInt,
+                max: setting.maxInt,
+                "aria-label": label,
+              },
             }}
             sx={{ maxWidth: 320 }}
           />
@@ -336,7 +338,7 @@ export function GeneralSection() {
         error={Boolean(error)}
         helperText={helperText}
         disabled={saving}
-        inputProps={{ "aria-label": label }}
+        slotProps={{ htmlInput: { "aria-label": label } }}
         sx={{ maxWidth: 480 }}
       />
     );

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.tsx
@@ -369,8 +369,9 @@ export function GeneralSection() {
           variant="body2"
           sx={{
             color: "text.secondary",
-            mb: 1
-          }}>
+            mb: 1,
+          }}
+        >
           These settings are stored in the database and apply to all users.
         </Typography>
       </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
@@ -712,7 +712,9 @@ export function OidcProviderFormDialog({
           {/* ── Section: Protocol ── */}
           <FormSection title="Protocol">
             {issuerRequired && (
-              <Stack direction="row" spacing={1} alignItems="flex-start">
+              <Stack direction="row" spacing={1} sx={{
+                alignItems: "flex-start"
+              }}>
                 <TextField
                   label="Issuer URI"
                   value={issuerUri}
@@ -994,7 +996,9 @@ function CreateSuccessStep({ provider }: CreateSuccessStepProps) {
           Plugwerk side: complete
         </Typography>
       </Box>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" sx={{
+        color: "text.secondary"
+      }}>
         Your provider is registered and disabled. Once the upstream callback URL
         is set up, enable the provider from the providers list to start
         accepting logins.
@@ -1150,9 +1154,11 @@ function FormSection({ title, children }: FormSectionProps) {
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Typography
         variant="overline"
-        color="text.secondary"
-        sx={{ letterSpacing: 0.6, lineHeight: 1 }}
-      >
+        sx={{
+          color: "text.secondary",
+          letterSpacing: 0.6,
+          lineHeight: 1
+        }}>
         {title}
       </Typography>
       {children}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
@@ -712,9 +712,13 @@ export function OidcProviderFormDialog({
           {/* ── Section: Protocol ── */}
           <FormSection title="Protocol">
             {issuerRequired && (
-              <Stack direction="row" spacing={1} sx={{
-                alignItems: "flex-start"
-              }}>
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{
+                  alignItems: "flex-start",
+                }}
+              >
                 <TextField
                   label="Issuer URI"
                   value={issuerUri}
@@ -996,9 +1000,12 @@ function CreateSuccessStep({ provider }: CreateSuccessStepProps) {
           Plugwerk side: complete
         </Typography>
       </Box>
-      <Typography variant="body2" sx={{
-        color: "text.secondary"
-      }}>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
         Your provider is registered and disabled. Once the upstream callback URL
         is set up, enable the provider from the providers list to start
         accepting logins.
@@ -1157,8 +1164,9 @@ function FormSection({ title, children }: FormSectionProps) {
         sx={{
           color: "text.secondary",
           letterSpacing: 0.6,
-          lineHeight: 1
-        }}>
+          lineHeight: 1,
+        }}
+      >
         {title}
       </Typography>
       {children}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProviderFormDialog.tsx
@@ -636,7 +636,7 @@ export function OidcProviderFormDialog({
               size="small"
               error={visibleError("name") !== null}
               helperText={visibleError("name") ?? "Shown on the login page."}
-              inputProps={{ maxLength: 255 }}
+              slotProps={{ htmlInput: { maxLength: 255 } }}
               // Deliberately no `autoFocus`. Combining `autoFocus` with MUI's
               // Dialog focus-trap caused the input to fire `onBlur` immediately
               // after mount (focus enters the input, then the trap relocates
@@ -663,7 +663,7 @@ export function OidcProviderFormDialog({
               size="small"
               error={visibleError("clientId") !== null}
               helperText={visibleError("clientId") ?? undefined}
-              inputProps={{ maxLength: 255 }}
+              slotProps={{ htmlInput: { maxLength: 255 } }}
             />
 
             {clientIdChanged && (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -207,7 +207,9 @@ export function OidcProvidersSection() {
       key: "name",
       header: "Name",
       render: (provider) => (
-        <Typography variant="body2" fontWeight={500}>
+        <Typography variant="body2" sx={{
+          fontWeight: 500
+        }}>
           {provider.name}
         </Typography>
       ),
@@ -229,11 +231,15 @@ export function OidcProvidersSection() {
       header: "Issuer / Client ID",
       render: (provider) =>
         provider.issuerUri ? (
-          <Typography variant="caption" color="text.secondary">
+          <Typography variant="caption" sx={{
+            color: "text.secondary"
+          }}>
             {provider.issuerUri}
           </Typography>
         ) : (
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" sx={{
+            color: "text.disabled"
+          }}>
             {provider.clientId}
           </Typography>
         ),
@@ -296,13 +302,14 @@ export function OidcProvidersSection() {
           Add Provider
         </Button>
       </Box>
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : providers.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No OIDC providers configured.
         </Typography>
       ) : (
@@ -313,7 +320,6 @@ export function OidcProvidersSection() {
           ariaLabel="OIDC providers"
         />
       )}
-
       <OidcProviderFormDialog
         open={createOpen}
         mode="create"
@@ -322,7 +328,6 @@ export function OidcProvidersSection() {
           handleCreate(payload as OidcProviderCreateRequest)
         }
       />
-
       <OidcProviderFormDialog
         open={editingProvider !== null}
         mode="edit"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -207,9 +207,12 @@ export function OidcProvidersSection() {
       key: "name",
       header: "Name",
       render: (provider) => (
-        <Typography variant="body2" sx={{
-          fontWeight: 500
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 500,
+          }}
+        >
           {provider.name}
         </Typography>
       ),
@@ -231,15 +234,21 @@ export function OidcProvidersSection() {
       header: "Issuer / Client ID",
       render: (provider) =>
         provider.issuerUri ? (
-          <Typography variant="caption" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             {provider.issuerUri}
           </Typography>
         ) : (
-          <Typography variant="caption" sx={{
-            color: "text.disabled"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+            }}
+          >
             {provider.clientId}
           </Typography>
         ),
@@ -307,9 +316,12 @@ export function OidcProvidersSection() {
           <CircularProgress size={24} />
         </Box>
       ) : providers.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No OIDC providers configured.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/OidcProvidersSection.tsx
@@ -252,7 +252,7 @@ export function OidcProvidersSection() {
           checked={provider.enabled}
           size="small"
           onChange={() => handleToggleEnabled(provider)}
-          inputProps={{ "aria-label": `Toggle ${provider.name}` }}
+          slotProps={{ input: { "aria-label": `Toggle ${provider.name}` } }}
         />
       ),
     },

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ProviderCallbackInstructions.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ProviderCallbackInstructions.tsx
@@ -154,7 +154,9 @@ export function ProviderCallbackInstructions({
         bgcolor: isSuccess ? "rgba(46, 125, 50, 0.06)" : "rgba(0, 0, 0, 0.02)",
       }}
     >
-      <Stack direction="row" spacing={1} alignItems="baseline">
+      <Stack direction="row" spacing={1} sx={{
+        alignItems: "baseline"
+      }}>
         <Typography
           variant="overline"
           sx={{
@@ -166,12 +168,15 @@ export function ProviderCallbackInstructions({
         >
           Callback URL
         </Typography>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" sx={{
+          color: "text.secondary"
+        }}>
           register this at your provider
         </Typography>
       </Stack>
-
-      <Stack direction="row" spacing={1} alignItems="stretch">
+      <Stack direction="row" spacing={1} sx={{
+        alignItems: "stretch"
+      }}>
         <Box
           component="code"
           tabIndex={0}
@@ -230,14 +235,14 @@ export function ProviderCallbackInstructions({
           </IconButton>
         </Tooltip>
       </Stack>
-
       <Stack
         direction={{ xs: "column", sm: "row" }}
         spacing={1.25}
-        sx={{ mt: 0.25 }}
-        alignItems={{ xs: "flex-start", sm: "center" }}
-        justifyContent="space-between"
-      >
+        sx={{
+          alignItems: { xs: "flex-start", sm: "center" },
+          justifyContent: "space-between",
+          mt: 0.25
+        }}>
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="body2" sx={{ lineHeight: 1.45 }}>
             <Typography

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ProviderCallbackInstructions.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ProviderCallbackInstructions.tsx
@@ -154,9 +154,13 @@ export function ProviderCallbackInstructions({
         bgcolor: isSuccess ? "rgba(46, 125, 50, 0.06)" : "rgba(0, 0, 0, 0.02)",
       }}
     >
-      <Stack direction="row" spacing={1} sx={{
-        alignItems: "baseline"
-      }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          alignItems: "baseline",
+        }}
+      >
         <Typography
           variant="overline"
           sx={{
@@ -168,15 +172,22 @@ export function ProviderCallbackInstructions({
         >
           Callback URL
         </Typography>
-        <Typography variant="caption" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           register this at your provider
         </Typography>
       </Stack>
-      <Stack direction="row" spacing={1} sx={{
-        alignItems: "stretch"
-      }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          alignItems: "stretch",
+        }}
+      >
         <Box
           component="code"
           tabIndex={0}
@@ -241,8 +252,9 @@ export function ProviderCallbackInstructions({
         sx={{
           alignItems: { xs: "flex-start", sm: "center" },
           justifyContent: "space-between",
-          mt: 0.25
-        }}>
+          mt: 0.25,
+        }}
+      >
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="body2" sx={{ lineHeight: 1.45 }}>
             <Typography

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ReviewsSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ReviewsSection.tsx
@@ -113,14 +113,20 @@ export function ReviewsSection() {
       header: "Plugin",
       render: (item) => (
         <>
-          <Typography variant="body2" sx={{
-            fontWeight: 500
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 500,
+            }}
+          >
             {item.pluginName}
           </Typography>
-          <Typography variant="caption" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             {item.pluginId}
           </Typography>
         </>
@@ -130,9 +136,12 @@ export function ReviewsSection() {
       key: "namespace",
       header: "Namespace",
       render: () => (
-        <Typography variant="caption" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           {namespace}
         </Typography>
       ),
@@ -146,9 +155,12 @@ export function ReviewsSection() {
       key: "submitted",
       header: "Submitted",
       render: (item) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={item.submittedAt} />
         </Typography>
       ),
@@ -190,9 +202,12 @@ export function ReviewsSection() {
           <CircularProgress size={24} />
         </Box>
       ) : items.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No releases awaiting review.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ReviewsSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/ReviewsSection.tsx
@@ -113,10 +113,14 @@ export function ReviewsSection() {
       header: "Plugin",
       render: (item) => (
         <>
-          <Typography variant="body2" fontWeight={500}>
+          <Typography variant="body2" sx={{
+            fontWeight: 500
+          }}>
             {item.pluginName}
           </Typography>
-          <Typography variant="caption" color="text.secondary">
+          <Typography variant="caption" sx={{
+            color: "text.secondary"
+          }}>
             {item.pluginId}
           </Typography>
         </>
@@ -126,7 +130,9 @@ export function ReviewsSection() {
       key: "namespace",
       header: "Namespace",
       render: () => (
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" sx={{
+          color: "text.secondary"
+        }}>
           {namespace}
         </Typography>
       ),
@@ -140,7 +146,9 @@ export function ReviewsSection() {
       key: "submitted",
       header: "Submitted",
       render: (item) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={item.submittedAt} />
         </Typography>
       ),
@@ -177,13 +185,14 @@ export function ReviewsSection() {
         </Typography>
         <Divider sx={{ mb: 3 }} />
       </Box>
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : items.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No releases awaiting review.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -145,7 +145,9 @@ export function UsersSection() {
             flexWrap: "wrap",
           }}
         >
-          <Typography variant="body2" fontWeight={500}>
+          <Typography variant="body2" sx={{
+            fontWeight: 500
+          }}>
             {user.displayName}
           </Typography>
           {user.source === "EXTERNAL" && user.providerName ? (
@@ -154,13 +156,16 @@ export function UsersSection() {
             // Same priority as the namespace member picker (#412) — provider
             // wins over username because for OIDC the username is just the
             // IdP-assigned subject claim and rarely useful at a glance.
-            <Typography variant="caption" color="text.secondary">
-              ({user.providerName})
-            </Typography>
+            (<Typography variant="caption" sx={{
+              color: "text.secondary"
+            }}>({user.providerName})
+                          </Typography>)
           ) : (
             user.username &&
             user.username !== user.displayName && (
-              <Typography variant="caption" color="text.secondary">
+              <Typography variant="caption" sx={{
+                color: "text.secondary"
+              }}>
                 ({user.username})
               </Typography>
             )
@@ -201,7 +206,9 @@ export function UsersSection() {
       key: "email",
       header: "Email",
       render: (user) => (
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" sx={{
+          color: "text.secondary"
+        }}>
           {user.email}
         </Typography>
       ),
@@ -221,7 +228,9 @@ export function UsersSection() {
       key: "created",
       header: "Created",
       render: (user) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={user.createdAt} />
         </Typography>
       ),
@@ -230,7 +239,9 @@ export function UsersSection() {
       key: "lastLogin",
       header: "Last login",
       render: (user) => (
-        <Typography variant="caption" color="text.disabled">
+        <Typography variant="caption" sx={{
+          color: "text.disabled"
+        }}>
           <Timestamp date={user.lastLoginAt} variant="relative" />
         </Typography>
       ),
@@ -288,13 +299,14 @@ export function UsersSection() {
           Add User
         </Button>
       </Box>
-
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
       ) : users.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{
+          color: "text.secondary"
+        }}>
           No users found.
         </Typography>
       ) : (
@@ -305,7 +317,6 @@ export function UsersSection() {
           ariaLabel="Users"
         />
       )}
-
       <AppDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
@@ -347,7 +358,6 @@ export function UsersSection() {
           />
         </Box>
       </AppDialog>
-
       <ConfirmDeleteDialog
         open={!!deleteTarget}
         title="Delete User"

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -145,9 +145,12 @@ export function UsersSection() {
             flexWrap: "wrap",
           }}
         >
-          <Typography variant="body2" sx={{
-            fontWeight: 500
-          }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 500,
+            }}
+          >
             {user.displayName}
           </Typography>
           {user.source === "EXTERNAL" && user.providerName ? (
@@ -156,16 +159,23 @@ export function UsersSection() {
             // Same priority as the namespace member picker (#412) — provider
             // wins over username because for OIDC the username is just the
             // IdP-assigned subject claim and rarely useful at a glance.
-            (<Typography variant="caption" sx={{
-              color: "text.secondary"
-            }}>({user.providerName})
-                          </Typography>)
+            <Typography
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+              }}
+            >
+              ({user.providerName})
+            </Typography>
           ) : (
             user.username &&
             user.username !== user.displayName && (
-              <Typography variant="caption" sx={{
-                color: "text.secondary"
-              }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "text.secondary",
+                }}
+              >
                 ({user.username})
               </Typography>
             )
@@ -206,9 +216,12 @@ export function UsersSection() {
       key: "email",
       header: "Email",
       render: (user) => (
-        <Typography variant="caption" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           {user.email}
         </Typography>
       ),
@@ -228,9 +241,12 @@ export function UsersSection() {
       key: "created",
       header: "Created",
       render: (user) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={user.createdAt} />
         </Typography>
       ),
@@ -239,9 +255,12 @@ export function UsersSection() {
       key: "lastLogin",
       header: "Last login",
       render: (user) => (
-        <Typography variant="caption" sx={{
-          color: "text.disabled"
-        }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+          }}
+        >
           <Timestamp date={user.lastLoginAt} variant="relative" />
         </Typography>
       ),
@@ -304,9 +323,12 @@ export function UsersSection() {
           <CircularProgress size={24} />
         </Box>
       ) : users.length === 0 ? (
-        <Typography variant="body2" sx={{
-          color: "text.secondary"
-        }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           No users found.
         </Typography>
       ) : (

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -255,7 +255,7 @@ export function UsersSection() {
           size="small"
           onChange={() => handleToggleEnabled(user)}
           disabled={user.isSuperadmin}
-          inputProps={{ "aria-label": `Toggle ${user.displayName}` }}
+          slotProps={{ input: { "aria-label": `Toggle ${user.displayName}` } }}
         />
       ),
     },

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/errors/ErrorPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/errors/ErrorPage.tsx
@@ -65,7 +65,9 @@ export function ErrorPage({
             {code}
           </Typography>
           <Typography variant="h2">{title}</Typography>
-          <Typography variant="body1" color="text.secondary">
+          <Typography variant="body1" sx={{
+            color: "text.secondary"
+          }}>
             {message}
           </Typography>
           <Button component={Link} to="/" variant="contained">

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/errors/ErrorPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/errors/ErrorPage.tsx
@@ -65,9 +65,12 @@ export function ErrorPage({
             {code}
           </Typography>
           <Typography variant="h2">{title}</Typography>
-          <Typography variant="body1" sx={{
-            color: "text.secondary"
-          }}>
+          <Typography
+            variant="body1"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             {message}
           </Typography>
           <Button component={Link} to="/" variant="contained">


### PR DESCRIPTION
Closes #456.

## Was passiert

`@mui/material` springt von `^7.3.9` auf `^9.0.0` (überspringt v8 — MUI hat keinen separaten v8-Codemod-Tree ausgeliefert). Migration in **6 thematischen Commits**, damit der Diff trotz der Größe reviewbar bleibt.

## Commit-Sequenz

| # | Commit | Was | Diff-Größe |
|---|---|---|---|
| 1 | `2edb71d` | `chore(deps): mute @mui/material major bumps during v9 migration` | 1 File / +7 |
| 2 | `d0aa150` | `chore(deps): bump @mui/material to v9.0.0 + apply v9 system-props codemod` | 47 Files / +528 −333 |
| 3 | `7f4c4f3` | `refactor(admin): migrate Switch.inputProps to v9 slotProps API` | 3 Files / +3 −3 |
| 4 | `dbf4c81` | `refactor(ui): migrate TextField/Switch/Dialog to v9 slotProps API` | 7 Files / +46 −38 |
| 5 | `b71bda5` | `refactor(ui): migrate FilterAutocomplete to v9 AutocompleteRenderInputParams shape` | 1 File / +10 −2 |
| 6 | `7ac67d0` | `chore(deps): un-mute @mui/material major bumps now that v9 is in` | 1 File / −7 |

## Was vom Codemod kam, was Handarbeit war

Der originale Renovate-PR (#453) ging mit **62 Type-Errors über 27 Files** an die Wand — ein v7→v9-Sprung ist eben kein Renovate-Job. **`@mui/codemod@9.0.0/system-props`** hat ~58% der Arbeit erledigt: alle `<Box component="strong">`/`<Box component="span">`-Stellen, sämtliche System-Prop-Folds (`m=`, `p=`, `bgcolor=` → `sx={…}`), und ein paar weitere Patterns. Übrig blieben **26 Errors über 10 Files**, alle in einer Klasse: **Slot-API-Renamings**.

Migrations-Mappings, die ich manuell durchgeführt habe:

| Alte API | Neue API in v9 |
|---|---|
| `Switch.inputProps={…}` | `slotProps={{ input: {…} }}` |
| `TextField.inputProps={…}` | `slotProps={{ htmlInput: {…} }}` |
| `TextField.InputProps={…}` (capital I) | `slotProps={{ input: {…} }}` |
| `Dialog.PaperProps={…}` | `slotProps={{ paper: {…} }}` |
| `params.InputProps` in Autocomplete `renderInput` | `params.slotProps.input` (+ `params.slotProps.htmlInput` separat durchreichen!) |

`Select.inputProps` bleibt unverändert — v9 hat das auf `Select` nicht entfernt.

## Subtile Stolperfalle, die `FilterAutocomplete.test.tsx` aufgedeckt hat

Mein erster Fix für `params.InputProps` → `params.slotProps.input` ließ Build und Type-Check grün, aber 3 Autocomplete-Tests warfen zur Laufzeit `Cannot read properties of null (reading 'focus')`. Grund: in v9 hat `params.slotProps` **drei** Slots — `input`, `htmlInput`, `inputLabel` — und mein lokales `slotProps={{ input: {…} }}`-Override hat die anderen beiden überschrieben. `htmlInput` carriert aber den input-ref + die ARIA-Wiring vom `useAutocomplete`-Hook — ohne den fokussiert sich der Autocomplete nicht. Fix in `b71bda5`: `htmlInput` und `inputLabel` explizit weiterreichen.

Lehre: bei jedem `slotProps`-Override in v9 prüfen, ob der überschriebene Pfad in `params.slotProps` weitere Geschwister-Slots hat, die durchgereicht werden müssen.

## Test-Plan

- [x] `npm run build` — clean (war nach jedem Commit grün, vom system-props-Codemod-Commit abgesehen, der absichtlich rot geblieben ist)
- [x] `npm run test:run` — **48 files / 408 tests** alle grün
- [ ] **Visual-QA** in beiden Themes auf der Hotspot-Liste:
  - [ ] `/admin/users` (DataTable + FilterAutocomplete + Timestamp + Switch in einem Screen)
  - [ ] `/admin/email-server` (8 TextFields + SMTP-enabled-Switch + Test-Send)
  - [ ] `/admin/email/templates` → Liste → Template öffnen → Subject-TextField → Live-Preview → Reset-Confirm-Dialog (testet die `PaperProps`-Migration)
  - [ ] `/admin/oidc` → "Add Provider"-Dialog (Inline-Hilfetexte, Inputs mit `maxLength`)
  - [ ] `/admin/settings` (Toggles aus #420/#421, Integer-TextFields, Selects)
  - [ ] Logout → `/login`, `/register`, `/forgot-password`, `/reset-password?token=demo` → Show/Hide-Password-Toggles + Anti-Enumeration-Copy mit `<strong>`-Markup
  - [ ] Theme-Toggle, alles obige nochmal im anderen Mode (Carbon-Tokens `primary.main` + `text.disabled` + `divider` müssen sitzen)
- [ ] CI grün

## Out of scope (zu künftigen Issues)

- "While we're at it"-UI-Improvements — bewusst keine, der Diff sollte rein strukturell sein
- Bundle-Size-Warnung (das `client-Bc0GGdce.js`-Chunk ist 2.2 MB) — bestand schon vor dem Bump, separater Issue für Code-Splitting
- Renovate-Lock-Update für andere npm-Patches — Update-Bot wird das nach Merge selbständig nachholen

🤖 Generated with [Claude Code](https://claude.com/claude-code)