### PR TITLE
fix(catalog): pick deterministic latest release per plugin

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -114,23 +114,45 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
     fun sumDownloadCountsByPluginIds(@Param("pluginIds") pluginIds: Collection<UUID>): List<Array<Any>>
 
     /**
-     * Returns the full latest published release entity per plugin for a given set of plugin IDs.
-     * Replaces the three individual queries for version, draft version, and artifact size.
-     * One DB round-trip for the entire page.
+     * Returns the latest PUBLISHED release per plugin for the given set of
+     * plugin IDs. One DB round-trip for the entire page.
+     *
+     * **Tiebreaker (#482)**: when two releases of the same plugin share the
+     * same `created_at` (rapid CI imports, batched API calls, or any other
+     * sub-millisecond burst that the JVM clock cannot resolve), we want a
+     * **deterministic** winner so the catalog shows the same "latest
+     * version" on every read. The previous JPQL formulation
+     * (`r.createdAt = (SELECT MAX(r2.createdAt) ...)`) returned **both**
+     * tied rows, and `associateBy { plugin.id }` at the call site collapsed
+     * them implementation-defined-last-wins. Catalog "latest" therefore
+     * flickered between versions on identical inputs.
+     *
+     * The window-function variant below partitions by `plugin_id`, sorts
+     * each partition by `created_at DESC, id DESC`, and keeps the first
+     * row. `id` is a UUIDv7 so it carries time-ordering past the
+     * timestamp's resolution — `id DESC` semantically continues "later
+     * wins" past the millisecond precision boundary.
+     *
+     * Native query because JPQL does not support window functions
+     * portably across Hibernate versions. Postgres (production) and H2 in
+     * default mode (tests) both implement `ROW_NUMBER() OVER (PARTITION BY)`
+     * to ANSI SQL spec; no DB-specific syntax escapes the wrapper.
      */
     @Query(
-        """
-        SELECT r
-        FROM PluginReleaseEntity r
-        WHERE r.plugin.id IN :pluginIds
-          AND r.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
-          AND r.createdAt = (
-            SELECT MAX(r2.createdAt)
-            FROM PluginReleaseEntity r2
-            WHERE r2.plugin.id = r.plugin.id
-              AND r2.status = io.plugwerk.spi.model.ReleaseStatus.PUBLISHED
-          )
+        value = """
+        SELECT pr.* FROM (
+          SELECT inner_pr.*,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY plugin_id
+                   ORDER BY created_at DESC, id DESC
+                 ) AS rn
+          FROM plugin_release inner_pr
+          WHERE inner_pr.plugin_id IN (:pluginIds)
+            AND inner_pr.status = 'PUBLISHED'
+        ) pr
+        WHERE pr.rn = 1
         """,
+        nativeQuery = true,
     )
     fun findLatestPublishedReleasesForPlugins(
         @Param("pluginIds") pluginIds: Collection<UUID>,

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/PluginReleaseRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/repository/PluginReleaseRepositoryTest.kt
@@ -23,11 +23,14 @@ import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.spi.model.ReleaseStatus
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import kotlin.test.assertFailsWith
 
 open class PluginReleaseRepositoryTest : AbstractRepositoryTest() {
@@ -40,6 +43,9 @@ open class PluginReleaseRepositoryTest : AbstractRepositoryTest() {
 
     @Autowired
     lateinit var releaseRepository: PluginReleaseRepository
+
+    @Autowired
+    lateinit var entityManager: EntityManager
 
     lateinit var plugin: PluginEntity
 
@@ -188,6 +194,72 @@ open class PluginReleaseRepositoryTest : AbstractRepositoryTest() {
                 ),
             )
         }
+    }
+
+    @Test
+    fun `findLatestPublishedReleasesForPlugins is deterministic on createdAt ties (#482)`() {
+        // Two PUBLISHED releases of the same plugin with EXACTLY the same
+        // created_at. Pre-fix the query's correlated MAX(createdAt) subquery
+        // returned both rows; the caller's associateBy { plugin.id } collapsed
+        // them to a single map entry whose winner is implementation-defined
+        // (Hibernate iteration order without an ORDER BY). The catalog's
+        // "latest version" therefore flickered between versions on every
+        // query — a non-deterministic read, not a missing-plugin one as the
+        // original issue body claimed.
+        //
+        // Post-fix: ROW_NUMBER() OVER (PARTITION BY plugin_id ORDER BY
+        // created_at DESC, id DESC) breaks the tie deterministically using
+        // id as the secondary sort. UUIDv7 is time-ordered, so id-DESC
+        // semantically continues "later wins" past the timestamp resolution.
+        val r1 = releaseRepository.save(
+            PluginReleaseEntity(
+                plugin = plugin,
+                version = "1.0.0",
+                artifactSha256 = "sha1",
+                artifactKey = "release-ns/my-plugin/1.0.0",
+                status = ReleaseStatus.PUBLISHED,
+            ),
+        )
+        val r2 = releaseRepository.save(
+            PluginReleaseEntity(
+                plugin = plugin,
+                version = "1.0.1",
+                artifactSha256 = "sha2",
+                artifactKey = "release-ns/my-plugin/1.0.1",
+                status = ReleaseStatus.PUBLISHED,
+            ),
+        )
+
+        // Force identical created_at via native UPDATE — @CreationTimestamp
+        // does not let us set the value at save time. flush()+clear() so the
+        // following findLatestPublishedReleasesForPlugins sees the rewritten
+        // values, not the stale persistence-context cache.
+        val tieTimestamp = OffsetDateTime.parse("2026-05-10T12:00:00Z")
+            .withOffsetSameInstant(ZoneOffset.UTC)
+        entityManager.createNativeQuery(
+            "UPDATE plugin_release SET created_at = :ts WHERE id IN (:r1, :r2)",
+        )
+            .setParameter("ts", tieTimestamp)
+            .setParameter("r1", r1.id)
+            .setParameter("r2", r2.id)
+            .executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+
+        // Run the query 50 times and assert it always returns exactly one
+        // row, always with the same id. Without the tiebreaker the result
+        // is at the mercy of the underlying row order; the deterministic
+        // ORDER BY id DESC always picks the higher UUID.
+        val winners = (1..50).map {
+            val result = releaseRepository.findLatestPublishedReleasesForPlugins(listOf(plugin.id!!))
+            assertThat(result).hasSize(1)
+            result.single().id
+        }.distinct()
+
+        assertThat(winners).hasSize(1)
+        // UUIDv7 ids are time-ordered, so the later-saved release (r2) has
+        // the higher id and must win the tiebreaker.
+        assertThat(winners.single()).isEqualTo(r2.id)
     }
 
     @Test


### PR DESCRIPTION
## Summary

`PluginReleaseRepository.findLatestPublishedReleasesForPlugins` returned every release tied on the highest `created_at`. The two callers collapse the result via `associateBy { plugin.id }`, so when two releases of the same plugin shared a `created_at` value (rapid CI imports, batched API calls, sub-millisecond JVM clock resolution), the winner was Hibernate-iteration-order — implementation-defined.

This PR rewrites the query to a window-function form that picks exactly one row per plugin with a deterministic tiebreaker.

## Closes

- #482

## Diagnostic correction

The original issue body framed this as **"plugins silently disappear from the PUBLIC catalog"**. That symptom is **incorrect** — a tie does not drop the plugin (both tied rows share the same `plugin.id`, one wins on the `associateBy`). The real symptom is **non-deterministic latest version**: catalog "latest" flickered between versions on identical inputs, and the version-compatibility filter ran on the lottery winner.

(Audit-trail consistency note, analogous to the corrective comment on #476: when the reviewer-supplied symptom does not match the verified code, the PR documents the corrected diagnosis rather than parroting the original.)

## Diff

```
PluginReleaseRepository.kt          | 50 ++/--  (correlated MAX subquery → native ROW_NUMBER window)
PluginReleaseRepositoryTest.kt      | 72 ++  (tie-reproduce test, RED pre-fix, GREEN post-fix)
2 files changed, 108 insertions(+), 14 deletions(-)
```

## The new query

```sql
SELECT pr.* FROM (
  SELECT inner_pr.*,
         ROW_NUMBER() OVER (
           PARTITION BY plugin_id
           ORDER BY created_at DESC, id DESC
         ) AS rn
  FROM plugin_release inner_pr
  WHERE inner_pr.plugin_id IN (:pluginIds)
    AND inner_pr.status = 'PUBLISHED'
) pr
WHERE pr.rn = 1
```

`PARTITION BY plugin_id` with `ORDER BY created_at DESC, id DESC` keeps exactly one row per plugin. UUIDv7 is time-ordered, so `id DESC` semantically continues "later wins" past the timestamp resolution boundary.

## Why native query

JPQL window-function support varies across Hibernate versions. `ROW_NUMBER() OVER (PARTITION BY)` is ANSI SQL and implemented identically in Postgres (production) and H2 (tests) — the native `@Query(nativeQuery = true)` is portable across both. Caller signatures (`fun findLatestPublishedReleasesForPlugins(pluginIds: Collection<UUID>): List<PluginReleaseEntity>`) are unchanged.

## Test (Lerneffekt #476: prove the bug, then fix)

`findLatestPublishedReleasesForPlugins is deterministic on createdAt ties (#482)` — added before the query change:

- Saves two PUBLISHED releases of the same plugin, then forces identical `created_at` via native UPDATE (because `@CreationTimestamp` does not let us set the value at save time).
- Runs the query 50 times, asserts the result is always exactly one row with the same id every time.
- Pre-fix: assertion fails — `result.hasSize(1)` blows up because the correlated MAX subquery returns both tied rows.
- Post-fix: passes deterministically; the higher UUID (later-saved release) wins via the `id DESC` tiebreaker.

## What does NOT change

- Method signature, return type, caller code paths.
- Result shape for the **untied** case — single latest release per plugin, identical to before.
- Performance for current catalog sizes (sub-100 plugins/namespace) is indistinguishable from the correlated subquery; window-function variants are typically `O(N log N)` instead of `O(N²)` worst-case, but at this scale it is irrelevant.

## Local verification

```
./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck   # green
./gradlew :plugwerk-server:plugwerk-server-backend:test            # green
./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest # green
```

## Type of Change

- [x] Bug fix (data integrity / catalog determinism)

## Checklist

- [x] Tests pass locally (3 CI gates)
- [x] Documentation updated (KDoc on the query explains the tiebreaker rationale and references #482)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit \`rollback:\` block — N/A, no schema changes

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Opus 4.7)