### PR TITLE
fix(deps): bump axios to 1.16.0 to clear 13 code-scanning CVEs

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -4549,12 +4549,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }


### PR DESCRIPTION
Closes 13 open code-scanning alerts in one go (#19–#31), all against the same transitively-pinned `axios@1.15.0` in the frontend lockfile.

## Severity breakdown

| Count | Severity | CVEs |
|---|---|---|
| 3 | HIGH | CVE-2026-42033, CVE-2026-42035, CVE-2026-42043, CVE-2026-42264 |
| 8 | MEDIUM | CVE-2026-42034, -42036, -42037, -42038, -42039, -42041, -42042, -42044 |
| 1 | LOW | CVE-2026-42040 |

All advisories are clear in `axios@1.15.1` / `1.15.2`. `npm update axios` pulled `1.16.0` (latest minor in the `^1.15.0` range), which is past every fixed-version threshold the alerts list.

## Why this is a manual fix and not a Renovate PR

The manifest already declares `axios: ^1.15.0` — the range allows everything up to (but not including) `2.0.0`, so no semver gymnastics needed. What was stale is just the lockfile entry: Renovate's grouped npm-minor PR hasn't run since the CVEs landed, and the security alerts started piling up in the meantime. A targeted `npm update axios` resolves the exact dep without touching anything else.

## What changed

Single `package-lock.json` diff (+4 / -4 lines): `axios@1.15.0 → 1.16.0`, deduplicated across the three transitive callers (`@nestjs/axios`, `@vueuse/integrations`, top-level).

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:run` — 48 files / 408 tests green
- [ ] CI runs the same checks plus integration tests
- [ ] Code-scanning re-scan after merge should auto-close all 13 alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)