### PR TITLE
fix(deps): bump yaml to ^2.8.4 (CVE-2026-33532)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/package-lock.json
+++ b/plugwerk-server/plugwerk-server-frontend/package-lock.json
@@ -4740,15 +4740,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -11063,9 +11054,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/plugwerk-server/plugwerk-server-frontend/package.json
+++ b/plugwerk-server/plugwerk-server-frontend/package.json
@@ -62,6 +62,7 @@
   "overrides": {
     "dompurify": "^3.4.0",
     "follow-redirects": "^1.16.0",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "yaml": "^2.8.4"
   }
 }


### PR DESCRIPTION
Closes #250.

`yaml@2.8.4` shipped on 2026-05-02 with the alias-resolution opt-out behind `maxAliasCount: 0` (release note: *"Disable alias resolution with maxAliasCount:0 (#677)"*) — exactly the mitigation CVE-2026-33532 needs. Issue #250 had this on the watch-list as accepted risk because only 2.8.3 existed when the security audit landed; the wait is now over.

## Change

One npm `overrides` line in `plugwerk-server-frontend/package.json`:

```diff
   "overrides": {
     "dompurify": "^3.4.0",
     "follow-redirects": "^1.16.0",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "yaml": "^2.8.4"
   }
```

Lockfile regenerated; every transitive `yaml@2.8.3` subtree (Scalar API reference, monaco-yaml, the cosmiconfig path that held an old `yaml@1.10.3` from `@emotion/babel-plugin`) deduplicates cleanly to `2.8.4`. Verified with `npm ls yaml --all`.

## Test plan

- [x] `npm install` clean (no ERESOLVE)
- [x] `npm run build` green
- [x] `npm run test:run` — 48 files / 408 tests green
- [ ] Code-scanning alert for CVE-2026-33532 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)