### PR TITLE
refactor(ci): delegate Renovate to org-wide reusable workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,33 +1,21 @@
-# Self-hosted Renovate via GitHub Actions.
+# Self-hosted Renovate trigger for this repo.
 #
-# Why we run it ourselves instead of relying on Mend's hosted bot:
-#   - The hosted Free Plan iterates on its own opaque cadence (typically
-#     once per day) and does not expose run-history to repo collaborators.
-#     When a Dependency-Dashboard checkbox sits at `[x]` for hours with no
-#     visible bot tick, debugging that from the outside is impossible.
-#   - This workflow accepts `workflow_dispatch`, so any maintainer can
-#     trigger a run with `gh workflow run renovate.yml` and watch the logs
-#     in the Actions tab. Same Renovate binary, same `.github/renovate.json`
-#     configuration; only the trigger is local.
-#   - The cron mirrors the previous Mend cadence ("before 6am every
-#     weekday", in UTC because GitHub Actions cron is always UTC). The
-#     `schedule:` entry inside `renovate.json` still acts as a per-package
-#     filter — a workflow tick is the *opportunity* for Renovate to act,
-#     not an override of `before 6am every weekday` rules.
+# This workflow defines the schedule and permissions, then delegates
+# the actual Renovate run to the org-wide reusable workflow at
+# plugwerk/.github/.github/workflows/renovate.yml. See ADR-0032 for
+# the rationale and ADR-0026 for the original SHA-pin policy that
+# still applies to the reusable side.
 #
-# Token: GITHUB_TOKEN works for read access (it's a regular Actions token),
-# but Renovate also writes branches and opens PRs, which the default token
-# can do scoped to this repo. No PAT or app-install required for a
-# single-repo setup. If we ever go multi-repo, swap to a GitHub App token.
+# Cron mirrors the previous direct-trigger cadence (Mon-Fri 04:00 UTC,
+# matching the `before 6am every weekday` schedule filter inside
+# .github/renovate.json). workflow_dispatch lets any maintainer
+# trigger an on-demand run from the Actions tab or via
+# `gh workflow run renovate.yml`.
 
 name: Renovate
 
 on:
   schedule:
-    # Mon-Fri at 04:00 UTC (~05:00-06:00 CET/CEST). Matches the
-    # `schedule: ["before 6am every weekday"]` filter inside renovate.json
-    # so a tick that happens later in the day still cleanly skips most
-    # rules. Outside this window, runs only happen via workflow_dispatch.
     - cron: "0 4 * * 1-5"
   workflow_dispatch:
     inputs:
@@ -39,37 +27,15 @@ on:
           - info
           - debug
 
-# Only one Renovate run at a time per branch — concurrent runs against the
-# same repository fight over branch creation and corrupt the dependency
-# dashboard. `cancel-in-progress: false` keeps a running job intact and
-# queues the new one rather than dropping it.
-concurrency:
-  group: renovate-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    uses: plugwerk/.github/.github/workflows/renovate.yml@main
+    # Permissions belong on the calling job, not on the reusable
+    # workflow. Each caller declares the minimum it needs; the
+    # reusable workflow inherits these for the duration of the call.
     permissions:
-      contents: write          # branch + push
-      pull-requests: write     # open + label PRs
-      issues: write            # update Dependency Dashboard issue (#376)
-    # Lift the workflow_dispatch input into an env var so the run-step
-    # never interpolates user-controlled (even via choice-whitelisted)
-    # input straight into a shell or YAML field — defensive practice
-    # that satisfies the GitHub-hardened-runners injection-prevention
-    # guidance even though `choice` already restricts the surface to
-    # two known values.
-    env:
-      RENOVATE_LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run Renovate
-        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
-        with:
-          configurationFile: .github/renovate.json
-          token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          LOG_LEVEL: ${{ env.RENOVATE_LOG_LEVEL }}
+      contents: write       # branch + push
+      pull-requests: write  # open + label PRs
+      issues: write         # update Dependency Dashboard issue (#376)
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}

