### PR TITLE
fix(admin-users): paginate /admin/users endpoint and consumers

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1339,8 +1339,15 @@ paths:
     get:
       tags:
         - AdminUsers
-      summary: List all users
-      description: Returns all registered users. Requires superadmin privileges.
+      summary: List users (paginated)
+      description: |
+        Returns a paginated page of registered users. Requires superadmin
+        privileges. Sortable by `username`, `email`, `createdAt`, or
+        `lastLoginAt`. Sorts by `username,asc` when omitted.
+
+        **Pagination is mandatory.** Issue #485 introduced the page wrapper to
+        protect against unbounded result-set loads as the user base grows
+        (LDAP/OIDC mass-provisioning). Default page size is 20, maximum 100.
       operationId: listUsers
       security:
         - BearerAuth: []
@@ -1348,18 +1355,32 @@ paths:
         - name: enabled
           in: query
           required: false
-          description: Filter by enabled state. When omitted, all users are returned.
+          description: Filter by enabled state. When omitted, every user matching the page is returned.
           schema:
             type: boolean
+        - $ref: '#/components/parameters/PageQuery'
+        - $ref: '#/components/parameters/SizeQuery'
+        - name: sort
+          in: query
+          required: false
+          description: |
+            `<field>,<direction>` where field ∈ {`username`, `email`,
+            `createdAt`, `lastLoginAt`} and direction ∈ {`asc`, `desc`}.
+            Defaults to `username,asc`.
+          schema:
+            type: string
+            default: username,asc
+            pattern: '^(username|email|createdAt|lastLoginAt),(asc|desc)$'
+            maxLength: 32
       responses:
         '200':
-          description: List of all local users
+          description: Paginated page of users
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UserDto'
+                $ref: '#/components/schemas/UserPagedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3175,6 +3196,38 @@ components:
           type: integer
           format: int64
           description: Total number of releases matching the query (across all pages)
+        page:
+          type: integer
+          format: int32
+          description: Current zero-based page index
+        size:
+          type: integer
+          format: int32
+          description: Number of items per page
+        totalPages:
+          type: integer
+          format: int32
+          description: Total number of pages
+      required:
+        - content
+        - totalElements
+        - page
+        - size
+        - totalPages
+
+    UserPagedResponse:
+      type: object
+      description: Paginated response containing a list of users
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserDto'
+          description: User entries on this page
+        totalElements:
+          type: integer
+          format: int64
+          description: Total number of users matching the query (across all pages)
         page:
           type: integer
           format: int32

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -22,6 +22,7 @@ import io.plugwerk.api.AdminUsersApi
 import io.plugwerk.api.model.AdminPasswordResetResponse
 import io.plugwerk.api.model.UserCreateRequest
 import io.plugwerk.api.model.UserDto
