### PR TITLE
fix(security): @Transactional(readOnly=true) on TokenRevocationService.isRevoked (#486)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
@@ -88,11 +88,17 @@ class TokenRevocationService(
      * Checks whether a token identified by [jti] has been revoked, either explicitly
      * or because the user's password was changed after the token was issued.
      *
+     * Runs inside a read-only transaction (#486) so the existsByJti + findById
+     * pair on a cache miss share one connection. Without this annotation each
+     * repository call ran in its own auto-commit unit, doubling JDBC connection
+     * acquires for every authenticated request hitting a cold jti.
+     *
      * @param jti The JWT ID claim.
      * @param subject The JWT `sub` claim — `plugwerk_user.id` UUID-string after #351.
      * @param issuedAt The `iat` claim of the token.
      * @return `true` if the token must be rejected.
      */
+    @Transactional(readOnly = true)
     fun isRevoked(jti: String, subject: String, issuedAt: Instant): Boolean {
         // Check explicit revocation (cache → DB fallback). Both the cache key
         // and the repository lookup use the SHA-256 hash so the raw jti never

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/TokenRevocationServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/TokenRevocationServiceTest.kt
@@ -35,6 +35,7 @@ import org.mockito.kotlin.argThat
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.transaction.annotation.Transactional
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.time.Instant
@@ -194,6 +195,62 @@ class TokenRevocationServiceTest {
         service.cleanupExpired()
 
         verify(revokedTokenRepository).deleteExpiredBefore(any())
+    }
+
+    @Test
+    fun `isRevoked is annotated with Transactional readOnly true (#486)`() {
+        // Without the annotation isRevoked runs each repository call in its
+        // own auto-commit unit — two connection acquires per cache miss on
+        // every authenticated request. The annotation collapses both reads
+        // into one connection and adds isolation between them. Reflection
+        // assertion locks the contract so the annotation cannot quietly
+        // disappear during a future refactor.
+        val method = TokenRevocationService::class.java
+            .getDeclaredMethod("isRevoked", String::class.java, String::class.java, Instant::class.java)
+        val annotation = method.getAnnotation(Transactional::class.java)
+
+        assertThat(annotation)
+            .`as`("TokenRevocationService.isRevoked must be @Transactional (#486)")
+            .isNotNull
+        assertThat(annotation.readOnly)
+            .`as`("TokenRevocationService.isRevoked must be readOnly = true (#486)")
+            .isTrue()
+    }
+
+    @Test
+    fun `isRevoked still returns true for explicitly-revoked jti under read-only TX (#486 behavioural)`() {
+        // Pin the post-fix behaviour: even with readOnly = true the cache
+        // miss → DB lookup → cache put path still works. The cache.put is
+        // in-JVM (not JDBC), so readOnly does not block it. If a future
+        // change accidentally turned the cache write into a JDBC write,
+        // this test would catch it via the InvalidDataAccessApiUsageException
+        // Spring throws on writes inside a readOnly TX.
+        val jti = "explicitly-revoked-jti"
+        val jtiHash = sha256Hex(jti)
+        whenever(revokedTokenRepository.existsByJti(jtiHash)).thenReturn(true)
+
+        val result = service.isRevoked(jti, UUID.randomUUID().toString(), Instant.now())
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isRevoked returns true when user passwordInvalidatedBefore is after token iat (#486 behavioural)`() {
+        // The second branch of isRevoked: bulk invalidation via password
+        // change. Same readOnly safety check as the explicit-revocation
+        // test above.
+        val jti = "valid-jti"
+        val jtiHash = sha256Hex(jti)
+        val userId = UUID.randomUUID()
+        val issuedAt = Instant.parse("2026-05-10T12:00:00Z")
+        val invalidatedAt = OffsetDateTime.parse("2026-05-10T12:30:00Z")
+        whenever(revokedTokenRepository.existsByJti(jtiHash)).thenReturn(false)
+        whenever(userRepository.findById(userId))
+            .thenReturn(Optional.of(localUser(userId, passwordInvalidatedBefore = invalidatedAt)))
+
+        val result = service.isRevoked(jti, userId.toString(), issuedAt)
+
+        assertThat(result).isTrue()
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #486. Severity adjusted **HIGH → MEDIUM** — connection acquire with HikariCP is sub-ms, not ms, so the impact at realistic load is meaningful but not P0. The fix is still correct and low-risk.

`TokenRevocationService.isRevoked` is invoked from `DelegatingJwtDecoder.checkRevocation` on every authenticated request. Without `@Transactional`, the cache-miss branch executed:

1. `revokedTokenRepository.existsByJti(jtiHash)` (via Caffeine load callback) — connection 1
2. `userRepository.findById(userId)` — connection 2

Each in its own auto-commit unit. Two connection acquires per cache miss. Plus no isolation between the two reads — a parallel commit between them could yield an inconsistent answer for the same token.

## Fix

One annotation on `TokenRevocationService.isRevoked`:

```kotlin
@Transactional(readOnly = true)
fun isRevoked(jti: String, subject: String, issuedAt: Instant): Boolean { ... }
```

`readOnly = true` is safe — the only \"write\" inside the method is the Caffeine `cache.put`, which is in-JVM, not JDBC.

## Sweep

Per the issue's acceptance criterion, walked four service files for the same pattern (multi-repo reads without `@Transactional`):

| File | Result |
|---|---|
| `TokenRevocationService` | One miss (the issue target). Other three methods already annotated. |
| `RefreshTokenService` | All five public methods annotated. `findUpstreamIdToken` already `readOnly = true`. |
| `UserService` | Class-level `@Transactional` + four method-level `readOnly = true` overrides. |
| `OidcIdentityService` | Class-level `@Transactional`. Only one public method (write). |
| `service/auth/*` | All public methods in `AdminPasswordResetService`, `EmailVerificationTokenService`, `PasswordResetTokenService` annotated. `ExpiryFormatter` is a pure helper. |

**No additional candidates.** The missing annotation on `isRevoked` was an isolated miss, not a pattern.

## Test strategy

Picked **reflection + behavioural** over HikariCP MBean / wrapper DataSource:

- **Reflection assertion** locks the annotation contract — the test fails RED if the annotation is missing or `readOnly` flips to `false`. Cheapest possible structural guarantee for an annotation-only fix.
- **Two behavioural tests** prove `isRevoked` still returns the right answer under the new TX (explicit revocation branch + bulk-invalidation-via-password-change branch). If a future change accidentally turned the in-JVM cache write into a JDBC write, Spring would throw `InvalidDataAccessApiUsageException` and the test would catch it.
- **Existing E2E auth suite** (`integrationTest`) is the connection-pool / TX regression guard — every authenticated test runs through `DelegatingJwtDecoder.checkRevocation`.

Skipped a connection-counting wrapper DataSource because it would require `@SpringBootTest` for a one-line fix — poor leverage. HikariCP MBean route was rejected as fragile (timing-sensitive sampling, version-sensitive registration).

## Acceptance criteria

- [x] `isRevoked` is `@Transactional(readOnly = true)`
- [x] Test confirms only the right TX shape (reflection + behavioural — see Test Strategy above for why this beats a connection-counting wrapper)
- [x] Sweep documented (none found)
- [x] No regression in existing auth tests

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (incl. RED→GREEN verification of the reflection test)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green