### PR TITLE
refactor(spi)!: typed InstalledPluginRef parameter on PlugwerkUpdateChecker (#504)

### DIFF
--- a/plugwerk-client-plugin/README.md
+++ b/plugwerk-client-plugin/README.md
@@ -36,7 +36,7 @@ Plugin Classloader (isolated)
 | `PlugwerkClient` | Low-level OkHttp HTTP client, namespace-scoped URL construction, auth headers |
 | `PlugwerkCatalogImpl` | `GET /plugins`, search, filtering — maps server DTOs to SPI models |
 | `PlugwerkInstallerImpl` | Verified download (SHA-256), `install` = download + PF4J `loadPlugin` + `startPlugin`, `uninstall` = `stopPlugin` + `unloadPlugin` + delete artifact (#424) |
-| `PlugwerkUpdateCheckerImpl` | `POST /updates/check` with installed version map |
+| `PlugwerkUpdateCheckerImpl` | `POST /updates/check` with the installed-plugins list |
 | `DtoMappers` | Converts `plugwerk-api-model` DTOs to `plugwerk-spi` model classes |
 
 ## Configuration

--- a/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImpl.kt
+++ b/plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImpl.kt
@@ -22,15 +22,16 @@ import io.plugwerk.api.model.UpdateCheckResponse
 import io.plugwerk.client.PlugwerkClient
 import io.plugwerk.client.internal.toReleaseInfo
 import io.plugwerk.spi.extension.PlugwerkUpdateChecker
+import io.plugwerk.spi.model.InstalledPluginRef
 import io.plugwerk.spi.model.UpdateInfo
 
 /** HTTP-backed implementation of [PlugwerkUpdateChecker]. Calls the server's `/updates/check` endpoint. */
 internal class PlugwerkUpdateCheckerImpl(private val client: PlugwerkClient) : PlugwerkUpdateChecker {
-    override fun checkForUpdates(installedPlugins: Map<String, String>): List<UpdateInfo> {
+    override fun checkForUpdates(installedPlugins: List<InstalledPluginRef>): List<UpdateInfo> {
         if (installedPlugins.isEmpty()) return emptyList()
         val requestBody =
             UpdateCheckRequest(
-                plugins = installedPlugins.map { (id, version) -> InstalledPluginInfo(id, version) },
+                plugins = installedPlugins.map { InstalledPluginInfo(it.pluginId, it.version) },
             )
         return client.post<UpdateCheckResponse>("updates/check", requestBody).updates.map { it.toUpdateInfo() }
     }

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkMarketplaceIntegrationTest.kt
@@ -17,6 +17,7 @@ package io.plugwerk.client
 
 import io.plugwerk.spi.PlugwerkConfig
 import io.plugwerk.spi.model.InstallResult
+import io.plugwerk.spi.model.InstalledPluginRef
 import io.plugwerk.spi.model.PluginStatus
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -139,7 +140,7 @@ class PlugwerkMarketplaceIntegrationTest {
                 .setResponseCode(200),
         )
 
-        val updates = marketplace.updateChecker().checkForUpdates(mapOf("plugin-a" to "1.0.0"))
+        val updates = marketplace.updateChecker().checkForUpdates(listOf(InstalledPluginRef("plugin-a", "1.0.0")))
 
         assertEquals(1, updates.size)
         assertEquals("plugin-a", updates[0].pluginId)

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImplTest.kt
@@ -17,6 +17,7 @@ package io.plugwerk.client.updater
 
 import io.plugwerk.client.PlugwerkClient
 import io.plugwerk.spi.PlugwerkConfig
+import io.plugwerk.spi.model.InstalledPluginRef
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -66,7 +67,7 @@ class PlugwerkUpdateCheckerImplTest {
                 .setResponseCode(200),
         )
 
-        val updates = updateChecker.checkForUpdates(mapOf("my-plugin" to "1.0.0"))
+        val updates = updateChecker.checkForUpdates(listOf(InstalledPluginRef("my-plugin", "1.0.0")))
 
         assertEquals(1, updates.size)
         assertEquals("my-plugin", updates[0].pluginId)
@@ -79,7 +80,7 @@ class PlugwerkUpdateCheckerImplTest {
     fun `checkForUpdates sends POST to updates-check endpoint`() {
         server.enqueue(MockResponse().setBody("""{"updates":[]}""").setResponseCode(200))
 
-        updateChecker.checkForUpdates(mapOf("plugin-a" to "2.0.0"))
+        updateChecker.checkForUpdates(listOf(InstalledPluginRef("plugin-a", "2.0.0")))
 
         val request = server.takeRequest()
         assertTrue(request.path!!.contains("/updates/check")) { "Expected /updates/check in path: ${request.path}" }
@@ -89,7 +90,7 @@ class PlugwerkUpdateCheckerImplTest {
 
     @Test
     fun `checkForUpdates returns empty list for empty input`() {
-        val updates = updateChecker.checkForUpdates(emptyMap())
+        val updates = updateChecker.checkForUpdates(emptyList())
 
         assertTrue(updates.isEmpty())
         assertEquals(0, server.requestCount)

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt
@@ -34,7 +34,8 @@ import org.pf4j.ExtensionPoint
  * plugin.connect(config).use { marketplace ->
  *     val plugins = marketplace.catalog().listPlugins()
  *     marketplace.installer().install("io.example.my-plugin", "1.0.0")
- *     val updates = marketplace.updateChecker().checkForUpdates(installedVersions)
+ *     val installed = listOf(InstalledPluginRef("io.example.my-plugin", "1.0.0"))
+ *     val updates = marketplace.updateChecker().checkForUpdates(installed)
  * }
  * ```
  *
@@ -45,7 +46,8 @@ import org.pf4j.ExtensionPoint
  * try (PlugwerkMarketplace marketplace = plugin.connect(config)) {
  *     List<PluginInfo> plugins = marketplace.catalog().listPlugins();
  *     marketplace.installer().install("io.example.my-plugin", "1.0.0");
- *     Map<String, String> installed = Map.of("io.example.my-plugin", "1.0.0");
+ *     List<InstalledPluginRef> installed = List.of(
+ *         new InstalledPluginRef("io.example.my-plugin", "1.0.0"));
  *     List<UpdateInfo> updates = marketplace.updateChecker().checkForUpdates(installed);
  * }
  * ```

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkUpdateChecker.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkUpdateChecker.kt
@@ -15,6 +15,7 @@
  */
 package io.plugwerk.spi.extension
 
+import io.plugwerk.spi.model.InstalledPluginRef
 import io.plugwerk.spi.model.UpdateInfo
 import org.pf4j.ExtensionPoint
 
@@ -30,7 +31,9 @@ import org.pf4j.ExtensionPoint
  * Kotlin:
  * ```kotlin
  * val checker = pluginManager.getExtensions(PlugwerkUpdateChecker::class.java).first()
- * val installed = pluginManager.plugins.associate { it.pluginId to it.descriptor.version }
+ * val installed = pluginManager.plugins.map {
+ *     InstalledPluginRef(it.pluginId, it.descriptor.version)
+ * }
  * val updates = checker.checkForUpdates(installed)
  * updates.forEach { println("Update available: ${it.pluginId} ${it.currentVersion} → ${it.availableVersion}") }
  * ```
@@ -38,8 +41,9 @@ import org.pf4j.ExtensionPoint
  * Java:
  * ```java
  * PlugwerkUpdateChecker checker = pluginManager.getExtensions(PlugwerkUpdateChecker.class).get(0);
- * Map<String, String> installed = pluginManager.getPlugins().stream()
- *     .collect(Collectors.toMap(p -> p.getPluginId(), p -> p.getDescriptor().getVersion()));
+ * List<InstalledPluginRef> installed = pluginManager.getPlugins().stream()
+ *     .map(p -> new InstalledPluginRef(p.getPluginId(), p.getDescriptor().getVersion()))
+ *     .toList();
  * List<UpdateInfo> updates = checker.checkForUpdates(installed);
  * updates.forEach(u -> System.out.println(
  *     "Update available: " + u.getPluginId() + " " + u.getCurrentVersion() + " → " + u.getAvailableVersion()));
@@ -55,18 +59,21 @@ interface PlugwerkUpdateChecker : ExtensionPoint {
      * with a higher SemVer than the installed version are reported.
      * Plugins in [installedPlugins] that are unknown to the server are silently ignored.
      *
-     * @param installedPlugins map of plugin ID → currently installed SemVer version string
-     *   (e.g. `mapOf("io.example.my-plugin" to "1.0.0")`)
+     * @param installedPlugins list of [InstalledPluginRef] entries, one per plugin
+     *   currently installed on the host (e.g.
+     *   `listOf(InstalledPluginRef("io.example.my-plugin", "1.0.0"))`).
+     *   Pre-#504 this took a `Map<String, String>` — see [InstalledPluginRef] for
+     *   the rationale behind the typed shape.
      * @return list of [UpdateInfo] entries, one per plugin that has a newer version available;
      *   empty list if everything is up-to-date
      */
-    fun checkForUpdates(installedPlugins: Map<String, String>): List<UpdateInfo>
+    fun checkForUpdates(installedPlugins: List<InstalledPluginRef>): List<UpdateInfo>
 
     /**
      * Returns all updates available in the marketplace regardless of what is locally installed.
      *
      * **Not yet implemented** — Phase 2 will add a dedicated server endpoint for this.
-     * Use [checkForUpdates] with a map of currently installed plugin IDs and versions instead.
+     * Use [checkForUpdates] with a list of [InstalledPluginRef] entries instead.
      *
      * @throws UnsupportedOperationException always, until Phase 2 is implemented
      */

--- a/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstalledPluginRef.kt
+++ b/plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstalledPluginRef.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.spi.model
+
+/**
+ * Compact reference to a single plugin currently installed on the host. Used
+ * as the input shape for
+ * [io.plugwerk.spi.extension.PlugwerkUpdateChecker.checkForUpdates] (#504),
+ * replacing the previous weakly-typed `Map<String, String>` parameter so the
+ * compiler — not a comment — guarantees `pluginId` and `version` cannot be
+ * accidentally swapped at the call site.
+ *
+ * Carries only what the update checker needs: the plugin id and the version
+ * string currently installed on the host. Everything else about the plugin
+ * (display name, license, description, …) lives in [PluginInfo] and is the
+ * job of [io.plugwerk.spi.extension.PlugwerkCatalog].
+ *
+ * Kotlin:
+ * ```kotlin
+ * val installed = pluginManager.plugins.map {
+ *     InstalledPluginRef(it.pluginId, it.descriptor.version)
+ * }
+ * val updates = checker.checkForUpdates(installed)
+ * ```
+ *
+ * Java:
+ * ```java
+ * List<InstalledPluginRef> installed = pluginManager.getPlugins().stream()
+ *     .map(p -> new InstalledPluginRef(p.getPluginId(), p.getDescriptor().getVersion()))
+ *     .toList();
+ * List<UpdateInfo> updates = checker.checkForUpdates(installed);
+ * ```
+ *
+ * @property pluginId unique identifier of the plugin within its namespace
+ *   (typically reverse-domain notation, e.g. `"io.example.my-plugin"`)
+ * @property version  SemVer string of the version currently installed on the
+ *   host (e.g. `"1.0.0"`). The class name encodes the "currently installed"
+ *   semantic, so the field reads `installed.version`, not `currentVersion`.
+ */
+data class InstalledPluginRef(val pluginId: String, val version: String)


### PR DESCRIPTION
## Summary

Closes #504. **Breaking SPI change** — acceptable in 1.0.0-beta.4 (still pre-1.0).

`PlugwerkUpdateChecker.checkForUpdates` previously took `Map<String, String>`, the only weakly-typed parameter on the SPI surface. Replace with a typed `List<InstalledPluginRef>` so the compiler — not a comment — guarantees `pluginId` and `version` cannot be accidentally swapped at the call site.

## Migration

```kotlin
// before
checker.checkForUpdates(
    pluginManager.plugins.associate { it.pluginId to it.descriptor.version },
)

// after
checker.checkForUpdates(
    pluginManager.plugins.map { InstalledPluginRef(it.pluginId, it.descriptor.version) },
)
```

```java
// before
Map<String, String> installed = pluginManager.getPlugins().stream()
    .collect(Collectors.toMap(p -> p.getPluginId(), p -> p.getDescriptor().getVersion()));
List<UpdateInfo> updates = checker.checkForUpdates(installed);

// after
List<InstalledPluginRef> installed = pluginManager.getPlugins().stream()
    .map(p -> new InstalledPluginRef(p.getPluginId(), p.getDescriptor().getVersion()))
    .toList();
List<UpdateInfo> updates = checker.checkForUpdates(installed);
```

## Decisions made (per #504 acceptance criteria)

| Decision | Choice | Why |
|---|---|---|
| Type shape | New `InstalledPluginRef(pluginId, version)` (Option B) | `PluginInfo` (Option A) carries 11 optional fields that the update checker doesn't need; reusing the wire DTO `InstalledPluginInfo` (Option C) would create a SPI→API module dependency. |
| Field name | `version` not `currentVersion` | Class name encodes the "currently installed" semantic; `installed.version` reads cleanly without redundancy. |
| Migration strategy | Hard break, no `@Deprecated` overload | 1.0.0-beta.4 is explicitly pre-stability. A deprecated overload doubles the API surface and forces a second migration cycle. |
| Wire-API shape | Unchanged | `UpdateCheckRequest.plugins: List<InstalledPluginInfo>` was already typed — only the SPI input shape changes. |

## Touched files

- `plugwerk-spi/src/main/kotlin/io/plugwerk/spi/model/InstalledPluginRef.kt` (new)
- `plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkUpdateChecker.kt` (signature + KDoc Kotlin/Java samples)
- `plugwerk-spi/src/main/kotlin/io/plugwerk/spi/extension/PlugwerkMarketplace.kt` (KDoc samples)
- `plugwerk-client-plugin/src/main/kotlin/io/plugwerk/client/updater/PlugwerkUpdateCheckerImpl.kt` (1:1 field-mapping)
- `plugwerk-client-plugin/src/test/.../PlugwerkUpdateCheckerImplTest.kt` (3 call sites migrated)
- `plugwerk-client-plugin/src/test/.../PlugwerkMarketplaceIntegrationTest.kt` (1 call site migrated)
- `plugwerk-client-plugin/README.md` (single-line wording update)

`plugwerk-spi/README.md` is already type-agnostic — no change needed. Repo has no `CHANGELOG.md` — breaking-change communication via this PR body.

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] `./gradlew :plugwerk-client-plugin:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green