+import io.plugwerk.api.model.UserPagedResponse
 import io.plugwerk.api.model.UserUpdateRequest
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
@@ -31,6 +32,8 @@ import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.UserService
 import io.plugwerk.server.service.auth.AdminPasswordResetService
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RequestMapping
@@ -52,16 +55,30 @@ class AdminUserController(
     private val log = LoggerFactory.getLogger(AdminUserController::class.java)
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
-    override fun listUsers(enabled: Boolean?): ResponseEntity<List<UserDto>> {
+    override fun listUsers(enabled: Boolean?, page: Int, size: Int, sort: String): ResponseEntity<UserPagedResponse> {
         val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
-        val users = if (enabled != null) userService.findAllByEnabled(enabled) else userService.findAll()
+
+        // Sort string is also enforced by the OpenAPI regex pattern, but
+        // re-validate here so a hand-crafted request bypassing the generated
+        // controller still hits a 400 instead of an opaque Spring exception.
+        // The OpenAPI regex restricts the field set; this guard mirrors it
+        // close to the call site for grep-ability.
+        val pageable = parsePageable(page, size, sort)
+
+        val pageResult = if (enabled != null) {
+            userService.findAllByEnabled(enabled, pageable)
+        } else {
+            userService.findAll(pageable)
+        }
+        val pageContent = pageResult.content
+
         // Single batched lookup for the EXTERNAL subset's provider names so
         // the response payload (issue #412) stays one extra SQL query — never
         // N+1 — regardless of how many EXTERNAL users land on the page.
         // Empty subset short-circuits because some JDBC drivers reject an
         // empty `IN (…)` clause.
-        val externalUserIds = users.asSequence()
+        val externalUserIds = pageContent.asSequence()
             .filter { it.source == UserSource.EXTERNAL }
             .mapNotNull { it.id }
             .toList()
@@ -71,7 +88,49 @@ class AdminUserController(
             oidcIdentityRepository.findProviderNamesForUsers(externalUserIds)
                 .associate { it.userId to it.providerName }
         }
-        return ResponseEntity.ok(users.map { it.toDto(providerNames) })
+
+        return ResponseEntity.ok(
+            UserPagedResponse(
+                content = pageContent.map { it.toDto(providerNames) },
+                totalElements = pageResult.totalElements,
+                page = pageResult.number,
+                propertySize = pageResult.size,
+                totalPages = pageResult.totalPages,
+            ),
+        )
+    }
+
+    private fun parsePageable(page: Int, size: Int, sort: String): PageRequest {
+        // OpenAPI regex `^(username|email|createdAt|lastLoginAt),(asc|desc)$`
+        // already enforces the shape — split here is safe. Defensive guard
+        // included for direct callers that bypass the generated layer.
+        val (field, direction) = sort.split(",", limit = 2)
+            .takeIf { it.size == 2 }
+            ?: throw ResponseStatusException(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "Invalid sort parameter: '$sort' (expected 'field,asc|desc')",
+            )
+        if (field !in ALLOWED_SORT_FIELDS) {
+            throw ResponseStatusException(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "Sort field '$field' is not allowed (allowed: ${ALLOWED_SORT_FIELDS.joinToString()})",
+            )
+        }
+        val springDirection = when (direction.lowercase()) {
+            "asc" -> Sort.Direction.ASC
+
+            "desc" -> Sort.Direction.DESC
+
+            else -> throw ResponseStatusException(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "Sort direction '$direction' is not allowed (allowed: asc, desc)",
+            )
+        }
+        return PageRequest.of(page, size, Sort.by(springDirection, field))
+    }
+
+    private companion object {
+        private val ALLOWED_SORT_FIELDS = setOf("username", "email", "createdAt", "lastLoginAt")
     }
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
@@ -20,6 +20,8 @@ package io.plugwerk.server.repository
 
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -54,7 +56,7 @@ interface UserRepository : JpaRepository<UserEntity, UUID> {
     )
     fun existsByEmailAndSourceIgnoreCase(@Param("email") email: String, @Param("source") source: UserSource): Boolean
 
-    fun findAllByEnabled(enabled: Boolean): List<UserEntity>
+    fun findAllByEnabled(enabled: Boolean, pageable: Pageable): Page<UserEntity>
 
     /**
      * Username-or-email lookup scoped to a single [source]. Used by the

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
@@ -22,6 +22,8 @@ import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.domain.UserSource
 import io.plugwerk.server.repository.NamespaceMemberRepository
 import io.plugwerk.server.repository.UserRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -38,11 +40,24 @@ class UserService(
     private val tokenRevocationService: TokenRevocationService,
 ) {
 
+    /**
+     * Returns one paginated page of users, ordered by the supplied [pageable]
+     * sort. Issue #485 made pagination mandatory on this path to keep the
+     * admin user-list endpoint bounded as the user base grows (LDAP/OIDC
+     * mass-provisioning). Callers that genuinely need every row at once
+     * should add a dedicated bulk-export entry point with explicit
+     * justification, not call this method with `Pageable.unpaged()`.
+     */
     @Transactional(readOnly = true)
-    fun findAll(): List<UserEntity> = userRepository.findAll()
+    fun findAll(pageable: Pageable): Page<UserEntity> = userRepository.findAll(pageable)
 
+    /**
+     * Paginated counterpart to [findAll] filtered by [enabled]. See [findAll]
+     * for the rationale on mandatory pagination.
+     */
     @Transactional(readOnly = true)
-    fun findAllByEnabled(enabled: Boolean): List<UserEntity> = userRepository.findAllByEnabled(enabled)
+    fun findAllByEnabled(enabled: Boolean, pageable: Pageable): Page<UserEntity> =
+        userRepository.findAllByEnabled(enabled, pageable)
 
     @Transactional(readOnly = true)
     fun findById(id: UUID): UserEntity =

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -37,8 +37,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -48,6 +50,10 @@ import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSec
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
@@ -144,62 +150,77 @@ class AdminUserControllerTest {
             override val providerName: String = providerName
         }
 
+    /**
+     * Wraps a list of entities into a Spring Data [PageImpl] sized for the
+     * default request (page 0, size 20). Use [pageOf] when the test does not
+     * care about page metadata details — the mocks return whatever the
+     * controller asks for.
+     */
+    private fun pageOf(users: List<UserEntity>) =
+        PageImpl(users, PageRequest.of(0, 20, Sort.by("username").ascending()), users.size.toLong())
+
     @Test
-    fun `GET admin users returns list`() {
+    fun `GET admin users returns paginated content`() {
         val user = stubUser()
-        whenever(userService.findAll()).thenReturn(listOf(user))
+        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(user)))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$[0].username") { value("alice") }
-            jsonPath("$[0].enabled") { value(true) }
+            jsonPath("$.content[0].username") { value("alice") }
+            jsonPath("$.content[0].enabled") { value(true) }
+            jsonPath("$.totalElements") { value(1) }
+            jsonPath("$.page") { value(0) }
+            jsonPath("$.size") { value(20) }
+            jsonPath("$.totalPages") { value(1) }
         }
     }
 
     @Test
     fun `GET admin users with enabled=true returns only enabled users`() {
         val enabledUser = stubUser("alice", enabled = true)
-        whenever(userService.findAllByEnabled(true)).thenReturn(listOf(enabledUser))
+        whenever(userService.findAllByEnabled(eq(true), any())).thenReturn(pageOf(listOf(enabledUser)))
 
         mockMvc.get("/api/v1/admin/users?enabled=true").andExpect {
             status { isOk() }
-            jsonPath("$.length()") { value(1) }
-            jsonPath("$[0].username") { value("alice") }
-            jsonPath("$[0].enabled") { value(true) }
+            jsonPath("$.content.length()") { value(1) }
+            jsonPath("$.content[0].username") { value("alice") }
+            jsonPath("$.content[0].enabled") { value(true) }
         }
     }
 
     @Test
     fun `GET admin users with enabled=false returns only disabled users`() {
         val disabledUser = stubUser("bob", enabled = false)
-        whenever(userService.findAllByEnabled(false)).thenReturn(listOf(disabledUser))
+        whenever(userService.findAllByEnabled(eq(false), any())).thenReturn(pageOf(listOf(disabledUser)))
 
         mockMvc.get("/api/v1/admin/users?enabled=false").andExpect {
             status { isOk() }
-            jsonPath("$.length()") { value(1) }
-            jsonPath("$[0].username") { value("bob") }
-            jsonPath("$[0].enabled") { value(false) }
+            jsonPath("$.content.length()") { value(1) }
+            jsonPath("$.content[0].username") { value("bob") }
+            jsonPath("$.content[0].enabled") { value(false) }
         }
     }
 
     @Test
