### PR TITLE
feat(security): detect undecryptable client_secret_encrypted at startup (#501)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/CryptoDiagnostics.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/CryptoDiagnostics.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import javax.crypto.BadPaddingException
+
+/** Env-var name operators can grep for in logs after a key rotation goes wrong. */
+internal const val ENCRYPTION_KEY_ENV_VAR = "PLUGWERK_AUTH_ENCRYPTION_KEY"
+
+/**
+ * Walks the cause chain looking for [BadPaddingException] (covers
+ * `AEADBadTagException` for GCM). Returns `true` if any element matches,
+ * `false` otherwise. Detection by type is robust to Spring re-wording
+ * the wrapping `IllegalStateException` message in a future release.
+ *
+ * Spring's `Encryptors.delux()` produces an `IllegalStateException` with
+ * the literal `"Unable to invoke Cipher due to bad padding"` and the
+ * actual `BadPaddingException` as cause. We match the cause, not the
+ * message.
+ *
+ * Bounded by a small depth guard so a self-referential cause cycle (some
+ * libraries set `cause` to `this`) does not stack-overflow.
+ */
+internal fun Throwable.isBadPadding(): Boolean {
+    val seen = mutableSetOf<Throwable>()
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_CAUSE_DEPTH) {
+        if (current is BadPaddingException) return true
+        if (!seen.add(current)) return false
+        current = current.cause
+        depth++
+    }
+    return false
+}
+
+private const val MAX_CAUSE_DEPTH = 10
+
+/**
+ * Canonical operator-facing message for an encryption-key mismatch. Always
+ * mentions [ENCRYPTION_KEY_ENV_VAR] verbatim so it can be grepped from
+ * deployment logs, then names [subject] (which row / which setting) and
+ * ends with the verb-led [hint] for what to do next.
+ */
+internal fun encryptionKeyMismatchMessage(subject: String, hint: String): String =
+    "Cannot decrypt $subject. The data was encrypted with a different key than the " +
+        "current $ENCRYPTION_KEY_ENV_VAR. $hint"

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/DbClientRegistrationRepository.kt
@@ -18,6 +18,8 @@
  */
 package io.plugwerk.server.security
 
+import io.plugwerk.server.config.encryptionKeyMismatchMessage
+import io.plugwerk.server.config.isBadPadding
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
 import io.plugwerk.server.repository.OidcProviderRepository