--- a/docs/adrs/0032-reusable-renovate-workflow.md
+++ b/docs/adrs/0032-reusable-renovate-workflow.md
@@ -1,0 +1,118 @@
+# ADR-0032: Reusable Renovate workflow at the org level
+
+## Status
+
+Accepted
+
+## Context
+
+After the `plugwerk/.github` org-config bootstrap shipped (issue #398,
+ADR follow-up not required), every plugwerk repo extends the
+org-wide Renovate `default.json` for its package rules. That covered
+the *configuration* side of Renovate. The *triggering* side was still
+inconsistent:
+
+- `plugwerk/plugwerk` had a 76-line self-hosted Renovate workflow
+  (`.github/workflows/renovate.yml`) introduced in PR #462 to work
+  around opaque cadence on Mend-Hosted Renovate (#376 sat with a
+  ticked dashboard checkbox for hours with no observable bot run).
+- `plugwerk/examples` and `plugwerk/website` had no self-hosted
+  trigger at all and relied entirely on Mend-Hosted, with the same
+  opacity risk that motivated the original `plugwerk/plugwerk` move.
+
+Two paths were available:
+
+1. Copy the 76-line workflow into `examples` and `website` verbatim.
+   Solves the trigger problem but creates three places to update on
+   every `renovatebot/github-action` SHA bump (and we already burned
+   on this exact pattern with PR #470, the hotfix to PR #462).
+2. Move the workflow logic into a reusable workflow in
+   `plugwerk/.github` and have each repo call it via a thin stub.
+
+We chose option 2.
+
+## Decision
+
+The org-config repo (`plugwerk/.github`) hosts the canonical Renovate
+workflow as a reusable workflow:
+
+```text
+plugwerk/.github/.github/workflows/renovate.yml   # on: workflow_call
+```
+
+Each consumer repo carries a small stub (~25 lines) that defines its
+own schedule, permissions, and inputs, and delegates the run to the
+reusable workflow:
+
+```yaml
+jobs:
+  renovate:
+    uses: plugwerk/.github/.github/workflows/renovate.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+```
+
+Token model stays single-repo. `${{ secrets.GITHUB_TOKEN }}` in a
+`workflow_call` resolves to the **caller's** repo-scoped token, so
+the reusable workflow does not — and structurally cannot — write
+across repos. No PAT, no GitHub App.
+
+Concurrency in the reusable workflow keys on `${{ github.repository }}`,
+so two runs against the same repo serialize while different repos run
+in parallel without contention.
+
+The SHA pins for `actions/checkout` and `renovatebot/github-action`
+live in the reusable workflow only. Bumping a pin is a single PR in
+`plugwerk/.github`; the change reaches every consumer immediately
+without touching their code (because the stub references `@main`).
+This trades some surprise-risk (an unreviewed bump can affect three
+repos at once) against the maintenance burden of three parallel pin
+updates. Mitigation: the `renovate-config-validator` workflow in
+`plugwerk/.github` blocks malformed config; for action pin bumps the
+PR review in `plugwerk/.github` is the gate.
+
+## Consequences
+
+### Easier
+
+- One place to update the `renovatebot/github-action` SHA pin — no
+  more PR #470-style hotfix scenarios where one repo gets a
+  hallucinated version while others lag.
+- Adding self-hosted Renovate to a new plugwerk org repo is a
+  ~25-line stub, not a 76-line copy.
+- `examples` and `website` get the same observable Actions-tab cadence
+  that `plugwerk/plugwerk` already has, ending Mend-opacity risk
+  uniformly.
+
+### Harder
+
+- A bug or breaking change in the reusable workflow can affect three
+  repos in one merge. Mitigation: the workflow is small, the change
+  surface is narrow, and dispatching a manual `gh workflow run` in one
+  repo before merging across-the-board catches obvious regressions.
+- Caller stubs reference `@main`, not a pinned commit SHA. This is
+  intentional — pinning would defeat the central-update story — but
+  means a mistake on `plugwerk/.github`'s `main` ships immediately.
+  Revert is a single commit on the reusable side; recovery is fast.
+
+### Unchanged
+
+- Mend-Hosted Renovate continues to run in parallel against all repos
+  (it is org-installed). This workflow is an additional, observable
+  trigger, not a replacement.
+- The `.github/renovate.json` per-repo config is still where each
+  repo declares its own `extends` and `packageRules` overrides.
+- Schedule (`Mon-Fri 04:00 UTC`) and the in-config schedule filter
+  (`before 6am every weekday`) are unchanged.
+
+## References
+
+- ADR-0026: SHA-pin actions and base images (still applies; the
+  reusable workflow follows the policy).
+- Issue #398: org-config bootstrap (closed in `plugwerk/.github` PR #1).
+- PR #462 / #470: original self-hosted Renovate workflow and the
+  hotfix that motivated the central-update story.


### PR DESCRIPTION
## Summary

Replaces this repo's 76-line self-hosted Renovate workflow with a 25-line stub that delegates to the org-wide reusable workflow at [`plugwerk/.github/.github/workflows/renovate.yml`](https://github.com/plugwerk/.github/blob/main/.github/workflows/renovate.yml). Adds ADR-0032 documenting the rationale.

This consolidates three problems into one fix:

1. The `renovatebot/github-action` SHA pin lives in one place. The PR #470 hotfix scenario (where one repo got a hallucinated `@v44.1.1` while others lagged) cannot recur — bumping the pin once in `plugwerk/.github` reaches every consumer immediately.
2. `examples` and `website` (where parallel stub PRs are open) get the same observable Actions-tab cadence that this repo has had since PR #462. They can stop relying purely on Mend-Hosted opacity.
3. Adding self-hosted Renovate to a future plugwerk repo becomes a 25-line stub, not a 76-line copy.

## Blocked by

- plugwerk/.github#3 — the reusable workflow must be on `main` of `plugwerk/.github` before `uses: plugwerk/.github/.github/workflows/renovate.yml@main` can resolve.

## Diff size

```
.github/workflows/renovate.yml | 74 ++++++++++++------------------------------
docs/adrs/0032-reusable-renovate-workflow.md | 118 +++++++++++++++++++++++
```

## What does NOT change

- Schedule (`Mon-Fri 04:00 UTC`) and the in-config `before 6am every weekday` filter — identical.
- Token model — single-repo `GITHUB_TOKEN`, scoped to this repo. No PAT, no GitHub App.
- Concurrency — keyed per-repo in the reusable workflow, so this repo's runs still serialize as before.
- Action SHA pins (`actions/checkout@v6`, `renovatebot/github-action@v46.1.13`) — same pins, just relocated to the reusable workflow.
- Permissions on the calling job (`contents`, `pull-requests`, `issues`) — declared explicitly in the stub.
- The self-hosted Renovate binary still runs against this repo only and updates the Dependency Dashboard issue (#376) the same way.

## Trade-offs (covered in ADR-0032)

The stub references `@main`, not a pinned commit SHA. This is intentional — pinning would defeat the central-update story — but means an unreviewed bump in `plugwerk/.github` ships immediately to every consumer. Mitigation: PR review on the `plugwerk/.github` side is the gate, the workflow surface is small, and a revert is one commit.

## Verification after merge (and after plugwerk/.github#3 merge)

1. `gh workflow run renovate.yml --repo plugwerk/plugwerk` — manual trigger should run cleanly with the same log shape as before.
2. The next scheduled run (Mon-Fri 04:00 UTC) should produce the same Renovate behaviour against this repo.
3. The Dependency Dashboard issue (#376) should continue to be updated.

## Type of Change

- [x] Refactoring
- [x] CI/Build

## Checklist

- [x] Tests pass locally (no test changes; YAML validated)
- [x] Documentation updated (ADR-0032 added)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)