### PR TITLE
chore(ci): self-hosted Renovate via GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,75 @@
+# Self-hosted Renovate via GitHub Actions.
+#
+# Why we run it ourselves instead of relying on Mend's hosted bot:
+#   - The hosted Free Plan iterates on its own opaque cadence (typically
+#     once per day) and does not expose run-history to repo collaborators.
+#     When a Dependency-Dashboard checkbox sits at `[x]` for hours with no
+#     visible bot tick, debugging that from the outside is impossible.
+#   - This workflow accepts `workflow_dispatch`, so any maintainer can
+#     trigger a run with `gh workflow run renovate.yml` and watch the logs
+#     in the Actions tab. Same Renovate binary, same `.github/renovate.json`
+#     configuration; only the trigger is local.
+#   - The cron mirrors the previous Mend cadence ("before 6am every
+#     weekday", in UTC because GitHub Actions cron is always UTC). The
+#     `schedule:` entry inside `renovate.json` still acts as a per-package
+#     filter — a workflow tick is the *opportunity* for Renovate to act,
+#     not an override of `before 6am every weekday` rules.
+#
+# Token: GITHUB_TOKEN works for read access (it's a regular Actions token),
+# but Renovate also writes branches and opens PRs, which the default token
+# can do scoped to this repo. No PAT or app-install required for a
+# single-repo setup. If we ever go multi-repo, swap to a GitHub App token.
+
+name: Renovate
+
+on:
+  schedule:
+    # Mon-Fri at 04:00 UTC (~05:00-06:00 CET/CEST). Matches the
+    # `schedule: ["before 6am every weekday"]` filter inside renovate.json
+    # so a tick that happens later in the day still cleanly skips most
+    # rules. Outside this window, runs only happen via workflow_dispatch.
+    - cron: "0 4 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        type: choice
+        default: "info"
+        options:
+          - info
+          - debug
+
+# Only one Renovate run at a time per branch — concurrent runs against the
+# same repository fight over branch creation and corrupt the dependency
+# dashboard. `cancel-in-progress: false` keeps a running job intact and
+# queues the new one rather than dropping it.
+concurrency:
+  group: renovate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # branch + push
+      pull-requests: write     # open + label PRs
+      issues: write            # update Dependency Dashboard issue (#376)
+    # Lift the workflow_dispatch input into an env var so the run-step
+    # never interpolates user-controlled (even via choice-whitelisted)
+    # input straight into a shell or YAML field — defensive practice
+    # that satisfies the GitHub-hardened-runners injection-prevention
+    # guidance even though `choice` already restricts the surface to
+    # two known values.
+    env:
+      RENOVATE_LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v44.1.1
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ env.RENOVATE_LOG_LEVEL }}


### PR DESCRIPTION
Replaces the opaque Mend-hosted Renovate cadence with an in-repo workflow that any maintainer can trigger and observe.

## Why

The Free-Plan Mend bot iterates on its own schedule (roughly daily) and exposes zero run-history to repo collaborators. Two real incidents this week traced back to that opacity:

- **Pin migration** (#460): merged on 2026-05-08; the Dependency Dashboard (#376) immediately listed an "Awaiting Schedule" pin-bundle PR plus six other queued items. The dashboard checkbox `🔐 Create all awaiting schedule PRs at once 🔐` was clicked, then a Mend "Force Run" was triggered manually, and **nothing happened** for 12+ hours. The dashboard's `updatedAt` never moved past the original 22:32 UTC mark; no `renovate/*` branches appeared.
- **Earlier Renovate flakiness** with #452 / #453 / #454: PRs that needed manual intervention waited for the next bot tick before the matching follow-up ran.

We can't debug what we can't observe. A self-hosted GitHub Action solves both: the trigger is in our control, the logs are in the Actions tab, and the binary is identical (`renovatebot/github-action@v44.1.1`).

## What it does

- **Cron** (`0 4 * * 1-5`): Mon-Fri at 04:00 UTC. Mirrors the existing `"schedule": ["before 6am every weekday"]` filter in `.github/renovate.json` so a tick lands inside the configured window — outside that window, package-level schedule rules still skip cleanly.
- **`workflow_dispatch`**: any maintainer triggers a run with `gh workflow run renovate.yml` and watches the Actions log live. Optional `logLevel: debug` input for troubleshooting.
- **Concurrency guard**: `concurrency: renovate-${{ github.ref }}`, `cancel-in-progress: false`. A scheduled tick that overlaps a manual one queues rather than races.

## What it doesn't change

- `.github/renovate.json` is untouched. Same packageRules, same group definitions, same hourly/concurrent PR limits.
- Mend's hosted bot can keep running in parallel. They idempotently produce the same PRs against the same branches; whichever ticks first wins. Once we're confident in the self-hosted variant, the Mend installation can be removed (UI step, no repo change needed).

## Permissions

Minimal: `contents: write`, `pull-requests: write`, `issues: write` (the last is for updating the Dependency Dashboard issue #376). Uses the default `GITHUB_TOKEN`; no PAT or GitHub App required at this scope. If we ever go multi-repo, swap to an app-installation token.

## Test plan

- [x] Workflow YAML accepted by GitHub (rendered correctly in the PR's Files tab)
- [ ] After merge: `gh workflow run renovate.yml` triggers the Actions run
- [ ] Run completes; Dependency Dashboard `updatedAt` advances; the queued pin-dependencies PR opens
- [ ] Subsequent cron tick at 04:00 UTC executes automatically without manual touch

## Note on the security hook

The workflow lifts `inputs.logLevel` into an `env: RENOVATE_LOG_LEVEL` rather than interpolating it directly into the run step. Even though `inputs.logLevel` is a `choice` with a fixed two-value whitelist (no injection surface), the env-indirection is the documented hardened-runners pattern and keeps the workflow consistent with GitHub's own security guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)