### PR TITLE
refactor(downloads): take release id in REQUIRES_NEW boundary (#484)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/DownloadEventService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/DownloadEventService.kt
@@ -19,14 +19,15 @@
 package io.plugwerk.server.service
 
 import io.plugwerk.server.domain.DownloadEventEntity
-import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.DownloadEventRepository
+import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.net.InetAddress
+import java.util.UUID
 
 /**
  * Records download events in the audit log table.
@@ -40,13 +41,24 @@ import java.net.InetAddress
 @Service
 class DownloadEventService(
     private val downloadEventRepository: DownloadEventRepository,
+    private val releaseRepository: PluginReleaseRepository,
     private val settingsService: ApplicationSettingsService,
 ) {
 
     private val log = LoggerFactory.getLogger(DownloadEventService::class.java)
 
+    /**
+     * Records one download event for the release identified by [releaseId].
+     *
+     * Takes the release **id** rather than the entity (#484) so the caller
+     * does not have to hand a managed entity across the `REQUIRES_NEW`
+     * transaction boundary. The `@ManyToOne` on `DownloadEventEntity.release`
+     * has no cascade and only writes the FK column, so a Hibernate
+     * proxy from [PluginReleaseRepository.getReferenceById] is sufficient
+     * — no extra `SELECT` round-trip is issued.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun record(release: PluginReleaseEntity, clientIp: String?, userAgent: String?) {
+    fun record(releaseId: UUID, clientIp: String?, userAgent: String?) {
         if (!settingsService.trackingEnabled()) return
 
         val ip = when {
@@ -59,7 +71,7 @@ class DownloadEventService(
 
         downloadEventRepository.save(
             DownloadEventEntity(
-                release = release,
+                release = releaseRepository.getReferenceById(releaseId),
                 clientIp = ip,
                 userAgent = agent,
             ),

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -112,7 +112,11 @@ class PluginReleaseService(
         releaseRepository.incrementDownloadCount(
             requireNotNull(release.id) { "PluginRelease has no persisted id" },
         )
-        downloadEventService.record(release, clientIp, userAgent)
+        downloadEventService.record(
+            requireNotNull(release.id) { "PluginRelease has no persisted id" },
+            clientIp,
+            userAgent,
+        )
         return stream
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import io.plugwerk.descriptor.PlugwerkDescriptor
 import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.repository.DownloadEventRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -100,6 +101,8 @@ class DownloadEventServiceIntegrationTest {
 
     @Autowired lateinit var descriptorResolver: DescriptorResolver
 
+    @Autowired lateinit var entityManager: EntityManager
+
     lateinit var testNamespace: io.plugwerk.server.domain.NamespaceEntity
 
     @BeforeEach
@@ -121,7 +124,7 @@ class DownloadEventServiceIntegrationTest {
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
         val release = releaseService.upload("dl-event-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
-        downloadEventService.record(release, "10.20.30.40", "curl/7.88")
+        downloadEventService.record(release.id!!, "10.20.30.40", "curl/7.88")
 
         val events = downloadEventRepository.findAll()
         assertThat(events).hasSize(1)
@@ -132,13 +135,36 @@ class DownloadEventServiceIntegrationTest {
     }
 
     @Test
+    fun `record needs only the release id, not a managed entity (#484)`() {
+        // The post-#484 signature takes a UUID instead of the entity, so the
+        // REQUIRES_NEW transaction owned by record() resolves the FK target
+        // through PluginReleaseRepository.getReferenceById in its own
+        // persistence context. Brute-force-detach everything before the call
+        // (entityManager.clear) so any code path that secretly depended on
+        // the caller's managed-entity state would surface here as either an
+        // org.hibernate.PersistentObjectException or a missing-FK row.
+        val descriptor = PlugwerkDescriptor(id = "lockdown-plugin", version = "1.0.0", name = "Lockdown Plugin")
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        val releaseId = releaseService
+            .upload("dl-event-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
+            .id!!
+        entityManager.clear()
+
+        downloadEventService.record(releaseId, "9.9.9.9", null)
+
+        val events = downloadEventRepository.findAll()
+        assertThat(events).hasSize(1)
+        assertThat(events[0].release.id).isEqualTo(releaseId)
+    }
+
+    @Test
     fun `cascade delete removes events when release is deleted`() {
         val descriptor = PlugwerkDescriptor(id = "cascade-plugin", version = "1.0.0", name = "Cascade Plugin")
         whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
         val release = releaseService.upload("dl-event-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
-        downloadEventService.record(release, "1.2.3.4", null)
-        downloadEventService.record(release, "5.6.7.8", null)
+        downloadEventService.record(release.id!!, "1.2.3.4", null)
+        downloadEventService.record(release.id!!, "5.6.7.8", null)
         assertThat(downloadEventRepository.findAll()).hasSize(2)
 
         releaseService.delete("dl-event-ns", "cascade-plugin", "1.0.0")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceTest.kt
@@ -23,6 +23,7 @@ import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.DownloadEventRepository
+import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -32,21 +33,25 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class DownloadEventServiceTest {
 
     private lateinit var downloadEventRepository: DownloadEventRepository
+    private lateinit var releaseRepository: PluginReleaseRepository
     private lateinit var service: DownloadEventService
 
     private val namespace = NamespaceEntity(slug = "acme", name = "ACME Corp")
     private val plugin = PluginEntity(namespace = namespace, pluginId = "my-plugin", name = "My Plugin")
+    private val releaseId: UUID = UUID.randomUUID()
     private val release = PluginReleaseEntity(
         plugin = plugin,
         version = "1.0.0",
@@ -71,14 +76,17 @@ class DownloadEventServiceTest {
     @BeforeEach
     fun setUp() {
         downloadEventRepository = mock()
-        service = DownloadEventService(downloadEventRepository, buildSettings())
+        releaseRepository = mock {
+            on { getReferenceById(releaseId) } doReturn release
+        }
+        service = DownloadEventService(downloadEventRepository, releaseRepository, buildSettings())
     }
 
     @Test
     fun `record saves event when tracking is enabled`() {
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, "192.168.1.42", "Mozilla/5.0")
+        service.record(releaseId, "192.168.1.42", "Mozilla/5.0")
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())
@@ -89,9 +97,9 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record does nothing when tracking is disabled`() {
-        service = DownloadEventService(downloadEventRepository, buildSettings(enabled = false))
+        service = DownloadEventService(downloadEventRepository, releaseRepository, buildSettings(enabled = false))
 
-        service.record(release, "192.168.1.42", "Mozilla/5.0")
+        service.record(releaseId, "192.168.1.42", "Mozilla/5.0")
 
         verify(downloadEventRepository, never()).save(any<DownloadEventEntity>())
     }
@@ -100,7 +108,7 @@ class DownloadEventServiceTest {
     fun `record anonymizes IPv4 to slash 24`() {
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, "10.20.30.40", null)
+        service.record(releaseId, "10.20.30.40", null)
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())
@@ -111,7 +119,7 @@ class DownloadEventServiceTest {
     fun `record anonymizes IPv6 to slash 48`() {
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, "2001:db8:85a3:1234:5678:abcd:ef01:2345", null)
+        service.record(releaseId, "2001:db8:85a3:1234:5678:abcd:ef01:2345", null)
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())
@@ -120,10 +128,10 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record stores raw IP when anonymization is disabled`() {
-        service = DownloadEventService(downloadEventRepository, buildSettings(anonymizeIp = false))
+        service = DownloadEventService(downloadEventRepository, releaseRepository, buildSettings(anonymizeIp = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, "192.168.1.42", null)
+        service.record(releaseId, "192.168.1.42", null)
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())
@@ -132,10 +140,10 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record nullifies IP when captureIp is false`() {
-        service = DownloadEventService(downloadEventRepository, buildSettings(captureIp = false))
+        service = DownloadEventService(downloadEventRepository, releaseRepository, buildSettings(captureIp = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, "192.168.1.42", "Mozilla/5.0")
+        service.record(releaseId, "192.168.1.42", "Mozilla/5.0")
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())
@@ -144,10 +152,11 @@ class DownloadEventServiceTest {
 
     @Test
     fun `record nullifies user agent when captureUserAgent is false`() {
-        service = DownloadEventService(downloadEventRepository, buildSettings(captureUserAgent = false))
+        service =
+            DownloadEventService(downloadEventRepository, releaseRepository, buildSettings(captureUserAgent = false))
         whenever(downloadEventRepository.save(any<DownloadEventEntity>())).thenAnswer { it.getArgument(0) }
 
-        service.record(release, null, "Mozilla/5.0")
+        service.record(releaseId, null, "Mozilla/5.0")
 
         val captor = argumentCaptor<DownloadEventEntity>()
         verify(downloadEventRepository).save(captor.capture())

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -336,7 +336,7 @@ class PluginReleaseServiceTest {
         releaseService.downloadArtifact("acme", "my-plugin", "1.0.0")
 
         verify(releaseRepository).incrementDownloadCount(releaseId)
-        verify(downloadEventService).record(release, null, null)
+        verify(downloadEventService).record(releaseId, null, null)
     }
 
     @Test
@@ -356,7 +356,7 @@ class PluginReleaseServiceTest {
 
         releaseService.downloadArtifact("acme", "my-plugin", "1.0.0", "10.0.0.1", "curl/7.88")
 
-        verify(downloadEventService).record(release, "10.0.0.1", "curl/7.88")
+        verify(downloadEventService).record(releaseId, "10.0.0.1", "curl/7.88")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #484.

`DownloadEventService.record(...)` runs in `Propagation.REQUIRES_NEW`, so any managed `PluginReleaseEntity` handed in by the caller is detached from its own persistence context the moment the inner transaction starts. The reviewer flagged this as a `PersistentObjectException` waiting to happen.

**Reality check first** (lerneffekt #476): the existing integration test on `main` is GREEN — there is no reproducer. The reason is that `DownloadEventEntity.release` is a plain `@ManyToOne` with **no cascade**, so Hibernate writes only the FK column and never tries to merge the detached parent. The reviewer's diagnosis is therefore **theoretical**, not active. Severity downgraded **HIGH → MEDIUM** in the issue.

The refactor is still worth doing because the safety guarantee depends on a fragile invariant — adding any cascade or fetch annotation in the future would silently turn this into a `PersistentObjectException`. Better to make the boundary explicit.

## Changes

- `DownloadEventService.record(release: PluginReleaseEntity, ...)` → `record(releaseId: UUID, ...)`
- Inside the `REQUIRES_NEW` transaction, resolve via `PluginReleaseRepository.getReferenceById(releaseId)`. The proxy is created in the new persistence context — no cross-boundary attach/detach. No extra `SELECT` round-trip because only the FK column is written.
- `PluginReleaseService.downloadArtifact` (only production caller) updated to pass `release.id`.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (incl. migrated `DownloadEventServiceTest` and `PluginReleaseServiceTest`)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green (incl. migrated `DownloadEventServiceIntegrationTest`)
- [x] **Lockdown test** added: `record needs only the release id, not a managed entity (#484)` — calls `entityManager.clear()` before `record(releaseId, ...)`, proving the call no longer depends on caller-side managed-entity state. RED would catch any future regression where the API silently re-introduces an entity-typed parameter.