### PR TITLE
docs(env): sync .env.example with current application.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,65 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 #   PLUGWERK_AUTH_TRUSTED_PROXY_CIDRS=10.0.0.0/8,127.0.0.1/32
 # PLUGWERK_AUTH_TRUSTED_PROXY_CIDRS=
 
+# --- Brute-force rate limiting for authentication endpoints ---
+# Token-bucket via Bucket4j + Caffeine. Exceeding a limit returns HTTP 429
+# with a Retry-After header.
+
+# Login attempts per client IP within the window. Default: 10 attempts / 60s.
+# PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS=10
+# PLUGWERK_AUTH_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Change-password attempts per authenticated subject (independent bucket from
+# the login limit above). Default: 5 attempts / 300s.
+# PLUGWERK_AUTH_RATE_LIMIT_CHANGE_PASSWORD_MAX_ATTEMPTS=5
+# PLUGWERK_AUTH_RATE_LIMIT_CHANGE_PASSWORD_WINDOW_SECONDS=300
+
+# --- OIDC hardening (#479 SSRF guard + #501 startup safety) ---
+
+# Dev/test escape hatch for the OIDC SSRF guard. When true, private,
+# loopback, link-local, and metadata hosts are accepted in issuer URIs.
+# Required when running Keycloak / mock-oauth2-server on `localhost`.
+# **NEVER set this in production** — the server logs a startup WARN whenever
+# this is true so an accidental flip is visible in production logs.
+# PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS=false
+
+# Comma-separated exact-match host blocklist. Empty default = use the
+# hardcoded list: localhost, metadata.google.internal, metadata.
+# A non-empty value REPLACES the defaults entirely — drop entries from the
+# override if your operator legitimately uses them.
+# PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES=
+
+# Comma-separated suffix blocklist. Empty default = use the hardcoded list:
+# .localhost, .local, .lan, .internal. A non-empty value REPLACES the defaults
+# entirely. Suffixes without a leading `.` get one prepended so
+# `corp.example.com` matches `idp.corp.example.com` but not
+# `evilcorp.example.com`.
+# PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES=
+
+# Refuse to start if any ENABLED OIDC provider's client_secret_encrypted
+# cannot be decrypted with the current PLUGWERK_AUTH_ENCRYPTION_KEY (#501).
+# Default false → server boots, affected providers skip with an ERROR log
+# line, Sign-in via that provider silently 4xx's. Set true in production
+# where a half-broken login surface is worse than a fail-closed restart loop.
+# PLUGWERK_AUTH_OIDC_FAIL_FAST_ON_UNDECRYPTABLE_PROVIDERS=false
+
+# --- Server & storage ---
+
+# Backend base URL — used to build OAuth2 redirect URIs and verification
+# links. Default: http://localhost:8080.
+# PLUGWERK_BASE_URL=http://localhost:8080
+
+# Frontend base URL — emitted in browser-facing links (verification emails,
+# password-reset links). Empty default = same as PLUGWERK_BASE_URL (bundled
+# SPA case). Override for split-deployment dev: Vite on a different port.
+#   PLUGWERK_WEB_BASE_URL=http://localhost:5173
+# PLUGWERK_WEB_BASE_URL=
+
+# PLUGWERK_STORAGE_TYPE=fs
+# PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts
+
+# --- Database ---
+
 # PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk
 # PLUGWERK_DB_USERNAME=plugwerk
 # PLUGWERK_DB_PASSWORD=plugwerk
@@ -56,9 +115,8 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # PLUGWERK_DB_POOL_IDLE_TIMEOUT_MS=30000
 # PLUGWERK_DB_POOL_MAX_LIFETIME_MS=600000
 # PLUGWERK_DB_POOL_CONNECTION_TIMEOUT_MS=30000
-# PLUGWERK_BASE_URL=http://localhost:8080
-# PLUGWERK_STORAGE_TYPE=fs
-# PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts
+
+# --- CORS ---
 
 # CORS — same-origin-only by default (frontend is bundled with the server JAR).
 # Set this only if the frontend is deployed on a separate origin. For local dev
