### PR TITLE
feat(admin): server-side user search via q parameter

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -1358,6 +1358,21 @@ paths:
           description: Filter by enabled state. When omitted, every user matching the page is returned.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: |
+            Case-insensitive substring search across `username`, `displayName`,
+            and `email` (OR-joined). SQL wildcard characters (`%`, `_`, `\`)
+            in the input are escaped and matched literally. Empty or omitted
+            means "no text filter" — the unfiltered page is returned. Combines
+            with `enabled`, `page`, `size`, `sort`. Introduced in #492 to
+            replace the client-side 100-cap notnagel in the namespace
+            member-add picker.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
         - $ref: '#/components/parameters/PageQuery'
         - $ref: '#/components/parameters/SizeQuery'
         - name: sort

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminUserController.kt
@@ -55,7 +55,13 @@ class AdminUserController(
     private val log = LoggerFactory.getLogger(AdminUserController::class.java)
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
-    override fun listUsers(enabled: Boolean?, page: Int, size: Int, sort: String): ResponseEntity<UserPagedResponse> {
+    override fun listUsers(
+        enabled: Boolean?,
+        q: String?,
+        page: Int,
+        size: Int,
+        sort: String,
+    ): ResponseEntity<UserPagedResponse> {
         val auth = currentAuthentication()
         namespaceAuthorizationService.requireSuperadmin(auth)
 
@@ -66,11 +72,10 @@ class AdminUserController(
         // close to the call site for grep-ability.
         val pageable = parsePageable(page, size, sort)
 
-        val pageResult = if (enabled != null) {
-            userService.findAllByEnabled(enabled, pageable)
-        } else {
-            userService.findAll(pageable)
-        }
+        // userService.search routes to the unfiltered or enabled-filtered
+        // page when q is blank/null, so a single call covers all four
+        // (q, enabled) combinations without branching here. See #492.
+        val pageResult = userService.search(q, enabled, pageable)
         val pageContent = pageResult.content
 
         // Single batched lookup for the EXTERNAL subset's provider names so

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/UserRepository.kt
@@ -59,6 +59,40 @@ interface UserRepository : JpaRepository<UserEntity, UUID> {
     fun findAllByEnabled(enabled: Boolean, pageable: Pageable): Page<UserEntity>
 
     /**
+     * Case-insensitive substring search across `username`, `displayName`,
+     * and `email` (OR-joined), optionally filtered by `enabled` (#492).
+     *
+     * The caller must escape SQL wildcard chars (`%`, `_`, `\`) in the raw
+     * input before assembling [pattern], and wrap the result with `%…%`. The
+     * `ESCAPE '\'` clause makes the backslash the escape character so a
+     * literal `100%user` query matches only the user containing `100%user`,
+     * not anything containing `100<anything>user`.
+     *
+     * `COALESCE(field, '')` is necessary because `displayName` and `email`
+     * are nullable on EXTERNAL identities; `LIKE` against `NULL` evaluates
+     * to `UNKNOWN` and would wipe out the entire OR chain for that row.
+     *
+     * Portability: tested against Postgres (production) and H2 (tests).
+     * `LOWER(...) LIKE LOWER(...)` is the canonical lower-case-fold pattern
+     * supported by both. `pg_trgm` GIN index would be the next step if
+     * sequential-scan latency becomes problematic — out of scope for #492.
+     */
+    @Query(
+        """
+        SELECT u FROM UserEntity u
+        WHERE (:enabled IS NULL OR u.enabled = :enabled)
+          AND (LOWER(u.username) LIKE LOWER(:pattern) ESCAPE '\'
+               OR LOWER(COALESCE(u.displayName, '')) LIKE LOWER(:pattern) ESCAPE '\'
+               OR LOWER(COALESCE(u.email, '')) LIKE LOWER(:pattern) ESCAPE '\')
+        """,
+    )
+    fun searchByText(
+        @Param("pattern") pattern: String,
+        @Param("enabled") enabled: Boolean?,
+        pageable: Pageable,
+    ): Page<UserEntity>
+
+    /**
      * Username-or-email lookup scoped to a single [source]. Used by the
      * password-reset flow (#421): the user can submit either their
      * username or their email and we look both up against the same row,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/UserService.kt
@@ -59,6 +59,35 @@ class UserService(
     fun findAllByEnabled(enabled: Boolean, pageable: Pageable): Page<UserEntity> =
         userRepository.findAllByEnabled(enabled, pageable)
 
+    /**
+     * Case-insensitive substring search over `username`, `displayName`,
+     * `email`, optionally filtered by [enabled] (#492).
+     *
+     * Empty/blank [q] short-circuits to the unfiltered list — same effect as
+     * not passing `q` at all. SQL wildcards (`%`, `_`, `\`) in the input are
+     * escaped before reaching the DB so a search for `"100%user"` matches the
+     * literal substring rather than treating `%` as "match anything". The
+     * escape order matters: backslash first, then the wildcards, otherwise
+     * the wildcard escapes would themselves be re-escaped.
+     */
+    @Transactional(readOnly = true)
+    fun search(q: String?, enabled: Boolean?, pageable: Pageable): Page<UserEntity> {
+        val trimmed = q?.trim()
+        if (trimmed.isNullOrEmpty()) {
+            return if (enabled != null) {
+                findAllByEnabled(enabled, pageable)
+            } else {
+                findAll(pageable)
+            }
+        }
+        val escaped = trimmed
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        val pattern = "%$escaped%"
+        return userRepository.searchByText(pattern, enabled, pageable)
+    }
+
     @Transactional(readOnly = true)
     fun findById(id: UUID): UserEntity =
         userRepository.findById(id).orElseThrow { EntityNotFoundException("User", id.toString()) }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminUserControllerTest.kt
@@ -162,7 +162,7 @@ class AdminUserControllerTest {
     @Test
     fun `GET admin users returns paginated content`() {
         val user = stubUser()
-        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(user)))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(listOf(user)))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
@@ -178,7 +178,7 @@ class AdminUserControllerTest {
     @Test
     fun `GET admin users with enabled=true returns only enabled users`() {
         val enabledUser = stubUser("alice", enabled = true)
-        whenever(userService.findAllByEnabled(eq(true), any())).thenReturn(pageOf(listOf(enabledUser)))
+        whenever(userService.search(eq(null), eq(true), any())).thenReturn(pageOf(listOf(enabledUser)))
 
         mockMvc.get("/api/v1/admin/users?enabled=true").andExpect {
             status { isOk() }
@@ -191,7 +191,7 @@ class AdminUserControllerTest {
     @Test
     fun `GET admin users with enabled=false returns only disabled users`() {
         val disabledUser = stubUser("bob", enabled = false)
-        whenever(userService.findAllByEnabled(eq(false), any())).thenReturn(pageOf(listOf(disabledUser)))
+        whenever(userService.search(eq(null), eq(false), any())).thenReturn(pageOf(listOf(disabledUser)))
 
         mockMvc.get("/api/v1/admin/users?enabled=false").andExpect {
             status { isOk() }
@@ -204,7 +204,7 @@ class AdminUserControllerTest {
     @Test
     fun `GET admin users without enabled param returns the unfiltered page`() {
         val users = listOf(stubUser("alice", enabled = true), stubUser("bob", enabled = false))
-        whenever(userService.findAll(any())).thenReturn(pageOf(users))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(users))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
@@ -214,7 +214,7 @@ class AdminUserControllerTest {
 
     @Test
     fun `GET admin users returns empty page when no users`() {
-        whenever(userService.findAll(any())).thenReturn(pageOf(emptyList()))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(emptyList()))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
@@ -231,7 +231,7 @@ class AdminUserControllerTest {
         // from different providers. The lookup is one batched call; this test
         // pins the wiring end-to-end (controller → repository → DTO).
         val external = stubExternalUser("Alice Schmidt")
-        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(external)))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(listOf(external)))
         whenever(oidcIdentityRepository.findProviderNamesForUsers(listOf(external.id!!)))
             .thenReturn(listOf(providerProjection(external.id!!, "Company Keycloak")))
 
@@ -247,7 +247,7 @@ class AdminUserControllerTest {
         // INTERNAL users always return providerName = null. The controller
         // must NOT include their ids in the batched lookup.
         val internal = stubUser("alice")
-        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(internal)))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(listOf(internal)))
 
         mockMvc.get("/api/v1/admin/users").andExpect {
             status { isOk() }
@@ -262,7 +262,7 @@ class AdminUserControllerTest {
         // Performance regression guard — passing an empty `IN (…)` collection
         // is a JDBC dialect minefield, and the round-trip is wasted anyway.
         // The controller short-circuits; this test locks that behaviour.
-        whenever(userService.findAll(any())).thenReturn(
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(
             pageOf(listOf(stubUser("alice"), stubUser("bob"))),
         )
 
@@ -282,7 +282,7 @@ class AdminUserControllerTest {
         // page metadata. Without pagination the response would be 200 items.
         val twentyUsers = (1..20).map { stubUser("user-$it") }
         val backingPage = PageImpl(twentyUsers, PageRequest.of(0, 20, Sort.by("username").ascending()), 200L)
-        whenever(userService.findAll(any())).thenReturn(backingPage)
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(backingPage)
 
         mockMvc.get("/api/v1/admin/users?page=0&size=20").andExpect {
             status { isOk() }
@@ -297,12 +297,12 @@ class AdminUserControllerTest {
     @Test
     fun `GET admin users with valid sort passes Sort to service and rejects invalid sort with 400`() {
         // Valid sort: passes through and ends up on the Pageable.
-        whenever(userService.findAll(any())).thenReturn(pageOf(emptyList()))
+        whenever(userService.search(eq(null), eq(null), any())).thenReturn(pageOf(emptyList()))
         mockMvc.get("/api/v1/admin/users?sort=email,desc").andExpect {
             status { isOk() }
         }
         val pageableCaptor = argumentCaptor<Pageable>()
-        verify(userService).findAll(pageableCaptor.capture())
+        verify(userService).search(eq(null), eq(null), pageableCaptor.capture())
         val sort = pageableCaptor.firstValue.sort.toList().single()
         assert(sort.property == "email")
         assert(sort.direction == Sort.Direction.DESC)
@@ -317,7 +317,7 @@ class AdminUserControllerTest {
 
     @Test
     fun `GET admin users combines enabled filter with custom page and size`() {
-        whenever(userService.findAllByEnabled(eq(false), any()))
+        whenever(userService.search(eq(null), eq(false), any()))
             .thenReturn(pageOf(emptyList()))
 
         mockMvc.get("/api/v1/admin/users?enabled=false&page=1&size=10").andExpect {
@@ -325,10 +325,39 @@ class AdminUserControllerTest {
         }
 
         val pageableCaptor = argumentCaptor<Pageable>()
-        verify(userService).findAllByEnabled(eq(false), pageableCaptor.capture())
+        verify(userService).search(eq(null), eq(false), pageableCaptor.capture())
         val captured = pageableCaptor.firstValue
         assert(captured.pageNumber == 1)
         assert(captured.pageSize == 10)
+    }
+
+    // ---- Text-search tests (#492) -----------------------------------------
+
+    @Test
+    fun `GET admin users with q passes the query string through to the service`() {
+        // The controller is a thin pass-through for q; routing decisions
+        // (escape, blank → unfiltered) live in UserService.search itself
+        // and are unit-tested at the service layer where they belong. The
+        // controller test confirms only that the parameter survives the
+        // wire boundary.
+        whenever(userService.search(eq("alice"), eq(null), any())).thenReturn(pageOf(emptyList()))
+
+        mockMvc.get("/api/v1/admin/users?q=alice").andExpect {
+            status { isOk() }
+        }
+
+        verify(userService).search(eq("alice"), eq(null), any())
+    }
+
+    @Test
+    fun `GET admin users combines q with enabled filter`() {
+        whenever(userService.search(eq("zoe"), eq(true), any())).thenReturn(pageOf(emptyList()))
+
+        mockMvc.get("/api/v1/admin/users?q=zoe&enabled=true").andExpect {
+            status { isOk() }
+        }
+
+        verify(userService).search(eq("zoe"), eq(true), any())
     }
 
     @Test
@@ -339,7 +368,9 @@ class AdminUserControllerTest {
         val internal = stubUser("admin")
         val externalA = stubExternalUser("Alice Schmidt")
         val externalB = stubExternalUser("Bob Jones")
-        whenever(userService.findAll(any())).thenReturn(pageOf(listOf(internal, externalA, externalB)))
+        whenever(
+            userService.search(eq(null), eq(null), any()),
+        ).thenReturn(pageOf(listOf(internal, externalA, externalB)))
         whenever(
             oidcIdentityRepository.findProviderNamesForUsers(
                 listOf(externalA.id!!, externalB.id!!),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/UserServiceTest.kt
@@ -165,4 +165,96 @@ class UserServiceTest {
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("OIDC-sourced")
     }
+
+    // ---- Text search (#492) -----------------------------------------------
+
+    @Test
+    fun `search returns the unfiltered page when q is blank or null`() {
+        // q=null and q="   " must behave identically to no search at all —
+        // routes to findAll/findAllByEnabled directly, no LIKE query.
+        repeat(3) { i -> service.create("user-$i", "user-$i@example.com", "password12345") }
+
+        val nullQ = service.search(q = null, enabled = null, pageable = pageRequest())
+        val blankQ = service.search(q = "   ", enabled = null, pageable = pageRequest())
+
+        assertThat(nullQ.totalElements).isEqualTo(3)
+        assertThat(blankQ.totalElements).isEqualTo(3)
+    }
+
+    @Test
+    fun `search matches case-insensitively across username, displayName, and email`() {
+        // One user per searchable field. Each match query must hit exactly
+        // the user whose corresponding field contains the substring.
+        service.create("alice", "alice@example.com", "password12345", displayName = "Alice")
+        service.create("admin", "bob@example.com", "password12345", displayName = "Bob Builder")
+        service.create("carol", "carol+plugwerk@example.com", "password12345", displayName = "Carol")
+
+        // Hits username only (and case-insensitively).
+        val byUsername = service.search(q = "ALI", enabled = null, pageable = pageRequest())
+        assertThat(byUsername.content.map { it.username }).containsExactly("alice")
+
+        // Hits displayName only — `Bob Builder` is the displayName of the
+        // `admin` user, so the username column does not match `Builder`.
+        val byDisplayName = service.search(q = "builder", enabled = null, pageable = pageRequest())
+        assertThat(byDisplayName.content.map { it.username }).containsExactly("admin")
+
+        // Hits email only — `+plugwerk` is in the email of `carol` and not
+        // in their username or displayName.
+        val byEmail = service.search(q = "+plugwerk", enabled = null, pageable = pageRequest())
+        assertThat(byEmail.content.map { it.username }).containsExactly("carol")
+    }
+
+    @Test
+    fun `search combines q with enabled filter`() {
+        // Two users contain "test" in the username; one is enabled, one
+        // disabled. q + enabled=true returns only the enabled match.
+        val enabled = service.create("test-enabled", "te@example.com", "password12345")
+        val disabled = service.create("test-disabled", "td@example.com", "password12345")
+        // Disable one through the entity directly.
+        disabled.enabled = false
+        userRepository.save(disabled)
+
+        val onlyEnabled = service.search(q = "test", enabled = true, pageable = pageRequest())
+
+        assertThat(onlyEnabled.content.map { it.id })
+            .containsExactly(requireNotNull(enabled.id))
+    }
+
+    @Test
+    fun `search escapes SQL wildcard chars in q so percent and underscore are literal`() {
+        // Three users whose names contain literal SQL wildcards. A search
+        // for "100%" must match only the literal `100%user` row, not the
+        // `alice` row (which would match if `%` were treated as a wildcard).
+        service.create("alice", "alice@example.com", "password12345")
+        service.create("a_b", "a_b@example.com", "password12345")
+        // The literal "%" cannot live in a username (validation blocks it).
+        // Use displayName to carry the wildcard for this test.
+        val pctUser = service.create("pctuser", "pct@example.com", "password12345", displayName = "100%user")
+
+        val pct = service.search(q = "100%", enabled = null, pageable = pageRequest())
+        assertThat(pct.content.map { it.id }).containsExactly(requireNotNull(pctUser.id))
+
+        val underscore = service.search(q = "_", enabled = null, pageable = pageRequest())
+        assertThat(underscore.content.map { it.username }).containsExactly("a_b")
+    }
+
+    @Test
+    fun `search handles a result set larger than 100 users (issue #492 reproduce)`() {
+        // The 100-cap notnagel that #492 removes assumed nobody would
+        // exceed 100 users. Seed 150 and assert that searches actually
+        // reach users at indices 100+.
+        repeat(150) { i ->
+            service.create("user-${"%03d".format(i)}", "u$i@example.com", "password12345")
+        }
+
+        // user-149 lives well past index 100. Without server-side search
+        // (the old client-side filter on the first 100 results) it would
+        // be invisible. The pagination return path proves it is reachable.
+        val tail = service.search(q = "user-149", enabled = null, pageable = pageRequest())
+
+        assertThat(tail.totalElements).isEqualTo(1)
+        assertThat(tail.content.single().username).isEqualTo("user-149")
+    }
+
+    private fun pageRequest() = org.springframework.data.domain.PageRequest.of(0, 50)
 }

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -235,23 +235,34 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
   it("Autocomplete free-text search does NOT match the provider-name suffix", async () => {
     // Issue #412 invariant: the provider hint is decorative. Typing the
     // provider name must not surface every user from that provider.
-    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
-      data: pagedUsers([
-        userDto({
-          displayName: "Alice Schmidt",
-          source: "EXTERNAL",
-          username: undefined,
-          providerName: "Google",
-        }),
-        userDto({
-          displayName: "Diana Prince",
-          source: "INTERNAL",
-          username: "diana",
-        }),
-      ]),
-    } as unknown as Awaited<
-      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
-    >);
+    //
+    // After #492 search runs server-side, so this is now a contract on
+    // the SERVER's behaviour, not the client filter: the request goes out
+    // with `q="Google"`, and the server (which only matches against
+    // username/displayName/email) returns an empty page. The mock
+    // simulates that by branching on `q`.
+    const alice = userDto({
+      displayName: "Alice Schmidt",
+      source: "EXTERNAL",
+      username: undefined,
+      providerName: "Google",
+    });
+    const diana = userDto({
+      displayName: "Diana Prince",
+      source: "INTERNAL",
+      username: "diana",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockImplementation((req) => {
+      const q = (req as { q?: string } | undefined)?.q;
+      // The server only matches username/displayName/email — `Google` lives
+      // in `providerName`, not in any searchable column, so the search
+      // must come back empty. Without a query, the picker still wants the
+      // initial browse list.
+      const content = q?.toLowerCase().includes("google") ? [] : [alice, diana];
+      return Promise.resolve({
+        data: pagedUsers(content),
+      }) as unknown as ReturnType<typeof apiConfig.adminUsersApi.listUsers>;
+    });
 
     renderWithTheme(<MembersSection slug="ns-1" />);
     const { user, dialog } = await openAddMemberDialog();
@@ -260,9 +271,8 @@ describe("MembersSection — add-member user picker (issue #412)", () => {
     await user.click(input);
     await user.type(input, "Google");
 
-    // If the filter were leaking the provider suffix, Alice would still
-    // appear. The createFilterOptions stringify only sees displayName +
-    // username, so "Google" matches nothing.
+    // Server returned empty for "Google" → Alice does not appear in the
+    // picker even though her decorative label contains the word.
     await waitFor(() => {
       expect(
         screen.queryByText("Alice Schmidt (Google)"),

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.tsx
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useDebouncedValue } from "../../../hooks/useDebouncedValue";
 import {
   Box,
   Typography,
@@ -29,7 +30,6 @@ import {
   InputLabel,
   Autocomplete,
   TextField,
-  createFilterOptions,
 } from "@mui/material";
 import { Plus, Trash2 } from "lucide-react";
 import { AppDialog } from "../../common/AppDialog";
@@ -94,15 +94,6 @@ function buildUserOptionLabel(user: UserDto): string {
   return user.displayName;
 }
 
-/**
- * Autocomplete filter that matches the user's typed query against
- * `displayName` + `username` only — never the visible label, which carries
- * the decorative provider-name suffix for EXTERNAL users (issue #412).
- */
-const filterUserOptions = createFilterOptions<UserOption>({
-  stringify: (option) => option.searchKey,
-});
-
 export function MembersSection({ slug }: { slug: string }) {
   const addToast = useUiStore((s) => s.addToast);
   const queryClient = useQueryClient();
@@ -120,6 +111,15 @@ export function MembersSection({ slug }: { slug: string }) {
   const [addSaving, setAddSaving] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
   const [userOptions, setUserOptions] = useState<UserOption[]>([]);
+  const [searchInput, setSearchInput] = useState("");
+  const [searchLoading, setSearchLoading] = useState(false);
+  // Debounce 250ms so a fast typist does not fan out one request per
+  // keystroke. The min-length gate (2 chars) is below in the effect.
+  const [debouncedSearch] = useDebouncedValue(searchInput, 250);
+  // Cancel in-flight requests when the user keeps typing — without this a
+  // slow `q="al"` response can land after the fast `q="alice"` response
+  // and ghost-replace the correct results.
+  const searchAbortRef = useRef<AbortController | null>(null);
 
   const loadMembers = useCallback(async () => {
     setLoading(true);
@@ -138,20 +138,31 @@ export function MembersSection({ slug }: { slug: string }) {
   }, [loadMembers]);
 
   useEffect(() => {
-    if (!addOpen) return;
+    if (!addOpen) {
+      // Reset state when the dialog closes so a re-open starts fresh —
+      // avoids showing stale results from a previous session.
+      setSearchInput("");
+      setUserOptions([]);
+      return;
+    }
     async function loadUsers() {
+      // Cancel any prior in-flight request. Latest-wins semantics.
+      searchAbortRef.current?.abort();
+      const controller = new AbortController();
+      searchAbortRef.current = controller;
+
+      // Empty / 1-char input: still fetch the first page so the picker is
+      // usable on initial open without typing. Server-side search kicks in
+      // at >= 2 chars to avoid noisy result sets from single letters.
+      const q =
+        debouncedSearch.trim().length >= 2 ? debouncedSearch.trim() : undefined;
+      setSearchLoading(true);
       try {
-        // Pagination on /admin/users became mandatory in #485. The
-        // add-member dropdown wants every eligible candidate at once for
-        // client-side search, so we ask for the maximum page size (100)
-        // until a dedicated server-side user-search endpoint exists.
-        // TODO(#492): replace with the dedicated /admin/users/search
-        // endpoint once it lands. The 100-cap holds for current
-        // deployments; #492 tracks the proper fix.
-        const res = await adminUsersApi.listUsers({
-          enabled: true,
-          size: 100,
-        });
+        const res = await adminUsersApi.listUsers(
+          { enabled: true, q, size: 50 },
+          { signal: controller.signal },
+        );
+        if (controller.signal.aborted) return;
         const existing = new Set(members.map((m) => m.userId));
         setUserOptions(
           res.data.content
@@ -162,12 +173,24 @@ export function MembersSection({ slug }: { slug: string }) {
               searchKey: `${u.displayName} ${u.username ?? ""}`.trim(),
             })),
         );
-      } catch {
-        setUserOptions([]);
+      } catch (err) {
+        // axios cancels surface as `CanceledError` (or `AbortError` on
+        // older runtimes). Either is silent — only real failures should
+        // empty the option list.
+        const isCancel =
+          (err as { code?: string })?.code === "ERR_CANCELED" ||
+          (err as { name?: string })?.name === "AbortError" ||
+          (err as { name?: string })?.name === "CanceledError";
+        if (!isCancel) setUserOptions([]);
+      } finally {
+        if (!controller.signal.aborted) setSearchLoading(false);
       }
     }
     loadUsers();
-  }, [addOpen, members]);
+    return () => {
+      searchAbortRef.current?.abort();
+    };
+  }, [addOpen, debouncedSearch, members]);
 
   function invalidateRoleCache() {
     // A role change for the current user must be reflected in every
@@ -481,9 +504,16 @@ export function MembersSection({ slug }: { slug: string }) {
             options={userOptions}
             value={newUsers}
             onChange={(_, value) => setNewUsers(value)}
+            inputValue={searchInput}
+            onInputChange={(_, value) => setSearchInput(value)}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(a, b) => a.userId === b.userId}
-            filterOptions={filterUserOptions}
+            // Server-side search (#492). Identity filter so MUI does NOT
+            // re-filter the already-server-filtered options — a default
+            // client-side filter would drop legitimate hits whose label
+            // does not literally match the input string.
+            filterOptions={(x) => x}
+            loading={searchLoading}
             // Keep the option list open after a selection so picking
             // multiple users in a row stays a single fluid interaction.
             disableCloseOnSelect


### PR DESCRIPTION
## Summary

Replaces the `TODO(#492)` 100-cap notnagel from #485 with real server-side user search. `GET /admin/users` gains an optional `q` query parameter; `MembersSection.tsx` migrates from "fetch first 100 + client-side filter" to "debounced search-as-you-type with AbortController-based race-cancellation".

## Closes

- #492

## Why this PR exists

In #485 we made pagination on `/admin/users` mandatory, but the namespace member-add picker (`MembersSection`) needs every eligible candidate at once for client-side search. The interim notnagel was `size=100` — works for current deployments, breaks the moment a deployment crosses 100 users (rank-101 silently invisible).

This PR removes the cap by moving the search to the server.

## Diff

```
plugwerk-api/.../openapi/plugwerk-api.yaml          | 15 ++  (q parameter)
AdminUserController.kt                              | 17 ++/--  (delegate to userService.search)
UserRepository.kt                                   | 34 ++  (searchByText @Query)
UserService.kt                                      | 29 ++  (escape + route)
AdminUserControllerTest.kt                          | 59 ++/--  (mock route + 2 new q tests)
UserServiceTest.kt                                  | 92 ++  (5 new tests against H2)
MembersSection.test.tsx                             | 50 ++/--  (mock now branches on q)
MembersSection.tsx                                  | 84 ++/--  (debounced search-as-you-type)
8 files changed, 313 insertions(+), 67 deletions(-)
```

## API change

`GET /admin/users` accepts a new optional `q` (`minLength: 1`, `maxLength: 200`). Backward compatible — omitting it returns the same unfiltered page as before. Combines with `enabled`, `page`, `size`, `sort`.

## Backend

- **Repository**: `searchByText` is an explicit `@Query` with `OR` over `username`, `displayName`, `email`. `COALESCE(field, '')` because `displayName` and `email` are nullable on EXTERNAL identities (a `LIKE` against `NULL` evaluates to `UNKNOWN` and would wipe out the OR chain). `ESCAPE '\\'` clause so wildcard chars in user input match literally. Portable across Postgres (production) and H2 (tests) via `LOWER(...) LIKE LOWER(...)`.
- **Service**: `search(q, enabled, pageable)` routes blank/null `q` to the existing unfiltered path so a single call covers all `(q, enabled)` combinations. Escapes `\`, `%`, `_` in the user input — escape order matters (backslash first or the other escapes get re-escaped).
- **Controller**: thin pass-through, delegates to `userService.search`.

## Frontend

- `useDebouncedValue(searchInput, 250)` so a fast typist does not fan out one request per keystroke.
- `useRef<AbortController>` cancels in-flight requests when the user keeps typing — without this a slow `q="al"` response can land after the fast `q="alice"` response and ghost-replace the correct results.
- Min 2 chars before issuing a search. 0-1 chars fetch the first 50 users so the picker is usable on initial dialog open without typing.
- `filterOptions={(x) => x}` on the `Autocomplete` — without this MUI re-filters the already-server-filtered options client-side, which would drop legitimate hits whose label does not literally match the input.
- `TODO(#492)` comment removed.

## Out of scope (deliberately)

- **`pg_trgm` GIN index.** Sequential scan is fine for current Plugwerk deployments (sub-1k users). When p95 latency on `/admin/users?q=...` becomes a concern, a separate Liquibase migration can enable the extension and add the index without touching the query. Decision recorded in the kdoc.

## Tests

| Layer | Test | What it pins |
| --- | --- | --- |
| Backend (UserServiceTest, real H2) | `search returns the unfiltered page when q is blank or null` | Routing fallback |
| Backend (UserServiceTest, real H2) | `search matches case-insensitively across username, displayName, and email` | OR-over-three-fields contract |
| Backend (UserServiceTest, real H2) | `search combines q with enabled filter` | `(q, enabled)` combo |
| Backend (UserServiceTest, real H2) | `search escapes SQL wildcard chars in q so percent and underscore are literal` | Escape-bug regression guard |
| Backend (UserServiceTest, real H2) | `search handles a result set larger than 100 users (issue #492 reproduce)` | The whole point of #492 — user-149 is reachable |
| Backend (AdminUserControllerTest) | `GET admin users with q passes the query string through to the service` | Controller pass-through |
| Backend (AdminUserControllerTest) | `GET admin users combines q with enabled filter` | Same with enabled param |
| Frontend (MembersSection.test.tsx) | rewritten provider-name-not-searchable test | Same #412 invariant, now expressed against the server-side contract |

## Local verification

```
./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck   # green
./gradlew :plugwerk-server:plugwerk-server-backend:test            # green
./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest # green
npm run format:check                                               # green
npm run test:run                                                   # 416/416 green
npm run build                                                      # green
```

## Type of Change

- [x] New feature (server-side search endpoint)
- [x] Bug fix (closes the 100-cap visibility gap)

## Checklist

- [x] Tests pass locally (5 new backend tests + 2 new controller tests + 1 rewritten frontend test)
- [x] Documentation updated (OpenAPI description + kdoc on UserService.search)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit \`rollback:\` block — N/A, no schema changes
- [x] CLA signed

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)