### PR TITLE
fix(ci): renovatebot/github-action v44.1.1 → v46.1.13 (hot-fix)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v44.1.1
+        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR #462 merged with the wrong action version (\`v44.1.1\` doesn't exist; v46.1.13 is the real latest). My follow-up fix on the source branch landed *after* the merge button was clicked — small race, but main is now broken: every \`workflow_dispatch\` run since the merge fails with

> Unable to resolve action \`renovatebot/github-action@v44.1.1\`, unable to find version \`v44.1.1\`

This PR pins to the SHA of v46.1.13 (\`79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a\`) in line with the existing \`helpers:pinGitHubActionDigests\` preset — Renovate will keep the pin fresh from here on.

Single-line change. Merge as soon as CI is happy.