### PR TITLE
fix(security): fail loud when local JWT lacks jti/sub/iat (#483)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DelegatingJwtDecoder.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DelegatingJwtDecoder.kt
@@ -65,10 +65,27 @@ class DelegatingJwtDecoder(
         throw JwtException("Token is not valid for any configured issuer")
     }
 
+    /**
+     * Validates that the locally-issued [jwt] carries the three claims the
+     * revocation service relies on, then asks the service whether this jti is
+     * revoked. Pre-#483 this method silently bypassed the check on any missing
+     * claim — a security control silently disabled by a downstream regression.
+     *
+     * Loud-fail is safe because this method runs ONLY after [localDecoder]
+     * accepted the token (see [decode]). Locally-issued tokens carry all three
+     * claims by [io.plugwerk.server.service.JwtTokenService] contract; an
+     * external OIDC token would have failed [localDecoder] and never reach
+     * here. A token that decodes locally but lacks one of the claims is, by
+     * definition, a regression — fail fast so it surfaces in tests and logs
+     * instead of silently turning revocation off for an entire token type.
+     */
     private fun checkRevocation(jwt: Jwt) {
-        val jti = jwt.id ?: return
-        val subject = jwt.subject ?: return
-        val issuedAt = jwt.issuedAt ?: return
+        val jti = jwt.id
+            ?: throw JwtException("Local JWT missing required jti claim — revocation check would be bypassed")
+        val subject = jwt.subject
+            ?: throw JwtException("Local JWT missing required sub claim — revocation check would be bypassed")
+        val issuedAt = jwt.issuedAt
+            ?: throw JwtException("Local JWT missing required iat claim — revocation check would be bypassed")
         if (tokenRevocationService.isRevoked(jti, subject, issuedAt)) {
             log.debug("Token jti={} for user={} has been revoked", jti, subject)
             throw JwtException("Token has been revoked")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DelegatingJwtDecoderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DelegatingJwtDecoderTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.service.TokenRevocationService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtException
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Unit tests for [DelegatingJwtDecoder]'s revocation-check semantics (#483).
+ *
+ * The interesting contract: locally-issued tokens MUST carry `jti`, `sub`, and
+ * `iat`. Pre-#483 the decoder silently bypassed revocation when any was
+ * missing — a security control silently disabled by a missing claim. The fix
+ * is to fail loudly so a future [io.plugwerk.server.service.JwtTokenService]
+ * regression that drops a claim cannot quietly turn revocation off for a new
+ * token type.
+ *
+ * `checkRevocation` runs ONLY after the local decoder accepts the token —
+ * OIDC tokens bypass it entirely via the fallback loop. The OIDC-fallback
+ * test below pins that behaviour so the loud-fail does not leak into the
+ * external-token path.
+ */
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DelegatingJwtDecoderTest {
+
+    private lateinit var localDecoder: JwtDecoder
+    private lateinit var oidcProviderRegistry: OidcProviderRegistry
+    private lateinit var tokenRevocationService: TokenRevocationService
+    private lateinit var decoder: DelegatingJwtDecoder
+
+    @BeforeEach
+    fun setUp() {
+        localDecoder = mock()
+        oidcProviderRegistry = mock()
+        tokenRevocationService = mock()
+        whenever(oidcProviderRegistry.decoders()).thenReturn(emptyList())
+        decoder = DelegatingJwtDecoder(localDecoder, oidcProviderRegistry, tokenRevocationService)
+    }
+
+    @Test
+    fun `valid local token with all required claims passes through revocation check`() {
+        val jti = UUID.randomUUID().toString()
+        val subject = UUID.randomUUID().toString()
+        val issuedAt = Instant.parse("2026-05-10T12:00:00Z")
+        val jwt = jwt(jti = jti, subject = subject, issuedAt = issuedAt)
+        whenever(localDecoder.decode("token")).thenReturn(jwt)
+        whenever(tokenRevocationService.isRevoked(jti, subject, issuedAt)).thenReturn(false)
+
+        val result = decoder.decode("token")
+
+        assertThat(result).isSameAs(jwt)
+        verify(tokenRevocationService).isRevoked(jti, subject, issuedAt)
+    }
+
+    @Test
+    fun `revoked local token throws JwtException with revoked message`() {
+        val jti = UUID.randomUUID().toString()
+        val subject = UUID.randomUUID().toString()
+        val issuedAt = Instant.parse("2026-05-10T12:00:00Z")
+        val jwt = jwt(jti = jti, subject = subject, issuedAt = issuedAt)
+        whenever(localDecoder.decode("token")).thenReturn(jwt)
+        whenever(tokenRevocationService.isRevoked(jti, subject, issuedAt)).thenReturn(true)
+
+        assertThatThrownBy { decoder.decode("token") }
+            .isInstanceOf(JwtException::class.java)
+            .hasMessageContaining("revoked")
+    }
+
+    @Test
+    fun `local token missing jti throws JwtException with claim-name in message (#483)`() {
+        val jwt = jwt(jti = null, subject = UUID.randomUUID().toString(), issuedAt = Instant.now())
+        whenever(localDecoder.decode("token")).thenReturn(jwt)
+
+        assertThatThrownBy { decoder.decode("token") }
+            .isInstanceOf(JwtException::class.java)
+            .hasMessageContaining("jti")
+
+        verify(tokenRevocationService, never()).isRevoked(any(), any(), any())
+    }
+
+    @Test
+    fun `local token missing sub throws JwtException with claim-name in message (#483)`() {
+        val jwt = jwt(jti = UUID.randomUUID().toString(), subject = null, issuedAt = Instant.now())
+        whenever(localDecoder.decode("token")).thenReturn(jwt)
+
+        assertThatThrownBy { decoder.decode("token") }
+            .isInstanceOf(JwtException::class.java)
+            .hasMessageContaining("sub")
+
+        verify(tokenRevocationService, never()).isRevoked(any(), any(), any())
+    }
+
+    @Test
+    fun `local token missing iat throws JwtException with claim-name in message (#483)`() {
+        val jwt = jwt(jti = UUID.randomUUID().toString(), subject = UUID.randomUUID().toString(), issuedAt = null)
+        whenever(localDecoder.decode("token")).thenReturn(jwt)
+
+        assertThatThrownBy { decoder.decode("token") }
+            .isInstanceOf(JwtException::class.java)
+            .hasMessageContaining("iat")
+
+        verify(tokenRevocationService, never()).isRevoked(any(), any(), any())
+    }
+
+    @Test
+    fun `OIDC fallback token bypasses revocation check entirely (#483 contract preservation)`() {
+        // Local decoder rejects (HMAC mismatch / unknown issuer), an OIDC
+        // decoder accepts. checkRevocation must NOT run, and the missing-claim
+        // hardening from #483 must NOT leak into this path: the returned jwt
+        // intentionally has no jti — pre-#483 this was already silently
+        // accepted, post-#483 it must still be silently accepted because the
+        // local-revocation contract simply does not apply to external tokens.
+        val oidcJwt = jwt(jti = null, subject = "external-subject", issuedAt = Instant.now())
+        val oidcDecoder = mock<JwtDecoder>()
+        whenever(oidcDecoder.decode("token")).thenReturn(oidcJwt)
+        whenever(localDecoder.decode("token")).thenThrow(JwtException("not a local token"))
+        whenever(oidcProviderRegistry.decoders()).thenReturn(listOf(oidcDecoder))
+
+        val result = decoder.decode("token")
+
+        assertThat(result).isSameAs(oidcJwt)
+        verify(tokenRevocationService, never()).isRevoked(any(), any(), any())
+    }
+
+    private fun jwt(jti: String?, subject: String?, issuedAt: Instant?): Jwt {
+        // Build the mock directly with the targeted getters stubbed. We do
+        // not stub the rest of Jwt's API because the production
+        // checkRevocation only reads .id / .subject / .issuedAt.
+        val mockJwt = mock<Jwt>()
+        whenever(mockJwt.id).thenReturn(jti)
+        whenever(mockJwt.subject).thenReturn(subject)
+        whenever(mockJwt.issuedAt).thenReturn(issuedAt)
+        return mockJwt
+    }
+}


### PR DESCRIPTION
## Summary

Closes #483.

`DelegatingJwtDecoder.checkRevocation` silently bypassed the revocation check when any of `jti`, `sub`, or `iat` was missing. Today's contract makes this harmless (every locally-issued token carries all three claims, enforced by `JwtTokenService`), but the silent-return is a latent footgun: a future `JwtTokenService` regression that drops a claim would silently turn the revocation control off for that token type with no test, log, or exception pointing at the gap.

## Fix

Replace the three `?: return` with `?: throw JwtException(...)` and include the missing claim name in the message. Three lines.

## Reality-check

The reviewer suggested adding an `isLocallyIssued()` helper to differentiate local from OIDC tokens before failing loud. **That helper is not needed.** `checkRevocation` runs ONLY after `localDecoder.decode()` succeeds (see lines 54-57 of `DelegatingJwtDecoder.kt`):

```kotlin
runCatching { localDecoder.decode(token) }.onSuccess { jwt ->
    checkRevocation(jwt)
    return jwt
}
// OIDC fallback below — checkRevocation is NOT called here
```

So every token that reaches `checkRevocation` is, by construction, locally-issued. The call-site itself is the marker. Simpler fix, same correctness.

## Tests

New `DelegatingJwtDecoderTest` (file did not exist before — pure-mock unit tests, no Spring context):

| Test | Verifies |
|---|---|
| `valid local token + not revoked` | passes through, `isRevoked` called once |
| `valid local token + revoked` | `JwtException` with \"revoked\" message |
| `missing jti` | `JwtException` with \"jti\" in message; `isRevoked` not called |
| `missing sub` | `JwtException` with \"sub\" in message; `isRevoked` not called |
| `missing iat` | `JwtException` with \"iat\" in message; `isRevoked` not called |
| `OIDC fallback token without jti` | accepted (contract preserved); `isRevoked` not called |

**TDD-RED-GREEN verified**: ran the tests against the unmodified `DelegatingJwtDecoder` first — three of the six failed (the `#483` ones). After the one-line-per-claim fix, all six pass.

## Acceptance criteria

- [x] `checkRevocation` distinguishes local-issued from external tokens (via call-site placement, not a helper — see Reality-check).
- [x] Local tokens missing `jti`, `sub`, or `iat` throw `JwtException` with a clear message.
- [x] External OIDC tokens still pass through without revocation check (behaviour preserved + pinned by test).
- [x] Test: synthesize a local JWT without `jti`, assert `JwtException` thrown; same for `sub` and `iat`.
- [x] Test: synthesize an OIDC JWT without `jti`, assert no exception.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (incl. RED→GREEN verification of the three #483 tests)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green