### PR TITLE
fix(perf): batch queries in UpdateCheckService to eliminate N+1

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginRepository.kt
@@ -39,10 +39,7 @@ interface PluginRepository : JpaRepository<PluginEntity, UUID> {
      * group the result by `plugin.pluginId` in memory. Replaces per-id loops in update-check
      * paths to keep the statement count constant in the size of the input.
      */
-    fun findAllByNamespaceAndPluginIdIn(
-        namespace: NamespaceEntity,
-        pluginIds: Collection<String>,
-    ): List<PluginEntity>
+    fun findAllByNamespaceAndPluginIdIn(namespace: NamespaceEntity, pluginIds: Collection<String>): List<PluginEntity>
 
     fun findAllByNamespace(namespace: NamespaceEntity): List<PluginEntity>
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginRepository.kt
@@ -33,6 +33,17 @@ interface PluginRepository : JpaRepository<PluginEntity, UUID> {
 
     fun findByNamespaceAndPluginId(namespace: NamespaceEntity, pluginId: String): Optional<PluginEntity>
 
+    /**
+     * Batch variant of [findByNamespaceAndPluginId] — returns every plugin in the namespace
+     * whose `pluginId` is in the given collection, in a single query. Callers typically
+     * group the result by `plugin.pluginId` in memory. Replaces per-id loops in update-check
+     * paths to keep the statement count constant in the size of the input.
+     */
+    fun findAllByNamespaceAndPluginIdIn(
+        namespace: NamespaceEntity,
+        pluginIds: Collection<String>,
+    ): List<PluginEntity>
+
     fun findAllByNamespace(namespace: NamespaceEntity): List<PluginEntity>
 
     fun findAllByNamespace(namespace: NamespaceEntity, pageable: Pageable): Page<PluginEntity>

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UpdateCheckService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UpdateCheckService.kt
@@ -43,12 +43,27 @@ class UpdateCheckService(
         val namespace = namespaceRepository.findBySlug(namespaceSlug)
             .orElseThrow { NamespaceNotFoundException(namespaceSlug) }
 
-        val updates = installed.mapNotNull { info ->
-            val plugin = pluginRepository.findByNamespaceAndPluginId(namespace, info.pluginId)
-                .orElse(null) ?: return@mapNotNull null
+        if (installed.isEmpty()) return UpdateCheckResponse(updates = emptyList())
 
-            val latestRelease = releaseRepository.findAllByPluginAndStatus(plugin, ReleaseStatus.PUBLISHED)
-                .maxWithOrNull(Comparator { a, b -> compareSemVer(a.version, b.version) })
+        // Two batch queries instead of 2×N per-plugin lookups (#480, ADR-0023):
+        //   1. Resolve all PluginEntities for the requested pluginIds in one statement.
+        //   2. Fetch every PUBLISHED release for those plugins in one JOIN-FETCH statement.
+        // The semver "latest" pick stays client-side because JPQL has no semver awareness.
+        val pluginIds = installed.map { it.pluginId }.distinct()
+        val pluginsById = pluginRepository
+            .findAllByNamespaceAndPluginIdIn(namespace, pluginIds)
+            .associateBy { it.pluginId }
+
+        if (pluginsById.isEmpty()) return UpdateCheckResponse(updates = emptyList())
+
+        val releasesByPluginId = releaseRepository
+            .findAllByPluginInAndStatus(pluginsById.values, ReleaseStatus.PUBLISHED)
+            .groupBy { it.plugin.pluginId }
+
+        val updates = installed.mapNotNull { info ->
+            pluginsById[info.pluginId] ?: return@mapNotNull null
+            val latestRelease = releasesByPluginId[info.pluginId]
+                ?.maxWithOrNull(Comparator { a, b -> compareSemVer(a.version, b.version) })
                 ?: return@mapNotNull null
 
             if (compareSemVer(latestRelease.version, info.currentVersion) > 0) {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UpdateCheckServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UpdateCheckServiceTest.kt
@@ -32,6 +32,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Optional
 import java.util.UUID
@@ -52,19 +57,24 @@ class UpdateCheckServiceTest {
     private val namespace = NamespaceEntity(slug = "acme", name = "ACME Corp")
     private val plugin = PluginEntity(namespace = namespace, pluginId = "my-plugin", name = "My Plugin")
 
-    private fun release(version: String, status: ReleaseStatus = ReleaseStatus.PUBLISHED) = PluginReleaseEntity(
-        plugin = plugin,
+    private fun release(
+        version: String,
+        status: ReleaseStatus = ReleaseStatus.PUBLISHED,
+        owningPlugin: PluginEntity = plugin,
+    ) = PluginReleaseEntity(
+        plugin = owningPlugin,
         version = version,
         artifactSha256 = "sha-$version",
-        artifactKey = "acme/my-plugin/$version",
+        artifactKey = "${owningPlugin.namespace.slug}/${owningPlugin.pluginId}/$version",
         status = status,
     ).also { it.id = UUID.randomUUID() }
 
     @Test
     fun `checkUpdates returns update when newer version exists`() {
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
-        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
-        whenever(releaseRepository.findAllByPluginAndStatus(plugin, ReleaseStatus.PUBLISHED))
+        whenever(pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, listOf("my-plugin")))
+            .thenReturn(listOf(plugin))
+        whenever(releaseRepository.findAllByPluginInAndStatus(any(), eq(ReleaseStatus.PUBLISHED)))
             .thenReturn(listOf(release("1.0.0"), release("1.1.0"), release("2.0.0")))
 
         val installed = listOf(InstalledPluginInfo(pluginId = "my-plugin", currentVersion = "1.0.0"))
@@ -78,8 +88,9 @@ class UpdateCheckServiceTest {
     @Test
     fun `checkUpdates returns no updates when already on latest`() {
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
-        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
-        whenever(releaseRepository.findAllByPluginAndStatus(plugin, ReleaseStatus.PUBLISHED))
+        whenever(pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, listOf("my-plugin")))
+            .thenReturn(listOf(plugin))
+        whenever(releaseRepository.findAllByPluginInAndStatus(any(), eq(ReleaseStatus.PUBLISHED)))
             .thenReturn(listOf(release("1.0.0")))
 
         val installed = listOf(InstalledPluginInfo(pluginId = "my-plugin", currentVersion = "1.0.0"))
@@ -91,19 +102,24 @@ class UpdateCheckServiceTest {
     @Test
     fun `checkUpdates skips unknown plugins silently`() {
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
-        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "unknown")).thenReturn(Optional.empty())
+        whenever(pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, listOf("unknown")))
+            .thenReturn(emptyList())
 
         val installed = listOf(InstalledPluginInfo(pluginId = "unknown", currentVersion = "1.0.0"))
         val response = updateCheckService.checkUpdates("acme", installed)
 
         assertThat(response.updates).isEmpty()
+        // No batch release lookup should fire when no plugins matched.
+        verify(releaseRepository, never()).findAllByPluginInAndStatus(any(), any())
     }
 
     @Test
     fun `checkUpdates skips plugins with no published releases`() {
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
-        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
-        whenever(releaseRepository.findAllByPluginAndStatus(plugin, ReleaseStatus.PUBLISHED)).thenReturn(emptyList())
+        whenever(pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, listOf("my-plugin")))
+            .thenReturn(listOf(plugin))
+        whenever(releaseRepository.findAllByPluginInAndStatus(any(), eq(ReleaseStatus.PUBLISHED)))
+            .thenReturn(emptyList())
 
         val installed = listOf(InstalledPluginInfo(pluginId = "my-plugin", currentVersion = "1.0.0"))
         val response = updateCheckService.checkUpdates("acme", installed)
@@ -123,22 +139,17 @@ class UpdateCheckServiceTest {
     @Test
     fun `checkUpdates handles multiple plugins`() {
         val plugin2 = PluginEntity(namespace = namespace, pluginId = "other-plugin", name = "Other")
-        val release2 = PluginReleaseEntity(
-            plugin = plugin2,
-            version = "3.0.0",
-            artifactSha256 = "sha",
-            artifactKey = "acme/other-plugin/3.0.0",
-            status = ReleaseStatus.PUBLISHED,
-        ).also { it.id = UUID.randomUUID() }
         whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
-        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
         whenever(
-            pluginRepository.findByNamespaceAndPluginId(namespace, "other-plugin"),
-        ).thenReturn(Optional.of(plugin2))
-        whenever(releaseRepository.findAllByPluginAndStatus(plugin, ReleaseStatus.PUBLISHED))
-            .thenReturn(listOf(release("2.0.0")))
-        whenever(releaseRepository.findAllByPluginAndStatus(plugin2, ReleaseStatus.PUBLISHED))
-            .thenReturn(listOf(release2))
+            pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, listOf("my-plugin", "other-plugin")),
+        ).thenReturn(listOf(plugin, plugin2))
+        whenever(releaseRepository.findAllByPluginInAndStatus(any(), eq(ReleaseStatus.PUBLISHED)))
+            .thenReturn(
+                listOf(
+                    release("2.0.0", owningPlugin = plugin),
+                    release("3.0.0", owningPlugin = plugin2),
+                ),
+            )
 
         val installed = listOf(
             InstalledPluginInfo(pluginId = "my-plugin", currentVersion = "1.0.0"),
@@ -148,5 +159,34 @@ class UpdateCheckServiceTest {
 
         assertThat(response.updates).hasSize(1)
         assertThat(response.updates.first().pluginId).isEqualTo("my-plugin")
+    }
+
+    @Test
+    fun `checkUpdates issues only two batch repository calls regardless of input size (issue #480)`() {
+        // Build 25 plugins + 25 published releases (one each, 1.0.0).
+        val plugins = (1..25).map {
+            PluginEntity(namespace = namespace, pluginId = "plugin-$it", name = "Plugin $it")
+        }
+        val pluginIds = plugins.map { it.pluginId }
+        val releases = plugins.map { release("2.0.0", owningPlugin = it) }
+
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findAllByNamespaceAndPluginIdIn(namespace, pluginIds))
+            .thenReturn(plugins)
+        whenever(releaseRepository.findAllByPluginInAndStatus(any(), eq(ReleaseStatus.PUBLISHED)))
+            .thenReturn(releases)
+
+        val installed = pluginIds.map { InstalledPluginInfo(pluginId = it, currentVersion = "1.0.0") }
+        val response = updateCheckService.checkUpdates("acme", installed)
+
+        // All 25 plugins should report an update from 1.0.0 to 2.0.0.
+        assertThat(response.updates).hasSize(25)
+        // Statement count is bounded: exactly one plugin batch + one release batch,
+        // independent of installed.size. Regression-guards the N+1 fix.
+        verify(pluginRepository, times(1)).findAllByNamespaceAndPluginIdIn(any(), any())
+        verify(releaseRepository, times(1)).findAllByPluginInAndStatus(any(), any())
+        // The legacy per-plugin entry points must NOT be reached.
+        verify(pluginRepository, never()).findByNamespaceAndPluginId(any(), any())
+        verify(releaseRepository, never()).findAllByPluginAndStatus(any(), any())
     }
 }


### PR DESCRIPTION
## Summary

Replaces the per-installed-plugin loop in `UpdateCheckService.checkUpdates` with two batch queries. Before this change, the endpoint that PF4J clients poll for plugin updates issued **2 × N** SQL statements per request (one plugin lookup + one release lookup per installed plugin). After: **2 statements total**, regardless of installed.size.

## Closes

- #480

## Diff

| File | Change |
| --- | --- |
| `PluginRepository.kt` | New `findAllByNamespaceAndPluginIdIn(namespace, pluginIds)` Spring-Data finder. |
| `UpdateCheckService.kt` | `checkUpdates` rewritten to do plugin batch + release batch + in-memory grouping; semver `latest` pick stays client-side. |
| `UpdateCheckServiceTest.kt` | All existing tests updated to mock the batch repos; new regression test asserts statement count is bounded for 25-plugin input. |

```
PluginRepository.kt    | 11 +++
UpdateCheckService.kt  | 25 ++++--
UpdateCheckServiceTest | 88 ++++++++++++++++------
3 files changed, 95 insertions(+), 29 deletions(-)
```

## Why

`UpdateCheckService.checkUpdates` is on the hot PF4J client polling path. Typical workload: 100 active clients with ~50 installed plugins each, polled every few minutes. Before this change that translated into **10 000 DB round trips per polling tick** — connection-pool pressure that can starve unrelated endpoints under load. ADR-0023 explicitly mandates a regression-test pattern to detect exactly this; the new test in this PR enforces it for this code path.

The semver "pick latest" comparison stays client-side because JPQL has no semver awareness. With the batch query returning every PUBLISHED release for the whole plugin set in one round-trip plus JOIN FETCH on `release.plugin`, the in-memory grouping is trivial.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test --tests UpdateCheckServiceTest` — all 7 tests pass.
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test --tests "*UpdateCheck*"` — Controller and authorization tests still green.
- [x] New regression test `checkUpdates issues only two batch repository calls regardless of input size (issue #480)` asserts: (a) `findByNamespaceAndPluginId` and `findAllByPluginAndStatus` are never called, (b) `findAllByNamespaceAndPluginIdIn` and `findAllByPluginInAndStatus` are each called exactly once, (c) all 25 plugins in the synthetic input correctly resolve to update entries.
- [ ] Sanity-verify with Hibernate SQL logging on a real H2 run if reviewer wants belt-and-suspenders evidence.

## Type of Change

- [x] Bug fix (performance, no behavioural change)

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (commit message + this PR; ADR-0023 still applies, no new ADR needed)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit \`rollback:\` block — N/A, no schema changes

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)