### PR TITLE
fix(security): SSRF guard for OIDC discovery and stored URIs (#479)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/HttpClientDefaultsConfig.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/HttpClientDefaultsConfig.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Sets short, bounded JVM-wide defaults for the legacy `URLConnection` HTTP
+ * stack (#479). Spring Security 7 dropped the `.rest(RestOperations)` hook on
+ * `ClientRegistrations.fromIssuerLocation` / `JwtDecoders.fromIssuerLocation`
+ * — those classes use a `private static final RestTemplate` backed by
+ * `SimpleClientHttpRequestFactory`, which honours these system properties.
+ *
+ * 5s / 5s caps the SSRF "did this port answer" oracle to a 10s worst case
+ * per probe, short enough that error-based scanning is impractical without
+ * being so tight that legitimate WAN-distant providers fail. Other Plugwerk
+ * HTTP clients (OkHttp, JDK HttpClient if added later, Reactor Netty)
+ * ignore these properties — collateral damage is limited to anything that
+ * actually still uses `java.net.URLConnection`.
+ *
+ * Setting these as system properties (not just a `RestTemplate` bean) is
+ * required because `ClientRegistrations.rest` and `JwtDecoders.rest` are
+ * package-private static fields, not Spring-managed beans.
+ */
+@Configuration
+class HttpClientDefaultsConfig {
+
+    private val log = LoggerFactory.getLogger(HttpClientDefaultsConfig::class.java)
+
+    @PostConstruct
+    fun applyJvmDefaults() {
+        val connectTimeoutMs = "5000"
+        val readTimeoutMs = "5000"
+        System.setProperty("sun.net.client.defaultConnectTimeout", connectTimeoutMs)
+        System.setProperty("sun.net.client.defaultReadTimeout", readTimeoutMs)
+        log.info(
+            "URLConnection defaults set: connectTimeout={}ms, readTimeout={}ms",
+            connectTimeoutMs,
+            readTimeoutMs,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -94,6 +94,7 @@ import java.util.concurrent.atomic.AtomicReference
 class DbClientRegistrationRepository(
     private val oidcProviderRepository: OidcProviderRepository,
     private val textEncryptor: TextEncryptor,
+    private val ssrfPolicy: io.plugwerk.server.security.url.OidcSsrfPolicy,
 ) : ClientRegistrationRepository,
     Iterable<ClientRegistration> {
 
@@ -141,6 +142,9 @@ class DbClientRegistrationRepository(
                 val issuerUri = requireNotNull(provider.issuerUri) {
                     "issuerUri is required for provider type ${provider.providerType}"
                 }
+                // Defense-in-depth (#479): write-time guard already rejects private URIs
+                // in OidcProviderService, but legacy rows from before the fix might exist.
+                ssrfPolicy.requirePublicHttpUri(issuerUri, "issuerUri", required = true)
                 ClientRegistrations.fromIssuerLocation(issuerUri)
             }
 
@@ -192,6 +196,12 @@ class DbClientRegistrationRepository(
                 val userInfoUri = requireNotNull(provider.userInfoUri) {
                     "userInfoUri is required for provider type ${provider.providerType}"
                 }
+                // Defense-in-depth (#479): all three URIs are fetched at runtime
+                // (token / userinfo) or redirected-to (authorization). Legacy rows
+                // could carry private hosts that bypassed the write-time guard.
+                ssrfPolicy.requirePublicHttpUri(authorizationUri, "authorizationUri", required = true)
+                ssrfPolicy.requirePublicHttpUri(tokenUri, "tokenUri", required = true)
+                ssrfPolicy.requirePublicHttpUri(userInfoUri, "userInfoUri", required = true)
                 ClientRegistration.withRegistrationId(registrationId)
                     .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                     .redirectUri(DEFAULT_REDIRECT_URI_TEMPLATE)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcProviderRegistry.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcProviderRegistry.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.security
 
 import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.security.url.OidcSsrfPolicy
 import org.slf4j.LoggerFactory
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtDecoders
@@ -44,7 +45,10 @@ import java.util.concurrent.atomic.AtomicReference
  * [refresh] and [decoders] can be called concurrently without locking.
  */
 @Component
-class OidcProviderRegistry(private val oidcProviderRepository: OidcProviderRepository) {
+class OidcProviderRegistry(
+    private val oidcProviderRepository: OidcProviderRepository,
+    private val ssrfPolicy: OidcSsrfPolicy,
+) {
 
     private val log = LoggerFactory.getLogger(OidcProviderRegistry::class.java)
 
@@ -73,6 +77,11 @@ class OidcProviderRegistry(private val oidcProviderRepository: OidcProviderRepos
                         val issuerUri = requireNotNull(provider.issuerUri) {
                             "issuerUri is required for provider type ${provider.providerType}"
                         }
+                        // Defense-in-depth (#479): a saved private/loopback URI must not
+                        // reach Spring's static RestTemplate. Write-time guard already
+                        // rejects these in OidcProviderService, but legacy rows from
+                        // before the fix might exist — fail closed here too.
+                        ssrfPolicy.requirePublicHttpUri(issuerUri, "issuerUri", required = true)
                         JwtDecoders.fromIssuerLocation(issuerUri) as NimbusJwtDecoder
                     }
 
@@ -100,6 +109,7 @@ class OidcProviderRegistry(private val oidcProviderRepository: OidcProviderRepos
                                 "for resource-server use (browser-flow login still works) or set " +
                                 "jwkSetUri to enable JWT validation."
                         }
+                        ssrfPolicy.requirePublicHttpUri(jwkSetUri, "jwkSetUri", required = true)
                         NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
                     }
                 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/HostClassifier.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/HostClassifier.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security.url
+
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+
+/**
+ * Pure, DNS-free classifier that decides whether a host string points at a
+ * public-routable address or at something an outbound HTTP call should
+ * refuse to dial. Designed for SSRF defense in front of any "fetch URL the
+ * operator typed" code path (#479: OIDC discovery).
+ *
+ * **DNS is intentionally not consulted.** Resolving the host before the
+ * fetch and again at the fetch opens a DNS-rebinding gap, and the fix for
+ * that — pin to one resolved IP and pass it through — is bigger than this
+ * file's scope. Instead we operate on the literal: parse it as an IP if
+ * possible, otherwise apply hostname rules. The downstream HTTP client
+ * still resolves once at request time, which is acceptable risk for an
+ * admin-only feature behind a guard at write *and* read time.
+ *
+ * Blocked categories:
+ *  - RFC 1918 private (`10/8`, `172.16/12`, `192.168/16`)
+ *  - Loopback (`127/8`, `::1`, the literal `localhost`, the `*.localhost`
+ *    suffix per RFC 6761)
+ *  - Link-local (`169.254/16`, `fe80::/10`) — also covers AWS instance
+ *    metadata at `169.254.169.254` and the `fd00:ec2::254` IMDSv2 form via
+ *    the ULA range below
+ *  - Unspecified (`0.0.0.0`, `::`)
+ *  - Unique-local IPv6 (`fc00::/7`) — covers GCP/IMDSv2 metadata too
+ *  - Cloud-metadata exact-match names (`metadata.google.internal`,
+ *    `metadata`)
+ *  - mDNS / corporate-internal suffixes (`*.local`, `*.lan`, `*.internal`)
+ *  - IPv4-mapped IPv6 onto any of the above (`::ffff:10.0.0.1` etc.)
+ */
+object HostClassifier {
+
+    private val EXACT_BLOCKED_NAMES = setOf(
+        "localhost",
+        "metadata.google.internal",
+        "metadata",
+    )
+
+    private val BLOCKED_NAME_SUFFIXES = listOf(
+        ".localhost",
+        ".local",
+        ".lan",
+        ".internal",
+    )
+
+    private val IPV4_LITERAL_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
+
+    fun isPublicRoutable(host: String): Boolean {
+        val trimmed = host.trim()
+        if (trimmed.isEmpty()) return false
+
+        val normalized = trimmed.lowercase()
+
+        if (normalized in EXACT_BLOCKED_NAMES) return false
+        if (BLOCKED_NAME_SUFFIXES.any { normalized.endsWith(it) }) return false
+
+        val literal = parseIpLiteral(normalized) ?: return true
+        return !isPrivateOrSpecial(literal)
+    }
+
+    fun requirePublicHost(host: String, fieldName: String) {
+        require(isPublicRoutable(host)) {
+            "$fieldName must not target private, loopback, link-local, or metadata addresses"
+        }
+    }
+
+    /**
+     * Parses [host] as an IP literal (IPv4 dotted-quad or any IPv6 form,
+     * including bracketed and IPv4-mapped). Returns null when [host] is a
+     * DNS name — callers must NOT fall back to DNS resolution here.
+     */
+    private fun parseIpLiteral(host: String): InetAddress? {
+        val unwrapped = if (host.startsWith("[") && host.endsWith("]")) {
+            host.substring(1, host.length - 1)
+        } else {
+            host
+        }
+
+        // IPv4: only accept strict dotted-quad. InetAddress.getByName accepts
+        // partial forms ("10" → 0.0.0.10) and would treat plain hostnames
+        // as DNS lookups, which we want to avoid here.
+        if (IPV4_LITERAL_REGEX.matches(unwrapped)) {
+            return runCatching { InetAddress.getByName(unwrapped) }.getOrNull()
+        }
+
+        // IPv6 literal must contain a colon and parse without DNS lookup
+        // (InetAddress.getByName never resolves a literal IPv6).
+        if (':' in unwrapped) {
+            return runCatching { InetAddress.getByName(unwrapped) }.getOrNull()
+        }
+
+        return null
+    }
+
+    private fun isPrivateOrSpecial(addr: InetAddress): Boolean {
+        if (addr.isAnyLocalAddress) return true
+        if (addr.isLoopbackAddress) return true
+        if (addr.isLinkLocalAddress) return true
+        if (addr.isSiteLocalAddress) return true
+
+        if (addr is Inet6Address) {
+            // Unique-local: fc00::/7 (first byte 0xfc or 0xfd)
+            val first = addr.address[0].toInt() and 0xff
+            if (first == 0xfc || first == 0xfd) return true
+
+            // IPv4-mapped IPv6 → re-classify as the embedded IPv4 address
+            if (addr.isIPv4CompatibleAddress) {
+                val v4 = InetAddress.getByAddress(addr.address.copyOfRange(12, 16))
+                return isPrivateOrSpecial(v4)
+            }
+            val bytes = addr.address
+            val isIpv4Mapped = bytes.copyOfRange(0, 10).all { it == 0.toByte() } &&
+                bytes[10] == 0xff.toByte() &&
+                bytes[11] == 0xff.toByte()
+            if (isIpv4Mapped) {
+                val v4 = InetAddress.getByAddress(bytes.copyOfRange(12, 16))
+                return isPrivateOrSpecial(v4)
+            }
+        }
+
+        if (addr is Inet4Address) {
+            // 169.254/16 is link-local (already covered above), but explicit
+            // check is cheap and self-documenting.
+            val bytes = addr.address
+            val first = bytes[0].toInt() and 0xff
+            val second = bytes[1].toInt() and 0xff
+            if (first == 169 && second == 254) return true
+        }
+
+        return false
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/HostClassifier.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/HostClassifier.kt
@@ -36,36 +36,40 @@ import java.net.InetAddress
  * still resolves once at request time, which is acceptable risk for an
  * admin-only feature behind a guard at write *and* read time.
  *
- * Blocked categories:
- *  - RFC 1918 private (`10/8`, `172.16/12`, `192.168/16`)
- *  - Loopback (`127/8`, `::1`, the literal `localhost`, the `*.localhost`
- *    suffix per RFC 6761)
- *  - Link-local (`169.254/16`, `fe80::/10`) — also covers AWS instance
- *    metadata at `169.254.169.254` and the `fd00:ec2::254` IMDSv2 form via
- *    the ULA range below
- *  - Unspecified (`0.0.0.0`, `::`)
- *  - Unique-local IPv6 (`fc00::/7`) — covers GCP/IMDSv2 metadata too
- *  - Cloud-metadata exact-match names (`metadata.google.internal`,
- *    `metadata`)
- *  - mDNS / corporate-internal suffixes (`*.local`, `*.lan`, `*.internal`)
- *  - IPv4-mapped IPv6 onto any of the above (`::ffff:10.0.0.1` etc.)
+ * **IP-range blocks** (RFC 1918, loopback, link-local, ULA, IPv4-mapped
+ * forms) are hardcoded — they are Internet standards, not policy. The
+ * `plugwerk.auth.oidc.allow-private-discovery-uris` escape hatch
+ * disables them wholesale for dev profiles.
+ *
+ * **Hostname blocks** ([blockedNames], [blockedSuffixes]) ARE configurable
+ * — operators with a legitimate `*.internal` public domain or with their
+ * own corporate-internal suffixes (`*.corp.example.com`) override the
+ * defaults via `plugwerk.auth.oidc.blocked-host-names` /
+ * `plugwerk.auth.oidc.blocked-host-suffixes` (env:
+ * `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES` /
+ * `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES`). Default values match
+ * [DEFAULT_BLOCKED_NAMES] / [DEFAULT_BLOCKED_SUFFIXES].
  */
-object HostClassifier {
+class HostClassifier(
+    blockedNames: Collection<String> = DEFAULT_BLOCKED_NAMES,
+    blockedSuffixes: Collection<String> = DEFAULT_BLOCKED_SUFFIXES,
+) {
 
-    private val EXACT_BLOCKED_NAMES = setOf(
-        "localhost",
-        "metadata.google.internal",
-        "metadata",
-    )
+    /** Lowercased copy — host comparison is case-insensitive (RFC 5890). */
+    private val blockedNames: Set<String> = blockedNames
+        .map { it.trim().lowercase() }
+        .filter { it.isNotEmpty() }
+        .toSet()
 
-    private val BLOCKED_NAME_SUFFIXES = listOf(
-        ".localhost",
-        ".local",
-        ".lan",
-        ".internal",
-    )
-
-    private val IPV4_LITERAL_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
+    /**
+     * Lowercased copy. Suffixes that don't already start with `.` get one
+     * prepended so a configured `corp.example.com` matches
+     * `idp.corp.example.com` but NOT `evilcorp.example.com`.
+     */
+    private val blockedSuffixes: List<String> = blockedSuffixes
+        .map { it.trim().lowercase() }
+        .filter { it.isNotEmpty() }
+        .map { if (it.startsWith(".")) it else ".$it" }
 
     fun isPublicRoutable(host: String): Boolean {
         val trimmed = host.trim()
@@ -73,8 +77,8 @@ object HostClassifier {
 
         val normalized = trimmed.lowercase()
 
-        if (normalized in EXACT_BLOCKED_NAMES) return false
-        if (BLOCKED_NAME_SUFFIXES.any { normalized.endsWith(it) }) return false
+        if (normalized in blockedNames) return false
+        if (blockedSuffixes.any { normalized.endsWith(it) }) return false
 
         val literal = parseIpLiteral(normalized) ?: return true
         return !isPrivateOrSpecial(literal)
@@ -150,5 +154,32 @@ object HostClassifier {
         }
 
         return false
+    }
+
+    companion object {
+        /**
+         * Default exact-match host blocklist — applied when the operator
+         * does not override `plugwerk.auth.oidc.blocked-host-names`.
+         */
+        val DEFAULT_BLOCKED_NAMES: Set<String> = setOf(
+            "localhost",
+            "metadata.google.internal",
+            "metadata",
+        )
+
+        /**
+         * Default suffix blocklist — applied when the operator does not
+         * override `plugwerk.auth.oidc.blocked-host-suffixes`. Each
+         * default starts with `.` so it matches a full DNS label, not a
+         * substring.
+         */
+        val DEFAULT_BLOCKED_SUFFIXES: List<String> = listOf(
+            ".localhost",
+            ".local",
+            ".lan",
+            ".internal",
+        )
+
+        private val IPV4_LITERAL_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security.url
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Single source of truth for whether the OIDC SSRF guard is enforced (#479).
+ * Production runs with the default `false` for [allowPrivateDiscoveryUris]
+ * → [requirePublicHttpUri] applies the full [UriGuards.requirePublicHttpUri]
+ * gate (rejects private/loopback/link-local/metadata).
+ *
+ * Dev/test profiles can set
+ * `plugwerk.security.oidc.allow-private-discovery-uris=true`
+ * (env: `PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS`) to allow
+ * Keycloak / mock-oauth2-server on localhost. A startup WARN is logged
+ * whenever the escape hatch is enabled so an operator who flipped it
+ * accidentally in production sees it in the log.
+ *
+ * Injected from `OidcProviderService`, `OidcProviderRegistry`, and
+ * `DbClientRegistrationRepository` — all three reach Spring's static
+ * `ClientRegistrations.fromIssuerLocation` / `JwtDecoders.fromIssuerLocation`
+ * and must apply the same policy.
+ */
+@Component
+class OidcSsrfPolicy(
+    @param:Value("\${plugwerk.security.oidc.allow-private-discovery-uris:false}")
+    val allowPrivateDiscoveryUris: Boolean = false,
+) {
+
+    private val log = LoggerFactory.getLogger(OidcSsrfPolicy::class.java)
+
+    @PostConstruct
+    fun warnIfRelaxed() {
+        if (allowPrivateDiscoveryUris) {
+            log.warn(
+                "plugwerk.security.oidc.allow-private-discovery-uris=true — OIDC SSRF guard is " +
+                    "RELAXED. This is intended for local development against Keycloak or " +
+                    "mock-oauth2-server only. NEVER set this in production.",
+            )
+        }
+    }
+
+    /**
+     * Same contract as [UriGuards.requirePublicHttpUri], but routes through
+     * [UriGuards.requireHttpUri] (no host-class check) when the escape hatch
+     * is on. Syntax + scheme validation always applies.
+     */
+    fun requirePublicHttpUri(value: String?, fieldName: String, required: Boolean) {
+        if (allowPrivateDiscoveryUris) {
+            UriGuards.requireHttpUri(value, fieldName, required)
+        } else {
+            UriGuards.requirePublicHttpUri(value, fieldName, required)
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
  * gate (rejects private/loopback/link-local/metadata).
  *
  * Dev/test profiles can set
- * `plugwerk.security.oidc.allow-private-discovery-uris=true`
- * (env: `PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS`) to allow
+ * `plugwerk.auth.oidc.allow-private-discovery-uris=true`
+ * (env: `PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS`) to allow
  * Keycloak / mock-oauth2-server on localhost. A startup WARN is logged
  * whenever the escape hatch is enabled so an operator who flipped it
  * accidentally in production sees it in the log.
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class OidcSsrfPolicy(
-    @param:Value("\${plugwerk.security.oidc.allow-private-discovery-uris:false}")
+    @param:Value("\${plugwerk.auth.oidc.allow-private-discovery-uris:false}")
     val allowPrivateDiscoveryUris: Boolean = false,
 ) {
 
@@ -53,7 +53,7 @@ class OidcSsrfPolicy(
     fun warnIfRelaxed() {
         if (allowPrivateDiscoveryUris) {
             log.warn(
-                "plugwerk.security.oidc.allow-private-discovery-uris=true — OIDC SSRF guard is " +
+                "plugwerk.auth.oidc.allow-private-discovery-uris=true — OIDC SSRF guard is " +
                     "RELAXED. This is intended for local development against Keycloak or " +
                     "mock-oauth2-server only. NEVER set this in production.",
             )

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/OidcSsrfPolicy.kt
@@ -36,6 +36,16 @@ import org.springframework.stereotype.Component
  * whenever the escape hatch is enabled so an operator who flipped it
  * accidentally in production sees it in the log.
  *
+ * Two further properties — `plugwerk.auth.oidc.blocked-host-names` and
+ * `plugwerk.auth.oidc.blocked-host-suffixes` (both comma-separated, env
+ * `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES` /
+ * `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES`) — replace the hardcoded
+ * hostname blocklists in [HostClassifier] when an operator needs a
+ * different policy (e.g. legitimate `*.internal` public domain or an
+ * additional `*.corp.example.com`). IP-range blocks (RFC 1918, loopback,
+ * link-local, ULA) remain hardcoded — those are Internet standards and
+ * the only switch is [allowPrivateDiscoveryUris].
+ *
  * Injected from `OidcProviderService`, `OidcProviderRegistry`, and
  * `DbClientRegistrationRepository` — all three reach Spring's static
  * `ClientRegistrations.fromIssuerLocation` / `JwtDecoders.fromIssuerLocation`
@@ -45,9 +55,28 @@ import org.springframework.stereotype.Component
 class OidcSsrfPolicy(
     @param:Value("\${plugwerk.auth.oidc.allow-private-discovery-uris:false}")
     val allowPrivateDiscoveryUris: Boolean = false,
+    @param:Value("\${plugwerk.auth.oidc.blocked-host-names:}")
+    private val blockedHostNamesOverride: List<String> = emptyList(),
+    @param:Value("\${plugwerk.auth.oidc.blocked-host-suffixes:}")
+    private val blockedHostSuffixesOverride: List<String> = emptyList(),
 ) {
 
     private val log = LoggerFactory.getLogger(OidcSsrfPolicy::class.java)
+
+    /**
+     * Empty configured list → use the [HostClassifier] defaults. A
+     * deliberate `BLOCKED_HOST_NAMES=` (empty) override therefore still
+     * yields the defaults; to actually disable a hostname class the
+     * operator passes a non-empty replacement set. This avoids the
+     * "accidentally cleared all hostname blocks" footgun while keeping
+     * the override simple to express.
+     */
+    private val hostClassifier: HostClassifier = HostClassifier(
+        blockedNames = blockedHostNamesOverride.takeIf { it.isNotEmpty() }
+            ?: HostClassifier.DEFAULT_BLOCKED_NAMES,
+        blockedSuffixes = blockedHostSuffixesOverride.takeIf { it.isNotEmpty() }
+            ?: HostClassifier.DEFAULT_BLOCKED_SUFFIXES,
+    )
 
     @PostConstruct
     fun warnIfRelaxed() {
@@ -56,6 +85,18 @@ class OidcSsrfPolicy(
                 "plugwerk.auth.oidc.allow-private-discovery-uris=true — OIDC SSRF guard is " +
                     "RELAXED. This is intended for local development against Keycloak or " +
                     "mock-oauth2-server only. NEVER set this in production.",
+            )
+        }
+        if (blockedHostNamesOverride.isNotEmpty()) {
+            log.info(
+                "OIDC SSRF guard: blocked-host-names overridden ({} entries)",
+                blockedHostNamesOverride.size,
+            )
+        }
+        if (blockedHostSuffixesOverride.isNotEmpty()) {
+            log.info(
+                "OIDC SSRF guard: blocked-host-suffixes overridden ({} entries)",
+                blockedHostSuffixesOverride.size,
             )
         }
     }
@@ -69,7 +110,7 @@ class OidcSsrfPolicy(
         if (allowPrivateDiscoveryUris) {
             UriGuards.requireHttpUri(value, fieldName, required)
         } else {
-            UriGuards.requirePublicHttpUri(value, fieldName, required)
+            UriGuards.requirePublicHttpUri(value, fieldName, required, hostClassifier)
         }
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security.url
+
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * SSRF-aware URI validation primitives. Composes [HostClassifier] with
+ * URI-syntax + scheme checks. The naming is intentional: [requirePublicHttpUri]
+ * (vs. a generically-named "requireValidHttpUri") signals at every call-site
+ * that this path actively rejects private/loopback/link-local/metadata hosts.
+ */
+object UriGuards {
+
+    private val ALLOWED_SCHEMES = setOf("http", "https")
+
+    /**
+     * Validates that [value] parses as an `http(s)://host[/...]` URI whose
+     * host is public-routable per [HostClassifier]. Throws
+     * [IllegalArgumentException] with a stable, field-prefixed message on
+     * any violation so the caller can include the message in user-facing
+     * validation errors (write-time) or log it (read-time).
+     *
+     * `null` or blank input passes when [required] is `false` (matching the
+     * existing patch-semantics in `OidcProviderService.update`).
+     */
+    fun requirePublicHttpUri(value: String?, fieldName: String, required: Boolean) {
+        val host = parseHttpUriHostOrNull(value, fieldName, required) ?: return
+        HostClassifier.requirePublicHost(host, fieldName)
+    }
+
+    /**
+     * Same syntax + scheme + non-blank-host checks as [requirePublicHttpUri]
+     * but **without** the SSRF host-class guard. Use only behind an explicit
+     * dev/test escape hatch (#479: `plugwerk.security.oidc.allow-private-discovery-uris`).
+     */
+    fun requireHttpUri(value: String?, fieldName: String, required: Boolean) {
+        parseHttpUriHostOrNull(value, fieldName, required)
+    }
+
+    private fun parseHttpUriHostOrNull(value: String?, fieldName: String, required: Boolean): String? {
+        val trimmed = value?.trim()
+        if (trimmed.isNullOrEmpty()) {
+            require(!required) { "$fieldName is required" }
+            return null
+        }
+
+        val parsed = try {
+            URI(trimmed)
+        } catch (e: URISyntaxException) {
+            throw IllegalArgumentException("$fieldName is not a valid URI: ${e.message}")
+        }
+
+        require(parsed.scheme?.lowercase() in ALLOWED_SCHEMES) {
+            "$fieldName must use http or https scheme"
+        }
+        val host = parsed.host
+        require(!host.isNullOrBlank()) {
+            "$fieldName must include a host"
+        }
+        return host
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
@@ -49,7 +49,7 @@ object UriGuards {
     /**
      * Same syntax + scheme + non-blank-host checks as [requirePublicHttpUri]
      * but **without** the SSRF host-class guard. Use only behind an explicit
-     * dev/test escape hatch (#479: `plugwerk.security.oidc.allow-private-discovery-uris`).
+     * dev/test escape hatch (#479: `plugwerk.auth.oidc.allow-private-discovery-uris`).
      */
     fun requireHttpUri(value: String?, fieldName: String, required: Boolean) {
         parseHttpUriHostOrNull(value, fieldName, required)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/url/UriGuards.kt
@@ -41,10 +41,17 @@ object UriGuards {
      * `null` or blank input passes when [required] is `false` (matching the
      * existing patch-semantics in `OidcProviderService.update`).
      */
-    fun requirePublicHttpUri(value: String?, fieldName: String, required: Boolean) {
+    fun requirePublicHttpUri(
+        value: String?,
+        fieldName: String,
+        required: Boolean,
+        hostClassifier: HostClassifier = DEFAULT_HOST_CLASSIFIER,
+    ) {
         val host = parseHttpUriHostOrNull(value, fieldName, required) ?: return
-        HostClassifier.requirePublicHost(host, fieldName)
+        hostClassifier.requirePublicHost(host, fieldName)
     }
+
+    private val DEFAULT_HOST_CLASSIFIER = HostClassifier()
 
     /**
      * Same syntax + scheme + non-blank-host checks as [requirePublicHttpUri]

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/OidcProviderService.kt
@@ -25,13 +25,12 @@ import io.plugwerk.server.repository.OidcProviderRepository
 import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.security.DbClientRegistrationRepository
 import io.plugwerk.server.security.OidcProviderRegistry
+import io.plugwerk.server.security.url.OidcSsrfPolicy
 import org.slf4j.LoggerFactory
 import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.security.oauth2.client.registration.ClientRegistrations
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.net.URI
-import java.net.URISyntaxException
 import java.util.UUID
 
 /**
@@ -83,9 +82,23 @@ class OidcProviderService(
     private val oidcIdentityRepository: OidcIdentityRepository,
     private val userRepository: UserRepository,
     private val textEncryptor: TextEncryptor,
+    private val ssrfPolicy: OidcSsrfPolicy,
 ) {
 
     private val log = LoggerFactory.getLogger(OidcProviderService::class.java)
+
+    private companion object {
+        /**
+         * Stable, opaque error message returned to callers on any discovery
+         * failure (#479). The detailed cause goes to `log.debug` /
+         * `log.warn` only — never the response body — so an SSRF probe
+         * cannot distinguish "rejected by SSRF guard" from "connection
+         * refused" from "malformed metadata".
+         */
+        const val DISCOVERY_FAILED_MESSAGE =
+            "OIDC discovery failed — verify the issuer URI is reachable and serves a valid " +
+                "/.well-known/openid-configuration document."
+    }
 
     /**
      * Rebuilds both registries that depend on the enabled-providers list:
@@ -122,6 +135,12 @@ class OidcProviderService(
         if (trimmed.isEmpty()) {
             return OidcDiscoveryOutcome(success = false, error = "issuerUri must not be blank")
         }
+        try {
+            ssrfPolicy.requirePublicHttpUri(trimmed, "issuerUri", required = true)
+        } catch (e: IllegalArgumentException) {
+            log.warn("OIDC discovery rejected for issuerUri={}: {}", trimmed, e.message)
+            return OidcDiscoveryOutcome(success = false, error = DISCOVERY_FAILED_MESSAGE)
+        }
         return try {
             val registration = ClientRegistrations.fromIssuerLocation(trimmed).build()
             val details = registration.providerDetails
@@ -134,10 +153,7 @@ class OidcProviderService(
             )
         } catch (e: Exception) {
             log.debug("OIDC discovery failed for issuerUri={}: {}", trimmed, e.message)
-            OidcDiscoveryOutcome(
-                success = false,
-                error = e.message ?: "discovery failed without a message",
-            )
+            OidcDiscoveryOutcome(success = false, error = DISCOVERY_FAILED_MESSAGE)
         }
     }
 
@@ -168,11 +184,22 @@ class OidcProviderService(
         // skip it, leaving the operator wondering why their new provider does
         // not appear on the login page.
         if (providerType == OidcProviderType.OAUTH2) {
-            requireValidHttpUri(authorizationUri, "authorizationUri", required = true)
-            requireValidHttpUri(tokenUri, "tokenUri", required = true)
-            requireValidHttpUri(userInfoUri, "userInfoUri", required = true)
-            requireValidHttpUri(jwkSetUri, "jwkSetUri", required = false)
+            ssrfPolicy.requirePublicHttpUri(authorizationUri, "authorizationUri", required = true)
+            ssrfPolicy.requirePublicHttpUri(tokenUri, "tokenUri", required = true)
+            ssrfPolicy.requirePublicHttpUri(userInfoUri, "userInfoUri", required = true)
+            ssrfPolicy.requirePublicHttpUri(jwkSetUri, "jwkSetUri", required = false)
         }
+        // OIDC + generic OAUTH2 alike: an issuerUri that ends up in the DB must
+        // pass the same SSRF gate as discoverEndpoints — otherwise an attacker
+        // who lands a write call (admin-account compromise, CSRF gap, etc.)
+        // could plant `http://169.254.169.254` and let the next refresh fetch
+        // it. Required for OIDC, optional for OAUTH2 (where the explicit four
+        // endpoint URIs above carry the discovery payload).
+        ssrfPolicy.requirePublicHttpUri(
+            issuerUri,
+            "issuerUri",
+            required = providerType == OidcProviderType.OIDC,
+        )
         val provider = oidcProviderRepository.save(
             OidcProviderEntity(
                 name = name,
@@ -192,28 +219,6 @@ class OidcProviderService(
             ),
         )
         return provider
-    }
-
-    /**
-     * Validates that [value] (when present, or always when [required]) parses as
-     * an http(s) URI. Mirrors the issuerUri rule used elsewhere — every URI
-     * field on an OIDC/OAuth2 provider must be a real URL the server can later
-     * hand to a browser or HTTP client without surprises.
-     */
-    private fun requireValidHttpUri(value: String?, fieldName: String, required: Boolean) {
-        val trimmed = value?.trim()
-        if (trimmed.isNullOrEmpty()) {
-            require(!required) { "$fieldName is required for provider type OAUTH2" }
-            return
-        }
-        val parsed = try {
-            URI(trimmed)
-        } catch (e: URISyntaxException) {
-            throw IllegalArgumentException("$fieldName is not a valid URI: ${e.message}")
-        }
-        require(parsed.scheme in setOf("http", "https")) {
-            "$fieldName must use http or https scheme"
-        }
     }
 
     /**
@@ -277,14 +282,7 @@ class OidcProviderService(
         patch.issuerUri?.let {
             val trimmed = it.trim()
             require(trimmed.isNotEmpty()) { "issuerUri must not be blank" }
-            val parsed = try {
-                URI(trimmed)
-            } catch (e: URISyntaxException) {
-                throw IllegalArgumentException("issuerUri is not a valid URI: ${e.message}")
-            }
-            require(parsed.scheme in setOf("http", "https")) {
-                "issuerUri must use http or https scheme"
-            }
+            ssrfPolicy.requirePublicHttpUri(trimmed, "issuerUri", required = true)
             provider.issuerUri = trimmed
         }
 
@@ -321,7 +319,7 @@ class OidcProviderService(
         patch.jwkSetUri?.let {
             val trimmed = it.trim()
             require(trimmed.isNotEmpty()) { "jwkSetUri must not be blank — to disable, omit the field" }
-            requireValidHttpUri(trimmed, "jwkSetUri", required = false)
+            ssrfPolicy.requirePublicHttpUri(trimmed, "jwkSetUri", required = false)
             provider.jwkSetUri = trimmed
         }
 
@@ -355,7 +353,7 @@ class OidcProviderService(
         require(provider.providerType == OidcProviderType.OAUTH2) {
             "$fieldName is only meaningful on OAUTH2 providers (this is a ${provider.providerType})"
         }
-        requireValidHttpUri(trimmed, fieldName, required = true)
+        ssrfPolicy.requirePublicHttpUri(trimmed, fieldName, required = true)
         setter(trimmed)
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -158,6 +158,16 @@ plugwerk:
   # PLUGWERK_TRACKING_CAPTURE_USER_AGENT are no longer read. Manage these values via the
   # Admin UI or the `PATCH /api/v1/admin/settings` endpoint.
 
+  security:
+    oidc:
+      # SSRF guard for OIDC discovery and stored issuer/endpoint URIs (#479).
+      # Default: false → reject private/loopback/link-local/metadata hosts.
+      # Set to true ONLY for local dev against Keycloak / mock-oauth2-server
+      # bound to localhost. NEVER in production — a startup WARN is logged
+      # whenever this is true so an accidental flip is visible.
+      # Env: PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS
+      allow-private-discovery-uris: ${PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
+
 server:
   port: 8080
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -161,6 +161,24 @@ plugwerk:
       # Env: PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS
       allow-private-discovery-uris: ${PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
 
+      # Comma-separated exact-match host blocklist. Empty (the default)
+      # means "use the hardcoded defaults": localhost, metadata.google.internal,
+      # metadata. Setting a non-empty list REPLACES the defaults entirely
+      # — operators with a legitimate `metadata` public host need to drop
+      # it from the override. Case-insensitive.
+      # Env: PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES
+      blocked-host-names: ${PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES:}
+
+      # Comma-separated suffix blocklist. Empty (the default) means "use
+      # the hardcoded defaults": .localhost, .local, .lan, .internal.
+      # Setting a non-empty list REPLACES the defaults entirely — drop the
+      # suffix from the override if your operator legitimately uses it.
+      # Suffixes without a leading `.` get one prepended automatically so
+      # `corp.example.com` matches `idp.corp.example.com` but not
+      # `evilcorp.example.com`. Case-insensitive.
+      # Env: PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES
+      blocked-host-suffixes: ${PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES:}
+
   # Upload and download-tracking settings were moved to the `application_setting` database
   # table in 1.0.0-alpha.2 (ADR-0016). The environment variables PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB,
   # PLUGWERK_TRACKING_ENABLED, PLUGWERK_TRACKING_CAPTURE_IP, PLUGWERK_TRACKING_ANONYMIZE_IP and

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -152,21 +152,20 @@ plugwerk:
       # Generate with: openssl rand -base64 32
       scrape-password: ${PLUGWERK_AUTH_ACTUATOR_SCRAPE_PASSWORD:}
 
-  # Upload and download-tracking settings were moved to the `application_setting` database
-  # table in 1.0.0-alpha.2 (ADR-0016). The environment variables PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB,
-  # PLUGWERK_TRACKING_ENABLED, PLUGWERK_TRACKING_CAPTURE_IP, PLUGWERK_TRACKING_ANONYMIZE_IP and
-  # PLUGWERK_TRACKING_CAPTURE_USER_AGENT are no longer read. Manage these values via the
-  # Admin UI or the `PATCH /api/v1/admin/settings` endpoint.
-
-  security:
     oidc:
       # SSRF guard for OIDC discovery and stored issuer/endpoint URIs (#479).
       # Default: false → reject private/loopback/link-local/metadata hosts.
       # Set to true ONLY for local dev against Keycloak / mock-oauth2-server
       # bound to localhost. NEVER in production — a startup WARN is logged
       # whenever this is true so an accidental flip is visible.
-      # Env: PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS
-      allow-private-discovery-uris: ${PLUGWERK_SECURITY_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
+      # Env: PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS
+      allow-private-discovery-uris: ${PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
+
+  # Upload and download-tracking settings were moved to the `application_setting` database
+  # table in 1.0.0-alpha.2 (ADR-0016). The environment variables PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB,
+  # PLUGWERK_TRACKING_ENABLED, PLUGWERK_TRACKING_CAPTURE_IP, PLUGWERK_TRACKING_ANONYMIZE_IP and
+  # PLUGWERK_TRACKING_CAPTURE_USER_AGENT are no longer read. Manage these values via the
+  # Admin UI or the `PATCH /api/v1/admin/settings` endpoint.
 
 server:
   port: 8080

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -21,6 +21,7 @@ package io.plugwerk.server.security
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.security.url.OidcSsrfPolicy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -54,7 +55,12 @@ class DbClientRegistrationRepositoryTest {
     fun `findByRegistrationId returns null when no provider is enabled`() {
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
 
         assertThat(repo.findByRegistrationId(UUID.randomUUID().toString())).isNull()
         assertThat(repo.iterator().hasNext()).isFalse()
@@ -83,7 +89,11 @@ class DbClientRegistrationRepositoryTest {
         // Construction must not throw (the runCatching wrapper catches network failures
         // — that's the offline-CI case — but the not-yet-implemented IllegalStateException
         // path is gone for GOOGLE).
-        DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        DbClientRegistrationRepository(
+            oidcProviderRepository,
+            textEncryptor,
+            OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+        )
     }
 
     @Test
@@ -100,7 +110,12 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(github))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
         val registration = repo.findByRegistrationId(github.id.toString())
 
         assertThat(registration).isNotNull()
@@ -129,7 +144,12 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(facebook))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
         val registration = repo.findByRegistrationId(facebook.id.toString())
 
         assertThat(registration).isNotNull()
@@ -163,7 +183,12 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(generic))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
         val registration = repo.findByRegistrationId(generic.id.toString())
 
         assertThat(registration).isNotNull()
@@ -200,7 +225,12 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(generic))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
         val registration = repo.findByRegistrationId(generic.id.toString())
 
         assertThat(registration!!.providerDetails.userInfoEndpoint.userNameAttributeName)
@@ -225,7 +255,12 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(broken))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
 
         assertThat(repo.iterator().hasNext()).isFalse()
         assertThat(repo.findByRegistrationId(broken.id.toString())).isNull()
@@ -257,9 +292,43 @@ class DbClientRegistrationRepositoryTest {
         )
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(unreachableProvider))
 
-        val repo = DbClientRegistrationRepository(oidcProviderRepository, textEncryptor)
+        val repo =
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+            )
 
         assertThat(repo.iterator().hasNext()).isFalse()
         assertThat(repo.findByRegistrationId(unreachableProvider.id.toString())).isNull()
+    }
+
+    @Test
+    fun `provider with private issuerUri is skipped under production SSRF policy (#479)`() {
+        // Defense-in-depth: write-time guard already rejects private URIs in
+        // OidcProviderService.create/update, but legacy rows from before the
+        // fix could still carry one. With the SSRF policy in production mode
+        // (allowPrivateDiscoveryUris=false) the refresh path must skip the
+        // entry rather than letting Spring's static RestTemplate dial
+        // 169.254.169.254 every refresh.
+        val ssrfProvider = OidcProviderEntity(
+            id = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            name = "AWS Metadata Trap",
+            providerType = OidcProviderType.OIDC,
+            enabled = true,
+            clientId = "ignored",
+            clientSecretEncrypted = "{cipher}ignored",
+            issuerUri = "http://169.254.169.254/latest/meta-data/",
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(ssrfProvider))
+
+        val repo = DbClientRegistrationRepository(
+            oidcProviderRepository,
+            textEncryptor,
+            OidcSsrfPolicy(allowPrivateDiscoveryUris = false),
+        )
+
+        assertThat(repo.iterator().hasNext()).isFalse()
+        assertThat(repo.findByRegistrationId(ssrfProvider.id.toString())).isNull()
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/HostClassifierTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/HostClassifierTest.kt
@@ -24,6 +24,8 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class HostClassifierTest {
 
+    private val classifier = HostClassifier()
+
     @ParameterizedTest
     @ValueSource(
         strings = [
@@ -77,7 +79,7 @@ class HostClassifierTest {
         ],
     )
     fun `rejects private, loopback, link-local, ULA, metadata, and mDNS hosts`(host: String) {
-        assertThat(HostClassifier.isPublicRoutable(host))
+        assertThat(classifier.isPublicRoutable(host))
             .`as`("host=%s should be classified as non-public", host)
             .isFalse()
     }
@@ -105,7 +107,7 @@ class HostClassifierTest {
         ],
     )
     fun `accepts public hosts`(host: String) {
-        assertThat(HostClassifier.isPublicRoutable(host))
+        assertThat(classifier.isPublicRoutable(host))
             .`as`("host=%s should be classified as public", host)
             .isTrue()
     }
@@ -113,13 +115,13 @@ class HostClassifierTest {
     @ParameterizedTest
     @ValueSource(strings = ["", " ", "\t"])
     fun `rejects blank input`(host: String) {
-        assertThat(HostClassifier.isPublicRoutable(host)).isFalse()
+        assertThat(classifier.isPublicRoutable(host)).isFalse()
     }
 
     @org.junit.jupiter.api.Test
     fun `requirePublicHost throws IllegalArgumentException with field-prefixed message for non-public host`() {
         val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            HostClassifier.requirePublicHost("169.254.169.254", "issuerUri")
+            classifier.requirePublicHost("169.254.169.254", "issuerUri")
         }
         assertThat(ex.message)
             .startsWith("issuerUri")
@@ -128,6 +130,65 @@ class HostClassifierTest {
 
     @org.junit.jupiter.api.Test
     fun `requirePublicHost is silent for public host`() {
-        HostClassifier.requirePublicHost("login.example.com", "issuerUri")
+        classifier.requirePublicHost("login.example.com", "issuerUri")
+    }
+
+    // -- override tests ------------------------------------------------------
+
+    @org.junit.jupiter.api.Test
+    fun `custom blockedNames replaces the defaults entirely`() {
+        // Operator override: drop `localhost` etc. from the name list, add
+        // their own. Default suffixes still apply because we only overrode
+        // the names list.
+        val custom = HostClassifier(blockedNames = setOf("private-idp", "internal-only"))
+
+        assertThat(custom.isPublicRoutable("private-idp")).isFalse()
+        assertThat(custom.isPublicRoutable("internal-only")).isFalse()
+        // `metadata` was a default name-block but is no longer in the
+        // override → public (it is not an IP literal so IP-class checks
+        // do not catch it).
+        assertThat(custom.isPublicRoutable("metadata")).isTrue()
+        // default suffix still in effect.
+        assertThat(custom.isPublicRoutable("printer.local")).isFalse()
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `custom blockedSuffixes replaces the defaults entirely`() {
+        val custom = HostClassifier(blockedSuffixes = listOf(".corp.example.com", "intra"))
+
+        assertThat(custom.isPublicRoutable("idp.corp.example.com")).isFalse()
+        // suffix without a leading `.` gets one prepended → matches a label,
+        // not a substring.
+        assertThat(custom.isPublicRoutable("foo.intra")).isFalse()
+        assertThat(custom.isPublicRoutable("evilcorp.example.com")).isTrue()
+        // default suffix `.local` no longer blocked (we replaced the list).
+        assertThat(custom.isPublicRoutable("printer.local")).isTrue()
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `IP range blocks remain hardcoded even with empty hostname overrides`() {
+        // Operator passes empty lists explicitly — RFC 1918 / loopback /
+        // metadata IP-LITERALS must still be rejected. The escape hatch
+        // `allow-private-discovery-uris` is the only way to disable
+        // those.
+        val custom = HostClassifier(blockedNames = emptySet(), blockedSuffixes = emptyList())
+
+        assertThat(custom.isPublicRoutable("169.254.169.254")).isFalse()
+        assertThat(custom.isPublicRoutable("10.0.0.1")).isFalse()
+        assertThat(custom.isPublicRoutable("127.0.0.1")).isFalse()
+        assertThat(custom.isPublicRoutable("::1")).isFalse()
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `override entries are normalised case-insensitively and whitespace-trimmed`() {
+        val custom = HostClassifier(
+            blockedNames = setOf("  PRIVATE-IDP  ", "Other.Internal"),
+            blockedSuffixes = listOf("  .CORP.EXAMPLE.COM  "),
+        )
+
+        assertThat(custom.isPublicRoutable("private-idp")).isFalse()
+        assertThat(custom.isPublicRoutable("PRIVATE-IDP")).isFalse()
+        assertThat(custom.isPublicRoutable("other.internal")).isFalse()
+        assertThat(custom.isPublicRoutable("idp.corp.example.com")).isFalse()
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/HostClassifierTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/HostClassifierTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security.url
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class HostClassifierTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            // RFC 1918 — class A
+            "10.0.0.1",
+            "10.255.255.255",
+            // RFC 1918 — class B
+            "172.16.0.1",
+            "172.31.255.255",
+            // RFC 1918 — class C
+            "192.168.0.1",
+            "192.168.255.255",
+            // Loopback IPv4
+            "127.0.0.1",
+            "127.255.255.255",
+            // Loopback hostname (case-insensitive)
+            "localhost",
+            "LOCALHOST",
+            "LocalHost",
+            // *.localhost suffix (per RFC 6761)
+            "foo.localhost",
+            "deep.nested.localhost",
+            // Loopback IPv6
+            "::1",
+            "0:0:0:0:0:0:0:1",
+            // Link-local IPv4 + cloud metadata
+            "169.254.0.1",
+            "169.254.169.254",
+            // Link-local IPv6
+            "fe80::1",
+            "fe80:0:0:0:0:0:0:1",
+            // Unspecified
+            "0.0.0.0",
+            "::",
+            // Unique-local IPv6 (fc00::/7)
+            "fc00::1",
+            "fd00::1",
+            "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            // Cloud metadata exact-match names
+            "metadata.google.internal",
+            "metadata",
+            // mDNS / corporate-internal suffixes
+            "printer.local",
+            "fileshare.lan",
+            "intranet.internal",
+            "PRINTER.LOCAL",
+            // IPv4-mapped IPv6 onto private/loopback ranges
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::ffff:169.254.169.254",
+        ],
+    )
+    fun `rejects private, loopback, link-local, ULA, metadata, and mDNS hosts`(host: String) {
+        assertThat(HostClassifier.isPublicRoutable(host))
+            .`as`("host=%s should be classified as non-public", host)
+            .isFalse()
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            // RFC 1918 boundary negatives
+            "11.0.0.0",
+            "172.15.255.255",
+            "172.32.0.0",
+            "192.167.255.255",
+            "192.169.0.0",
+            // Public DNS names
+            "accounts.google.com",
+            "login.microsoftonline.com",
+            "github.com",
+            "auth.example.com",
+            // Public IPv4
+            "8.8.8.8",
+            "1.1.1.1",
+            // Public IPv6
+            "2001:4860:4860::8888",
+            "2606:4700:4700::1111",
+        ],
+    )
+    fun `accepts public hosts`(host: String) {
+        assertThat(HostClassifier.isPublicRoutable(host))
+            .`as`("host=%s should be classified as public", host)
+            .isTrue()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", " ", "\t"])
+    fun `rejects blank input`(host: String) {
+        assertThat(HostClassifier.isPublicRoutable(host)).isFalse()
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `requirePublicHost throws IllegalArgumentException with field-prefixed message for non-public host`() {
+        val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            HostClassifier.requirePublicHost("169.254.169.254", "issuerUri")
+        }
+        assertThat(ex.message)
+            .startsWith("issuerUri")
+            .contains("private, loopback, link-local, or metadata")
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `requirePublicHost is silent for public host`() {
+        HostClassifier.requirePublicHost("login.example.com", "issuerUri")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/UriGuardsTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/url/UriGuardsTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security.url
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatNoException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UriGuardsTest {
+
+    @Test
+    fun `accepts well-formed public https URI`() {
+        assertThatNoException().isThrownBy {
+            UriGuards.requirePublicHttpUri("https://accounts.google.com", "issuerUri", required = true)
+        }
+    }
+
+    @Test
+    fun `accepts well-formed public http URI`() {
+        assertThatNoException().isThrownBy {
+            UriGuards.requirePublicHttpUri("http://login.example.com", "issuerUri", required = true)
+        }
+    }
+
+    @Test
+    fun `null + not required is silent`() {
+        assertThatNoException().isThrownBy {
+            UriGuards.requirePublicHttpUri(null, "jwkSetUri", required = false)
+        }
+    }
+
+    @Test
+    fun `blank + not required is silent`() {
+        assertThatNoException().isThrownBy {
+            UriGuards.requirePublicHttpUri("   ", "jwkSetUri", required = false)
+        }
+    }
+
+    @Test
+    fun `null + required throws with field-prefixed message`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri(null, "issuerUri", required = true)
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("required")
+    }
+
+    @Test
+    fun `blank + required throws with field-prefixed message`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri("", "issuerUri", required = true)
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("required")
+    }
+
+    @Test
+    fun `invalid URI syntax throws with field-prefixed message`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri("ht!tp://broken url", "issuerUri", required = true)
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("valid URI")
+    }
+
+    @Test
+    fun `non-http scheme throws with field-prefixed message`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri("file:///etc/passwd", "issuerUri", required = true)
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("http or https")
+    }
+
+    @Test
+    fun `URI without host throws with field-prefixed message`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri("https:///path-only", "issuerUri", required = true)
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("host")
+    }
+
+    @Test
+    fun `private host throws via HostClassifier`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UriGuards.requirePublicHttpUri(
+                "http://169.254.169.254/.well-known/openid-configuration",
+                "issuerUri",
+                required = true,
+            )
+        }
+        assertThat(ex.message).startsWith("issuerUri").contains("private")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
@@ -25,6 +25,7 @@ import io.plugwerk.server.repository.OidcProviderRepository
 import io.plugwerk.server.repository.UserRepository
 import io.plugwerk.server.security.DbClientRegistrationRepository
 import io.plugwerk.server.security.OidcProviderRegistry
+import io.plugwerk.server.security.url.OidcSsrfPolicy
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -79,6 +80,8 @@ class OidcProviderServiceTest {
             on { encrypt(any()) } doAnswerReturn { "ENCRYPTED-${it.arguments[0]}" }
         }
 
+        // Default to the production policy (SSRF guard active). Tests that
+        // need the relaxed mode rebuild `service` with allowPrivate = true.
         service = OidcProviderService(
             oidcProviderRepository,
             oidcProviderRegistry,
@@ -86,6 +89,7 @@ class OidcProviderServiceTest {
             oidcIdentityRepository,
             userRepository,
             textEncryptor,
+            OidcSsrfPolicy(allowPrivateDiscoveryUris = false),
         )
     }
 
@@ -252,15 +256,17 @@ class OidcProviderServiceTest {
     }
 
     @Test
-    fun `discoverEndpoints returns failure outcome with error message for unreachable issuer`() {
-        // Port 1 is closed by convention — Spring's ClientRegistrations.fromIssuerLocation
-        // will fail with a connection / network error, which the service must surface as
-        // success=false rather than rethrowing. The UI uses this branch to render an
-        // operator-actionable hint.
-        val outcome = service.discoverEndpoints("http://localhost:1/realms/never")
+    fun `discoverEndpoints returns generic failure outcome for unreachable public issuer`() {
+        // example.invalid (RFC 2606) is reserved and DNS-fails fast — exercises
+        // the post-guard exception branch so we know SSRF rejection and
+        // connection-failure rejection both land on the same generic message.
+        val outcome = service.discoverEndpoints("https://example.invalid/realms/never")
 
         assertThat(outcome.success).isFalse()
-        assertThat(outcome.error).isNotBlank()
+        assertThat(outcome.error).isEqualTo(
+            "OIDC discovery failed — verify the issuer URI is reachable and serves a valid " +
+                "/.well-known/openid-configuration document.",
+        )
         assertThat(outcome.authorizationUri).isNull()
     }
 
@@ -270,6 +276,61 @@ class OidcProviderServiceTest {
 
         assertThat(outcome.success).isFalse()
         assertThat(outcome.error).contains("issuerUri")
+    }
+
+    @Test
+    fun `discoverEndpoints rejects AWS instance metadata with generic error (#479)`() {
+        val outcome = service.discoverEndpoints("http://169.254.169.254/.well-known/openid-configuration")
+
+        assertThat(outcome.success).isFalse()
+        assertThat(outcome.error)
+            .startsWith("OIDC discovery failed")
+            .doesNotContain("169.254")
+            .doesNotContain("private")
+    }
+
+    @Test
+    fun `discoverEndpoints rejects loopback with generic error (#479)`() {
+        val outcome = service.discoverEndpoints("http://127.0.0.1:6379/")
+
+        assertThat(outcome.success).isFalse()
+        assertThat(outcome.error).startsWith("OIDC discovery failed")
+    }
+
+    @Test
+    fun `discoverEndpoints rejects RFC1918 private host with generic error (#479)`() {
+        val outcome = service.discoverEndpoints("http://10.0.0.5/realms/internal")
+
+        assertThat(outcome.success).isFalse()
+        assertThat(outcome.error).startsWith("OIDC discovery failed")
+    }
+
+    @Test
+    fun `discoverEndpoints rejects localhost with generic error (#479)`() {
+        val outcome = service.discoverEndpoints("http://localhost/realms/dev")
+
+        assertThat(outcome.success).isFalse()
+        assertThat(outcome.error).startsWith("OIDC discovery failed")
+    }
+
+    @Test
+    fun `discoverEndpoints accepts localhost when escape hatch is on (#479)`() {
+        val relaxed = OidcProviderService(
+            oidcProviderRepository,
+            oidcProviderRegistry,
+            dbClientRegistrationRepository,
+            oidcIdentityRepository,
+            userRepository,
+            textEncryptor,
+            OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+        )
+        // The guard does not run, so the call falls through to Spring's
+        // ClientRegistrations and ultimately to the connection-failure branch
+        // (port 1 is convention-closed). Same generic error string either way.
+        val outcome = relaxed.discoverEndpoints("http://localhost:1/realms/dev")
+
+        assertThat(outcome.success).isFalse()
+        assertThat(outcome.error).startsWith("OIDC discovery failed")
     }
 }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -16,3 +16,8 @@ plugwerk:
     rate-limit:
       max-attempts: 1000
       window-seconds: 3600
+  security:
+    oidc:
+      # Integration tests run mock-oauth2-server on 127.0.0.1 — see
+      # application.yml for the production rationale (default false).
+      allow-private-discovery-uris: true

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -16,7 +16,6 @@ plugwerk:
     rate-limit:
       max-attempts: 1000
       window-seconds: 3600
-  security:
     oidc:
       # Integration tests run mock-oauth2-server on 127.0.0.1 — see
       # application.yml for the production rationale (default false).

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
@@ -14,7 +14,7 @@ spring:
     enabled: false
 
 plugwerk:
-  security:
+  auth:
     oidc:
       # Tests use mock-oauth2-server / Keycloak on 127.0.0.1 — relax SSRF
       # guard so the discovery + refresh paths still work. Production

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
@@ -12,3 +12,11 @@ spring:
         order_updates: true
   liquibase:
     enabled: false
+
+plugwerk:
+  security:
+    oidc:
+      # Tests use mock-oauth2-server / Keycloak on 127.0.0.1 — relax SSRF
+      # guard so the discovery + refresh paths still work. Production
+      # default is false, see application.yml comment for the rationale.
+      allow-private-discovery-uris: true


### PR DESCRIPTION
## Summary

Closes #479. Severity HIGH stays HIGH — the bug is real and the fix is non-trivial.

`OidcProviderService.discoverEndpoints` handed a superadmin-supplied URI straight to Spring's `ClientRegistrations.fromIssuerLocation` and echoed `e.message` back to the response body. SSRF + error-based port scanner. AWS instance metadata, GCP metadata, internal Redis/Elasticsearch — all reachable from the admin form.

## What changed

**New utilities** (`security/url/`):
- `HostClassifier` — DNS-free classifier rejecting RFC 1918 / loopback / link-local / unspecified / ULA / IPv4-mapped / configurable hostname blocklists. **IP-range blocks are hardcoded** (Internet standards). **Hostname blocklists are configurable** — operators with a legitimate `*.internal` public domain or with their own corporate-internal suffixes override the defaults.
- `UriGuards.requirePublicHttpUri` / `requireHttpUri` — composable URI-syntax + scheme + host-class checks.
- `OidcSsrfPolicy` — Spring component, owns three properties (allow-private-discovery-uris + the two hostname-blocklist overrides) and the `HostClassifier` instance built from them. Logs a startup WARN when the escape hatch is on, INFO when either blocklist was overridden.

**Sweep** (write-time + read-time, fail-closed):
- `OidcProviderService.discoverEndpoints` — guard + generic error string + `e.message` only in `log.warn`/`log.debug`.
- `OidcProviderService.create`/`update` — issuer + four OAUTH2 endpoint URIs all guarded. `create` was previously unvalidated for `issuerUri` entirely.
- `OidcProviderRegistry.refresh` + `DbClientRegistrationRepository.buildRegistration` — defense-in-depth for legacy rows from before the fix.

**HTTP timeouts** (the trickier piece):
- Spring Security 7 dropped `.rest(RestOperations)` on `ClientRegistrations.fromIssuerLocation` / `JwtDecoders.fromIssuerLocation` — their `RestTemplate` is `private static final`, no injection point. We bound the SSRF probe oracle through JVM-wide `URLConnection` defaults instead: new `HttpClientDefaultsConfig` sets `sun.net.client.defaultConnectTimeout=5000` / `sun.net.client.defaultReadTimeout=5000`. Other Plugwerk HTTP clients (OkHttp, Reactor Netty) ignore these properties — collateral damage limited.

## Configuration

| Property | Env | Default | Purpose |
|---|---|---|---|
| `plugwerk.auth.oidc.allow-private-discovery-uris` | `PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS` | `false` | Brute-force escape hatch — disables the entire host-class check (incl. RFC 1918 / loopback). For local Keycloak / mock-oauth2-server only. Logs WARN at startup when `true`. |
| `plugwerk.auth.oidc.blocked-host-names` | `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES` | _empty → use defaults_ | Comma-separated exact-match host blocklist. Defaults: `localhost,metadata.google.internal,metadata`. Non-empty value REPLACES the defaults. |
| `plugwerk.auth.oidc.blocked-host-suffixes` | `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES` | _empty → use defaults_ | Comma-separated suffix blocklist. Defaults: `.localhost,.local,.lan,.internal`. Non-empty value REPLACES the defaults. Suffixes without a leading `.` get one prepended. |

`application-test.yml` and `application-integration.yml` both default `allow-private-discovery-uris` to `true` so `mock-oauth2-server` on `127.0.0.1` keeps working. Production fail-closed.

## What was deliberately NOT done

- **No HTTP allowlist of public DNS providers.** Issue itself flags this as overkill.
- **No DNS-rebinding hardening** beyond classifier-doesn't-resolve. Pinning a resolved IP through to the request would require replacing Spring's static `RestTemplate`, which is bigger than this fix.
- **No `.rest(...)` polyfill.** The JVM-wide timeout default achieves the same risk reduction with one bean instead of a Spring-internals patch.
- **No additive override mode** for the hostname blocklists. The replace-only semantics keep the property surface tight; operators who need additive build the union themselves before exporting.
- **IP-range blocks NOT made configurable.** Those are Internet standards, not policy — the `allow-private-discovery-uris` switch is the only way to disable them. Verified by regression test (`IP range blocks remain hardcoded even with empty hostname overrides`).

## Acceptance criteria

- [x] URI validated before any outbound HTTP call.
- [x] Hosts in RFC 1918, loopback, link-local, unspecified, ULA, and known cloud-metadata addresses are rejected.
- [x] Generic error messages (no `e.message` leak).
- [x] Connect/read timeouts configured on the HTTP client used by `ClientRegistrations` (5s / 5s, JVM-wide URLConnection defaults).
- [x] Regression test that asserts a request to `http://169.254.169.254/...` is rejected with a generic error.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (`HostClassifierTest` incl. 4 override tests, `UriGuardsTest`, `OidcProviderServiceTest`, `DbClientRegistrationRepositoryTest`)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green