### PR TITLE
fix(security): switch textEncryptor from AES-CBC to AES-GCM (AEAD)

### DIFF
--- a/docs/adrs/0033-aes-gcm-text-encryptor.md
+++ b/docs/adrs/0033-aes-gcm-text-encryptor.md
@@ -1,0 +1,164 @@
+# ADR-0033: AES-GCM (AEAD) for `TextEncryptor` — `Encryptors.text()` → `Encryptors.delux()`
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR-0022](0022-encryption-key-size.md) documented the contract of the
+`textEncryptor` bean (used to encrypt OIDC client secrets and PASSWORD-typed
+application settings at rest) and listed three "Revisit conditions". One of
+them was:
+
+> **AEAD required.** A shift from CBC to GCM (or equivalent AEAD) would give
+> integrity guarantees in addition to confidentiality, at the cost of a
+> ciphertext migration.
+
+Issue [#476] re-opened that discussion. The original write-up of #476 claimed
+the CBC-based `Encryptors.text()` produced **deterministic** ciphertexts
+("identical plaintexts → identical ciphertexts"). Verification against the
+Spring Security 7.0.5 source proved that claim incorrect — `Encryptors.text()`
+wraps `AesBytesEncryptor` with `KeyGenerators.secureRandom(16)`, which
+generates a **fresh random IV per encryption**. The pre-existing test
+`same plaintext encrypts to different ciphertexts (random IV)` in
+`SecurityConfigurationTextEncryptorTest` was already passing under the old
+code. The original "deterministic ciphertext" framing was therefore a
+misreading of the Spring API; see the corrective comment on #476.
+
+What **is** worth fixing is the lack of **AEAD integrity**:
+
+- Under CBC, a tampered ciphertext silently decrypts to garbage. The caller
+  cannot distinguish a corrupted row from a valid one and may pass garbage
+  credentials to an OIDC provider, surface a meaningless string in an admin
+  UI, or write further state derived from corrupted plaintext.
+- Under GCM, a tampered ciphertext fails the authenticated-encryption tag
+  check and the decrypt call throws. The corruption is loud.
+
+Plus two collateral reasons:
+
+- `Encryptors.text()` is deprecated in modern Spring Security versions in
+  favour of GCM-based alternatives. Staying on the deprecated API accumulates
+  upgrade risk.
+- AEAD (specifically AES-GCM with random nonce) is the modern default for
+  at-rest secret encryption.
+
+## Decision
+
+Switch the `textEncryptor()` bean from `Encryptors.text(...)` (AES-256-CBC,
+no MAC) to `Encryptors.delux(...)` (AES-256-GCM, AEAD, hex-encoded
+`TextEncryptor` wrapper around `Encryptors.stronger()`).
+
+Both functions return the same `TextEncryptor` Spring interface — the bean
+type and every consumer's constructor signature stays identical. The only
+caller-visible difference is that GCM ciphertexts are slightly longer than
+CBC ciphertexts (12-byte nonce + 16-byte tag overhead) and that any
+modification to a stored ciphertext now throws on decrypt instead of
+returning garbage.
+
+### Updated contract
+
+| Aspect | Value |
+|---|---|
+| Cipher | **AES-256-GCM (AEAD)** |
+| Key size | 256 bits (fixed by `AesBytesEncryptor`, unchanged) |
+| Key derivation | `PBKDF2WithHmacSHA1`, 1024 iterations (unchanged — see "Out of scope" below) |
+| Salt | Deterministic, SHA-256(password) first 8 bytes hex-encoded (unchanged) |
+| Nonce / IV | **16-byte random per ciphertext, with GCM 16-byte authentication tag** |
+| Encoding | Hex-encoded (unchanged — `HexEncodingTextEncryptor` wraps both `text()` and `delux()`) |
+| Stored in | `oidc_provider.client_secret_encrypted`, `application_setting.value` (PASSWORD-typed) (unchanged) |
+| Validation | `@NotBlank` + `@Size(min = 16, max = 256)` (unchanged) |
+| Recommendation | 32+ characters (e.g. `openssl rand -base64 32`) (unchanged) |
+
+### Why no ciphertext migration
+
+The standard concern when changing cipher modes is that pre-existing
+ciphertexts encrypted with the old algorithm cannot be decrypted with the
+new one. We are at Plugwerk Phase 2 alpha. There are no production
+deployments holding `oidc_provider`-rows or PASSWORD-typed
+`application_setting`-rows that need to be preserved across this change.
+The greenfield assumption was confirmed before adopting this decision.
+
+For any deployment that does have existing CBC-encrypted secrets, the
+operator-facing remediation is the same as for an encryption-key rotation
+(see ADR-0022 "Rotation"): re-enter each OIDC provider's client secret
+through the admin UI, and re-set any PASSWORD-typed application settings.
+The behaviour is identical to a fresh deployment from that point forward.
+
+If a future Plugwerk version ships into a customer base that holds CBC
+ciphertexts, a Liquibase `customChange` migration that decrypts with the
+legacy bean and re-encrypts with the GCM bean would be the path. That work
+is explicitly **not** part of this ADR; track it separately if and when it
+becomes relevant.
+
+### Out of scope
+
+- **PBKDF2 iteration count.** ADR-0022 already flagged 1024 iterations as a
+  legacy default. This ADR does not address it. Same risk profile, different
+  fix, deserves its own decision.
+- **Argon2id / scrypt KDF migration.** Same.
+- **First-class encryption-key rotation workflow.** Still on the
+  ADR-0022 revisit list.
+- **Re-encryption migration for existing CBC ciphertexts.** Out of scope by
+  the greenfield assumption above. If/when needed, separate ADR + Liquibase
+  customChange.
+
+## Rotation
+
+Unchanged from ADR-0022 — rotating `PLUGWERK_AUTH_ENCRYPTION_KEY` still
+invalidates every encrypted row because the PBKDF2-derived AES key changes
+with the password. Operators re-enter secrets after rotation. The cipher
+mode (CBC vs. GCM) does not affect rotation semantics.
+
+## Consequences
+
+### Good
+
+- **AEAD integrity.** Tampered ciphertexts fail the GCM tag check and throw
+  on decrypt instead of silently returning garbage. The
+  `tampered ciphertext is rejected on decrypt` test in
+  `SecurityConfigurationTextEncryptorTest` pins this property as a
+  regression guard.
+- **Off the deprecated API.** `Encryptors.text()` is deprecated; this moves
+  to a non-deprecated alternative without changing any consumer code.
+- **Modern default.** AES-256-GCM is the current standard for at-rest
+  secret encryption. Future Plugwerk versions and security audits will
+  expect this baseline.
+
+### Neutral
+
+- **No DB migration in this PR.** Greenfield assumption — see "Why no
+  ciphertext migration" above.
+- **Bean type and consumer signatures unchanged.** `Encryptors.delux()`
+  returns the same `TextEncryptor` interface as `Encryptors.text()`. None
+  of `OidcProviderService`, `DbClientRegistrationRepository`, or
+  `ApplicationSettingsService` change.
+- **Hex encoding unchanged.** Both `text()` and `delux()` wrap their
+  underlying `BytesEncryptor` in `HexEncodingTextEncryptor`. Column
+  storage characteristics (charset, hex digits) are identical.
+
+### Watch
+
+- **Ciphertext size increase.** GCM adds ~28 bytes (12-byte nonce + 16-byte
+  tag) over the raw CBC equivalent, hex-encoded ~56 chars more. The
+  `oidc_provider.client_secret_encrypted` column is `length = 1024`, well
+  above realistic OIDC client-secret sizes after the GCM overhead.
+  `application_setting.value` is `TEXT` (no fixed limit). No schema change
+  needed.
+- **Greenfield assumption.** If a deployment with pre-existing CBC
+  ciphertexts is encountered, every decrypt of an old row will throw. The
+  symptom is OIDC login failure or "Could not decrypt smtp.password" at
+  startup. Recovery: re-enter the secrets via admin UI.
+
+## References
+
+- Issue [#476] (with corrective comment on the original "deterministic
+  ciphertext" claim)
+- ADR-0022 — encryption-key size, originally listed AEAD as a revisit
+  condition
+- Spring Security source: `spring-security-crypto-7.0.5-sources.jar` →
+  `Encryptors.delux`, `Encryptors.stronger`, `AesBytesEncryptor`
+- `plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt`
+- `plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityConfigurationTextEncryptorTest.kt`
+
+[#476]: https://github.com/plugwerk/plugwerk/issues/476

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SecurityConfiguration.kt
@@ -135,18 +135,26 @@ class SecurityConfiguration(
     }
 
     /**
-     * AES-256-CBC text encryptor for OIDC provider client secrets stored in the database.
+     * AES-256-GCM text encryptor for OIDC provider client secrets and PASSWORD-typed
+     * application settings stored in the database.
+     *
+     * Uses Spring Security's `Encryptors.delux()`, which wraps `Encryptors.stronger()`
+     * (AES-256-GCM with a fresh random 16-byte IV per encryption) in a hex-encoding
+     * `TextEncryptor`. GCM provides AEAD — both confidentiality and integrity — and
+     * because every encryption produces a different ciphertext for the same plaintext,
+     * a database dump no longer leaks plaintext-equality between rows. See ADR-0033.
      *
      * [PlugwerkProperties.AuthProperties.encryptionKey] is a **password** fed to
-     * Spring Security's `Encryptors.text()`, which uses `PBKDF2WithHmacSHA1` to derive a
-     * 256-bit AES key. The password length controls PBKDF2 input entropy — it does **not**
-     * change the AES key size. See ADR-0022 for the full record of this contract and the
-     * migration procedure when the password is rotated.
+     * `PBKDF2WithHmacSHA1` to derive the 256-bit AES key. The password length controls
+     * PBKDF2 input entropy — it does **not** change the AES key size. See ADR-0022 for
+     * the original key-size record and the migration procedure when the password is
+     * rotated.
      *
-     * The salt is derived deterministically from the encryption key (SHA-256 of the key,
-     * first 8 bytes hex-encoded) so that it is unique per deployment but stable across
-     * restarts — existing encrypted values remain decryptable as long as the password
-     * does not change.
+     * The salt is derived deterministically from the encryption key (SHA-256 of the
+     * key, first 8 bytes hex-encoded) so that it is unique per deployment but stable
+     * across restarts — existing encrypted values remain decryptable as long as the
+     * password does not change. The per-deployment salt does NOT compromise GCM's
+     * security guarantees because GCM's per-encryption nonce is independently random.
      *
      * Environment variable: `PLUGWERK_AUTH_ENCRYPTION_KEY`
      */
@@ -156,7 +164,7 @@ class SecurityConfiguration(
             .digest(props.auth.encryptionKey.toByteArray())
             .take(8)
             .joinToString("") { "%02x".format(it) }
-        return Encryptors.text(props.auth.encryptionKey, salt)
+        return Encryptors.delux(props.auth.encryptionKey, salt)
     }
 
     companion object {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityConfigurationTextEncryptorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/SecurityConfigurationTextEncryptorTest.kt
@@ -26,17 +26,28 @@ import org.mockito.kotlin.mock
 
 /**
  * Pins the round-trip contract for `SecurityConfiguration.textEncryptor()`.
- * Audit row SBS-003 / ADR-0022.
+ * Audit row SBS-003 / ADR-0022 / ADR-0033.
  *
- * The encryptor encrypts OIDC provider client secrets at rest via
- * Spring Security's `Encryptors.text()`, which derives an AES-256 key from the
- * supplied password with `PBKDF2WithHmacSHA1`. The tests below verify:
+ * The encryptor protects OIDC provider client secrets and PASSWORD-typed
+ * application settings at rest via Spring Security's `Encryptors.delux()`,
+ * which wraps `Encryptors.stronger()` (AES-256-GCM with a fresh random
+ * 16-byte nonce per encryption) in a hex-encoding `TextEncryptor`. The
+ * tests below verify:
  *
  * 1. A 16-char password (historical lower bound) round-trips successfully.
  * 2. A 32-char password (recommended length) round-trips successfully.
  * 3. Ciphertext produced with one password cannot be decrypted with another —
- *    this is the migration invariant that makes key rotation a re-enter-secrets
- *    operation, not an in-place upgrade.
+ *    this is the migration invariant documented in ADR-0022: rotating the
+ *    encryption key invalidates every existing `client_secret_encrypted` row,
+ *    which is why operators must re-enter each OIDC provider's client secret
+ *    through the admin UI after rotation.
+ * 4. Two encryptions of the same plaintext produce different ciphertexts —
+ *    GCM uses a fresh random nonce per call, so a database dump cannot leak
+ *    plaintext-equality between rows by comparing ciphertexts.
+ * 5. A tampered ciphertext is rejected on decrypt — GCM is AEAD and detects
+ *    any modification of the ciphertext or its associated data. This is the
+ *    integrity guarantee that the previous CBC-based `Encryptors.text()`
+ *    did not provide and is the primary reason for ADR-0033's migration.
  */
 class SecurityConfigurationTextEncryptorTest {
 
@@ -102,9 +113,10 @@ class SecurityConfigurationTextEncryptorTest {
 
     /**
      * Each `encrypt()` call must produce different ciphertext for the same plaintext.
-     * `AesBytesEncryptor` uses a random 16-byte IV per encryption, so two calls
-     * with the same plaintext must never emit identical output — otherwise
-     * equal ciphertexts would leak equal plaintexts.
+     * `AesBytesEncryptor` (in GCM mode, see ADR-0033) generates a fresh random
+     * 16-byte nonce per encryption, so two calls with the same plaintext must
+     * never emit identical output — otherwise equal ciphertexts would leak equal
+     * plaintexts to anyone with database read access.
      */
     @Test
     fun `same plaintext encrypts to different ciphertexts (random IV)`() {
@@ -117,5 +129,35 @@ class SecurityConfigurationTextEncryptorTest {
         assertThat(first).isNotEqualTo(second)
         assertThat(encryptor.decrypt(first)).isEqualTo(plaintext)
         assertThat(encryptor.decrypt(second)).isEqualTo(plaintext)
+    }
+
+    /**
+     * GCM's authenticated-encryption tag must reject any ciphertext that has
+     * been modified after encryption. This is the integrity property AES-CBC
+     * never had — under the previous `Encryptors.text()` (CBC mode without a
+     * MAC), a flipped bit decrypted to garbage instead of throwing, so the
+     * caller could not distinguish a corrupted row from a valid one and might
+     * silently feed garbage credentials to an OIDC provider. With GCM the
+     * decrypt call throws on tampering, surfacing the corruption clearly.
+     *
+     * The test flips one byte in the middle of the hex-encoded ciphertext;
+     * any single-byte modification anywhere in the ciphertext or in the GCM
+     * tag must invalidate the AEAD check.
+     */
+    @Test
+    fun `tampered ciphertext is rejected on decrypt (GCM AEAD integrity)`() {
+        val encryptor = buildSecurityConfig("k".repeat(32)).textEncryptor()
+        val plaintext = "oidc-client-secret-value"
+        val ciphertext = encryptor.encrypt(plaintext)
+
+        // Flip one byte (= two hex chars) somewhere in the middle. The exact
+        // offset does not matter as long as it is not a no-op; the GCM tag
+        // covers the entire ciphertext + nonce.
+        val mid = ciphertext.length / 2
+        val flippedChar = if (ciphertext[mid] == '0') '1' else '0'
+        val tampered = ciphertext.substring(0, mid) + flippedChar + ciphertext.substring(mid + 1)
+
+        assertThatThrownBy { encryptor.decrypt(tampered) }
+            .isInstanceOf(Exception::class.java)
     }
 }


### PR DESCRIPTION
## Summary

Replaces the `textEncryptor` bean's underlying cipher from AES-256-CBC (`Encryptors.text()`, no MAC) to AES-256-GCM (`Encryptors.delux()`, AEAD). The bean type stays `TextEncryptor`, so all consumers (`OidcProviderService`, `DbClientRegistrationRepository`, `ApplicationSettingsService`) keep their constructor signatures and call shapes unchanged.

## Closes

- #476

## Diagnostic correction first

The original write-up of #476 claimed CBC-based `Encryptors.text()` produced **deterministic** ciphertexts ("identical plaintexts → identical ciphertexts") because of the deterministic salt. **That claim is incorrect.** Spring's `AesBytesEncryptor` uses `KeyGenerators.secureRandom(16)` to generate a fresh random IV per encryption. The pre-existing test `same plaintext encrypts to different ciphertexts (random IV)` in `SecurityConfigurationTextEncryptorTest` was already passing under the old code — verified locally before this PR.

See the corrective comment on #476 (severity downgraded `severity:critical` → `severity:high`) for the full investigation.

## Why migrate anyway

The migration is still the right call, just for different reasons than the original write-up:

1. **AEAD integrity.** CBC has no MAC. A tampered ciphertext under CBC silently decrypts to garbage; under GCM it throws on decrypt. This is the property the new test pins.
2. **`Encryptors.text()` is deprecated** in modern Spring Security versions. Staying on the deprecated API accumulates upgrade risk.
3. **Modern default.** AES-256-GCM is the current standard for at-rest secret encryption.

ADR-0022 already listed "AEAD required" as one of the explicit revisit conditions for the encryption-key contract. ADR-0033 in this PR documents the AEAD-aware shape.

## Diff

```
SecurityConfiguration.kt                       | 28 ++++++----  (1-liner cipher swap + kdoc)
SecurityConfigurationTextEncryptorTest.kt      | 60 ++++++++++++----  (1 new test + kdoc)
docs/adrs/0033-aes-gcm-text-encryptor.md       | 165 +++++++++++  (new ADR)
3 files changed, 233 insertions(+), 19 deletions(-)
```

The actual code change is **one method call**: `Encryptors.text(...)` → `Encryptors.delux(...)`. The rest of the diff is documentation and test coverage.

## Greenfield assumption

This PR does **not** ship a Liquibase re-encryption customChange. Plugwerk is at Phase 2 alpha; no production deployments hold pre-existing CBC-encrypted secrets that need to be preserved across this change. Confirmed with the maintainer before adopting this scope.

If a future deployment turns out to have existing CBC ciphertexts, the operator-facing remediation is the same as for an encryption-key rotation (ADR-0022 *Rotation*): re-enter each OIDC client secret and PASSWORD-typed setting via the admin UI. ADR-0033 explicitly records this assumption so a future re-encryption migration has a clear pointer.

## Tests

| Test | Behaviour pinned |
| --- | --- |
| `tampered ciphertext is rejected on decrypt (GCM AEAD integrity)` (new) | Flips one byte in the middle of the hex ciphertext, asserts decrypt throws. **The property CBC never had.** |
| `same plaintext encrypts to different ciphertexts (random IV)` (existing) | Random nonce per encryption, ciphertexts differ. Stays green; kdoc corrected to reference GCM mode. |
| `16-character key round-trips ciphertext` (existing) | Round-trip on minimum-length password. |
| `32-character key round-trips ciphertext` (existing) | Round-trip on recommended-length password. |
| `ciphertext from one key is not decryptable with a different key` (existing) | Cross-key isolation invariant from ADR-0022 *Rotation*. |

All five pass locally. Class-level kdoc updated to reference GCM and ADR-0033.

## Local verification

```
./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck
./gradlew :plugwerk-server:plugwerk-server-backend:test
./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest
```

All three CI gates green.

## What does NOT change

- Bean type — still `TextEncryptor`.
- Caller signatures — unchanged in all three consumer files.
- Hex encoding — both `text()` and `delux()` wrap their underlying `BytesEncryptor` in `HexEncodingTextEncryptor`. Column storage characteristics identical.
- Key derivation — `PBKDF2WithHmacSHA1`, 1024 iterations, deterministic salt — all unchanged. Iteration-count upgrade is a separate ADR/PR (still on the ADR-0022 revisit list).
- DB schema — no column widening needed; `oidc_provider.client_secret_encrypted` is `length=1024` (well above realistic OIDC secret + GCM overhead) and `application_setting.value` is `TEXT`.

## Type of Change

- [x] Bug fix (security hardening — AEAD integrity)
- [x] Documentation (ADR-0033)

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (ADR-0033 added; existing test class kdoc corrected)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit \`rollback:\` block — N/A, no schema changes

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)