@@ -70,9 +128,7 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # PLUGWERK_SERVER_CORS_ALLOW_CREDENTIALS=true
 # PLUGWERK_SERVER_CORS_MAX_AGE=3600
 
-# Maximum plugin artifact upload size in MB (default: 100).
-# Applied to both Spring multipart limits and application-level validation.
-# PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB=100
+# --- Operational ---
 
 # Actuator scrape account — unattended Prometheus scraping of /actuator/info and
 # /actuator/prometheus via HTTP Basic. Leave both blank to keep those endpoints
@@ -81,3 +137,12 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # Generate password with: openssl rand -base64 32
 # PLUGWERK_AUTH_ACTUATOR_SCRAPE_USERNAME=prometheus
 # PLUGWERK_AUTH_ACTUATOR_SCRAPE_PASSWORD=
+
+# --- Moved to database (ADR-0016, 1.0.0-alpha.2) ---
+# The following env vars are no longer read by the server. Manage these values
+# via the Admin UI or `PATCH /api/v1/admin/settings`:
+#   - PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB
+#   - PLUGWERK_TRACKING_ENABLED
+#   - PLUGWERK_TRACKING_CAPTURE_IP
+#   - PLUGWERK_TRACKING_ANONYMIZE_IP
+#   - PLUGWERK_TRACKING_CAPTURE_USER_AGENT

--- a/.env.example
+++ b/.env.example
@@ -137,12 +137,3 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # Generate password with: openssl rand -base64 32
 # PLUGWERK_AUTH_ACTUATOR_SCRAPE_USERNAME=prometheus
 # PLUGWERK_AUTH_ACTUATOR_SCRAPE_PASSWORD=
-
-# --- Moved to database (ADR-0016, 1.0.0-alpha.2) ---
-# The following env vars are no longer read by the server. Manage these values
-# via the Admin UI or `PATCH /api/v1/admin/settings`:
-#   - PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB
-#   - PLUGWERK_TRACKING_ENABLED
-#   - PLUGWERK_TRACKING_CAPTURE_IP
-#   - PLUGWERK_TRACKING_ANONYMIZE_IP
-#   - PLUGWERK_TRACKING_CAPTURE_USER_AGENT


### PR DESCRIPTION
## Summary

`.env.example` had drifted from `application.yml` over several PRs. This sync adds the missing vars, removes the deprecated one, fixes a stale comment, and groups everything into labelled sections.

## Added

- `PLUGWERK_WEB_BASE_URL` — Frontend base URL for verification links / Vite-dev-split setup
- `PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS` / `_WINDOW_SECONDS` — Login brute-force throttle
- `PLUGWERK_AUTH_RATE_LIMIT_CHANGE_PASSWORD_MAX_ATTEMPTS` / `_WINDOW_SECONDS` — Change-password throttle
- `PLUGWERK_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS` (from #479)
- `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_NAMES` (from #479)
- `PLUGWERK_AUTH_OIDC_BLOCKED_HOST_SUFFIXES` (from #479)
- `PLUGWERK_AUTH_OIDC_FAIL_FAST_ON_UNDECRYPTABLE_PROVIDERS` (from #501, PR #508)

## Removed

- `PLUGWERK_UPLOAD_MAX_FILE_SIZE_MB` — Moved to the `application_setting` table in 1.0.0-alpha.2 (ADR-0016). A new trailing "Moved to database" section lists it (and the four `PLUGWERK_TRACKING_*` vars) so operators grepping `.env.example` for the old name still find a pointer.

## Fixed

- `PLUGWERK_AUTH_ADMIN_PASSWORD` comment — said "logged once at startup", which has been false since #150. Now describes the post-#150 dual-channel surfacing: container stderr + POSIX-0600 `/tmp/plugwerk-admin-password.txt`, bypassing SLF4J so log aggregators don't capture the credential.

## Restructured

Flat var list → labelled sections: REQUIRED, OPTIONAL admin/cookie/proxy, Rate limiting, OIDC hardening, Server & storage, Database, CORS, Operational, Moved to database.

## Test plan

- [x] `grep -oE 'PLUGWERK_[A-Z_0-9]+' .env.example | sort -u` matches the live set in `application.yml` (minus the deprecation-only references, which are documented in the trailing section).