### PR TITLE
chore(renovate): pin npm dependency versions (no ^/~ ranges)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,6 +105,12 @@
       "description": "npm major updates — one PR per package (no grouping). Bundling unrelated majors caused PR #394 to ship a broken lockfile because typescript-eslint v8 still pinned eslint <10 while the group already advanced eslint to 10. Per-package PRs let each major be reviewed and merged independently of incompatible peers.",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Pin npm dependency versions exactly (no ^/~ ranges). Plugwerk is an application, not a library — every CI build, every Docker image, and every dev clone should resolve to the identical bytes. Pinning keeps `package.json` and `package-lock.json` honest about what's actually in production, makes 'works for me' debugging much easier, and turns every patch into an explicit Renovate PR with a real changelog instead of a silent lockfile drift. Pin applies to `dependencies` and `devDependencies` only — peer-deps and bundled-deps keep their ranges so library authors who consume our types still get flexibility. Gradle keeps its existing version catalog (gradle/libs.versions.toml is pinned by construction).",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "rangeStrategy": "pin"
     }
   ]
 }


### PR DESCRIPTION
Adds a `packageRules` entry to `.github/renovate.json` with `rangeStrategy: "pin"` scoped to npm `dependencies` + `devDependencies`. After this lands, Renovate will open one big PR that rewrites every `^x.y.z` / `~x.y.z` in `plugwerk-server-frontend/package.json` to its exact resolved version, and from that point on every minor/patch upstream lands as its own explicit PR — no more silent drift between manifest range and lockfile pin.

## Why

We have just spent a string of incidents on exactly this class of bug:

- **#455 (postcss CVE-2026-41305)** — manifest range allowed 8.5.10 but the lockfile was stuck on 8.5.8. Code-scanning flagged it; the manifest looked clean.
- **#459 (axios CVE bundle, 13 alerts)** — `^1.15.0` in the manifest, `1.15.0` exact in the lockfile, 13 advisories piled up between Renovate runs because the bot saw "range still satisfied".
- **PR #452 ERESOLVE** — eslint v10 manifest bump, but `eslint-plugin-react-hooks@7.0.1` (peer caps at v9) was hidden behind a caret and Renovate didn't sweep it.

Pinning makes all three impossible-by-construction: the manifest can only ever say what the lockfile says.

## Scope

- npm `dependencies` and `devDependencies` only. Peer- and bundled-deps keep their ranges so consumers of our types stay flexible (we're not a library, but the OpenAPI-generated client we ship under `src/api/generated/` does have a peer surface).
- Gradle is unaffected — `gradle/libs.versions.toml` is already pinned by construction.
- The two existing npm rules (grouped minor/patch, ungrouped majors) keep their grouping behaviour — `pin` is a write-format directive, orthogonal to grouping.

## Trade-off

PR volume goes up. The existing `prHourlyLimit: 2` and `prConcurrentLimit: 5` throttle the firehose, but expect one Renovate PR per upstream patch instead of a silent in-range auto-resolve. That's the point — every dep change becomes auditable.

## What to expect after merge

1. Renovate's next scheduled run (within `before 6am every weekday`) will open a single "pin npm dependencies" PR rewriting all caret ranges to exact versions. Lockfile won't change.
2. From then on, the existing grouped minor/patch flow keeps batching weekly bumps; individual majors stay one-per-PR.
3. Code-scanning alerts on transitively-pinned packages should clear as soon as Renovate's first patch-cycle runs against the pinned manifest.

## Test plan

- [x] `renovate-config-validator` accepts the change (`Config validated successfully`)
- [ ] CI runs `npm ci` against the pinned lockfile (no drift)
- [ ] After merge, watch for the auto-generated pin PR and review its diff before merging it

🤖 Generated with [Claude Code](https://claude.com/claude-code)