-    fun `GET admin users without enabled param returns all users`() {
+    fun `GET admin users without enabled param returns the unfiltered page`() {
         val users = listOf(stubUser("alice", enabled = true), stubUser("bob", enabled = false))
-        whenever(userService.findAll()).thenReturn(users)
+        whenever(userService.findAll(any())).thenReturn(pageOf(users))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$.length()") { value(2) }
+            jsonPath("$.content.length()") { value(2) }
         }
     }
 
     @Test
-    fun `GET admin users returns empty list when no users`() {
-        whenever(userService.findAll()).thenReturn(emptyList())
+    fun `GET admin users returns empty page when no users`() {
+        whenever(userService.findAll(any())).thenReturn(pageOf(emptyList()))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$") { isArray() }
+            jsonPath("$.content") { isArray() }
+            jsonPath("$.content.length()") { value(0) }
+            jsonPath("$.totalElements") { value(0) }
         }
     }
 
@@ -210,14 +231,14 @@ class AdminUserControllerTest {
         // from different providers. The lookup is one batched call; this test
         // pins the wiring end-to-end (controller → repository → DTO).
         val external = stubExternalUser("Alice Schmidt")
-        whenever(userService.findAll()).thenReturn(listOf(external))
+        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(external)))
         whenever(oidcIdentityRepository.findProviderNamesForUsers(listOf(external.id!!)))
             .thenReturn(listOf(providerProjection(external.id!!, "Company Keycloak")))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$[0].source") { value("EXTERNAL") }
