### PR TITLE
feat(admin): superadmin-triggered password reset with notification email

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1461,6 +1461,69 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /admin/users/{userId}/reset-password:
+    post:
+      tags:
+        - AdminUsers
+      summary: Trigger an admin-initiated password reset
+      operationId: adminResetUserPassword
+      description: |
+        Issues a single-use password-reset token for the target INTERNAL
+        user, emails an admin-initiated reset link to the user's address,
+        and revokes every active session — both access tokens (via
+        `passwordInvalidatedBefore`) and the refresh-token family. Idempotent:
+        re-running supersedes the previous unconsumed token. Requires
+        superadmin privileges.
+
+        Bypasses the `auth.password_reset_enabled` operator gate that gates
+        the public forgot-password flow — admin-driven path is an
+        independent trust chain (#421 covered the public surface; #450
+        added this admin surface).
+
+        SMTP-disabled fallback: if the SMTP server is not configured the
+        endpoint still succeeds server-side (token is issued, sessions
+        revoked) and returns the reset URL in the response body so the
+        operator can deliver it out of band. The reset URL is omitted
+        from the response when the email was sent successfully.
+
+        Refusal cases (HTTP 400):
+          - target user is EXTERNAL (OIDC) — credentials are managed by the
+            upstream IdP,
+          - target user is the caller themselves — superadmins must use
+            `/auth/change-password` for self-service changes.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: |
+            Reset triggered. `tokenIssued` is always `true` on this path;
+            `emailSent` is `false` when SMTP is unconfigured or the send
+            failed, in which case `resetUrl` carries the link the
+            operator can deliver out of band.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPasswordResetResponse'
+        '400':
+          description: Target user is EXTERNAL or the caller's own row
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /namespaces/{ns}/members/me:
     get:
       tags:
@@ -3272,6 +3335,49 @@ components:
           type: string
           minLength: 12
           nullable: true