@@ -95,6 +97,10 @@ class DbClientRegistrationRepository(
     private val oidcProviderRepository: OidcProviderRepository,
     private val textEncryptor: TextEncryptor,
     private val ssrfPolicy: io.plugwerk.server.security.url.OidcSsrfPolicy,
+    @param:org.springframework.beans.factory.annotation.Value(
+        "\${plugwerk.auth.oidc.fail-fast-on-undecryptable-providers:false}",
+    )
+    private val failFastOnUndecryptableProviders: Boolean = false,
 ) : ClientRegistrationRepository,
     Iterable<ClientRegistration> {
 
@@ -115,24 +121,59 @@ class DbClientRegistrationRepository(
      * Reload the registration map from the database. Called at startup and
      * by [io.plugwerk.server.service.OidcProviderService] after any change
      * that affects which providers participate in the browser login flow.
+     *
+     * Bad-padding (i.e. PLUGWERK_AUTH_ENCRYPTION_KEY mismatch — #501) gets
+     * its own ERROR log line with an actionable hint, separate from the
+     * outer WARN envelope that catches generic registration-build failures.
+     * If `plugwerk.auth.oidc.fail-fast-on-undecryptable-providers=true` and
+     * any **enabled** provider's secret is undecryptable, this method
+     * collects all such failures so every operator-facing ERROR is emitted
+     * before throwing — one boot attempt yields the complete list.
      */
     fun refresh() {
+        val undecryptable = mutableListOf<String>()
         val byId = oidcProviderRepository.findAllByEnabledTrue()
             .mapNotNull { provider ->
                 runCatching { buildRegistration(provider) }
-                    .onFailure {
-                        log.warn(
-                            "Skipping OIDC provider {} (registrationId={}) — failed to build ClientRegistration: {}",
-                            provider.name,
-                            OidcRegistrationIds.of(provider),
-                            it.message,
-                        )
+                    .onFailure { ex ->
+                        if (ex.isBadPadding()) {
+                            val regId = OidcRegistrationIds.of(provider)
+                            log.error(
+                                encryptionKeyMismatchMessage(
+                                    subject = "OIDC provider '${provider.name}' (registrationId=$regId) client secret",
+                                    hint = "Re-enter the client secret in the Admin UI under " +
+                                        "Admin → OIDC Providers, or restore the previous " +
+                                        "PLUGWERK_AUTH_ENCRYPTION_KEY value.",
+                                ),
+                                ex,
+                            )
+                            undecryptable += regId
+                        } else {
+                            log.warn(
+                                "Skipping OIDC provider {} (registrationId={}) — failed to build ClientRegistration: {}",
+                                provider.name,
+                                OidcRegistrationIds.of(provider),
+                                ex.message,
+                            )
+                        }
                     }
                     .getOrNull()
             }
             .associateBy { it.registrationId }
         activeRegistrations.set(byId)
         log.info("OAuth2 client registrations loaded: {} active provider(s)", byId.size)
+
+        if (failFastOnUndecryptableProviders && undecryptable.isNotEmpty()) {
+            throw IllegalStateException(
+                "Refusing to start: ${undecryptable.size} enabled OIDC provider(s) have an " +
+                    "undecryptable client_secret_encrypted under the current " +
+                    "PLUGWERK_AUTH_ENCRYPTION_KEY (registrationIds=$undecryptable). " +
+                    "Either restore the previous key or re-enter the client secret(s) in the " +
+                    "Admin UI, then restart. Set " +
+                    "plugwerk.auth.oidc.fail-fast-on-undecryptable-providers=false to allow " +
+                    "startup with affected providers skipped instead.",
+            )
+        }
     }
 
     private fun buildRegistration(provider: OidcProviderEntity): ClientRegistration {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsService.kt
@@ -18,6 +18,8 @@
  */
 package io.plugwerk.server.service.settings
 
+import io.plugwerk.server.config.encryptionKeyMismatchMessage
+import io.plugwerk.server.config.isBadPadding
 import io.plugwerk.server.domain.ApplicationSettingEntity
 import io.plugwerk.server.domain.SettingValueType
 import io.plugwerk.server.repository.ApplicationSettingRepository
@@ -184,11 +186,25 @@ class ApplicationSettingsService(
     fun smtpPasswordPlaintext(): String {
         val stored = cache.get()[ApplicationSettingKey.SMTP_PASSWORD.key]?.rawValue ?: return ""
         if (stored.isEmpty()) return ""
-        return decryptOrNull(stored) ?: run {
-            log.warn(
-                "Could not decrypt smtp.password — value is corrupted or the encryption key " +
-                    "changed. Treating as unset.",
-            )
+        return try {
+            encryptor?.decrypt(stored) ?: ""
+        } catch (ex: Exception) {
+            if (ex.isBadPadding()) {
+                log.error(
+                    encryptionKeyMismatchMessage(
+                        subject = "application setting 'smtp.password'",
+                        hint = "Re-enter the value in the Admin UI under Admin → Settings, or " +
+                            "restore the previous PLUGWERK_AUTH_ENCRYPTION_KEY value. Treating " +
+                            "as unset for now.",
+                    ),
+                    ex,
+                )
+            } else {
+                log.warn(
+                    "Could not decrypt smtp.password — value is corrupted. Treating as unset.",
+                    ex,
+                )
+            }
             ""
         }
     }
@@ -405,12 +421,6 @@ class ApplicationSettingsService(
                 log.warn("Settings update listener threw for key '{}': {}", key.key, ex.message)
             }
         }
-    }
-
-    private fun decryptOrNull(ciphertext: String): String? = try {
-        encryptor?.decrypt(ciphertext)
-    } catch (_: Exception) {
-        null
     }
 
     companion object {

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -179,6 +179,17 @@ plugwerk:
       # Env: PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES
       blocked-host-suffixes: ${PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES:}
 
+      # Refuse to start the server if any ENABLED OIDC provider's client
+      # secret is undecryptable under the current PLUGWERK_AUTH_ENCRYPTION_KEY
+      # (#501). Default false → server boots, affected providers are skipped
+      # with an ERROR log line per provider, and Sign-in via that provider
+      # silently 4xx's. Set true in production deployments where a half-broken
+      # login surface is worse than a fail-closed restart loop. The startup
+      # error message lists every affected registrationId so one boot attempt
+      # surfaces the complete list.
+      # Env: PLUGWERK_AUTH_OIDC_FAIL_FAST_ON_UNDECRYPTABLE_PROVIDERS
+      fail-fast-on-undecryptable-providers: ${PLUGWERK_AUTH_OIDC_FAIL_FAST_ON_UNDECRYPTABLE_PROVIDERS:false}
+
   # Upload and download-tracking settings were moved to the `application_setting` database
   # table in 1.0.0-alpha.2 (ADR-0016). The environment variables PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB,
   # PLUGWERK_TRACKING_ENABLED, PLUGWERK_TRACKING_CAPTURE_IP, PLUGWERK_TRACKING_ANONYMIZE_IP and

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/CryptoDiagnosticsTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/config/CryptoDiagnosticsTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+
+class CryptoDiagnosticsTest {
+
+    @Test
+    fun `isBadPadding detects direct BadPaddingException`() {
+        assertThat(BadPaddingException("decrypt").isBadPadding()).isTrue()
+    }
+
+    @Test
+    fun `isBadPadding detects Spring-wrapped form (#501)`() {
+        // Spring's Encryptors.delux() wraps BadPaddingException in IllegalStateException
+        // with the literal "Unable to invoke Cipher due to bad padding" — exact form
+        // a misconfigured PLUGWERK_AUTH_ENCRYPTION_KEY produces in production.
+        val wrapped = IllegalStateException(
+            "Unable to invoke Cipher due to bad padding",
+            BadPaddingException("decrypt"),
+        )
+
+        assertThat(wrapped.isBadPadding()).isTrue()
+    }
+
+    @Test
+    fun `isBadPadding detects AEADBadTagException as a BadPaddingException subclass`() {
+        // GCM authentication failures land here. Same root cause from an operator's
+        // perspective: the ciphertext can't be authenticated under the current key.
+        assertThat(AEADBadTagException("tag mismatch").isBadPadding()).isTrue()
+    }
+
+    @Test
+    fun `isBadPadding returns false for unrelated exceptions`() {
+        assertThat(IllegalArgumentException("nope").isBadPadding()).isFalse()
+        assertThat(RuntimeException("network down").isBadPadding()).isFalse()
+        assertThat(NullPointerException().isBadPadding()).isFalse()
+    }
+
+    @Test
+    fun `isBadPadding terminates on null cause chain`() {
+        // Standard Throwable has cause == null at the bottom — must not loop.
+        assertThat(RuntimeException("boom").isBadPadding()).isFalse()
+    }
+
+    @Test
+    fun `isBadPadding bounds traversal via depth guard for very long chains`() {
+        // Throwable.initCause forbids cause == this, so we cannot construct a
+        // true self-referential cycle. The depth guard's job is to also bound
+        // pathologically long but acyclic chains — build one deeper than the
+        // guard and assert detection terminates without locating a non-existent
+        // BadPaddingException.
+        var chain: Throwable = RuntimeException("leaf")
+        repeat(50) { chain = RuntimeException("level-$it", chain) }
+
+        assertThat(chain.isBadPadding()).isFalse()
+    }
+
+    @Test
+    fun `encryptionKeyMismatchMessage names the env var verbatim`() {
+        // The literal string "PLUGWERK_AUTH_ENCRYPTION_KEY" must appear so operators
+        // can `grep` their logs for the exact env-var name.
+        val msg = encryptionKeyMismatchMessage(
+            subject = "OIDC provider 'foo'",
+            hint = "Re-enter the secret.",
+        )
+
+        assertThat(msg).contains("PLUGWERK_AUTH_ENCRYPTION_KEY")
+        assertThat(msg).contains("OIDC provider 'foo'")
+        assertThat(msg).contains("Re-enter the secret.")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/DbClientRegistrationRepositoryTest.kt
@@ -331,4 +331,97 @@ class DbClientRegistrationRepositoryTest {
         assertThat(repo.iterator().hasNext()).isFalse()
         assertThat(repo.findByRegistrationId(ssrfProvider.id.toString())).isNull()
     }
+
+    @Test
+    fun `bad-padding on client_secret_encrypted is logged with PLUGWERK_AUTH_ENCRYPTION_KEY hint (#501)`() {
+        // Mirrors the field-incident: PLUGWERK_AUTH_ENCRYPTION_KEY rotated, the
+        // existing client_secret_encrypted no longer decrypts. Pre-#501 this
+        // surfaced as a generic WARN. Post-#501 it must be an ERROR that names
+        // the env var, names the provider, and tells the operator what to do.
+        whenever(textEncryptor.decrypt("{cipher}rotated-secret"))
+            .thenThrow(
+                java.lang.IllegalStateException(
+                    "Unable to invoke Cipher due to bad padding",
+                    javax.crypto.BadPaddingException("decrypt"),
+                ),
+            )
+        val provider = OidcProviderEntity(
+            id = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            name = "Rotated-Key Google",
+            providerType = OidcProviderType.GITHUB, // GITHUB skips network discovery — isolates the decrypt failure
+            enabled = true,
+            clientId = "ignored",
+            clientSecretEncrypted = "{cipher}rotated-secret",
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(provider))
+
+        val (logEvents, detach) = captureLogs(DbClientRegistrationRepository::class.java)
+        try {
+            val repo = DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+                failFastOnUndecryptableProviders = false,
+            )
+
+            // Behaviour preserved: bad-padding row is skipped, the rest of the registry would still load.
+            assertThat(repo.iterator().hasNext()).isFalse()
+            assertThat(repo.findByRegistrationId(provider.id.toString())).isNull()
+
+            val errorLine = logEvents.single { it.level == ch.qos.logback.classic.Level.ERROR }
+            assertThat(errorLine.formattedMessage)
+                .contains("PLUGWERK_AUTH_ENCRYPTION_KEY")
+                .contains("Rotated-Key Google")
+                .contains("Re-enter the client secret")
+        } finally {
+            detach()
+        }
+    }
+
+    @Test
+    fun `failFastOnUndecryptableProviders=true throws when an enabled provider's secret is undecryptable (#501)`() {
+        whenever(textEncryptor.decrypt(org.mockito.kotlin.any()))
+            .thenThrow(
+                java.lang.IllegalStateException(
+                    "Unable to invoke Cipher due to bad padding",
+                    javax.crypto.BadPaddingException("decrypt"),
+                ),
+            )
+        val provider = OidcProviderEntity(
+            id = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            name = "Production OIDC",
+            providerType = OidcProviderType.GITHUB,
+            enabled = true,
+            clientId = "ignored",
+            clientSecretEncrypted = "{cipher}rotated",
+        )
+        whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(listOf(provider))
+
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            DbClientRegistrationRepository(
+                oidcProviderRepository,
+                textEncryptor,
+                OidcSsrfPolicy(allowPrivateDiscoveryUris = true),
+                failFastOnUndecryptableProviders = true,
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("PLUGWERK_AUTH_ENCRYPTION_KEY")
+            .hasMessageContaining(provider.id.toString())
+    }
+
+    /**
+     * Attaches a Logback [ListAppender] to the named logger and returns the
+     * captured events plus a detach lambda the caller invokes in a `finally`
+     * block. Tests that assert on log output rely on this rather than on
+     * SLF4J's `MDC` or Mockito-stubbed loggers — Logback's appender API is
+     * the documented way to drive this from tests.
+     */
+    private fun captureLogs(loggerClass: Class<*>): Pair<List<ch.qos.logback.classic.spi.ILoggingEvent>, () -> Unit> {
+        val logger = org.slf4j.LoggerFactory.getLogger(loggerClass) as ch.qos.logback.classic.Logger
+        val appender = ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>()
+        appender.start()
+        logger.addAppender(appender)
+        return appender.list to { logger.detachAppender(appender) }
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/settings/ApplicationSettingsServiceTest.kt
@@ -19,6 +19,7 @@
 package io.plugwerk.server.service.settings
 
 import io.plugwerk.server.domain.ApplicationSettingEntity
+import io.plugwerk.server.domain.SettingValueType
 import io.plugwerk.server.repository.ApplicationSettingRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -195,5 +196,93 @@ class ApplicationSettingsServiceTest {
         override fun getObject(vararg args: Any?): TextEncryptor = error("not used in these tests")
         override fun getIfAvailable(): TextEncryptor? = null
         override fun getIfUnique(): TextEncryptor? = null
+    }
+
+    @org.junit.jupiter.api.Nested
+    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+    inner class SmtpPasswordDecryptDiagnostics {
+        @Test
+        fun `bad-padding on smtp_password is logged as ERROR with PLUGWERK_AUTH_ENCRYPTION_KEY hint (#501)`() {
+            // Plant a ciphertext for smtp.password, mock the encryptor to throw the
+            // Spring-wrapped bad-padding shape, and verify the ERROR carries the
+            // env-var name + remediation hint.
+            val encryptor = org.mockito.Mockito.mock(TextEncryptor::class.java)
+            org.mockito.kotlin.whenever(encryptor.decrypt("ciphertext-rotated")).thenThrow(
+                java.lang.IllegalStateException(
+                    "Unable to invoke Cipher due to bad padding",
+                    javax.crypto.BadPaddingException("decrypt"),
+                ),
+            )
+            val provider = object : ObjectProvider<TextEncryptor> {
+                override fun getObject() = encryptor
+                override fun getObject(vararg args: Any?) = encryptor
+                override fun getIfAvailable() = encryptor
+                override fun getIfUnique() = encryptor
+            }
+            storage[ApplicationSettingKey.SMTP_PASSWORD.key] = ApplicationSettingEntity(
+                settingKey = ApplicationSettingKey.SMTP_PASSWORD.key,
+                settingValue = "ciphertext-rotated",
+                valueType = SettingValueType.PASSWORD,
+            )
+            val sut = ApplicationSettingsService(repository = repository, encryptorProvider = provider)
+            invokePostConstruct(sut)
+
+            val (events, detach) = captureLogs(ApplicationSettingsService::class.java)
+            try {
+                val plaintext = sut.smtpPasswordPlaintext()
+
+                org.assertj.core.api.Assertions.assertThat(plaintext).isEmpty()
+                val error = events.single { it.level == ch.qos.logback.classic.Level.ERROR }
+                org.assertj.core.api.Assertions.assertThat(error.formattedMessage)
+                    .contains("PLUGWERK_AUTH_ENCRYPTION_KEY")
+                    .contains("smtp.password")
+                    .contains("Re-enter the value")
+            } finally {
+                detach()
+            }
+        }
+
+        @Test
+        fun `non-bad-padding decrypt failure is logged as WARN (#501)`() {
+            val encryptor = org.mockito.Mockito.mock(TextEncryptor::class.java)
+            org.mockito.kotlin.whenever(encryptor.decrypt("corrupted")).thenThrow(
+                java.lang.IllegalArgumentException("malformed ciphertext"),
+            )
+            val provider = object : ObjectProvider<TextEncryptor> {
+                override fun getObject() = encryptor
+                override fun getObject(vararg args: Any?) = encryptor
+                override fun getIfAvailable() = encryptor
+                override fun getIfUnique() = encryptor
+            }
+            storage[ApplicationSettingKey.SMTP_PASSWORD.key] = ApplicationSettingEntity(
+                settingKey = ApplicationSettingKey.SMTP_PASSWORD.key,
+                settingValue = "corrupted",
+                valueType = SettingValueType.PASSWORD,
+            )
+            val sut = ApplicationSettingsService(repository = repository, encryptorProvider = provider)
+            invokePostConstruct(sut)
+
+            val (events, detach) = captureLogs(ApplicationSettingsService::class.java)
+            try {
+                sut.smtpPasswordPlaintext()
+                val warn = events.single { it.level == ch.qos.logback.classic.Level.WARN }
+                org.assertj.core.api.Assertions.assertThat(warn.formattedMessage)
+                    .contains("Could not decrypt smtp.password")
+                    .doesNotContain("PLUGWERK_AUTH_ENCRYPTION_KEY")
+                org.assertj.core.api.Assertions.assertThat(
+                    events.none { it.level == ch.qos.logback.classic.Level.ERROR },
+                ).isTrue()
+            } finally {
+                detach()
+            }
+        }
+    }
+
+    private fun captureLogs(loggerClass: Class<*>): Pair<List<ch.qos.logback.classic.spi.ILoggingEvent>, () -> Unit> {
+        val logger = org.slf4j.LoggerFactory.getLogger(loggerClass) as ch.qos.logback.classic.Logger
+        val appender = ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>()
+        appender.start()
+        logger.addAppender(appender)
+        return appender.list to { logger.detachAppender(appender) }
     }
 }


### PR DESCRIPTION
## Summary

Closes #501. Phase 1 + 3 of the original 3-phase plan — Phase 2 (Admin UI badge + health endpoint) deliberately deferred to its own PR.

When `PLUGWERK_AUTH_ENCRYPTION_KEY` changes, every existing OIDC provider's `client_secret_encrypted` fails to decrypt. Pre-#501 this surfaced as a generic WARN that operators rarely connected to the later opaque \"Sign in with Google → InvalidClientRegistrationIdException\".

## Phase 1 — actionable logging (before/after)

**Before:**
```
WARN  Skipping OIDC provider Google ... — failed to build ClientRegistration: Unable to invoke Cipher due to bad padding
```

**After:**
```
ERROR Cannot decrypt OIDC provider 'Google' (registrationId=c0a80161-...) client secret.
      The data was encrypted with a different key than the current PLUGWERK_AUTH_ENCRYPTION_KEY.
      Re-enter the client secret in the Admin UI under Admin → OIDC Providers, or restore
      the previous PLUGWERK_AUTH_ENCRYPTION_KEY value.
```

Same ERROR shape applied to `ApplicationSettingsService.smtpPasswordPlaintext()` — replaces the catch-all \"value is corrupted or the encryption key changed\" line that left operators guessing which.

## Phase 3 — opt-in production safety net

| Property | Env | Default | Purpose |
|---|---|---|---|
| `plugwerk.auth.oidc.fail-fast-on-undecryptable-providers` | `PLUGWERK_AUTH_OIDC_FAIL_FAST_ON_UNDECRYPTABLE_PROVIDERS` | `false` | When `true` and an **enabled** provider's secret is undecryptable, Spring context fails to start. The startup error lists every affected `registrationId` so one boot attempt yields the complete list. For production where a half-broken login surface is worse than a fail-closed restart loop. |

## Architecture

- **New `CryptoDiagnostics.kt`** — `Throwable.isBadPadding()` walks the cause chain for `BadPaddingException` (covers Spring's wrapping `IllegalStateException` and `AEADBadTagException`). Cause-chain detection is robust against Spring re-wording the message string in a future release. Bounded by depth-guard. Plus `encryptionKeyMismatchMessage()` for consistent operator-facing wording.
- **`DbClientRegistrationRepository.refresh`** — distinguishes bad-padding (ERROR + remediation) from generic build failures (existing WARN envelope). Behaviour preserved (provider still skipped). Post-loop throw on fail-fast so all ERRORs land first.
- **`ApplicationSettingsService.smtpPasswordPlaintext`** — same shape applied for SMTP password decryption. Inlined the previous `decryptOrNull` helper at the call site so the bad-padding-vs-other distinction is visible.

## What was deliberately NOT done

- **Phase 2 (Admin UI signal)**: separate UX decisions, badge styling, banner placement, frontend state plumbing, OpenAPI changes. Belongs in its own PR.
- **Automatic key rotation / re-encryption**: out of scope per #501 and ADR-0022 — operator-managed today.
- **`.env.example` / `AGENTS.md` env-var inventory**: #479 didn't add the other three `PLUGWERK_AUTH_OIDC_*` vars there either; staying consistent. `application.yml` is the source of truth.

## Acceptance criteria

- [x] Phase 1: undecryptable-secret warnings include the explicit remediation hint and ENV-var name.
- [x] Phase 1: covered by unit test that mocks `TextEncryptor.decrypt` to throw the wrapped form.
- [x] Phase 3: toggleable property, default off, documented in `application.yml`.

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (includes `CryptoDiagnosticsTest`, `DbClientRegistrationRepositoryTest` (#501 cases), `ApplicationSettingsServiceTest > SmtpPasswordDecryptDiagnostics`)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green