-            jsonPath("$[0].providerName") { value("Company Keycloak") }
+            jsonPath("$.content[0].source") { value("EXTERNAL") }
+            jsonPath("$.content[0].providerName") { value("Company Keycloak") }
         }
     }
 
@@ -226,12 +247,12 @@ class AdminUserControllerTest {
         // INTERNAL users always return providerName = null. The controller
         // must NOT include their ids in the batched lookup.
         val internal = stubUser("alice")
-        whenever(userService.findAll()).thenReturn(listOf(internal))
+        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(internal)))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$[0].source") { value("INTERNAL") }
-            jsonPath("$[0].providerName") { doesNotExist() }
+            jsonPath("$.content[0].source") { value("INTERNAL") }
+            jsonPath("$.content[0].providerName") { doesNotExist() }
         }
         verify(oidcIdentityRepository, never()).findProviderNamesForUsers(any())
     }
@@ -241,15 +262,73 @@ class AdminUserControllerTest {
         // Performance regression guard — passing an empty `IN (…)` collection
         // is a JDBC dialect minefield, and the round-trip is wasted anyway.
         // The controller short-circuits; this test locks that behaviour.
-        whenever(userService.findAll()).thenReturn(
-            listOf(stubUser("alice"), stubUser("bob")),
+        whenever(userService.findAll(any())).thenReturn(
+            pageOf(listOf(stubUser("alice"), stubUser("bob"))),
         )
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$.length()") { value(2) }
+            jsonPath("$.content.length()") { value(2) }
         }
         verify(oidcIdentityRepository, never()).findProviderNamesForUsers(any())
+    }
+
+    // ---- Pagination-specific tests (#485) ---------------------------------
+
+    @Test
+    fun `GET admin users returns paged subset when total exceeds page size`() {
+        // Pflicht-Regression-Guard for #485: 200 users in DB, request the
+        // first page of size 20 → response carries 20 entries plus accurate
+        // page metadata. Without pagination the response would be 200 items.
+        val twentyUsers = (1..20).map { stubUser("user-$it") }
+        val backingPage = PageImpl(twentyUsers, PageRequest.of(0, 20, Sort.by("username").ascending()), 200L)
+        whenever(userService.findAll(any())).thenReturn(backingPage)
+
+        mockMvc.get("/api/v1/admin/users?page=0&size=20").andExpect {
+            status { isOk() }
+            jsonPath("$.content.length()") { value(20) }
+            jsonPath("$.totalElements") { value(200) }
+            jsonPath("$.page") { value(0) }
+            jsonPath("$.size") { value(20) }
+            jsonPath("$.totalPages") { value(10) }
+        }
+    }
+
+    @Test
+    fun `GET admin users with valid sort passes Sort to service and rejects invalid sort with 400`() {
+        // Valid sort: passes through and ends up on the Pageable.
+        whenever(userService.findAll(any())).thenReturn(pageOf(emptyList()))
+        mockMvc.get("/api/v1/admin/users?sort=email,desc").andExpect {
+            status { isOk() }
+        }
+        val pageableCaptor = argumentCaptor<Pageable>()
+        verify(userService).findAll(pageableCaptor.capture())
+        val sort = pageableCaptor.firstValue.sort.toList().single()
+        assert(sort.property == "email")
+        assert(sort.direction == Sort.Direction.DESC)
+
+        // Invalid sort field — OpenAPI regex rejects at the framework boundary
+        // with 400. The controller's defensive parsePageable() is the second
+        // line of defence; either way the user sees 400.
+        mockMvc.get("/api/v1/admin/users?sort=password,asc").andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    @Test
+    fun `GET admin users combines enabled filter with custom page and size`() {
+        whenever(userService.findAllByEnabled(eq(false), any()))
+            .thenReturn(pageOf(emptyList()))
+
+        mockMvc.get("/api/v1/admin/users?enabled=false&page=1&size=10").andExpect {
+            status { isOk() }
+        }
+
+        val pageableCaptor = argumentCaptor<Pageable>()
+        verify(userService).findAllByEnabled(eq(false), pageableCaptor.capture())
+        val captured = pageableCaptor.firstValue
+        assert(captured.pageNumber == 1)
+        assert(captured.pageSize == 10)
     }
 
     @Test
@@ -260,7 +339,7 @@ class AdminUserControllerTest {
         val internal = stubUser("admin")
         val externalA = stubExternalUser("Alice Schmidt")
         val externalB = stubExternalUser("Bob Jones")
-        whenever(userService.findAll()).thenReturn(listOf(internal, externalA, externalB))
+        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(internal, externalA, externalB)))
         whenever(
             oidcIdentityRepository.findProviderNamesForUsers(
                 listOf(externalA.id!!, externalB.id!!),
@@ -274,10 +353,10 @@ class AdminUserControllerTest {
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
-            jsonPath("$.length()") { value(3) }
-            jsonPath("$[0].providerName") { doesNotExist() }
-            jsonPath("$[1].providerName") { value("Google") }
-            jsonPath("$[2].providerName") { value("GitHub") }
+            jsonPath("$.content.length()") { value(3) }
+            jsonPath("$.content[0].providerName") { doesNotExist() }
+            jsonPath("$.content[1].providerName") { value("Google") }
+            jsonPath("$.content[2].providerName") { value("GitHub") }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcWebLoginIT.kt
@@ -135,8 +135,8 @@ class OidcWebLoginIT {
         // table cleans everything we touch.
         refreshTokenRepository.deleteAll()
         oidcIdentityRepository.deleteAll()
-        userRepository.findAllByEnabled(true)
-            .filter { it.source == UserSource.EXTERNAL }
+        userRepository.findAll()
+            .filter { it.enabled && it.source == UserSource.EXTERNAL }
             .forEach { userRepository.delete(it) }
         oidcProviderRepository.deleteAll()
 

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -50,6 +50,22 @@ function userDto(overrides: Partial<UserDto>): UserDto {
 }
 
 /**
+ * Wraps a list of users into the paged-response shape that listUsers returns
+ * after #485. The test bypasses strict typing via the `as unknown as` cast
+ * already in use throughout this file, so missing UserPagedResponse fields
+ * (none for this test's purposes) do not need to be filled in.
+ */
+function pagedUsers(users: UserDto[]) {
+  return {
+    content: users,
+    totalElements: users.length,
+    page: 0,
+    size: users.length,
+    totalPages: users.length === 0 ? 0 : 1,
+  };
+}
+
+/**
  * Opens the "Add Members" dialog and waits for the user-options effect to
  * fire. Returns both the userEvent instance and the dialog element.
  */
@@ -76,14 +92,14 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
 
   it("renders EXTERNAL user with provider name in parentheses", async () => {
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [
+      data: pagedUsers([
         userDto({
           displayName: "Alice Schmidt",
           source: "EXTERNAL",
           username: undefined,
           providerName: "Company Keycloak",
         }),
-      ],
+      ]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);
@@ -105,14 +121,14 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
     // missing by the time the API serialises. The dropdown still renders a
     // valid label rather than "Bob (undefined)".
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [
+      data: pagedUsers([
         userDto({
           displayName: "Bob Müller",
           source: "EXTERNAL",
           username: undefined,
           providerName: undefined,
         }),
-      ],
+      ]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);
@@ -128,13 +144,13 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
 
   it("renders INTERNAL user with distinct username as 'displayName (username)' — existing behaviour", async () => {
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [
+      data: pagedUsers([
         userDto({
           displayName: "Charlie Admin",
           username: "charlie",
           source: "INTERNAL",
         }),
-      ],
+      ]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);
@@ -165,7 +181,7 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
       username: "bob",
     });
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [alice, bob],
+      data: pagedUsers([alice, bob]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);
@@ -220,7 +236,7 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
     // Issue #412 invariant: the provider hint is decorative. Typing the
     // provider name must not surface every user from that provider.
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [
+      data: pagedUsers([
         userDto({
           displayName: "Alice Schmidt",
           source: "EXTERNAL",
@@ -232,7 +248,7 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
           source: "INTERNAL",
           username: "diana",
         }),
-      ],
+      ]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);
@@ -262,7 +278,7 @@ describe("MembersSection — members table (issue #412)", () => {
     // dialog in this block. Stub a quiet listUsers so the picker effect,
     // which fires only on dialog open, does not race anything.
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [],
+      data: pagedUsers([]),
     } as unknown as Awaited<
       ReturnType<typeof apiConfig.adminUsersApi.listUsers>
     >);

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -141,10 +141,20 @@ export function MembersSection({ slug }: { slug: string }) {
     if (!addOpen) return;
     async function loadUsers() {
       try {
-        const res = await adminUsersApi.listUsers({ enabled: true });
+        // Pagination on /admin/users became mandatory in #485. The
+        // add-member dropdown wants every eligible candidate at once for
+        // client-side search, so we ask for the maximum page size (100)
+        // until a dedicated server-side user-search endpoint exists.
+        // TODO(#492): replace with the dedicated /admin/users/search
+        // endpoint once it lands. The 100-cap holds for current
+        // deployments; #492 tracks the proper fix.
+        const res = await adminUsersApi.listUsers({
+          enabled: true,
+          size: 100,
+        });
         const existing = new Set(members.map((m) => m.userId));
         setUserOptions(
-          res.data
+          res.data.content
             .filter((u) => !u.isSuperadmin && !existing.has(u.id))
             .map((u) => ({
               userId: u.id,

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
@@ -102,7 +102,13 @@ describe("UsersSection — admin reset password (#450)", () => {
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockReset();
     vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockReset();
     vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: [aliceInternal, bobOidc, callerSelf, carolDisabled],
+      data: {
+        content: [aliceInternal, bobOidc, callerSelf, carolDisabled],
+        totalElements: 4,
+        page: 0,
+        size: 20,
+        totalPages: 1,
+      },
     } as never);
   });
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.tsx
@@ -26,6 +26,7 @@ import {
   CircularProgress,
   Chip,
   Switch,
+  TablePagination,
 } from "@mui/material";
 import { KeyRound, Plus, Shield, Trash2 } from "lucide-react";
 import { AppDialog } from "../../components/common/AppDialog";
@@ -43,8 +44,20 @@ import type {
   UserDto,
 } from "../../api/generated/model";
 
+// Default page size matches the OpenAPI SizeQuery default and the MUI
+// TablePagination convention. The 100 cap mirrors the backend SizeQuery
+// max so the dropdown cannot offer values the server would reject.
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+const DEFAULT_SORT = "username,asc";
+
 export function UsersSection() {
   const [users, setUsers] = useState<UserDto[]>([]);
+  const [totalElements, setTotalElements] = useState(0);
+  const [page, setPage] = useState(0);
+  const [size, setSize] = useState(DEFAULT_PAGE_SIZE);
+  const [sort] = useState(DEFAULT_SORT);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [username, setUsername] = useState("");
@@ -62,20 +75,28 @@ export function UsersSection() {
     response: AdminPasswordResetResponse;
   } | null>(null);
 
+  // Refetch on every page/size/sort change and after every mutation
+  // (refreshTrigger). Keeping the source of truth on the server side avoids
+  // the optimistic-cache bugs that the previous "mutate users array in place"
+  // code was prone to once the data set spans multiple pages.
   useEffect(() => {
     async function load() {
       setLoading(true);
       try {
-        const res = await adminUsersApi.listUsers();
-        setUsers(res.data);
+        const res = await adminUsersApi.listUsers({ page, size, sort });
+        setUsers(res.data.content);
+        setTotalElements(res.data.totalElements);
       } catch {
         setUsers([]);
+        setTotalElements(0);
       } finally {
         setLoading(false);
       }
     }
     load();
-  }, []);
+  }, [page, size, sort, refreshTrigger]);
+
+  const refresh = () => setRefreshTrigger((n) => n + 1);
 
   async function handleToggleEnabled(user: UserDto) {
     try {
@@ -83,6 +104,8 @@ export function UsersSection() {
         userId: user.id,
         userUpdateRequest: { enabled: !user.enabled },
       });
+      // Optimistic local update is safe — the toggled row stays on the same
+      // page. A full refresh would just be wasted bytes.
       setUsers((prev) => prev.map((u) => (u.id === user.id ? res.data : u)));
       addToast({
         message: `User "${user.displayName}" ${res.data.enabled ? "enabled" : "disabled"}.`,
@@ -101,7 +124,10 @@ export function UsersSection() {
     setDeleting(true);
     try {
       await adminUsersApi.deleteUser({ userId: deleteTarget.id });
-      setUsers((prev) => prev.filter((u) => u.id !== deleteTarget.id));
+      // Refetch so the page metadata (totalElements/totalPages) stays
+      // consistent and the next page promotes a row into the slot we
+      // just freed. Local filter would leave a hole.
+      refresh();
       addToast({
         message: `User "${deleteTarget.displayName}" deleted.`,
         type: "success",
@@ -171,7 +197,9 @@ export function UsersSection() {
           password,
         },
       });
-      setUsers((prev) => [...prev, res.data]);
+      // Refetch to keep page metadata accurate and let the new user fall
+      // into the right slot per the active sort.
+      refresh();
       addToast({
         message: `User "${res.data.displayName}" created.`,
         type: "success",
@@ -404,7 +432,7 @@ export function UsersSection() {
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress size={24} />
         </Box>
-      ) : users.length === 0 ? (
+      ) : users.length === 0 && totalElements === 0 ? (
         <Typography
           variant="body2"
           sx={{
@@ -414,12 +442,28 @@ export function UsersSection() {
           No users found.
         </Typography>
       ) : (
-        <DataTable<UserDto>
-          columns={userColumns}
-          rows={users}
-          keyFn={(user) => user.id}
-          ariaLabel="Users"
-        />
+        <Box>
+          <DataTable<UserDto>
+            columns={userColumns}
+            rows={users}
+            keyFn={(user) => user.id}
+            ariaLabel="Users"
+          />
+          <TablePagination
+            component="div"
+            count={totalElements}
+            page={page}
+            onPageChange={(_event, newPage) => setPage(newPage)}
+            rowsPerPage={size}
+            onRowsPerPageChange={(event) => {
+              const newSize = parseInt(event.target.value, 10);
+              setSize(newSize);
+              setPage(0);
+            }}
+            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+            labelRowsPerPage="Users per page"
+          />
+        </Box>
       )}
       <AppDialog
         open={dialogOpen}


### PR DESCRIPTION
## Summary

`GET /admin/users` returned an unbounded `array<UserDto>`. Past a few hundred users (LDAP / OIDC mass-provisioning) this loads the entire `plugwerk_user` table into the heap, serialises it, and pins a request thread for the duration of the fetch. This PR applies the established `PluginPagedResponse`-style pattern 1:1 to the user list — backend, OpenAPI, both frontend consumers.

## Closes

- #485

## Diff

```
plugwerk-api/.../openapi/plugwerk-api.yaml          | 67 ++++++++--
AdminUserController.kt                              | 67 +++++++++--
UserRepository.kt                                   |  4 +-
UserService.kt                                      | 19 ++-
AdminUserControllerTest.kt                          | 143 +++++++++++++++-----  (incl. 3 new pagination tests)
OidcWebLoginIT.kt                                   |  4 +-  (test cleanup adapt)
MembersSection.test.tsx                             | 36 +++--
MembersSection.tsx                                  | 14 +-
UsersSection.test.tsx                               |  8 +-
UsersSection.tsx                                    | 68 ++++++++--
10 files changed, 357 insertions(+), 73 deletions(-)
```

## Breaking change

`GET /admin/users` response shape changes from `array<UserDto>` to `UserPagedResponse` (`content`, `totalElements`, `page`, `size`, `totalPages`). Two internal frontend callers updated in this PR; no known external consumers (Phase 2 alpha).

## Backend

- `UserRepository`: `findAllByEnabled(Boolean) -> findAllByEnabled(Boolean, Pageable)`. `findAll(Pageable)` is inherited from `PagingAndSortingRepository`.
- `UserService`: `findAll(Pageable)` and `findAllByEnabled(Boolean, Pageable)`. Unbounded variants gone. Kdoc records the rationale and points future bulk-export needs to a dedicated entry point rather than `Pageable.unpaged()`.
- `AdminUserController.listUsers`:
  - Takes `page`/`size`/`sort` and an `enabled` filter
  - Builds `UserPagedResponse` from `Page<UserEntity>`
  - Validates the sort field against an explicit whitelist (`username|email|createdAt|lastLoginAt`); the OpenAPI regex is the first line of defence, the controller's `parsePageable` is the second for any caller bypassing the generated layer
  - Returns `400` for invalid sort
  - The EXTERNAL-user-provider-name lookup (#412) operates on `page.content`, preserving the batched single-query semantic

## OpenAPI

- New `UserPagedResponse` schema (mirror of `PluginPagedResponse`)
- `/admin/users` references `PageQuery` / `SizeQuery`, plus a `sort` parameter with regex `^(username|email|createdAt|lastLoginAt),(asc|desc)$`
- Response shape now `UserPagedResponse`

## Tests (backend)

Existing `AdminUserControllerTest` cases updated to the new `Page<UserEntity>` mocks and `\$.content[...]` response shape. **Three new tests** pin the pagination contract:

1. `GET admin users returns paged subset when total exceeds page size` — 200-user dataset, request page 0 size 20 → 20 entries + `totalElements=200`/`totalPages=10`
2. `GET admin users with valid sort passes Sort to service and rejects invalid sort with 400` — captures the `Pageable` to assert `Sort` direction; asserts 400 on `?sort=password,asc`
3. `GET admin users combines enabled filter with custom page and size` — `?enabled=false&page=1&size=10` ends up as `findAllByEnabled(false, PageRequest(1, 10))`

`OidcWebLoginIT` cleanup adapts away from `findAllByEnabled` (test cleanup only, uses `repository.findAll()` with a client-side filter — no production impact).

## Frontend

- **`UsersSection.tsx`**: state for `page`/`size`/`sort` plus MUI `TablePagination` footer. Refetch on state change. Mutations (`create`/`delete`) refresh from the server so `totalElements`/`totalPages` stay accurate; `toggleEnabled` stays optimistic because the row stays on the same page.
- **`MembersSection.tsx`**: the add-member picker wants every eligible candidate at once for client-side search. Until a dedicated `/admin/users/search` endpoint lands ([tracked in #492](https://github.com/plugwerk/plugwerk/issues/492)), the picker fetches the first 100 users with a `TODO(#492)` reference. This is a known limitation for deployments past 100 users; current Plugwerk deployments are well below that threshold.
- Both component test files updated to the new paged response shape via a small `pagedUsers()` helper.

## Follow-up

[#492](https://github.com/plugwerk/plugwerk/issues/492) — server-side user search endpoint to replace the `MembersSection` 100-cap.

## Local verification

```
./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck   # green
./gradlew :plugwerk-server:plugwerk-server-backend:test            # green
./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest # green
npm run test:run                                                   # 416/416 green
npm run build                                                      # green
```

## Type of Change

- [x] Bug fix (scalability hardening)
- [x] Refactoring
- [x] Documentation (OpenAPI spec; service/controller kdoc)

## Checklist

- [x] Tests pass locally (4 CI gates)
- [x] Documentation updated (OpenAPI + kdoc)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit \`rollback:\` block — N/A, no schema changes
- [x] CLA signed

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)