+
+    AdminPasswordResetResponse:
+      type: object
+      description: |
+        Outcome of `POST /admin/users/{userId}/reset-password` (#450).
+
+        Server-side side effects (token issue, dual session revocation,
+        structured audit log) always happen on the success path. The
+        boolean fields tell the caller whether the user was reachable
+        through the normal email channel.
+      properties:
+        tokenIssued:
+          type: boolean
+          description: |
+            Always `true` on the 200 response. Surfaced for forward
+            compatibility — a future enhancement might return 200 with
+            `tokenIssued=false` if the operator turns off the admin-driven
+            reset flow per-deployment.
+        emailSent:
+          type: boolean
+          description: |
+            `true` when SMTP was configured and the mail provider accepted
+            the message; `false` when SMTP is disabled or the send failed
+            (server log carries the reason in the latter case).
+        expiresAt:
+          type: string
+          format: date-time
+          description: |
+            Absolute UTC timestamp at which the issued reset token expires.
+            Operators surfacing the link out-of-band can use this to tell
+            the user how long they have to act.
+        resetUrl:
+          type: string
+          nullable: true
+          description: |
+            Absolute reset URL (`{webBaseUrl}/reset-password?token=…`).
+            Populated only when `emailSent` is `false`, so the operator can
+            deliver the link out-of-band (Slack, phone, in-person). Omitted
+            on the happy path so the link does not appear in API logs.
+      required:
+        - tokenIssued
+        - emailSent
+        - expiresAt
 
     NamespaceMembershipDto:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -19,6 +19,7 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.api.AdminUsersApi
+import io.plugwerk.api.model.AdminPasswordResetResponse
 import io.plugwerk.api.model.UserCreateRequest
 import io.plugwerk.api.model.UserDto
 import io.plugwerk.api.model.UserUpdateRequest
@@ -28,10 +29,13 @@ import io.plugwerk.server.repository.OidcIdentityRepository
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.auth.AdminPasswordResetService
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.net.URI
 import java.util.UUID
 
@@ -42,7 +46,10 @@ class AdminUserController(
     private val namespaceAuthorizationService: NamespaceAuthorizationService,
     private val namespaceMemberRepository: io.plugwerk.server.repository.NamespaceMemberRepository,
     private val oidcIdentityRepository: OidcIdentityRepository,
+    private val adminPasswordResetService: AdminPasswordResetService,
 ) : AdminUsersApi {
+
+    private val log = LoggerFactory.getLogger(AdminUserController::class.java)
 
     override fun listUsers(enabled: Boolean?): ResponseEntity<List<UserDto>> {
         val auth = currentAuthentication()
@@ -87,6 +94,52 @@ class AdminUserController(
         userUpdateRequest.enabled?.let { user = userService.setEnabled(userId, it) }
         userUpdateRequest.newPassword?.let { user = userService.resetPassword(userId, it) }
         return ResponseEntity.ok(user.toDto())
+    }
+
+    /**
+     * Admin-initiated password reset for a target user (#450).
+     *
+     * Issues a single-use reset token, emails the admin-initiated reset link,
+     * revokes every active session (access tokens + refresh-token family).
+     * On SMTP-disabled / mail-failure the link is returned in the response
+     * body so the operator can deliver it out-of-band.
+     *
+     * Bypasses `auth.password_reset_enabled` — admin is an independent trust
+     * chain (the `@PreAuthorize` on this method is the gate). Refusal cases
+     * (EXTERNAL user, self-reset) surface as HTTP 400 via
+     * [io.plugwerk.server.controller.GlobalExceptionHandler].
+     */
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun adminResetUserPassword(userId: UUID): ResponseEntity<AdminPasswordResetResponse> {
+        val auth = currentAuthentication()
+        namespaceAuthorizationService.requireSuperadmin(auth)
+        val actorId = parseAuthSubjectAsUuid(auth.name)
+        val result = adminPasswordResetService.trigger(targetUserId = userId, actorUserId = actorId)
+        return ResponseEntity.ok(
+            AdminPasswordResetResponse(
+                tokenIssued = result.tokenIssued,
+                emailSent = result.emailSent,
+                expiresAt = result.expiresAt,
+                resetUrl = result.resetUrl,
+            ),
+        )
+    }
+
+    /**
+     * The JWT principal is `plugwerk_user.id` (UUID) since the identity-hub
+     * split (#351 / ADR-0029). Defensive parse: if a future change introduces
+     * a non-UUID subject we want to fail loudly rather than silently miscompare
+     * against the target row.
+     */
+    private fun parseAuthSubjectAsUuid(subject: String): UUID = try {
+        UUID.fromString(subject)
+    } catch (ex: IllegalArgumentException) {
+        log.error("Cannot derive caller UUID from auth subject '{}'", subject, ex)
+        throw ResponseStatusException(
+            org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+            "Cannot derive caller identity from authentication context",
+            ex,
+        )
     }
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthPasswordResetController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthPasswordResetController.kt
@@ -30,6 +30,7 @@ import io.plugwerk.server.security.RateLimitResult
 import io.plugwerk.server.security.RefreshTokenCookieFactory
 import io.plugwerk.server.service.RefreshTokenService
 import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.auth.ExpiryFormatter
 import io.plugwerk.server.service.auth.PasswordResetTokenService
 import io.plugwerk.server.service.mail.MailService
 import io.plugwerk.server.service.mail.MailTemplate
@@ -41,9 +42,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.time.Duration
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
 
 /**
  * Public endpoints for the opt-in self-service password-reset flow (#421).
@@ -190,7 +188,7 @@ class AuthPasswordResetController(
     private fun issueAndSend(user: UserEntity) {
         val issued = tokenService.issue(user)
         val resetLink = buildResetLink(issued.rawToken)
-        val expiresAtHuman = formatExpiry(issued.expiresAt)
+        val expiresAtHuman = ExpiryFormatter.formatHuman(issued.expiresAt)
         val send = mailService.sendMailFromTemplate(
             template = MailTemplate.AUTH_PASSWORD_RESET,
             to = user.email,
@@ -217,25 +215,5 @@ class AuthPasswordResetController(
         // bundled-SPA production deployments.
         val base = plugwerkProperties.server.effectiveWebBaseUrl().trimEnd('/')
         return "$base/reset-password?token=$rawToken"
-    }
-
-    /**
-     * "in 30 minutes" / "in 1 hours" for short windows, otherwise the
-     * absolute UTC timestamp. Matches the verification-email tone from
-     * `AuthRegistrationController.formatExpiry`.
-     */
-    private fun formatExpiry(expiresAt: OffsetDateTime): String {
-        val secondsLeft = Duration.between(OffsetDateTime.now(), expiresAt).seconds
-        return when {
-            secondsLeft <= 0 -> "now (link already expired)"
-            secondsLeft < 3600 -> "in ${(secondsLeft / 60).coerceAtLeast(1)} minutes"
-            secondsLeft < 86_400 -> "in ${(secondsLeft / 3600).coerceAtLeast(1)} hours"
-            else -> "on ${expiresAt.format(ABSOLUTE_FMT)}"
-        }
-    }
-
-    private companion object {
-        private val ABSOLUTE_FMT: DateTimeFormatter =
-            DateTimeFormatter.ofPattern("d MMM yyyy 'at' HH:mm 'UTC'")
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthRegistrationController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AuthRegistrationController.kt
@@ -28,6 +28,7 @@ import io.plugwerk.server.security.RegisterRateLimitService
 import io.plugwerk.server.service.ConflictException
 import io.plugwerk.server.service.UserService
 import io.plugwerk.server.service.auth.EmailVerificationTokenService
+import io.plugwerk.server.service.auth.ExpiryFormatter
 import io.plugwerk.server.service.mail.MailService
 import io.plugwerk.server.service.mail.MailTemplate
 import io.plugwerk.server.service.settings.ApplicationSettingsService
@@ -37,8 +38,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.time.Duration
-import java.time.format.DateTimeFormatter
 
 /**
  * Public endpoints for self-service account creation (#420).
@@ -118,7 +117,7 @@ class AuthRegistrationController(
         if (verificationRequired) {
             val issued = tokenService.issue(user)
             val verificationLink = buildVerificationLink(issued.rawToken)
-            val expiresAtHuman = formatExpiry(issued.expiresAt)
+            val expiresAtHuman = ExpiryFormatter.formatHuman(issued.expiresAt)
             val send = mailService.sendMailFromTemplate(
                 template = MailTemplate.AUTH_REGISTRATION_VERIFICATION,
                 to = user.email,
@@ -189,24 +188,5 @@ class AuthRegistrationController(
         // hasn't overridden it, preserving same-origin production deployments.
         val base = plugwerkProperties.server.effectiveWebBaseUrl().trimEnd('/')
         return "$base/verify-email?token=$rawToken"
-    }
-
-    /**
-     * "in 24 hours" for short windows, otherwise the absolute UTC
-     * timestamp. Operator-localisation lands with #436's i18n iteration.
-     */
-    private fun formatExpiry(expiresAt: java.time.OffsetDateTime): String {
-        val secondsLeft = Duration.between(java.time.OffsetDateTime.now(), expiresAt).seconds
-        return when {
-            secondsLeft <= 0 -> "now (link already expired)"
-            secondsLeft < 3600 -> "in ${(secondsLeft / 60).coerceAtLeast(1)} minutes"
-            secondsLeft < 86_400 -> "in ${(secondsLeft / 3600).coerceAtLeast(1)} hours"
-            else -> "on ${expiresAt.format(ABSOLUTE_FMT)}"
-        }
-    }
-
-    private companion object {
-        private val ABSOLUTE_FMT: DateTimeFormatter =
-            DateTimeFormatter.ofPattern("d MMM yyyy 'at' HH:mm 'UTC'")
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/GlobalExceptionHandler.kt
@@ -36,8 +36,10 @@ import io.plugwerk.server.service.PluginNotFoundException
 import io.plugwerk.server.service.ReleaseAlreadyExistsException
 import io.plugwerk.server.service.ReleaseNotFoundException
 import io.plugwerk.server.service.UnauthorizedException
+import io.plugwerk.server.service.auth.ExternalUserResetNotAllowedException
 import io.plugwerk.server.service.auth.InvalidPasswordResetTokenException
 import io.plugwerk.server.service.auth.InvalidVerificationTokenException
+import io.plugwerk.server.service.auth.SelfResetNotAllowedException
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -176,6 +178,28 @@ class GlobalExceptionHandler {
     @ExceptionHandler(InvalidPasswordResetTokenException::class)
     fun handleInvalidPasswordResetToken(ex: InvalidPasswordResetTokenException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Password-reset token is invalid")
+
+    /**
+     * Admin-driven reset on the caller's own row (#450). Maps to 400 with the
+     * exception's actionable message ("Use Profile → Change password to update
+     * your own password.") so the Admin UI can surface it as an inline toast.
+     */
+    @ExceptionHandler(SelfResetNotAllowedException::class)
+    fun handleSelfReset(ex: SelfResetNotAllowedException): ResponseEntity<ErrorResponse> =
+        errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Self-reset not permitted via admin endpoint")
+
+    /**
+     * Admin-driven reset on an EXTERNAL (OIDC) user (#450). Same 400 mapping
+     * as the existing [io.plugwerk.server.service.UserService.resetPassword]
+     * `require(user.isInternal())` path — the dedicated exception type lets
+     * the controller produce a stable, non-generic message.
+     */
+    @ExceptionHandler(ExternalUserResetNotAllowedException::class)
+    fun handleExternalUserReset(ex: ExternalUserResetNotAllowedException): ResponseEntity<ErrorResponse> =
+        errorResponse(
+            HttpStatus.BAD_REQUEST,
+            ex.message ?: "Cannot reset password on an OIDC user",
+        )
 
     /**
      * Honour the status code carried inside any [ResponseStatusException]

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetService.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.service.EntityNotFoundException
+import io.plugwerk.server.service.RefreshTokenService
+import io.plugwerk.server.service.TokenRevocationService
+import io.plugwerk.server.service.mail.MailService
+import io.plugwerk.server.service.mail.MailTemplate
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Drives the superadmin-triggered password reset for a target user (#450).
+ *
+ * Side effects on every successful invocation:
+ *  1. A fresh single-use token is issued via [PasswordResetTokenService.issue]
+ *     (supersedes any previous unconsumed token for the same user).
+ *  2. `passwordChangeRequired = true` on the target row so that — even in
+ *     the SMTP-disabled fallback where the user might still know their old
+ *     password — the next login is funneled through `/change-password` by
+ *     `PasswordChangeRequiredFilter`.
+ *  3. **Both** revocation atoms run: `passwordInvalidatedBefore` (access-token
+ *     side, via [TokenRevocationService]) **and** the refresh-token family
+ *     (via [RefreshTokenService.revokeAllForUser]). The dual revocation is
+ *     mandatory — `AuthController.refresh` does not consult
+ *     `passwordInvalidatedBefore`, verified for #421 in PR #448, so a stolen
+ *     refresh cookie would otherwise keep minting fresh access tokens after
+ *     the reset.
+ *  4. The admin-initiated mail template (`AUTH_ADMIN_PASSWORD_RESET`) is
+ *     dispatched via [MailService].
+ *
+ * Refusal cases:
+ *  - target user is EXTERNAL — credentials live with the upstream OIDC
+ *    provider; raises [IllegalArgumentException] which `GlobalExceptionHandler`
+ *    maps to HTTP 400.
+ *  - target user is the caller — superadmins must use `/auth/change-password`
+ *    for self-service password changes. Same 400 mapping.
+ *
+ * SMTP-disabled / mail-send-fail behaviour: server-side state changes
+ * (token, session revocation, flag) **always succeed**. Only the mail step
+ * is best-effort: on `Disabled` / `Misconfigured` / `Failed` the call returns
+ * 200 with `emailSent=false` and the absolute reset URL inlined into the
+ * response so the operator can deliver the link out-of-band (Slack, phone,
+ * in-person). The link is intentionally **not** logged on the wire — the
+ * admin sees it once on the API response and that is the only ambient copy
+ * outside the mail provider's relay.
+ *
+ * Audit: the action is recorded structurally via SLF4J + MDC
+ * (`actor`, `target`, `kind=ADMIN_PASSWORD_RESET`, `smtpDelivered`). A
+ * persistent audit-log table is intentionally out of scope for this issue —
+ * see follow-up issue for the dedicated infrastructure.
+ *
+ * Bypasses the `auth.password_reset_enabled` operator gate that protects
+ * the public forgot-password flow — the admin-driven path is an
+ * independent trust chain (the caller is already authenticated as a
+ * superadmin via `@PreAuthorize` on `AdminUserController`).
+ */
+@Service
+class AdminPasswordResetService(
+    private val userRepository: UserRepository,
+    private val tokenService: PasswordResetTokenService,
+    private val tokenRevocationService: TokenRevocationService,
+    private val refreshTokenService: RefreshTokenService,
+    private val mailService: MailService,
+    private val settings: ApplicationSettingsService,
+    private val plugwerkProperties: PlugwerkProperties,
+) {
+    private val log = LoggerFactory.getLogger(AdminPasswordResetService::class.java)
+
+    /**
+     * Executes the admin-driven reset for [targetUserId] on behalf of
+     * [actorUserId] (typically the superadmin currently authenticated).
+     *
+     * @throws SelfResetNotAllowedException when [targetUserId] equals
+     *   [actorUserId] — superadmins must use `/auth/change-password`.
+     * @throws ExternalUserResetNotAllowedException when the target row is
+     *   `source = EXTERNAL` — credentials are managed upstream.
+     * @throws EntityNotFoundException when no user matches [targetUserId].
+     */
+    @Transactional
+    fun trigger(targetUserId: UUID, actorUserId: UUID): Result {
+        if (targetUserId == actorUserId) {
+            throw SelfResetNotAllowedException(
+                "Use Profile → Change password to update your own password.",
+            )
+        }
+
+        val user = userRepository.findById(targetUserId).orElseThrow {
+            EntityNotFoundException("User", targetUserId.toString())
+        }
+
+        if (user.isExternal()) {
+            throw ExternalUserResetNotAllowedException(
+                "Cannot reset password on OIDC users — credentials live with the upstream provider.",
+            )
+        }
+
+        // Server-side state changes — always succeed regardless of SMTP status.
+        //
+        // Ordering matters because `RefreshTokenRepository.revokeAllForUser`
+        // is annotated `@Modifying(clearAutomatically = true)`: Hibernate
+        // clears the persistence context AFTER the bulk UPDATE without
+        // flushing any pending entity changes first (`flushAutomatically=false`
+        // is the Spring Data default, and Hibernate's auto-flush only fires
+        // for queries whose target entity-type overlaps with pending changes
+        // — a bulk update on `RefreshTokenEntity` does not overlap with
+        // pending inserts on `PasswordResetTokenEntity` or pending updates
+        // on `UserEntity`).
+        //
+        // Anything that mutates the persistence context BEFORE this bulk
+        // query — issuing the new password-reset token, flipping
+        // `passwordChangeRequired`, bumping `passwordInvalidatedBefore` — is
+        // silently discarded on the PC clear. The most user-visible
+        // symptom: an unflushed `PasswordResetTokenEntity` insert never
+        // reaches the DB, so the emailed reset link looks up against an
+        // empty hash and the user gets "Password-reset token is invalid"
+        // on submit.
+        //
+        // The fix is to run the bulk @Modifying query FIRST, then re-fetch
+        // and apply all entity-state changes — those land naturally on the
+        // commit-time flush.
+
+        // 1. Bulk refresh-token revocation FIRST (clears PC; nothing to lose).
+        refreshTokenService.revokeAllForUser(targetUserId, RefreshTokenService.LOGOUT)
+
+        // 2. Re-fetch the user — `user` was detached by the PC clear above.
+        val freshUser = userRepository.findById(targetUserId).orElseThrow {
+            EntityNotFoundException("User", targetUserId.toString())
+        }
+
+        // 3. Issue the single-use reset token. Insert lives in the PC and is
+        //    flushed at commit (no further bulk queries follow that could
+        //    discard it).
+        val issued = tokenService.issue(freshUser)
+
+        // 4. Force the next login through /change-password as defence-in-depth
+        //    for the SMTP-disabled path: even if the user still knows their
+        //    old password and tries to log in normally, PasswordChangeRequiredFilter
+        //    funnels them to a password change.
+        freshUser.passwordChangeRequired = true
+        userRepository.save(freshUser)
+
+        // 5. Access-token revocation. `tokenRevocationService.revokeAllForUser`
+        //    re-fetches the user (returns the same managed instance from PC
+        //    in this transaction), sets `passwordInvalidatedBefore`, saves.
+        //    Both field updates accumulate on the same managed entity and
+        //    Hibernate emits a single UPDATE on commit.
+        tokenRevocationService.revokeAllForUser(targetUserId)
+
+        // 6. Dispatch mail (best-effort).
+        val resetUrl = buildResetLink(issued.rawToken)
+        val expiresAtHuman = ExpiryFormatter.formatHuman(issued.expiresAt)
+        val sendOutcome = runCatching {
+            mailService.sendMailFromTemplate(
+                template = MailTemplate.AUTH_ADMIN_PASSWORD_RESET,
+                to = freshUser.email,
+                vars = mapOf(
+                    "username" to freshUser.displayName,
+                    "resetLink" to resetUrl,
+                    "expiresAtHuman" to expiresAtHuman,
+                    "siteName" to settings.siteName(),
+                ),
+            )
+        }.getOrElse { ex ->
+            log.error(
+                "ADMIN_PASSWORD_RESET: mail send threw for user {} — degrading to out-of-band response",
+                targetUserId,
+                ex,
+            )
+            MailService.SendResult.Failed(ex.message ?: ex::class.simpleName ?: "mail send threw")
+        }
+
+        val emailSent = sendOutcome is MailService.SendResult.Sent
+        if (!emailSent) {
+            log.warn(
+                "ADMIN_PASSWORD_RESET: mail not delivered for user {} (outcome={}); reset URL returned to caller for out-of-band delivery",
+                targetUserId,
+                sendOutcome,
+            )
+        }
+
+        // Structured audit log (#450 follow-up issue tracks persistent storage).
+        // MDC keys are unconditional so a log-aggregator pipeline can index on
+        // `kind=ADMIN_PASSWORD_RESET` without parsing the message string.
+        MDC.putCloseable("actor", actorUserId.toString()).use {
+            MDC.putCloseable("target", targetUserId.toString()).use {
+                MDC.putCloseable("kind", "ADMIN_PASSWORD_RESET").use {
+                    MDC.putCloseable("smtpDelivered", emailSent.toString()).use {
+                        log.info(
+                            "ADMIN_PASSWORD_RESET: actor={} target={} smtpDelivered={} expiresAt={}",
+                            actorUserId,
+                            targetUserId,
+                            emailSent,
+                            issued.expiresAt,
+                        )
+                    }
+                }
+            }
+        }
+
+        return Result(
+            tokenIssued = true,
+            emailSent = emailSent,
+            expiresAt = issued.expiresAt,
+            resetUrl = if (emailSent) null else resetUrl,
+        )
+    }
+
+    private fun buildResetLink(rawToken: String): String {
+        val base = plugwerkProperties.server.effectiveWebBaseUrl().trimEnd('/')
+        return "$base/reset-password?token=$rawToken"
+    }
+
+    /** Outcome surfaced to [io.plugwerk.server.controller.AdminUserController]. */
+    data class Result(
+        val tokenIssued: Boolean,
+        val emailSent: Boolean,
+        val expiresAt: OffsetDateTime,
+        val resetUrl: String?,
+    )
+}
+
+/** Mapped to HTTP 400 by `GlobalExceptionHandler`. */
+class SelfResetNotAllowedException(message: String) : RuntimeException(message)
+
+/** Mapped to HTTP 400 by `GlobalExceptionHandler`. */
+class ExternalUserResetNotAllowedException(message: String) : RuntimeException(message)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/ExpiryFormatter.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/ExpiryFormatter.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Renders an absolute expiry timestamp into the short human phrase used in
+ * transactional emails: "in 30 minutes" for short windows, "in 12 hours" for
+ * the same-day band, and an absolute UTC stamp for anything beyond 24 hours.
+ *
+ * Extracted in #450 to deduplicate the same logic that lived inline in
+ * `AuthRegistrationController`, `AuthPasswordResetController`, and now also
+ * `AdminPasswordResetService`. Operator-localisation lands with #436's i18n
+ * iteration.
+ */
+internal object ExpiryFormatter {
+
+    private val ABSOLUTE_FMT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("d MMM yyyy 'at' HH:mm 'UTC'")
+
+    fun formatHuman(expiresAt: OffsetDateTime, now: OffsetDateTime = OffsetDateTime.now()): String {
+        val secondsLeft = Duration.between(now, expiresAt).seconds
+        return when {
+            secondsLeft <= 0 -> "now (link already expired)"
+            secondsLeft < 3600 -> "in ${(secondsLeft / 60).coerceAtLeast(1)} minutes"
+            secondsLeft < 86_400 -> "in ${(secondsLeft / 3600).coerceAtLeast(1)} hours"
+            else -> "on ${expiresAt.format(ABSOLUTE_FMT)}"
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/mail/MailTemplate.kt
@@ -189,6 +189,61 @@ enum class MailTemplate(
             "siteName" to "marketplace.plugwerk.test",
         ),
     ),
+
+    /**
+     * Admin-initiated password-reset email triggered from the Admin → Users
+     * surface (#450). Differs from [AUTH_PASSWORD_RESET] in two intentional
+     * ways:
+     *  - body copy makes the **admin-initiated** part obvious so a recipient
+     *    who did not request a reset themselves understands who triggered it,
+     *  - body explicitly states that every active session has been signed
+     *    out — operationally true and a reassurance signal in the case of a
+     *    suspected-compromise reset.
+     *
+     * Reuses the same `{{resetLink}}` placeholder shape as the public flow,
+     * so the existing `ResetPasswordPage.tsx` consumes the link unchanged.
+     */
+    AUTH_ADMIN_PASSWORD_RESET(
+        key = "auth.admin_password_reset",
+        defaultSubject = "An administrator reset your Plugwerk password",
+        defaultBodyPlainTemplate = """
+            Hi {{username}},
+
+            A Plugwerk administrator has initiated a password reset on your
+            account. Click the link below to choose a new password — the link
+            is valid {{expiresAtHuman}}.
+
+            {{resetLink}}
+
+            For your security, every active Plugwerk session on this account
+            has been signed out. You did not request this reset yourself; it
+            was triggered by a site administrator. If this was unexpected,
+            contact your administrator.
+
+            —
+            Sent by Plugwerk · {{siteName}}
+            You're receiving this because an administrator initiated a password reset on your account.
+        """.trimIndent(),
+        defaultBodyHtmlTemplate = EmailLayoutBuilder.wrap(
+            contentHtml = """
+              <p style="margin:0 0 16px;">Hi {{username}},</p>
+              <p style="margin:0 0 16px;">A Plugwerk administrator has initiated a password reset on your account. Click the button below to choose a new password — this link is valid {{expiresAtHuman}}.</p>
+              <p style="margin:24px 0 8px;font-size:13px;color:#6F6F6F;">If the button doesn't work, paste this link into your browser:</p>
+              <p style="margin:0;font-size:13px;word-break:break-all;"><a href="{{resetLink}}" class="pw-fallback-link" style="color:#0F62FE;text-decoration:underline;">{{resetLink}}</a></p>
+              <p style="margin:24px 0 0;font-size:13px;color:#6F6F6F;">For your security, every active Plugwerk session on this account has been signed out. If this was unexpected, contact your administrator.</p>
+            """.trimIndent(),
+            ctaUrl = "{{resetLink}}",
+            ctaText = "Choose new password",
+            footerLine2 = "You're receiving this because an administrator initiated a password reset on your account.",
+        ),
+        placeholders = setOf("username", "resetLink", "expiresAtHuman", "siteName"),
+        previewSampleVars = mapOf(
+            "username" to "Alice",
+            "resetLink" to "https://app.plugwerk.test/reset-password?token=demo-token-123",
+            "expiresAtHuman" to "in 30 minutes",
+            "siteName" to "marketplace.plugwerk.test",
+        ),
+    ),
     ;
 
     init {

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -61,3 +61,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0030_add_password_reset_settings.yaml
   - include:
       file: db/changelog/migrations/0031_email_template_polish.yaml
+  - include:
+      file: db/changelog/migrations/0032_admin_password_reset_template.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0032_admin_password_reset_template.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0032_admin_password_reset_template.yaml
@@ -1,0 +1,138 @@
+# Seed the admin-initiated password-reset email template (#450).
+#
+# Unlike #436's auth.password_reset which the user triggers themselves
+# from the public forgot-password flow, this template is for the
+# super-admin-driven reset surface in Admin → Users. The body copy
+# differs in two ways: it names the administrator as the trigger, and
+# it states explicitly that every active session has been signed out.
+#
+# The seeded HTML is the same Carbon-Blue layout produced by
+# EmailLayoutBuilder.wrap that #449 / #438 polished onto the other two
+# transactional templates — operators who later edit this template
+# through the Admin → Email Templates page (#438) keep their version,
+# Plugwerk does not re-seed.
+#
+# Rollback: dedicated DELETE rather than a no-op SELECT 1, mirroring
+# the original 0026 seed migration. LiquibaseRollbackIT requires every
+# changeset to be rollback-capable.
+databaseChangeLog:
+  - changeSet:
+      id: 0032-seed-auth-admin-password-reset-en
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: template_key
+                  value: auth.admin_password_reset
+              - column:
+                  name: locale
+                  value: en
+              - column:
+                  name: subject
+                  value: "An administrator reset your Plugwerk password"
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{username}},
+
+                    A Plugwerk administrator has initiated a password reset on your
+                    account. Click the link below to choose a new password — the link
+                    is valid {{expiresAtHuman}}.
+
+                    {{resetLink}}
+
+                    For your security, every active Plugwerk session on this account
+                    has been signed out. You did not request this reset yourself; it
+                    was triggered by a site administrator. If this was unexpected,
+                    contact your administrator.
+
+                    —
+                    Sent by Plugwerk · {{siteName}}
+                    You're receiving this because an administrator initiated a password reset on your account.
+              - column:
+                  name: body_html
+                  value: |
+                    <!doctype html>
+                    <html lang="en">
+                    <head>
+                      <meta charset="utf-8">
+                      <meta name="viewport" content="width=device-width, initial-scale=1">
+                      <meta name="color-scheme" content="light dark">
+                      <meta name="supported-color-schemes" content="light dark">
+                      <title>Plugwerk</title>
+                      <style>
+                        @media (prefers-color-scheme: dark) {
+                          body, .pw-page { background-color: #1E1E1E !important; }
+                          .pw-card { background-color: #262626 !important; border-color: #393939 !important; }
+                          .pw-card-body, .pw-wordmark { color: #FFFFFF !important; }
+                          .pw-footer { color: #A8A8A8 !important; }
+                          .pw-fallback-link { color: #4589FF !important; }
+                        }
+                      </style>
+                    </head>
+                    <body class="pw-page" style="margin:0;padding:32px 16px;background-color:#F4F4F4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                        <tr>
+                          <td align="center">
+                            <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;max-width:600px;">
+                              <tr>
+                                <td style="padding:0 4px 24px;">
+                                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                      <td class="pw-wordmark" style="padding:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:22px;font-weight:700;letter-spacing:-0.01em;color:#161616;">Plugwerk</td>
+                                    </tr>
+                                    <tr>
+                                      <td style="height:2px;line-height:2px;font-size:0;background-color:#0F62FE;">&nbsp;</td>
+                                    </tr>
+                                  </table>
+                                </td>
+                              </tr>
+                            </table>
+                            <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" class="pw-card" style="margin:0 auto;max-width:600px;background-color:#FFFFFF;border:1px solid #E0E0E0;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.08);overflow:hidden;">
+                              <tr>
+                                <td width="4" class="pw-accent" style="width:4px;background-color:#0F62FE;line-height:0;font-size:0;">&nbsp;</td>
+                                <td class="pw-card-body" style="padding:32px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;line-height:1.6;color:#161616;">
+                    <p style="margin:0 0 16px;">Hi {{username}},</p>
+                    <p style="margin:0 0 16px;">A Plugwerk administrator has initiated a password reset on your account. Click the button below to choose a new password — this link is valid {{expiresAtHuman}}.</p>
+                    <p style="margin:24px 0 8px;font-size:13px;color:#6F6F6F;">If the button doesn't work, paste this link into your browser:</p>
+                    <p style="margin:0;font-size:13px;word-break:break-all;"><a href="{{resetLink}}" class="pw-fallback-link" style="color:#0F62FE;text-decoration:underline;">{{resetLink}}</a></p>
+                    <p style="margin:24px 0 0;font-size:13px;color:#6F6F6F;">For your security, every active Plugwerk session on this account has been signed out. If this was unexpected, contact your administrator.</p>
+
+                                  <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="margin:24px 0 0;">
+                                    <tr>
+                                      <td align="left" bgcolor="#0F62FE" style="border-radius:6px;">
+                                        <a href="{{resetLink}}" target="_blank" class="pw-cta" style="display:inline-block;padding:12px 24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;font-weight:600;line-height:1;color:#FFFFFF;text-decoration:none;border-radius:6px;">Choose new password</a>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </td>
+                              </tr>
+                            </table>
+                            <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="margin:24px auto 0;max-width:600px;">
+                              <tr>
+                                <td class="pw-footer" style="padding:0 4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:12px;line-height:1.5;color:#6F6F6F;">
+                                  Sent by Plugwerk &middot; {{siteName}}<br>
+                                  You're receiving this because an administrator initiated a password reset on your account.
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </body>
+                    </html>
+              - column:
+                  name: updated_at
+                  valueComputed: now()
+              - column:
+                  name: updated_by
+                  value: liquibase-0032
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.admin_password_reset' AND locale = 'en'"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminEmailTemplatesControllerTest.kt
@@ -141,6 +141,8 @@ class AdminEmailTemplatesControllerTest {
             .thenReturn(overrideView(MailTemplate.AUTH_REGISTRATION_VERIFICATION))
         whenever(templates.findEffective(MailTemplate.AUTH_PASSWORD_RESET, "en"))
             .thenReturn(defaultView(MailTemplate.AUTH_PASSWORD_RESET))
+        whenever(templates.findEffective(MailTemplate.AUTH_ADMIN_PASSWORD_RESET, "en"))
+            .thenReturn(defaultView(MailTemplate.AUTH_ADMIN_PASSWORD_RESET))
 
         mockMvc.get("/api/v1/admin/email/templates").andExpect {
             status { isOk() }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -94,6 +94,9 @@ class AdminUserControllerTest {
     @MockitoBean
     private lateinit var oidcIdentityRepository: io.plugwerk.server.repository.OidcIdentityRepository
 
+    @MockitoBean
+    private lateinit var adminPasswordResetService: io.plugwerk.server.service.auth.AdminPasswordResetService
+
     @BeforeEach
     fun setUp() {
         // Simulate an authenticated superadmin — requireSuperadmin mock does nothing by default
@@ -407,6 +410,122 @@ class AdminUserControllerTest {
             .whenever(namespaceAuthorizationService).requireSuperadmin(any())
 
         mockMvc.delete("/api/v1/admin/users/$userId").andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // POST /admin/users/{userId}/reset-password — admin-initiated reset (#450)
+    // ------------------------------------------------------------------------
+
+    private val callerSuperadminId: UUID = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111")
+
+    /** Re-stamp the security context with a UUID principal so the controller's
+     *  `UUID.fromString(auth.name)` cast succeeds. Tests calling this method
+     *  use [callerSuperadminId] for the actor. */
+    private fun authenticateAsCallerSuperadmin() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(callerSuperadminId.toString(), null, emptyList())
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 200 with emailSent=true on success`() {
+        authenticateAsCallerSuperadmin()
+        val targetUserId = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222")
+        val expiresAt = java.time.OffsetDateTime.parse("2026-05-09T13:00:00Z")
+        whenever(adminPasswordResetService.trigger(targetUserId, callerSuperadminId)).thenReturn(
+            io.plugwerk.server.service.auth.AdminPasswordResetService.Result(
+                tokenIssued = true,
+                emailSent = true,
+                expiresAt = expiresAt,
+                resetUrl = null,
+            ),
+        )
+
+        mockMvc.post("/api/v1/admin/users/$targetUserId/reset-password").andExpect {
+            status { isOk() }
+            jsonPath("$.tokenIssued") { value(true) }
+            jsonPath("$.emailSent") { value(true) }
+            jsonPath("$.expiresAt") { value("2026-05-09T13:00:00Z") }
+            jsonPath("$.resetUrl") { doesNotExist() }
+        }
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 200 with resetUrl when SMTP disabled`() {
+        authenticateAsCallerSuperadmin()
+        val targetUserId = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222")
+        val expiresAt = java.time.OffsetDateTime.parse("2026-05-09T13:00:00Z")
+        whenever(adminPasswordResetService.trigger(targetUserId, callerSuperadminId)).thenReturn(
+            io.plugwerk.server.service.auth.AdminPasswordResetService.Result(
+                tokenIssued = true,
+                emailSent = false,
+                expiresAt = expiresAt,
+                resetUrl = "https://plugwerk.example.com/reset-password?token=raw",
+            ),
+        )
+
+        mockMvc.post("/api/v1/admin/users/$targetUserId/reset-password").andExpect {
+            status { isOk() }
+            jsonPath("$.tokenIssued") { value(true) }
+            jsonPath("$.emailSent") { value(false) }
+            jsonPath("$.resetUrl") { value("https://plugwerk.example.com/reset-password?token=raw") }
+        }
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 400 on EXTERNAL user`() {
+        authenticateAsCallerSuperadmin()
+        val targetUserId = UUID.randomUUID()
+        whenever(adminPasswordResetService.trigger(targetUserId, callerSuperadminId)).thenThrow(
+            io.plugwerk.server.service.auth.ExternalUserResetNotAllowedException(
+                "Cannot reset password on OIDC users — credentials live with the upstream provider.",
+            ),
+        )
+
+        mockMvc.post("/api/v1/admin/users/$targetUserId/reset-password").andExpect {
+            status { isBadRequest() }
+            jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("OIDC")) }
+        }
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 400 on self-reset`() {
+        authenticateAsCallerSuperadmin()
+        // Same UUID for caller and target — controller's UUID parse + service self-reset check
+        // produce the same 400.
+        whenever(adminPasswordResetService.trigger(callerSuperadminId, callerSuperadminId)).thenThrow(
+            io.plugwerk.server.service.auth.SelfResetNotAllowedException(
+                "Use Profile → Change password to update your own password.",
+            ),
+        )
+
+        mockMvc.post("/api/v1/admin/users/$callerSuperadminId/reset-password").andExpect {
+            status { isBadRequest() }
+            jsonPath("$.message") { value(org.hamcrest.Matchers.containsString("Profile")) }
+        }
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 404 when user not found`() {
+        authenticateAsCallerSuperadmin()
+        val targetUserId = UUID.randomUUID()
+        whenever(adminPasswordResetService.trigger(targetUserId, callerSuperadminId)).thenThrow(
+            io.plugwerk.server.service.EntityNotFoundException("User", targetUserId.toString()),
+        )
+
+        mockMvc.post("/api/v1/admin/users/$targetUserId/reset-password").andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `POST admin users reset-password returns 403 for non-superadmin`() {
+        authenticateAsCallerSuperadmin()
+        doThrow(ForbiddenException("Superadmin privileges required"))
+            .whenever(namespaceAuthorizationService).requireSuperadmin(any())
+
+        mockMvc.post("/api/v1/admin/users/${UUID.randomUUID()}/reset-password").andExpect {
             status { isForbidden() }
         }
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminUserEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminUserEndpointAuthzTest.kt
@@ -125,6 +125,14 @@ class AdminUserEndpointAuthzTest : AbstractAuthorizationTest() {
             .andExpect(status().isNoContent)
     }
 
+    @ParameterizedTest(name = "POST /admin/users/[id]/reset-password {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `admin reset-password denied for non-superadmins`(case: ActorExpectation) {
+        val userId = createEphemeralUser()
+        mockMvc.perform(post("/api/v1/admin/users/$userId/reset-password").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
     @Test
     fun `deleting user removes all namespace memberships`() {
         // Create a user and add them to both namespaces

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetServiceIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetServiceIT.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import io.plugwerk.server.SharedPostgresContainer
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.PasswordResetTokenRepository
+import io.plugwerk.server.repository.RefreshTokenRepository
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.service.UserService
+import io.plugwerk.server.service.mail.MailService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.security.MessageDigest
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Real-Postgres integration test that pins the dual-revocation persistence
+ * contract (#450).
+ *
+ * The bug this test guards against: `RefreshTokenRepository.revokeAllForUser`
+ * is annotated `@Modifying(clearAutomatically = true)`. Hibernate clears
+ * the persistence context AFTER the bulk UPDATE without flushing pending
+ * entity changes first (`flushAutomatically = false` is the default).
+ *
+ * If `AdminPasswordResetService.trigger` mutated the `UserEntity`
+ * (`passwordChangeRequired = true`) BEFORE the refresh-token bulk
+ * revocation ran, those pending changes would be silently discarded on
+ * the PC clear. The fix reorders the bulk query to run first; this test
+ * verifies the DB ends up in the right state regardless of intra-TX
+ * persistence-context shape.
+ *
+ * Mocks `MailService` only — every other collaborator runs against the
+ * real Postgres so JPA semantics are exercised end-to-end.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(AdminPasswordResetServiceIT.MockConfig::class)
+@Tag("integration")
+class AdminPasswordResetServiceIT {
+
+    @TestConfiguration
+    class MockConfig {
+        @Bean fun mailService(): MailService = org.mockito.Mockito.mock(MailService::class.java)
+    }
+
+    companion object {
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { SharedPostgresContainer.instance.jdbcUrl }
+            registry.add("spring.datasource.username") { SharedPostgresContainer.instance.username }
+            registry.add("spring.datasource.password") { SharedPostgresContainer.instance.password }
+        }
+    }
+
+    @Autowired private lateinit var service: AdminPasswordResetService
+
+    @Autowired private lateinit var userService: UserService
+
+    @Autowired private lateinit var userRepository: UserRepository
+
+    @Autowired private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @Autowired
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @Autowired private lateinit var mailService: MailService
+
+    private lateinit var actor: UserEntity
+
+    private lateinit var target: UserEntity
+
+    @AfterEach
+    fun tearDown() {
+        // The MailService stub is reset per-test by the Spring test context
+        // but `@SpringBootTest` reuses the context — clear users so consecutive
+        // runs do not collide on the unique-username constraint.
+        target.id?.let { runCatching { userRepository.deleteById(it) } }
+        actor.id?.let { runCatching { userRepository.deleteById(it) } }
+    }
+
+    /**
+     * Uses `createSelfRegistered` rather than the admin `create` so the
+     * resulting row starts with `passwordChangeRequired = false`. The
+     * post-condition `passwordChangeRequired = true` then proves the
+     * trigger flipped the flag — the admin-create default is `true`,
+     * which would mask the regression class this test guards against.
+     */
+    private fun freshUser(prefix: String): UserEntity {
+        val tag = UUID.randomUUID().toString().take(8)
+        return userService.createSelfRegistered(
+            username = "$prefix-$tag",
+            email = "$prefix-$tag@example.com",
+            password = "correct-horse-battery-staple",
+            displayName = "$prefix $tag",
+            enabled = true,
+        )
+    }
+
+    @Test
+    fun `trigger persists passwordChangeRequired=true to the database after dual revocation`() {
+        // Arrange: SMTP-disabled stub so MailService.sendMailFromTemplate
+        // returns Disabled — server-side state changes must still happen.
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenReturn(MailService.SendResult.Disabled)
+
+        actor = freshUser("admin")
+        target = freshUser("alice")
+        val targetId = requireNotNull(target.id)
+        // Sanity: the column starts out at false on a fresh row.
+        assertThat(target.passwordChangeRequired).isFalse
+
+        // Act
+        val result = service.trigger(targetUserId = targetId, actorUserId = requireNotNull(actor.id))
+
+        // Assert: DB row reflects the admin-reset state. Re-fetch via the
+        // repository to defeat any stale persistence-context caching from
+        // the test thread.
+        assertThat(result.tokenIssued).isTrue
+        assertThat(result.emailSent).isFalse
+        assertThat(result.resetUrl).isNotBlank
+
+        val persisted = userRepository.findById(targetId).orElseThrow()
+        assertThat(persisted.passwordChangeRequired)
+            .withFailMessage(
+                "password_change_required must be true after admin reset (regression: cleared by @Modifying(clearAutomatically=true) without preceding flush)",
+            )
+            .isTrue
+        assertThat(persisted.passwordInvalidatedBefore)
+            .withFailMessage("password_invalidated_before must be set after admin reset (same regression class)")
+            .isNotNull
+        assertThat(persisted.passwordInvalidatedBefore)
+            .isAfter(OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1))
+
+        // Pin the token-row persistence: derive the expected hash from
+        // result.resetUrl's `?token=…` segment and look it up. The user-
+        // visible regression that triggered this test class is precisely
+        // an unflushed `PasswordResetTokenEntity` insert getting discarded
+        // by the bulk-revocation PC clear — without this assertion the IT
+        // would be green even when the emailed link is broken.
+        val rawToken = result.resetUrl!!.substringAfter("?token=")
+        val tokenHash = sha256Hex(rawToken)
+        val tokenRow = passwordResetTokenRepository.findByTokenHash(tokenHash)
+        assertThat(tokenRow.isPresent)
+            .withFailMessage(
+                "PasswordResetTokenEntity row must be persisted after admin reset (regression: unflushed insert discarded by @Modifying(clearAutomatically=true))",
+            )
+            .isTrue
+        assertThat(tokenRow.get().consumedAt).isNull()
+        assertThat(tokenRow.get().user.id).isEqualTo(targetId)
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { "%02x".format(it) }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/AdminPasswordResetServiceTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.UserEntity
+import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.service.EntityNotFoundException
+import io.plugwerk.server.service.RefreshTokenService
+import io.plugwerk.server.service.TokenRevocationService
+import io.plugwerk.server.service.mail.MailService
+import io.plugwerk.server.service.mail.MailTemplate
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.whenever
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class AdminPasswordResetServiceTest {
+
+    @Mock private lateinit var userRepository: UserRepository
+
+    @Mock private lateinit var tokenService: PasswordResetTokenService
+
+    @Mock private lateinit var tokenRevocationService: TokenRevocationService
+
+    @Mock private lateinit var refreshTokenService: RefreshTokenService
+
+    @Mock private lateinit var mailService: MailService
+
+    @Mock private lateinit var settings: ApplicationSettingsService
+
+    private val plugwerkProperties = PlugwerkProperties(
+        server = PlugwerkProperties.ServerProperties(
+            baseUrl = "https://plugwerk.example.com",
+        ),
+    )
+
+    private lateinit var service: AdminPasswordResetService
+
+    private val targetUserId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    private val actorUserId = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    private val expiresAt: OffsetDateTime = OffsetDateTime.of(2026, 5, 9, 13, 0, 0, 0, ZoneOffset.UTC)
+
+    @BeforeEach
+    fun setUp() {
+        service = AdminPasswordResetService(
+            userRepository = userRepository,
+            tokenService = tokenService,
+            tokenRevocationService = tokenRevocationService,
+            refreshTokenService = refreshTokenService,
+            mailService = mailService,
+            settings = settings,
+            plugwerkProperties = plugwerkProperties,
+        )
+    }
+
+    @Test
+    fun `success — issues token, revokes both atoms, sends mail, returns emailSent=true and no resetUrl`() {
+        val user = internalUser()
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user))
+            .thenReturn(IssuedResetToken(rawToken = "raw-token-abc", expiresAt = expiresAt))
+        whenever(settings.siteName()).thenReturn("plugwerk.example.com")
+        whenever(
+            mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()),
+        ).thenReturn(MailService.SendResult.Sent)
+
+        val result = service.trigger(targetUserId, actorUserId)
+
+        assertThat(result.tokenIssued).isTrue
+        assertThat(result.emailSent).isTrue
+        assertThat(result.resetUrl).isNull()
+        assertThat(result.expiresAt).isEqualTo(expiresAt)
+        // Mark passwordChangeRequired and persist
+        assertThat(user.passwordChangeRequired).isTrue
+        verify(userRepository).save(user)
+        // Both revocation atoms — both are mandatory.
+        verify(tokenRevocationService).revokeAllForUser(targetUserId)
+        verify(refreshTokenService).revokeAllForUser(targetUserId, RefreshTokenService.LOGOUT)
+        // Mail uses the admin-specific template and the canonical reset link.
+        val templateCaptor = argumentCaptor<MailTemplate>()
+        val varsCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mailService).sendMailFromTemplate(
+            templateCaptor.capture(),
+            eq("alice@example.com"),
+            varsCaptor.capture(),
+            isNull(),
+        )
+        assertThat(templateCaptor.firstValue).isEqualTo(MailTemplate.AUTH_ADMIN_PASSWORD_RESET)
+        assertThat(
+            varsCaptor.firstValue,
+        ).containsEntry("username", "Alice").containsEntry("siteName", "plugwerk.example.com")
+        assertThat(
+            varsCaptor.firstValue["resetLink"],
+        ).isEqualTo("https://plugwerk.example.com/reset-password?token=raw-token-abc")
+        assertThat(varsCaptor.firstValue).containsKey("expiresAtHuman")
+    }
+
+    @Test
+    fun `success but SMTP disabled — returns emailSent=false with absolute resetUrl in response`() {
+        val user = internalUser()
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user))
+            .thenReturn(IssuedResetToken(rawToken = "raw-token-xyz", expiresAt = expiresAt))
+        whenever(settings.siteName()).thenReturn("plugwerk.example.com")
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenReturn(MailService.SendResult.Disabled)
+
+        val result = service.trigger(targetUserId, actorUserId)
+
+        assertThat(result.tokenIssued).isTrue
+        assertThat(result.emailSent).isFalse
+        assertThat(result.resetUrl).isEqualTo("https://plugwerk.example.com/reset-password?token=raw-token-xyz")
+        // Server-side state changes still happened — the operator can deliver the link out-of-band.
+        assertThat(user.passwordChangeRequired).isTrue
+        verify(tokenRevocationService).revokeAllForUser(targetUserId)
+        verify(refreshTokenService).revokeAllForUser(targetUserId, RefreshTokenService.LOGOUT)
+    }
+
+    @Test
+    fun `mail-send-failure (Failed) — degraded same shape as SMTP-disabled (resetUrl populated)`() {
+        val user = internalUser()
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user))
+            .thenReturn(IssuedResetToken(rawToken = "raw-token-fail", expiresAt = expiresAt))
+        whenever(settings.siteName()).thenReturn("plugwerk.example.com")
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenReturn(MailService.SendResult.Failed("connection refused"))
+
+        val result = service.trigger(targetUserId, actorUserId)
+
+        assertThat(result.emailSent).isFalse
+        assertThat(result.resetUrl).isEqualTo("https://plugwerk.example.com/reset-password?token=raw-token-fail")
+    }
+
+    @Test
+    fun `mail-send-throws — caught and treated as Failed (degraded)`() {
+        val user = internalUser()
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.of(user))
+        whenever(tokenService.issue(user))
+            .thenReturn(IssuedResetToken(rawToken = "raw-token-throw", expiresAt = expiresAt))
+        whenever(settings.siteName()).thenReturn("plugwerk.example.com")
+        whenever(mailService.sendMailFromTemplate(any(), any(), any(), anyOrNull()))
+            .thenThrow(RuntimeException("template render exploded"))
+
+        val result = service.trigger(targetUserId, actorUserId)
+
+        // Server-side side effects still completed before mail dispatch.
+        assertThat(result.emailSent).isFalse
+        assertThat(result.resetUrl).contains("raw-token-throw")
+        verify(tokenRevocationService).revokeAllForUser(targetUserId)
+        verify(refreshTokenService).revokeAllForUser(targetUserId, RefreshTokenService.LOGOUT)
+    }
+
+    @Test
+    fun `EXTERNAL user — refused with ExternalUserResetNotAllowedException, no side effects`() {
+        val externalUser = internalUser().also { it.source = UserSource.EXTERNAL }
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.of(externalUser))
+
+        assertThatThrownBy { service.trigger(targetUserId, actorUserId) }
+            .isInstanceOf(ExternalUserResetNotAllowedException::class.java)
+            .hasMessageContaining("OIDC")
+
+        verifyNoInteractions(tokenService, tokenRevocationService, refreshTokenService, mailService)
+    }
+
+    @Test
+    fun `self-reset — refused with SelfResetNotAllowedException before any DB lookup`() {
+        assertThatThrownBy { service.trigger(actorUserId, actorUserId) }
+            .isInstanceOf(SelfResetNotAllowedException::class.java)
+            .hasMessageContaining("Profile")
+
+        verifyNoInteractions(
+            userRepository,
+            tokenService,
+            tokenRevocationService,
+            refreshTokenService,
+            mailService,
+        )
+    }
+
+    @Test
+    fun `unknown user — propagates EntityNotFoundException, no side effects`() {
+        whenever(userRepository.findById(targetUserId)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.trigger(targetUserId, actorUserId) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+            .hasMessageContaining(targetUserId.toString())
+
+        verifyNoInteractions(tokenService, tokenRevocationService, refreshTokenService, mailService)
+    }
+
+    private fun internalUser(): UserEntity = UserEntity(
+        username = "alice",
+        email = "alice@example.com",
+        displayName = "Alice",
+        passwordHash = "\$2a\$10\$dummyHashThatLooksLikeBcrypt",
+        source = UserSource.INTERNAL,
+        enabled = true,
+        passwordChangeRequired = false,
+        isSuperadmin = false,
+    ).also { it.id = targetUserId }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/ExpiryFormatterTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/auth/ExpiryFormatterTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class ExpiryFormatterTest {
+
+    private val now: OffsetDateTime = OffsetDateTime.of(2026, 5, 9, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    @Test
+    fun `expired window returns explicit expired phrase`() {
+        val past = now.minusMinutes(5)
+        assertThat(ExpiryFormatter.formatHuman(past, now = now)).isEqualTo("now (link already expired)")
+    }
+
+    @Test
+    fun `sub-hour window returns minutes phrase rounded down with floor of one minute`() {
+        // 90 seconds → "in 1 minutes" (the coerceAtLeast(1) floor)
+        val ninetySeconds = now.plusSeconds(90)
+        assertThat(ExpiryFormatter.formatHuman(ninetySeconds, now = now)).isEqualTo("in 1 minutes")
+
+        // 30 minutes
+        val thirtyMin = now.plusMinutes(30)
+        assertThat(ExpiryFormatter.formatHuman(thirtyMin, now = now)).isEqualTo("in 30 minutes")
+    }
+
+    @Test
+    fun `sub-day window returns hours phrase`() {
+        val twelveHours = now.plusHours(12)
+        assertThat(ExpiryFormatter.formatHuman(twelveHours, now = now)).isEqualTo("in 12 hours")
+    }
+
+    @Test
+    fun `multi-day window returns absolute UTC timestamp`() {
+        val twoDays = now.plusDays(2)
+        assertThat(ExpiryFormatter.formatHuman(twoDays, now = now))
+            .isEqualTo("on 11 May 2026 at 12:00 UTC")
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminResetLinkDialog.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminResetLinkDialog.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from "react";
+import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
+import { Check, Copy } from "lucide-react";
+import { AppDialog } from "../common/AppDialog";
+import { useUiStore } from "../../stores/uiStore";
+
+interface AdminResetLinkDialogProps {
+  /** Whether the dialog is visible. */
+  open: boolean;
+  /** Display name of the user the reset was triggered for; used in copy. */
+  targetDisplayName: string;
+  /** Absolute reset URL the operator must deliver out-of-band. */
+  resetUrl: string;
+  /** Closes the dialog. */
+  onClose: () => void;
+}
+
+/**
+ * Surfaces the admin-initiated reset URL when SMTP is unavailable (#450).
+ *
+ * Triggered after `POST /admin/users/{id}/reset-password` returns
+ * `emailSent: false` — the server-side state changes (token, sessions
+ * revoked) all happened, but the email could not be sent. The operator
+ * needs the link to deliver out-of-band (Slack, phone, in-person).
+ *
+ * The URL is shown in a read-only `TextField` so the operator can pick
+ * it up via the clipboard or by selecting + copying manually. The
+ * dedicated copy button calls `navigator.clipboard.writeText` and surfaces
+ * a transient toast plus an icon swap as confirmation.
+ */
+export function AdminResetLinkDialog({
+  open,
+  targetDisplayName,
+  resetUrl,
+  onClose,
+}: AdminResetLinkDialogProps) {
+  const [justCopied, setJustCopied] = useState(false);
+  const addToast = useUiStore((s) => s.addToast);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(resetUrl);
+      setJustCopied(true);
+      addToast({
+        message: "Reset link copied to clipboard.",
+        type: "success",
+      });
+      // Reset the icon swap after 1.5 s so a follow-up copy is obvious.
+      setTimeout(() => setJustCopied(false), 1500);
+    } catch {
+      addToast({
+        message: "Could not copy link automatically — please copy it manually.",
+        type: "error",
+      });
+    }
+  }
+
+  return (
+    <AppDialog
+      open={open}
+      onClose={onClose}
+      title="SMTP unavailable — deliver this reset link"
+      description={`The reset for "${targetDisplayName}" succeeded server-side: a single-use token was issued and every active session was revoked. SMTP is not configured (or the send failed), so the email could not be delivered. Copy the link below and deliver it to the user out-of-band — once they open it they can choose a new password.`}
+      actionLabel="Done"
+      onAction={onClose}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Box sx={{ display: "flex", alignItems: "stretch", gap: 1 }}>
+          <TextField
+            value={resetUrl}
+            // MUI 7: `slotProps.htmlInput` is the supported escape hatch for
+            // attributes that need to land on the underlying `<input>`. The
+            // legacy `inputProps` prop does not always propagate `readOnly`
+            // reliably, which #450's test suite caught.
+            slotProps={{
+              htmlInput: { readOnly: true, "aria-label": "Reset link" },
+            }}
+            size="small"
+            fullWidth
+            // Single-line, no overflow truncation: long tokens should be
+            // visible by horizontal scroll, not truncated, so a manual copy
+            // out of the field always grabs the full URL.
+          />
+          <Tooltip title={justCopied ? "Copied" : "Copy to clipboard"}>
+            <IconButton
+              onClick={handleCopy}
+              aria-label="Copy reset link to clipboard"
+              size="small"
+              sx={{ alignSelf: "center" }}
+            >
+              {justCopied ? <Check size={16} /> : <Copy size={16} />}
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
+          The link is single-use and time-limited. It will become invalid as
+          soon as the user opens it and chooses a new password — or after the
+          configured expiry passes.
+        </Typography>
+      </Box>
+    </AppDialog>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UsersSection } from "./UsersSection";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import { useUiStore } from "../../stores/uiStore";
+import { useAuthStore } from "../../stores/authStore";
+import * as apiConfig from "../../api/config";
+import type { UserDto } from "../../api/generated/model";
+
+vi.mock("../../api/config", () => ({
+  adminUsersApi: {
+    listUsers: vi.fn(),
+    createUser: vi.fn(),
+    updateUser: vi.fn(),
+    deleteUser: vi.fn(),
+    adminResetUserPassword: vi.fn(),
+  },
+}));
+
+const CALLER_ID = "00000000-0000-0000-0000-aaaaaaaaaaaa";
+
+const aliceInternal: UserDto = {
+  id: "00000000-0000-0000-0000-000000000001",
+  username: "alice",
+  displayName: "Alice",
+  email: "alice@example.com",
+  source: "INTERNAL",
+  enabled: true,
+  passwordChangeRequired: false,
+  isSuperadmin: false,
+  createdAt: "2026-04-01T10:00:00Z",
+  namespaceMembershipCount: 1,
+};
+
+const bobOidc: UserDto = {
+  id: "00000000-0000-0000-0000-000000000002",
+  displayName: "Bob",
+  email: "bob@example.com",
+  source: "EXTERNAL",
+  providerName: "Company Keycloak",
+  enabled: true,
+  passwordChangeRequired: false,
+  isSuperadmin: false,
+  createdAt: "2026-04-02T10:00:00Z",
+  namespaceMembershipCount: 0,
+};
+
+const callerSelf: UserDto = {
+  id: CALLER_ID,
+  username: "root",
+  displayName: "Root Admin",
+  email: "root@example.com",
+  source: "INTERNAL",
+  enabled: true,
+  passwordChangeRequired: false,
+  isSuperadmin: true,
+  createdAt: "2026-01-01T10:00:00Z",
+  namespaceMembershipCount: 0,
+};
+
+const carolDisabled: UserDto = {
+  id: "00000000-0000-0000-0000-000000000004",
+  username: "carol",
+  displayName: "Carol",
+  email: "carol@example.com",
+  source: "INTERNAL",
+  enabled: false,
+  passwordChangeRequired: false,
+  isSuperadmin: false,
+  createdAt: "2026-04-03T10:00:00Z",
+  namespaceMembershipCount: 0,
+};
+
+describe("UsersSection — admin reset password (#450)", () => {
+  beforeEach(() => {
+    useUiStore.setState({ toasts: [] });
+    useAuthStore.setState({
+      isAuthenticated: true,
+      userId: CALLER_ID,
+      username: "root",
+      isSuperadmin: true,
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: [aliceInternal, bobOidc, callerSelf, carolDisabled],
+    } as never);
+  });
+
+  function findResetButtonForRow(displayName: string): HTMLElement {
+    const cell = screen.getByText(displayName);
+    const row = cell.closest("tr");
+    if (!row) throw new Error(`No row found for ${displayName}`);
+    return within(row).getByRole("button", {
+      name: /reset password|oidc users|use profile|enable the user/i,
+    });
+  }
+
+  it("renders a reset-password action button for each row", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+    const resetButton = findResetButtonForRow("Alice");
+    expect(resetButton).toBeEnabled();
+    expect(resetButton).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/reset password/i),
+    );
+  });
+
+  it("disables the reset button for EXTERNAL (OIDC) users with provider hint", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Bob")).toBeInTheDocument());
+    const resetButton = findResetButtonForRow("Bob");
+    expect(resetButton).toBeDisabled();
+    expect(resetButton).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/Company Keycloak/i),
+    );
+  });
+
+  it("disables the reset button for the caller's own row (self-reset guard)", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() =>
+      expect(screen.getByText("Root Admin")).toBeInTheDocument(),
+    );
+    const resetButton = findResetButtonForRow("Root Admin");
+    expect(resetButton).toBeDisabled();
+    expect(resetButton).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/profile/i),
+    );
+  });
+
+  it("disables the reset button for disabled users", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Carol")).toBeInTheDocument());
+    const resetButton = findResetButtonForRow("Carol");
+    expect(resetButton).toBeDisabled();
+  });
+
+  it("opens a confirmation dialog naming the target user when reset is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+    await user.click(findResetButtonForRow("Alice"));
+    const description = await screen.findByText(
+      /Reset password for "Alice"\? An email with a single-use reset link/i,
+    );
+    // Scope email assertion to the description text — `alice@example.com`
+    // also appears in the row above.
+    expect(description.textContent).toMatch(/alice@example\.com/i);
+  });
+
+  it("on success with emailSent=true shows success toast and closes dialog", async () => {
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockResolvedValue(
+      {
+        data: {
+          tokenIssued: true,
+          emailSent: true,
+          expiresAt: "2026-05-09T13:00:00Z",
+        },
+      } as never,
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(findResetButtonForRow("Alice"));
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      const toasts = useUiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.message && /Reset email sent/i.test(t.message)),
+      ).toBe(true);
+    });
+    expect(apiConfig.adminUsersApi.adminResetUserPassword).toHaveBeenCalledWith(
+      { userId: aliceInternal.id },
+    );
+  });
+
+  it("on emailSent=false with resetUrl shows AdminResetLinkDialog with copy button", async () => {
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockResolvedValue(
+      {
+        data: {
+          tokenIssued: true,
+          emailSent: false,
+          expiresAt: "2026-05-09T13:00:00Z",
+          resetUrl: "https://plugwerk.example.com/reset-password?token=raw-xyz",
+        },
+      } as never,
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(findResetButtonForRow("Alice"));
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(
+      await screen.findByText(/SMTP unavailable — deliver this reset link/i),
+    ).toBeInTheDocument();
+    // The TextField holds the URL as its display value — search by value
+    // instead of by label, since MUI's inputProps spread does not always
+    // surface aria-label as a discoverable accessible name.
+    const linkInput = screen.getByDisplayValue(
+      "https://plugwerk.example.com/reset-password?token=raw-xyz",
+    ) as HTMLInputElement;
+    expect(linkInput.readOnly).toBe(true);
+    expect(
+      screen.getByRole("button", {
+        name: /copy reset link to clipboard/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("on API failure shows error toast and keeps the confirm dialog open", async () => {
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockRejectedValue(
+      new Error("boom"),
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(findResetButtonForRow("Alice"));
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      const toasts = useUiStore.getState().toasts;
+      expect(
+        toasts.some(
+          (t) => t.message && /Failed to reset password/i.test(t.message),
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -27,16 +27,21 @@ import {
   Chip,
   Switch,
 } from "@mui/material";
-import { Plus, Shield, Trash2 } from "lucide-react";
+import { KeyRound, Plus, Shield, Trash2 } from "lucide-react";
 import { AppDialog } from "../../components/common/AppDialog";
 import { ConfirmDeleteDialog } from "../../components/common/ConfirmDeleteDialog";
 import { DataTable } from "../../components/common/DataTable";
 import type { DataColumn } from "../../components/common/DataTable";
 import { ActionIconButton } from "../../components/common/ActionIconButton";
 import { Timestamp } from "../../components/common/Timestamp";
+import { AdminResetLinkDialog } from "../../components/admin/AdminResetLinkDialog";
 import { adminUsersApi } from "../../api/config";
 import { useUiStore } from "../../stores/uiStore";
-import type { UserDto } from "../../api/generated/model";
+import { useAuthStore } from "../../stores/authStore";
+import type {
+  AdminPasswordResetResponse,
+  UserDto,
+} from "../../api/generated/model";
 
 export function UsersSection() {
   const [users, setUsers] = useState<UserDto[]>([]);
@@ -47,8 +52,15 @@ export function UsersSection() {
   const [password, setPassword] = useState("");
   const [saving, setSaving] = useState(false);
   const addToast = useUiStore((s) => s.addToast);
+  const currentUserId = useAuthStore((s) => s.userId);
   const [deleteTarget, setDeleteTarget] = useState<UserDto | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [resetTarget, setResetTarget] = useState<UserDto | null>(null);
+  const [resetting, setResetting] = useState(false);
+  const [resetLinkResult, setResetLinkResult] = useState<{
+    user: UserDto;
+    response: AdminPasswordResetResponse;
+  } | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -102,6 +114,49 @@ export function UsersSection() {
       });
     } finally {
       setDeleting(false);
+    }
+  }
+
+  async function handleConfirmReset() {
+    if (!resetTarget) return;
+    setResetting(true);
+    try {
+      const res = await adminUsersApi.adminResetUserPassword({
+        userId: resetTarget.id,
+      });
+      const response: AdminPasswordResetResponse = res.data;
+      if (response.emailSent) {
+        addToast({
+          message: `Reset email sent to ${resetTarget.email}. All sessions revoked.`,
+          type: "success",
+        });
+        setResetTarget(null);
+      } else if (response.resetUrl) {
+        // SMTP unavailable — surface the link so the operator can deliver
+        // it out-of-band. The toast has a `warning` severity to differentiate
+        // from the happy-path "everything went fine" message.
+        addToast({
+          message: `Reset triggered for ${resetTarget.displayName}, but email could not be sent. Copy the link to deliver it manually.`,
+          type: "warning",
+        });
+        setResetLinkResult({ user: resetTarget, response });
+        setResetTarget(null);
+      } else {
+        // Defensive — server returned emailSent=false without a resetUrl;
+        // shouldn't happen by API contract but surface it cleanly.
+        addToast({
+          message: `Reset triggered for ${resetTarget.displayName}, but the email could not be sent and no fallback link was returned.`,
+          type: "error",
+        });
+        setResetTarget(null);
+      }
+    } catch {
+      addToast({
+        message: `Failed to reset password for ${resetTarget.displayName}.`,
+        type: "error",
+      });
+    } finally {
+      setResetting(false);
     }
   }
 
@@ -282,15 +337,42 @@ export function UsersSection() {
       key: "actions",
       header: "",
       align: "right",
-      render: (user) => (
-        <ActionIconButton
-          icon={Trash2}
-          tooltip="Delete"
-          color="error"
-          onClick={() => setDeleteTarget(user)}
-          disabled={user.isSuperadmin}
-        />
-      ),
+      render: (user) => {
+        const isExternal = user.source === "EXTERNAL";
+        const isSelf = currentUserId !== null && user.id === currentUserId;
+        const resetTooltip = isExternal
+          ? `OIDC users reset upstream${
+              user.providerName ? ` with ${user.providerName}` : ""
+            }`
+          : isSelf
+            ? "Use Profile → Change password instead"
+            : !user.enabled
+              ? "Enable the user before resetting their password"
+              : "Reset password";
+        return (
+          <Box
+            sx={{
+              display: "inline-flex",
+              gap: 0.5,
+              justifyContent: "flex-end",
+            }}
+          >
+            <ActionIconButton
+              icon={KeyRound}
+              tooltip={resetTooltip}
+              onClick={() => setResetTarget(user)}
+              disabled={isExternal || isSelf || !user.enabled}
+            />
+            <ActionIconButton
+              icon={Trash2}
+              tooltip="Delete"
+              color="error"
+              onClick={() => setDeleteTarget(user)}
+              disabled={user.isSuperadmin}
+            />
+          </Box>
+        );
+      },
     },
   ];
 
@@ -393,6 +475,27 @@ export function UsersSection() {
         loading={deleting}
         actionLabel="Delete User"
       />
+      <AppDialog
+        open={!!resetTarget}
+        onClose={() => setResetTarget(null)}
+        title="Reset password"
+        description={
+          resetTarget
+            ? `Reset password for "${resetTarget.displayName}"? An email with a single-use reset link will be sent to ${resetTarget.email}. All existing sessions for this user will be revoked immediately, and the user will be required to choose a new password.`
+            : ""
+        }
+        actionLabel="Send reset link"
+        onAction={handleConfirmReset}
+        actionLoading={resetting}
+      />
+      {resetLinkResult && (
+        <AdminResetLinkDialog
+          open={true}
+          targetDisplayName={resetLinkResult.user.displayName}
+          resetUrl={resetLinkResult.response.resetUrl ?? ""}
+          onClose={() => setResetLinkResult(null)}
+        />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Adds a first-class **Reset password** action to the Admin → Users surface (#450). The trigger:
- Issues a single-use reset token via `PasswordResetTokenService.issue` (supersedes any previous unconsumed token)
- Sets `passwordChangeRequired = true` as defence-in-depth for the SMTP-disabled path
- Revokes every active session — both the access-token side (`passwordInvalidatedBefore`) AND the refresh-token family (mandatory: `AuthController.refresh` does not consult `passwordInvalidatedBefore`)
- Emails the user an admin-initiated reset link via the new `MailTemplate.AUTH_ADMIN_PASSWORD_RESET`
- Records a structured SLF4J + MDC audit log (`actor`, `target`, `kind=ADMIN_PASSWORD_RESET`, `smtpDelivered`)

Refusal paths return HTTP 400: target is EXTERNAL (OIDC) or target is the caller themselves. Bypasses the `auth.password_reset_enabled` operator gate — the admin path is an independent trust chain (the `@PreAuthorize` superadmin gate is the gate).

When SMTP is disabled or the send fails, the endpoint still succeeds server-side and returns the reset URL in the response body — the frontend opens an `AdminResetLinkDialog` with a copy-to-clipboard widget so the operator can deliver the link out-of-band.

## Related Issues

Closes #450

## Type of Change

- [x] New feature

## Notable design choices

- **Variant B (token link in email)** over variant A (temp password in email). Reuses the existing `PasswordResetTokenService` and `ResetPasswordPage.tsx`; no plaintext password ever in transit through any mail relay.
- **Structured logging instead of a persistent `admin_audit` table.** The codebase has no such table today (verified). A persistent audit-log table is a separate concern that would explode this PR's scope and warrants its own design — tracked as a follow-up issue. MDC keys make the action grep-able from container logs.
- **Two action icons** on each user row (`KeyRound` + `Trash2`) instead of a `MoreVert` menu — only two row actions don't justify a menu pattern; refactor when a third action lands.

## JPA persistence ordering — load-bearing

`RefreshTokenRepository.revokeAllForUser` is annotated `@Modifying(clearAutomatically = true)`. Hibernate clears the persistence context **after** the bulk UPDATE, **without** flushing pending entity changes first (`flushAutomatically = false` is the Spring Data default, and Hibernate's auto-flush only fires for queries whose target entity-type overlaps with pending changes — a bulk update on `RefreshTokenEntity` does not overlap with pending `PasswordResetTokenEntity` inserts or `UserEntity` updates).

Anything mutating the persistence context **before** the bulk query is silently discarded on the PC clear. The user-visible symptom found during local testing was an unflushed `PasswordResetTokenEntity` insert never reaching the DB → `findByTokenHash` returns empty → user sees `Password-reset token is invalid` on submit.

The implementation orders the bulk `@Modifying` query first; everything else (token issue, user mutations, access-token revocation) follows and lands naturally on the commit-time flush. The integration test pins the contract end-to-end against a real Postgres so the regression cannot reintroduce silently.

## Test coverage

### Backend

| Test | Type | Coverage |
|---|---|---|
| `AdminPasswordResetServiceTest` | Mockito unit | 7 cases — success / SMTP-disabled / mail-failure-degraded / mail-throws / EXTERNAL refusal / self-reset refusal / unknown user |
| `AdminPasswordResetServiceIT` | `@SpringBootTest` + Testcontainers Postgres | Pins `password_change_required = true`, `password_invalidated_before` set, **and** the `password_reset_token` row actually persisted with the correct hash, `consumed_at = null`, correct `user_id` |
| `AdminUserControllerTest` | `@WebMvcTest` | 6 new cases covering 200 happy path, 200 with `resetUrl` on SMTP-disabled, 400 on EXTERNAL, 400 on self-reset, 404 on unknown user, 403 on non-superadmin |
| `AdminUserEndpointAuthzTest` | E2E authz | Parameterised entry for the new `POST /admin/users/{id}/reset-password` |
| `ExpiryFormatterTest` | unit | 4 branch tests for the extracted helper |
| `PreAuthorizeCoverageTest` | regression guard | Picks up the new endpoint automatically (it carries `@PreAuthorize`) |

### Frontend

| Test | Type | Coverage |
|---|---|---|
| `UsersSection.test.tsx` | Vitest + RTL | 8 cases — disabled-tooltip matrix (EXTERNAL / self / disabled / providerName), confirm dialog, success toast on `emailSent=true`, `AdminResetLinkDialog` on `emailSent=false`, error toast |

## Test plan

- [x] `./gradlew build` — green (641 backend tests, 415 frontend tests)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest --tests AdminPasswordResetServiceIT` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest --tests AdminUserEndpointAuthzTest` — green
- [x] `./gradlew spotlessApply` — clean
- [x] `npm run lint && npm run format && npm run license:check` — clean
- [x] Local Mailpit smoke test — admin trigger → email arrives at `mailpit:8025` → click link → set new password → login with new password works, old refresh cookie 401s

## Liquibase

- [x] New changeset `0032_admin_password_reset_template.yaml` includes an explicit `rollback:` block (per #293)

## Checklist

- [x] Tests pass locally
- [x] Documentation updated where applicable (KDoc on `AdminPasswordResetService` documents the persistence-context ordering)
- [x] No secrets or credentials committed
- [x] Commit message follows Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block
- [x] CLA signed

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7, 1M context)

## Follow-up

- Open a separate issue for a persistent `admin_audit` table covering security-relevant admin actions (currently structured SLF4J only).