### PR TITLE
feat(storage): S3-compatible object storage backend (#191)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,8 +97,36 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 #   PLUGWERK_WEB_BASE_URL=http://localhost:5173
 # PLUGWERK_WEB_BASE_URL=
 
+# Storage backend selector — `fs` (default, local filesystem) or `s3`
+# (S3-compatible object storage; AWS S3 / MinIO / Hetzner / Cloudflare R2).
 # PLUGWERK_STORAGE_TYPE=fs
 # PLUGWERK_STORAGE_ROOT=/var/plugwerk/artifacts
+
+# --- S3-compatible storage (only used when PLUGWERK_STORAGE_TYPE=s3) ---
+# Required:
+# PLUGWERK_STORAGE_S3_BUCKET=plugwerk-artifacts
+# PLUGWERK_STORAGE_S3_REGION=eu-central-1
+# Optional endpoint override — leave blank for AWS S3, set for MinIO / R2 /
+# Hetzner Object Storage:
+#   MinIO local:   http://localhost:9000
+#   Cloudflare R2: https://<account>.r2.cloudflarestorage.com
+#   Hetzner OS:    https://fsn1.your-objectstorage.com
+# PLUGWERK_STORAGE_S3_ENDPOINT=
+# Static credentials — leave BOTH blank to use the AWS DefaultCredentialsProvider
+# chain (env, instance profile, IRSA, ECS task role). Half-configured states
+# (one set, one blank) are rejected at startup.
+# PLUGWERK_STORAGE_S3_ACCESS_KEY=
+# PLUGWERK_STORAGE_S3_SECRET_KEY=
+# Optional prefix prepended to every artifact key — lets multiple Plugwerk
+# installations share one bucket. Must not start with '/'.
+# PLUGWERK_STORAGE_S3_KEY_PREFIX=
+# `true` for MinIO and other endpoints that need path-style URLs. Default
+# `false` (DNS-style; AWS S3, R2, Hetzner all work with this).
+# PLUGWERK_STORAGE_S3_PATH_STYLE_ACCESS=false
+# Refuse to start when the bucket-existence probe fails. Default `false` →
+# probe failure logs ERROR and the server keeps running. Set `true` for
+# orchestrators that prefer a restart loop over a half-broken artifact store.
+# PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING=false
 
 # --- Database ---
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Wait for `curl http://localhost:8080/actuator/health` to return `{"status":"UP"}
 
 See [`.env.example`](.env.example) for the full list of environment variables (CORS, storage, auth tuning).
 
+### S3-compatible storage (optional)
+
+Local filesystem is the default. To run against an S3-compatible backend (AWS S3, MinIO, Hetzner Object Storage, Cloudflare R2), set `PLUGWERK_STORAGE_TYPE=s3` plus the `PLUGWERK_STORAGE_S3_*` variables documented in `.env.example`. A local MinIO container ships under a compose profile:
+
+```bash
+docker compose --profile s3-dev up -d minio minio-init
+# Console: http://localhost:9001 (minioadmin / minioadmin)
+# Bucket `plugwerk-artifacts` is created automatically.
+```
+
+Trade-offs and design rationale are recorded in [`docs/adrs/0034-s3-storage-backend.md`](docs/adrs/0034-s3-storage-backend.md).
+
 ### Initial admin credentials
 
 On first startup, Plugwerk generates a random superadmin password and surfaces it on two channels that bypass SLF4J entirely (so log aggregators like Datadog/ELK/CloudWatch do **not** capture the credential):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,59 @@ services:
       retries: 6
       start_period: 5s
 
+  # ------------------------------------------------------------------------
+  # MinIO — S3-compatible object storage for local development against
+  # plugwerk.storage.type=s3 (#191). Start with `docker compose --profile
+  # s3-dev up`. Console UI on http://localhost:9001; default credentials
+  # are minioadmin/minioadmin. The init container creates the
+  # `plugwerk-artifacts` bucket on first start.
+  #
+  # When Plugwerk runs in this compose stack, point it at the container:
+  #   PLUGWERK_STORAGE_TYPE=s3
+  #   PLUGWERK_STORAGE_S3_ENDPOINT=http://minio:9000
+  #   PLUGWERK_STORAGE_S3_BUCKET=plugwerk-artifacts
+  #   PLUGWERK_STORAGE_S3_REGION=us-east-1
+  #   PLUGWERK_STORAGE_S3_ACCESS_KEY=minioadmin
+  #   PLUGWERK_STORAGE_S3_SECRET_KEY=minioadmin
+  #   PLUGWERK_STORAGE_S3_PATH_STYLE_ACCESS=true
+  #
+  # When Plugwerk runs natively, replace `minio` with `localhost`.
+  minio:
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
+    profiles: ["s3-dev"]
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "127.0.0.1:9000:9000"   # S3 API
+      - "127.0.0.1:9001:9001"   # Console UI
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+
+  # One-shot init: wait for MinIO, create the bucket, exit. Tagged with the
+  # same profile so it only runs when the operator opted into s3-dev.
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+    profiles: ["s3-dev"]
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc mb --ignore-existing local/plugwerk-artifacts &&
+        echo 'plugwerk-artifacts bucket ready'
+      "
+
 volumes:
   postgres-data:
   plugwerk-artifacts:
   keycloak-data:
+  minio-data:

--- a/docs/adrs/0034-s3-storage-backend.md
+++ b/docs/adrs/0034-s3-storage-backend.md
@@ -1,0 +1,78 @@
+# ADR-0034: S3-compatible storage backend
+
+- Status: Accepted
+- Date: 2026-05-12
+- Issue: [#191](https://github.com/plugwerk/plugwerk/issues/191)
+
+## Context
+
+Plugwerk shipped with a filesystem-only artifact store. That choice is a hard blocker for horizontal scaling (multi-node deployments cannot share a local FS), most managed-hosting platforms (no persistent volumes), disaster-recovery setups (no geographic replication), and any SaaS-style multi-tenant deployment.
+
+The `ArtifactStorageService` interface, the filesystem implementation, and the `plugwerk.storage.type` selector property already existed from earlier preparation work — only the second implementation was missing.
+
+## Decision
+
+Add an `S3ArtifactStorageService` that targets any S3-compatible endpoint (AWS S3, MinIO, Hetzner Object Storage, Cloudflare R2), gated by `plugwerk.storage.type=s3`. The following load-bearing trade-offs are recorded here so future readers don't need to mine the PR thread.
+
+### SDK choice — AWS SDK for Java v2
+
+Picked `software.amazon.awssdk:s3` over the MinIO Java SDK and over Spring Cloud AWS's `S3Template`. Rationale:
+
+- Universal S3 compatibility via `endpointOverride(URI)` — proven against every endpoint Plugwerk advertises.
+- First-party AWS support — long-term security patches, no third-party Spring autoconfig glue.
+- We pin the synchronous `apache-client` HTTP module and exclude `netty-nio-client`: Plugwerk's servlet stack is blocking, and Netty would inflate the fat-jar without paying for itself.
+
+Cost: ~6 MB transitive size delta. Accepted.
+
+### Key encoding — keep colons
+
+`PluginReleaseService` builds keys as `<namespace-uuid>:<plugin-id>:<version>:<extension>`. S3 accepts colons in object keys (RFC 3986 sub-delims) and AWS, MinIO, R2, and Hetzner all serve them transparently. Converting to slash-separated paths would:
+
+- force every existing filesystem deployment through a rename migration,
+- require a parallel re-keying pass on any production S3 bucket already in use, and
+- ask the storage interface to either grow a "what's the native separator" method or to leak backend knowledge into `PluginReleaseService`.
+
+A slash redesign remains possible but lives in its own future issue with its own migration story. Until then, key encoding is backend-agnostic by contract.
+
+### Credentials — hybrid (static or default-chain)
+
+When `accessKey` AND `secretKey` are both set, `StaticCredentialsProvider` is used. When BOTH are blank, the SDK's `DefaultCredentialsProvider` runs (env, instance profile, IRSA, ECS task role). Half-configured states (one set, one blank) are caught at startup by a Bean-Validation `@AssertTrue`.
+
+The hybrid serves two operator profiles cleanly:
+
+- MinIO / dev / fixed-key cloud providers (Hetzner, R2) → static creds via env vars.
+- AWS production on EKS / ECS / EC2 with IRSA → leave env vars blank, let the SDK negotiate.
+
+### Bucket startup probe — `HeadBucket`, opt-in fail-fast
+
+An `ApplicationRunner` issues one `HeadBucket` on context start. Two operator outcomes:
+
+- Default (`fail-fast-on-bucket-missing=false`) → probe failure logs `ERROR` with bucket, region, endpoint, and the SDK message; the server keeps running so an operator can fix the bucket without a restart loop.
+- Opt-in (`fail-fast-on-bucket-missing=true`) → probe failure throws; the Spring context fails to start; the orchestrator's own restart loop kicks in. Mirrors the [#501](https://github.com/plugwerk/plugwerk/issues/501) fail-fast pattern for the encryption-key mismatch.
+
+`NoSuchBucket` and `PermanentRedirect` (region mismatch) both land in the same log line — the SDK message disambiguates without an extra branch.
+
+### Streaming — return the SDK's response stream directly
+
+`getObject(...)` returns `ResponseInputStream<GetObjectResponse>`, which IS an `InputStream`. We return it through `ArtifactStorageService.retrieve` unchanged so the response body streams to the client without buffering. The controller layer uses Spring's `InputStreamResource`, which closes the stream after the response writes — verified during implementation.
+
+Buffering would force every download into RAM, which is wrong for an artifact store with operator-controlled upload size limits.
+
+### `listKeys` on the interface
+
+Added in this PR even though no current caller needs it. [#190](https://github.com/plugwerk/plugwerk/issues/190) (StorageConsistencyService) will, and pushing the interface change into that PR would force a second cross-implementation update. Filesystem materialises eagerly (artifact directory is bounded); S3 paginates lazily via `ListObjectsV2Paginator` wrapped in a Kotlin `sequence { ... }`.
+
+## Consequences
+
+- Plugwerk now scales horizontally with shared object storage. Multiple server instances behind a load balancer point at the same bucket.
+- Operators must choose `fs` or `s3` at deploy time; switching post-hoc requires manual artifact migration (out of scope for this ADR).
+- The fat-jar gains ~6 MB. CycloneDX SBOM picks up the new transitive deps automatically.
+- A new MinIO Testcontainer participates in the integration-test suite; CI runners must have outbound Docker access.
+
+## Out of scope (recorded for future work)
+
+- Filesystem → S3 artifact migration tool.
+- Multi-bucket / multi-region setups.
+- Pre-signed URLs for direct client uploads.
+- GCS, Azure Blob Storage backends — would follow the same abstraction.
+- Slash-based key encoding (see "Key encoding" above).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ greenmail = "2.1.8"
 jmustache = "1.16"
 spotless = "8.4.0"
 cyclonedx = "3.2.4"
+aws-sdk = "2.36.3"
 
 [libraries]
 # Kotlin
@@ -102,6 +103,8 @@ mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
+aws-sdk-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-sdk" }
+aws-sdk-apache-client = { module = "software.amazon.awssdk:apache-client", version.ref = "aws-sdk" }
 mock-oauth2-server = { module = "no.nav.security:mock-oauth2-server", version.ref = "mock-oauth2-server" }
 
 [plugins]

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -57,6 +57,15 @@ dependencies {
     implementation(libs.bucket4j.core)
     implementation(libs.caffeine)
 
+    // AWS SDK for Java v2 — S3-compatible storage backend (#191).
+    // Versions pinned in libs.versions.toml via aws-sdk. apache-client is the
+    // synchronous Java HTTP client; exclude the default Netty client to keep
+    // Netty out of the fat-jar (servlet stack uses blocking I/O).
+    implementation(libs.aws.sdk.s3) {
+        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+    }
+    implementation(libs.aws.sdk.apache.client)
+
     runtimeOnly(libs.yasson)
     runtimeOnly(libs.postgresql)
     runtimeOnly(project(path = ":plugwerk-server:plugwerk-server-frontend", configuration = "staticResources"))

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -76,8 +76,13 @@ data class PlugwerkProperties(
      *   ```
      *
      * @property fs Settings for the filesystem backend. Only relevant when [type] is `fs`.
+     * @property s3 Settings for the S3-compatible backend. Only relevant when [type] is `s3`.
      */
-    data class StorageProperties(val type: String = "fs", val fs: FsProperties = FsProperties()) {
+    data class StorageProperties(
+        val type: String = "fs",
+        val fs: FsProperties = FsProperties(),
+        @field:Valid val s3: S3Properties? = null,
+    ) {
         /**
          * Filesystem storage settings (`plugwerk.storage.fs.*`).
          *
@@ -102,6 +107,124 @@ data class PlugwerkProperties(
          *   ```
          */
         data class FsProperties(val root: String = "/var/plugwerk/artifacts")
+
+        /**
+         * S3-compatible object-storage settings (`plugwerk.storage.s3.*`). Used when
+         * `plugwerk.storage.type=s3` (#191).
+         *
+         * Supports any S3-compatible endpoint via [endpoint] override: AWS S3, MinIO,
+         * Hetzner Object Storage, Cloudflare R2, etc.
+         *
+         * @property bucket REQUIRED. Bucket name that holds plugin artefacts. The
+         *   bucket must already exist; Plugwerk does not create buckets. A startup
+         *   `HeadBucket` probe verifies access — see [failFastOnBucketMissing].
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_BUCKET`
+         *
+         * @property region REQUIRED. AWS region or region-compatible identifier of
+         *   the bucket. For non-AWS endpoints this is still required by the SDK but
+         *   often a placeholder (`auto`, `us-east-1`).
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_REGION`
+         *
+         * @property endpoint Optional override URL for non-AWS S3-compatible endpoints.
+         *   Leave blank for AWS S3 (the SDK derives the endpoint from [region]).
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_ENDPOINT`
+         *
+         *   ```yaml
+         *   # MinIO local dev:
+         *   plugwerk.storage.s3.endpoint: http://localhost:9000
+         *
+         *   # Cloudflare R2:
+         *   plugwerk.storage.s3.endpoint: https://<account>.r2.cloudflarestorage.com
+         *
+         *   # Hetzner Object Storage (fsn1 region):
+         *   plugwerk.storage.s3.endpoint: https://fsn1.your-objectstorage.com
+         *   ```
+         *
+         * @property accessKey Optional. When [accessKey] AND [secretKey] are both set,
+         *   the SDK uses static credentials. When BOTH are blank, the SDK falls back
+         *   to the `DefaultCredentialsProvider` chain (env, instance profile, IRSA,
+         *   ECS task role). Half-configured states are rejected at startup.
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_ACCESS_KEY`
+         *
+         * @property secretKey Optional. See [accessKey].
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_SECRET_KEY`
+         *
+         * @property keyPrefix Optional prefix prepended to every artefact key.
+         *   Lets multiple Plugwerk installations share one bucket (`prod/plugwerk/`,
+         *   `staging/plugwerk/`). Default empty. **Must not start with `/`.**
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_KEY_PREFIX`
+         *
+         * @property pathStyleAccess `true` for MinIO and other endpoints that do not
+         *   support virtual-hosted–style URLs. Default `false` (DNS-style, the
+         *   default for AWS S3 / R2 / Hetzner).
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_PATH_STYLE_ACCESS`
+         *
+         * @property failFastOnBucketMissing When `true`, the server refuses to start
+         *   if the startup `HeadBucket` probe fails. Default `false` (probe failure
+         *   logs ERROR and the server keeps running so the operator can fix the
+         *   bucket without a restart loop). Set `true` in container orchestrators
+         *   that have their own restart loop and prefer fail-closed semantics
+         *   (mirrors #501).
+         *
+         *   Environment variable: `PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING`
+         */
+        data class S3Properties(
+            @field:NotBlank val bucket: String = "",
+            @field:NotBlank val region: String = "",
+            val endpoint: String? = null,
+            val accessKey: String? = null,
+            val secretKey: String? = null,
+            val keyPrefix: String = "",
+            val pathStyleAccess: Boolean = false,
+            val failFastOnBucketMissing: Boolean = false,
+        ) {
+            /**
+             * Static credentials must be supplied as a pair: both set or both blank.
+             * A half-configured state means the operator forgot one half — fail
+             * fast at startup rather than silently using the default provider chain.
+             */
+            @AssertTrue(
+                message = "S3 accessKey and secretKey must either both be set or both be blank " +
+                    "(blank means fall back to the default AWS credentials chain).",
+            )
+            fun isCredentialPairConsistent(): Boolean {
+                val accessBlank = accessKey.isNullOrBlank()
+                val secretBlank = secretKey.isNullOrBlank()
+                return accessBlank == secretBlank
+            }
+
+            /**
+             * A leading slash in `key-prefix` becomes a key segment named `""` on
+             * S3, which is valid but always wrong (no object browser will show it
+             * as the operator expects). Reject it.
+             */
+            @AssertTrue(message = "S3 key-prefix must not start with '/' (use 'env/plugwerk/' not '/env/plugwerk/').")
+            fun isKeyPrefixWellFormed(): Boolean = !keyPrefix.startsWith("/")
+
+            /** Redact [secretKey] from any accidental log line. */
+            override fun toString(): String = "S3Properties(bucket='$bucket', region='$region', endpoint=$endpoint, " +
+                "accessKey=${accessKey?.let { "<set>" } ?: "<unset>"}, " +
+                "secretKey=${secretKey?.let { "<set>" } ?: "<unset>"}, " +
+                "keyPrefix='$keyPrefix', pathStyleAccess=$pathStyleAccess, " +
+                "failFastOnBucketMissing=$failFastOnBucketMissing)"
+        }
+
+        /**
+         * When [type] is `s3`, the [s3] sub-section must be present and have a non-blank
+         * bucket. Without this, a half-configured deploy boots and silently falls back to
+         * the filesystem default, which is exactly the surprise we want to avoid.
+         */
+        @AssertTrue(
+            message = "plugwerk.storage.type=s3 requires plugwerk.storage.s3.bucket to be set.",
+        )
+        fun isS3ConfigPresentWhenS3Selected(): Boolean = type != "s3" || (s3 != null && s3.bucket.isNotBlank())
     }
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/S3BucketStartupCheck.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/S3BucketStartupCheck.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import io.plugwerk.server.PlugwerkProperties
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+
+/**
+ * Verifies that the configured S3 bucket is reachable at startup (#191).
+ *
+ * Only registered when `plugwerk.storage.type=s3`. Issues one `HeadBucket`
+ * request against the configured bucket. Outcome depends on
+ * `plugwerk.storage.s3.fail-fast-on-bucket-missing`:
+ *
+ *   - `false` (default): probe failure logs ERROR and the server continues
+ *     starting. Operators get a clear log line and can fix the bucket
+ *     without a restart loop.
+ *   - `true`: probe failure rethrows, the Spring context fails to start, and
+ *     the container orchestrator's restart loop kicks in. Suitable for
+ *     production where a silently-broken artifact store is worse than a
+ *     fail-closed pod restart (mirrors the #501 fail-fast pattern).
+ *
+ * Region-mismatch errors (`PermanentRedirect`) and `NoSuchBucket` both land
+ * here; the log line names bucket, region, endpoint, and the underlying SDK
+ * message so operators can tell the two apart without reading the trace.
+ */
+@Component
+@ConditionalOnProperty(prefix = "plugwerk.storage", name = ["type"], havingValue = "s3")
+class S3BucketStartupCheck(private val s3Client: S3Client, private val properties: PlugwerkProperties) :
+    ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(S3BucketStartupCheck::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val s3 = checkNotNull(properties.storage.s3) {
+            "plugwerk.storage.s3 must be configured when plugwerk.storage.type=s3"
+        }
+        val bucket = s3.bucket
+
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build())
+            log.info(
+                "S3 bucket '{}' is reachable (region={}, endpoint={})",
+                bucket,
+                s3.region,
+                s3.endpoint ?: "<aws-default>",
+            )
+        } catch (ex: Exception) {
+            val msg = "S3 bucket '$bucket' is not reachable — region=${s3.region}, " +
+                "endpoint=${s3.endpoint ?: "<aws-default>"}, cause: ${ex.message}. " +
+                "Verify the bucket exists, the region matches, and the configured " +
+                "credentials have HeadBucket permission."
+            if (s3.failFastOnBucketMissing) {
+                log.error("$msg [fail-fast-on-bucket-missing=true → refusing to start]", ex)
+                throw IllegalStateException(msg, ex)
+            }
+            log.error(msg, ex)
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/S3ClientConfig.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/S3ClientConfig.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import io.plugwerk.server.PlugwerkProperties
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import java.net.URI
+
+/**
+ * Wires the AWS SDK v2 [S3Client] bean for the S3 storage backend (#191).
+ *
+ * Only loaded when `plugwerk.storage.type=s3` so a filesystem-only deployment
+ * does not pay the SDK init cost or carry the S3 client into its bean graph.
+ *
+ * The hybrid credential strategy mirrors what the [PlugwerkProperties.StorageProperties.S3Properties]
+ * KDoc documents: if `accessKey`/`secretKey` are both set, [StaticCredentialsProvider]
+ * is used; if both are blank, the SDK's [DefaultCredentialsProvider] chain runs
+ * (env, instance profile, IRSA, ECS task role). The half-configured case is
+ * rejected at startup by the @AssertTrue validator on `S3Properties`.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "plugwerk.storage", name = ["type"], havingValue = "s3")
+class S3ClientConfig {
+
+    private val log = LoggerFactory.getLogger(S3ClientConfig::class.java)
+
+    @Bean(destroyMethod = "close")
+    fun s3Client(properties: PlugwerkProperties): S3Client {
+        val s3 = checkNotNull(properties.storage.s3) {
+            "plugwerk.storage.s3 must be configured when plugwerk.storage.type=s3 " +
+                "— this should have been caught by the @AssertTrue validator on " +
+                "StorageProperties.isS3ConfigPresentWhenS3Selected; please file a bug if you see this"
+        }
+
+        val credentialsProvider = resolveCredentialsProvider(s3)
+
+        val builder = S3Client.builder()
+            .region(Region.of(s3.region))
+            .credentialsProvider(credentialsProvider)
+            .httpClient(ApacheHttpClient.builder().build())
+            .serviceConfiguration(
+                S3Configuration.builder()
+                    .pathStyleAccessEnabled(s3.pathStyleAccess)
+                    .build(),
+            )
+
+        if (!s3.endpoint.isNullOrBlank()) {
+            builder.endpointOverride(URI.create(s3.endpoint))
+        }
+
+        log.info(
+            "S3 client initialised: bucket={}, region={}, endpoint={}, pathStyleAccess={}, " +
+                "credentialsProvider={}",
+            s3.bucket,
+            s3.region,
+            s3.endpoint ?: "<aws-default>",
+            s3.pathStyleAccess,
+            credentialsProvider.javaClass.simpleName,
+        )
+        return builder.build()
+    }
+
+    private fun resolveCredentialsProvider(
+        s3: PlugwerkProperties.StorageProperties.S3Properties,
+    ): AwsCredentialsProvider {
+        val accessKey = s3.accessKey
+        val secretKey = s3.secretKey
+        return if (!accessKey.isNullOrBlank() && !secretKey.isNullOrBlank()) {
+            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+        } else {
+            DefaultCredentialsProvider.create()
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/ArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/ArtifactStorageService.kt
@@ -29,4 +29,24 @@ interface ArtifactStorageService {
     fun delete(key: String)
 
     fun exists(key: String): Boolean
+
+    /**
+     * Returns every key in the backend whose path starts with [prefix] (#191).
+     *
+     * Designed for the consistency-check use case in #190 (find orphaned artifacts).
+     * The empty default returns every key; **do not call without a prefix on a
+     * production bucket unless you mean it**.
+     *
+     * Backend semantics:
+     *   - Filesystem: keyspace is bounded by the artifact directory; returns
+     *     eagerly-materialised contents wrapped in a Sequence for API symmetry.
+     *   - S3: lazy pagination via `ListObjectsV2`; callers MUST either fully
+     *     consume the sequence or wrap their use in a try-finally so the
+     *     underlying pager is released. Filtering should be done by passing a
+     *     non-empty [prefix] so S3 can skip non-matching pages server-side.
+     *
+     * Returned keys are storage-relative (no bucket prefix, no root path) and
+     * match the format passed to [store] / [retrieve] / [delete] / [exists].
+     */
+    fun listKeys(prefix: String = ""): Sequence<String>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageService.kt
@@ -67,6 +67,26 @@ class FilesystemArtifactStorageService(properties: PlugwerkProperties) : Artifac
 
     override fun exists(key: String): Boolean = resolveKey(key).exists()
 
+    override fun listKeys(prefix: String): Sequence<String> {
+        if (!root.exists()) return emptySequence()
+        return try {
+            // Eager materialisation: the filesystem artifact directory is bounded
+            // (one file per release), so walking it once and closing the stream
+            // immediately is correct. Lazy iteration would force callers to close
+            // the Files.walk stream — extra contract burden for no real benefit.
+            Files.walk(root).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) }
+                    .map { root.relativize(it).toString() }
+                    .filter { it.startsWith(prefix) }
+                    .toList()
+                    .asSequence()
+            }
+        } catch (e: Exception) {
+            throw ArtifactStorageException("Failed to list artifacts with prefix '$prefix'", e)
+        }
+    }
+
     private fun resolveKey(key: String): Path = root.resolve(key).normalize().also {
         require(it.startsWith(root)) { "Key '$key' resolves outside storage root" }
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageService.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.ArtifactNotFoundException
+import io.plugwerk.server.service.ArtifactStorageException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+import java.io.InputStream
+
+/**
+ * S3-compatible [ArtifactStorageService] backed by the AWS SDK v2 (#191).
+ *
+ * Selected when `plugwerk.storage.type=s3`. Hands every SDK call through
+ * [mapExceptions] so callers see the project's own
+ * [ArtifactNotFoundException] / [ArtifactStorageException] regardless of
+ * which underlying `S3Exception` subtype the SDK throws.
+ *
+ * Key handling: every public method routes through [prefixed] so the
+ * operator-configured `key-prefix` is opaque to callers. Returned keys
+ * from [listKeys] are stripped of the prefix again so consumers see the
+ * same keys they passed in.
+ */
+@Service
+@ConditionalOnProperty(prefix = "plugwerk.storage", name = ["type"], havingValue = "s3")
+class S3ArtifactStorageService(private val s3Client: S3Client, properties: PlugwerkProperties) :
+    ArtifactStorageService {
+
+    private val s3 = checkNotNull(properties.storage.s3) {
+        "plugwerk.storage.s3 must be configured when plugwerk.storage.type=s3"
+    }
+    private val bucket: String = s3.bucket
+    private val keyPrefix: String = s3.keyPrefix
+
+    override fun store(key: String, content: InputStream, contentLength: Long): String {
+        mapExceptions(key) {
+            s3Client.putObject(
+                PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(prefixed(key))
+                    .contentLength(contentLength)
+                    .build(),
+                RequestBody.fromInputStream(content, contentLength),
+            )
+        }
+        return key
+    }
+
+    override fun retrieve(key: String): InputStream = mapExceptions(key) {
+        s3Client.getObject(
+            GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(prefixed(key))
+                .build(),
+        )
+    }
+
+    override fun delete(key: String) {
+        // S3 DeleteObject is silently idempotent — matches Files.deleteIfExists.
+        mapExceptions(key) {
+            s3Client.deleteObject(
+                DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(prefixed(key))
+                    .build(),
+            )
+        }
+    }
+
+    override fun exists(key: String): Boolean = try {
+        s3Client.headObject(
+            HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(prefixed(key))
+                .build(),
+        )
+        true
+    } catch (_: NoSuchKeyException) {
+        false
+    } catch (ex: S3Exception) {
+        // 404 from HeadObject is reported as a generic S3Exception with status
+        // 404, not NoSuchKeyException — that variant is only thrown for
+        // GetObject. Treat both as "not found".
+        if (ex.statusCode() == 404) {
+            false
+        } else {
+            throw ArtifactStorageException(
+                "S3 headObject failed for key '$key': ${ex.message}",
+                ex,
+            )
+        }
+    }
+
+    override fun listKeys(prefix: String): Sequence<String> {
+        val combinedPrefix = prefixed(prefix)
+        // Lazy: every iteration step calls the paginator, which transparently
+        // pulls the next page when the current one is exhausted. Callers MUST
+        // either consume the sequence fully or wrap iteration in a try-finally
+        // because the paginator keeps SDK state alive between pages.
+        return sequence {
+            val request = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(combinedPrefix)
+                .build()
+            try {
+                s3Client.listObjectsV2Paginator(request).forEach { page ->
+                    page.contents().forEach { obj ->
+                        // Strip the configured prefix so the caller sees the same
+                        // keys they passed to store/retrieve/delete.
+                        val raw = obj.key()
+                        yield(if (keyPrefix.isNotEmpty()) raw.removePrefix(keyPrefix) else raw)
+                    }
+                }
+            } catch (ex: S3Exception) {
+                throw ArtifactStorageException(
+                    "S3 listObjects failed for prefix '$prefix': ${ex.message}",
+                    ex,
+                )
+            }
+        }
+    }
+
+    private fun prefixed(key: String): String = if (keyPrefix.isEmpty()) key else "$keyPrefix$key"
+
+    private inline fun <T> mapExceptions(key: String, block: () -> T): T = try {
+        block()
+    } catch (ex: NoSuchKeyException) {
+        throw ArtifactNotFoundException(key)
+    } catch (ex: S3Exception) {
+        throw ArtifactStorageException(
+            "S3 operation failed for key '$key': ${ex.message}",
+            ex,
+        )
+    } catch (ex: Exception) {
+        throw ArtifactStorageException(
+            "Unexpected error during S3 operation for key '$key': ${ex.message}",
+            ex,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -50,9 +50,56 @@ spring:
 
 plugwerk:
   storage:
+    # Storage backend selector. `fs` = local filesystem (single-node, default).
+    # `s3` = S3-compatible object storage (AWS S3, MinIO, Hetzner OS, Cloudflare R2).
+    # Env: PLUGWERK_STORAGE_TYPE
     type: ${PLUGWERK_STORAGE_TYPE:fs}
+
+    # Filesystem-backend settings — only used when type=fs.
     fs:
       root: ${PLUGWERK_STORAGE_ROOT:/var/plugwerk/artifacts}
+
+    # S3-compatible-backend settings — only used when type=s3 (#191).
+    # `bucket` and `region` are required when type=s3. The bucket must already
+    # exist; Plugwerk does not create buckets.
+    s3:
+      # Env: PLUGWERK_STORAGE_S3_BUCKET
+      bucket: ${PLUGWERK_STORAGE_S3_BUCKET:}
+      # AWS region or region-compatible identifier (`auto`, `us-east-1` for
+      # non-AWS endpoints).
+      # Env: PLUGWERK_STORAGE_S3_REGION
+      region: ${PLUGWERK_STORAGE_S3_REGION:}
+      # Override the endpoint for non-AWS S3-compatible providers. Leave blank
+      # for AWS S3 (the SDK derives the endpoint from region).
+      # Examples:
+      #   MinIO local:    http://localhost:9000
+      #   Cloudflare R2:  https://<account>.r2.cloudflarestorage.com
+      #   Hetzner OS:     https://fsn1.your-objectstorage.com
+      # Env: PLUGWERK_STORAGE_S3_ENDPOINT
+      endpoint: ${PLUGWERK_STORAGE_S3_ENDPOINT:}
+      # When BOTH accessKey AND secretKey are set, static credentials are used.
+      # When BOTH are blank, the SDK falls back to the DefaultCredentialsProvider
+      # (env, instance profile, IRSA, ECS task role). Half-configured states
+      # (one set, one blank) are rejected at startup.
+      # Env: PLUGWERK_STORAGE_S3_ACCESS_KEY
+      access-key: ${PLUGWERK_STORAGE_S3_ACCESS_KEY:}
+      # Env: PLUGWERK_STORAGE_S3_SECRET_KEY
+      secret-key: ${PLUGWERK_STORAGE_S3_SECRET_KEY:}
+      # Optional prefix prepended to every artifact key. Lets multiple Plugwerk
+      # installations share one bucket (e.g. "prod/plugwerk/"). Must NOT start
+      # with '/'.
+      # Env: PLUGWERK_STORAGE_S3_KEY_PREFIX
+      key-prefix: ${PLUGWERK_STORAGE_S3_KEY_PREFIX:}
+      # `true` for MinIO and other endpoints that do not support virtual-hosted
+      # style URLs. Default `false` (DNS-style; works for AWS S3, R2, Hetzner).
+      # Env: PLUGWERK_STORAGE_S3_PATH_STYLE_ACCESS
+      path-style-access: ${PLUGWERK_STORAGE_S3_PATH_STYLE_ACCESS:false}
+      # Refuse to start when the bucket-existence probe fails at startup.
+      # Default false → probe failure logs ERROR and server keeps running so the
+      # operator can fix the bucket without a restart loop. Set true in container
+      # orchestrators that already have a restart loop and prefer fail-closed.
+      # Env: PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING
+      fail-fast-on-bucket-missing: ${PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING:false}
   server:
     base-url: ${PLUGWERK_BASE_URL:http://localhost:8080}
     # Frontend base URL for browser-facing links emitted by the server (e.g. the

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/PlugwerkPropertiesS3ValidationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/PlugwerkPropertiesS3ValidationTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server
+
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates [PlugwerkProperties.StorageProperties.S3Properties] and the
+ * cross-field [PlugwerkProperties.StorageProperties.isS3ConfigPresentWhenS3Selected]
+ * guard (#191). Each test pins one validation path so a future relaxation of
+ * the contract fails one assertion at a time instead of silently widening the
+ * accepted config surface.
+ */
+class PlugwerkPropertiesS3ValidationTest {
+
+    private val validator: Validator =
+        Validation.buildDefaultValidatorFactory().use { it.validator }
+
+    @Test
+    fun `valid S3 config with static creds passes`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            accessKey = "AKIA...",
+            secretKey = "secret",
+        )
+        assertThat(validator.validate(props)).isEmpty()
+    }
+
+    @Test
+    fun `valid S3 config with default credentials chain (both blank) passes`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+        )
+        assertThat(validator.validate(props)).isEmpty()
+    }
+
+    @Test
+    fun `half-configured credential pair is rejected (accessKey set, secretKey blank)`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            accessKey = "AKIA...",
+            secretKey = null,
+        )
+        val violations = validator.validate(props)
+        assertThat(violations.map { it.message })
+            .anyMatch { it.contains("both be set or both be blank") }
+    }
+
+    @Test
+    fun `half-configured credential pair is rejected (secretKey set, accessKey blank)`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            accessKey = "",
+            secretKey = "secret",
+        )
+        val violations = validator.validate(props)
+        assertThat(violations.map { it.message })
+            .anyMatch { it.contains("both be set or both be blank") }
+    }
+
+    @Test
+    fun `blank bucket is rejected`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "",
+            region = "eu-central-1",
+        )
+        assertThat(validator.validate(props)).isNotEmpty
+    }
+
+    @Test
+    fun `blank region is rejected`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "",
+        )
+        assertThat(validator.validate(props)).isNotEmpty
+    }
+
+    @Test
+    fun `key-prefix with leading slash is rejected`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            keyPrefix = "/env/plugwerk/",
+        )
+        val violations = validator.validate(props)
+        assertThat(violations.map { it.message })
+            .anyMatch { it.contains("must not start with") }
+    }
+
+    @Test
+    fun `key-prefix without leading slash is accepted`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            keyPrefix = "env/plugwerk/",
+        )
+        assertThat(validator.validate(props)).isEmpty()
+    }
+
+    @Test
+    fun `cross-field guard rejects type=s3 with null s3 sub-section`() {
+        val storage = PlugwerkProperties.StorageProperties(type = "s3", s3 = null)
+        val violations = validator.validate(storage)
+        assertThat(violations.map { it.message })
+            .anyMatch { it.contains("plugwerk.storage.s3.bucket") }
+    }
+
+    @Test
+    fun `cross-field guard rejects type=s3 with blank bucket`() {
+        val storage = PlugwerkProperties.StorageProperties(
+            type = "s3",
+            s3 = PlugwerkProperties.StorageProperties.S3Properties(
+                bucket = "",
+                region = "eu-central-1",
+            ),
+        )
+        val violations = validator.validate(storage)
+        assertThat(violations.map { it.message })
+            .anyMatch { it.contains("plugwerk.storage.s3.bucket") }
+    }
+
+    @Test
+    fun `cross-field guard accepts type=fs with no s3 sub-section`() {
+        val storage = PlugwerkProperties.StorageProperties(type = "fs")
+        assertThat(validator.validate(storage)).isEmpty()
+    }
+
+    @Test
+    fun `toString redacts accessKey and secretKey`() {
+        val props = PlugwerkProperties.StorageProperties.S3Properties(
+            bucket = "plugwerk-artifacts",
+            region = "eu-central-1",
+            accessKey = "AKIA-public-id-no-secret",
+            secretKey = "do-not-log-this-secret",
+        )
+        val str = props.toString()
+        assertThat(str)
+            .doesNotContain("AKIA-public-id-no-secret")
+            .doesNotContain("do-not-log-this-secret")
+        assertThat(str).contains("accessKey=<set>", "secretKey=<set>")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/SharedMinioContainer.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/SharedMinioContainer.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+/**
+ * Shared MinIO Testcontainer for S3-backend integration tests (#191).
+ *
+ * Singleton: spun up once per Gradle test JVM, reused across every test class
+ * that touches S3. Mirrors [SharedPostgresContainer]'s start-once pattern.
+ *
+ * Default credentials are MinIO's `minioadmin` / `minioadmin` — fine for
+ * test isolation. Each test class is responsible for creating its own bucket
+ * (or per-test prefixes) to avoid cross-test interference.
+ *
+ * Image is pinned: refreshing requires a deliberate version bump (and a
+ * Testcontainers image cache eviction on CI).
+ */
+object SharedMinioContainer {
+    const val ACCESS_KEY: String = "minioadmin"
+    const val SECRET_KEY: String = "minioadmin"
+
+    @Suppress("HttpUrlsUsage")
+    val instance: GenericContainer<*> =
+        GenericContainer("minio/minio:RELEASE.2024-12-18T13-15-44Z")
+            .withCommand("server", "/data", "--console-address", ":9001")
+            .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+            .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+            .withExposedPorts(9000, 9001)
+            .waitingFor(Wait.forHttp("/minio/health/live").forPort(9000))
+            .apply { start() }
+
+    val endpoint: String
+        get() = "http://${instance.host}:${instance.getMappedPort(9000)}"
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageServiceTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+class FilesystemArtifactStorageServiceTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    private lateinit var storage: FilesystemArtifactStorageService
+
+    @BeforeEach
+    fun setUp() {
+        storage = FilesystemArtifactStorageService(propsWithRoot(tmp))
+    }
+
+    @Test
+    fun `store retrieve roundtrip preserves bytes`() {
+        val bytes = "hello-plugwerk".toByteArray()
+
+        storage.store("acme:hello:1.0.0:jar", ByteArrayInputStream(bytes), bytes.size.toLong())
+
+        val read = storage.retrieve("acme:hello:1.0.0:jar").readAllBytes()
+        assertThat(read).isEqualTo(bytes)
+    }
+
+    @Test
+    fun `exists returns true after store and false after delete`() {
+        storage.store("acme:plugin-a:1.0.0:jar", ByteArrayInputStream(byteArrayOf(1, 2, 3)), 3)
+
+        assertThat(storage.exists("acme:plugin-a:1.0.0:jar")).isTrue()
+
+        storage.delete("acme:plugin-a:1.0.0:jar")
+
+        assertThat(storage.exists("acme:plugin-a:1.0.0:jar")).isFalse()
+    }
+
+    @Test
+    fun `delete is idempotent for missing keys`() {
+        storage.delete("never:existed:0.0.0:jar")
+        // No exception. Matches S3.DeleteObject and the broader contract.
+    }
+
+    @Test
+    fun `listKeys returns empty sequence when root does not exist`() {
+        val freshTmp = tmp.resolve("does-not-exist")
+        val s = FilesystemArtifactStorageService(propsWithRoot(freshTmp))
+
+        assertThat(s.listKeys().toList()).isEmpty()
+    }
+
+    @Test
+    fun `listKeys returns every key with empty prefix`() {
+        listOf(
+            "acme:plugin-a:1.0.0:jar",
+            "acme:plugin-b:2.0.0:jar",
+            "other:plugin-c:0.1.0:zip",
+        ).forEach { storage.store(it, ByteArrayInputStream(byteArrayOf(0)), 1) }
+
+        assertThat(storage.listKeys().toList())
+            .containsExactlyInAnyOrder(
+                "acme:plugin-a:1.0.0:jar",
+                "acme:plugin-b:2.0.0:jar",
+                "other:plugin-c:0.1.0:zip",
+            )
+    }
+
+    @Test
+    fun `listKeys filters by prefix`() {
+        listOf(
+            "acme:plugin-a:1.0.0:jar",
+            "acme:plugin-b:2.0.0:jar",
+            "other:plugin-c:0.1.0:zip",
+        ).forEach { storage.store(it, ByteArrayInputStream(byteArrayOf(0)), 1) }
+
+        assertThat(storage.listKeys("acme:").toList())
+            .containsExactlyInAnyOrder(
+                "acme:plugin-a:1.0.0:jar",
+                "acme:plugin-b:2.0.0:jar",
+            )
+    }
+
+    @Test
+    fun `listKeys ignores directories and only returns regular files`() {
+        // Plant a bare directory inside root — it must not be reported as a key.
+        Files.createDirectories(tmp.resolve("subdir/nested"))
+        storage.store("acme:plugin:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+
+        assertThat(storage.listKeys().toList())
+            .containsExactly("acme:plugin:1.0.0:jar")
+    }
+
+    private fun propsWithRoot(root: Path): PlugwerkProperties = PlugwerkProperties(
+        storage = PlugwerkProperties.StorageProperties(
+            type = "fs",
+            fs = PlugwerkProperties.StorageProperties.FsProperties(root = root.toString()),
+        ),
+        auth = PlugwerkProperties.AuthProperties(
+            jwtSecret = "test-secret-at-least-32-chars-long!!",
+        ),
+    )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageServiceIntegrationTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.SharedMinioContainer
+import io.plugwerk.server.service.ArtifactNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.util.UUID
+
+/**
+ * End-to-end coverage for [S3ArtifactStorageService] against a real MinIO
+ * Testcontainer (#191). Unit tests in `S3ArtifactStorageServiceTest` cover
+ * the exception-mapping and key-prefix contracts in isolation; this class
+ * verifies the wire-level behaviour against a genuine S3-compatible server.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("integration")
+class S3ArtifactStorageServiceIntegrationTest {
+
+    private val bucket = "plugwerk-it-${UUID.randomUUID()}"
+    private lateinit var s3Client: S3Client
+    private lateinit var storage: S3ArtifactStorageService
+
+    @BeforeAll
+    fun setUp() {
+        s3Client = S3Client.builder()
+            .region(Region.of("us-east-1"))
+            .endpointOverride(URI.create(SharedMinioContainer.endpoint))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                        SharedMinioContainer.ACCESS_KEY,
+                        SharedMinioContainer.SECRET_KEY,
+                    ),
+                ),
+            )
+            .httpClient(ApacheHttpClient.builder().build())
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+            .build()
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build())
+        storage = S3ArtifactStorageService(s3Client, props(bucket = bucket))
+    }
+
+    @Test
+    fun `store retrieve roundtrip preserves bytes`() {
+        val bytes = "hello-plugwerk-s3".toByteArray()
+
+        storage.store("acme:hello:1.0.0:jar", ByteArrayInputStream(bytes), bytes.size.toLong())
+
+        val read = storage.retrieve("acme:hello:1.0.0:jar").readAllBytes()
+        assertThat(read).isEqualTo(bytes)
+    }
+
+    @Test
+    fun `exists returns true after store and false after delete`() {
+        storage.store("acme:exists-test:1.0.0:jar", ByteArrayInputStream(byteArrayOf(1, 2, 3)), 3)
+        assertThat(storage.exists("acme:exists-test:1.0.0:jar")).isTrue()
+
+        storage.delete("acme:exists-test:1.0.0:jar")
+        assertThat(storage.exists("acme:exists-test:1.0.0:jar")).isFalse()
+    }
+
+    @Test
+    fun `retrieve of missing key throws ArtifactNotFoundException`() {
+        assertThatThrownBy { storage.retrieve("never:existed:0.0.0:jar") }
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+    }
+
+    @Test
+    fun `delete of missing key is silently idempotent`() {
+        storage.delete("never:existed:0.0.0:jar")
+        // no exception
+    }
+
+    @Test
+    fun `listKeys returns every key under a prefix`() {
+        storage.store("ns-list:plugin-a:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+        storage.store("ns-list:plugin-b:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+        storage.store("other-list:plugin-c:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+
+        val results = storage.listKeys("ns-list:").toList()
+
+        assertThat(results).containsExactlyInAnyOrder(
+            "ns-list:plugin-a:1.0.0:jar",
+            "ns-list:plugin-b:1.0.0:jar",
+        )
+    }
+
+    @Test
+    fun `listKeys crosses the 1000-key pagination boundary`() {
+        // S3 ListObjectsV2 returns up to 1000 keys per page; we seed 1100 to
+        // force pagination and verify the paginator surfaces every key.
+        val prefix = "pagination:run-${UUID.randomUUID()}:"
+        repeat(1100) { i ->
+            storage.store("$prefix$i:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+        }
+
+        val results = storage.listKeys(prefix).toList()
+
+        assertThat(results).hasSize(1100)
+    }
+
+    @Test
+    fun `keyPrefix is opaque to callers — store with prefix, listKeys returns unprefixed`() {
+        val prefixedStorage = S3ArtifactStorageService(
+            s3Client,
+            props(bucket = bucket, keyPrefix = "tenant-a/"),
+        )
+
+        prefixedStorage.store("acme:prefix-test:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+
+        // Caller sees the key without the configured prefix.
+        val listed = prefixedStorage.listKeys("acme:").toList()
+        assertThat(listed).containsExactly("acme:prefix-test:1.0.0:jar")
+        assertThat(prefixedStorage.exists("acme:prefix-test:1.0.0:jar")).isTrue()
+    }
+
+    private fun props(bucket: String, keyPrefix: String = ""): PlugwerkProperties = PlugwerkProperties(
+        storage = PlugwerkProperties.StorageProperties(
+            type = "s3",
+            s3 = PlugwerkProperties.StorageProperties.S3Properties(
+                bucket = bucket,
+                region = "us-east-1",
+                endpoint = SharedMinioContainer.endpoint,
+                accessKey = SharedMinioContainer.ACCESS_KEY,
+                secretKey = SharedMinioContainer.SECRET_KEY,
+                keyPrefix = keyPrefix,
+                pathStyleAccess = true,
+            ),
+        ),
+        auth = PlugwerkProperties.AuthProperties(
+            jwtSecret = "test-secret-at-least-32-chars-long!!",
+        ),
+    )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageServiceTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.ArtifactNotFoundException
+import io.plugwerk.server.service.ArtifactStorageException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+
+/**
+ * Unit tests for [S3ArtifactStorageService] (#191).
+ *
+ * Covers the exception-mapping contract (SDK exception → project exception),
+ * key-prefix handling, and basic request shape. Integration coverage against
+ * a real MinIO container lives in `S3ArtifactStorageServiceIntegrationTest`.
+ */
+class S3ArtifactStorageServiceTest {
+
+    private lateinit var s3Client: S3Client
+    private lateinit var storage: S3ArtifactStorageService
+
+    @BeforeEach
+    fun setUp() {
+        s3Client = mock()
+        storage = S3ArtifactStorageService(s3Client, props(keyPrefix = ""))
+    }
+
+    // -- exception mapping -------------------------------------------------
+
+    @Test
+    fun `retrieve maps NoSuchKeyException to ArtifactNotFoundException`() {
+        whenever(s3Client.getObject(any<GetObjectRequest>()))
+            .thenThrow(NoSuchKeyException.builder().message("not found").build())
+
+        assertThatThrownBy { storage.retrieve("missing:plugin:1.0.0:jar") }
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("missing:plugin:1.0.0:jar")
+    }
+
+    @Test
+    fun `retrieve maps generic S3Exception to ArtifactStorageException with cause`() {
+        val cause = S3Exception.builder().message("AccessDenied").build()
+        whenever(s3Client.getObject(any<GetObjectRequest>())).thenThrow(cause)
+
+        assertThatThrownBy { storage.retrieve("acme:plugin:1.0.0:jar") }
+            .isInstanceOf(ArtifactStorageException::class.java)
+            .hasMessageContaining("acme:plugin:1.0.0:jar")
+            .hasCause(cause)
+    }
+
+    @Test
+    fun `exists returns true for HeadObject success`() {
+        whenever(s3Client.headObject(any<HeadObjectRequest>())).thenReturn(null)
+
+        assertThat(storage.exists("acme:plugin:1.0.0:jar")).isTrue()
+    }
+
+    @Test
+    fun `exists returns false for NoSuchKeyException`() {
+        whenever(s3Client.headObject(any<HeadObjectRequest>()))
+            .thenThrow(NoSuchKeyException.builder().message("not found").build())
+
+        assertThat(storage.exists("acme:plugin:1.0.0:jar")).isFalse()
+    }
+
+    @Test
+    fun `exists returns false for 404 S3Exception (HeadObject path)`() {
+        // HeadObject reports 404 as a plain S3Exception with statusCode=404,
+        // not a NoSuchKeyException — that subtype is only thrown by GetObject.
+        // Build an S3Exception with awsErrorDetails so statusCode() returns 404.
+        val notFound = S3Exception.builder()
+            .statusCode(404)
+            .message("Not Found")
+            .build()
+        whenever(s3Client.headObject(any<HeadObjectRequest>())).thenThrow(notFound)
+
+        assertThat(storage.exists("acme:plugin:1.0.0:jar")).isFalse()
+    }
+
+    @Test
+    fun `exists rethrows for non-404 S3Exception`() {
+        val accessDenied = S3Exception.builder()
+            .statusCode(403)
+            .message("AccessDenied")
+            .build()
+        whenever(s3Client.headObject(any<HeadObjectRequest>())).thenThrow(accessDenied)
+
+        assertThatThrownBy { storage.exists("acme:plugin:1.0.0:jar") }
+            .isInstanceOf(ArtifactStorageException::class.java)
+    }
+
+    @Test
+    fun `delete is silently idempotent (SDK DeleteObject returns 204 for missing keys)`() {
+        storage.delete("never:existed:0.0.0:jar")
+
+        verify(s3Client).deleteObject(any<DeleteObjectRequest>())
+    }
+
+    // -- key prefix --------------------------------------------------------
+
+    @Test
+    fun `keyPrefix is prepended to every S3 key`() {
+        val sut = S3ArtifactStorageService(s3Client, props(keyPrefix = "prod/plugwerk/"))
+
+        sut.delete("acme:plugin:1.0.0:jar")
+
+        val captor = argumentCaptor<DeleteObjectRequest>()
+        verify(s3Client).deleteObject(captor.capture())
+        assertThat(captor.firstValue.key()).isEqualTo("prod/plugwerk/acme:plugin:1.0.0:jar")
+    }
+
+    @Test
+    fun `empty keyPrefix passes keys through verbatim`() {
+        storage.delete("acme:plugin:1.0.0:jar")
+
+        val captor = argumentCaptor<DeleteObjectRequest>()
+        verify(s3Client).deleteObject(captor.capture())
+        assertThat(captor.firstValue.key()).isEqualTo("acme:plugin:1.0.0:jar")
+    }
+
+    @Test
+    fun `store passes contentLength through to PutObjectRequest`() {
+        storage.store("acme:plugin:1.0.0:jar", "ignored".byteInputStream(), 7L)
+
+        val captor = argumentCaptor<PutObjectRequest>()
+        verify(s3Client).putObject(captor.capture(), any<software.amazon.awssdk.core.sync.RequestBody>())
+        assertThat(captor.firstValue.bucket()).isEqualTo("plugwerk-artifacts")
+        assertThat(captor.firstValue.key()).isEqualTo("acme:plugin:1.0.0:jar")
+        assertThat(captor.firstValue.contentLength()).isEqualTo(7L)
+    }
+
+    private fun props(keyPrefix: String): PlugwerkProperties = PlugwerkProperties(
+        storage = PlugwerkProperties.StorageProperties(
+            type = "s3",
+            s3 = PlugwerkProperties.StorageProperties.S3Properties(
+                bucket = "plugwerk-artifacts",
+                region = "eu-central-1",
+                keyPrefix = keyPrefix,
+            ),
+        ),
+        auth = PlugwerkProperties.AuthProperties(
+            jwtSecret = "test-secret-at-least-32-chars-long!!",
+        ),
+    )
+}


### PR DESCRIPTION
## Summary

Closes #191. Adds an `S3ArtifactStorageService` so plugin artifacts can live in any S3-compatible bucket (AWS S3, MinIO, Hetzner Object Storage, Cloudflare R2). Filesystem stays the default and zero existing deployments need to change anything.

The `ArtifactStorageService` interface, the filesystem implementation, and the `plugwerk.storage.type` selector already existed from earlier preparation work — this PR is the second implementation plus the supporting wiring.

## What's in the box

| Commit | Scope |
|---|---|
| `feat(storage): add listKeys to ArtifactStorageService interface` | Interface extension so #190 (StorageConsistencyService) doesn't need another cross-impl PR. Eager on filesystem, lazy paginator on S3. |
| `feat(storage): add S3 properties + AWS SDK v2 deps` | Nested `S3Properties` data class with full KDoc, three `@AssertTrue` validators (half-configured creds, leading-slash prefix, type=s3 without bucket), redacted `toString`, application.yml block, AWS SDK v2 wiring (`apache-client`; Netty excluded). |
| `feat(storage): add S3 client bean + bucket startup probe` | `S3ClientConfig` (hybrid creds: static OR `DefaultCredentialsProvider`). `S3BucketStartupCheck` ApplicationRunner with opt-in `fail-fast-on-bucket-missing` mirroring the #501 pattern. |
| `feat(storage): add S3ArtifactStorageService implementation` | Five methods + private `prefixed()` and `mapExceptions()` helpers. Returns the SDK's `ResponseInputStream` directly for true streaming-on-get. |
| `test(storage): MinIO Testcontainer integration coverage` | `SharedMinioContainer` + full method-set IT including the 1100-key pagination crossing. |
| `docs(storage): dev tooling, env vars, ADR for S3 backend` | `docker compose --profile s3-dev` with MinIO + `mc` init container; `.env.example`; README quickstart; ADR-0034 capturing the load-bearing trade-offs. |

## Design decisions (full reasoning in [`docs/adrs/0034-s3-storage-backend.md`](docs/adrs/0034-s3-storage-backend.md))

| Decision | Choice | Why |
|---|---|---|
| S3 client | AWS SDK v2 + `apache-client` (Netty excluded) | Universal endpoint override, first-party support, blocking I/O matches the servlet stack |
| Size impact | ~6 MB transitive | Accepted; documented |
| Key encoding | Keep `<uuid>:<plugin>:<ver>:<ext>` | S3 accepts colons; zero migration; slash redesign is its own future issue |
| Credentials | Hybrid: static OR `DefaultCredentialsProvider` | Serves MinIO-style and IRSA/ECS production cleanly |
| Bucket probe | `HeadBucket` ApplicationRunner with opt-in fail-fast | Default keeps the server running; production can fail closed |
| Streaming | Return SDK's `ResponseInputStream` directly | True streaming download; Spring's `InputStreamResource` closes the stream |
| `listKeys` | Added in this PR | Closes the door on the interface so #190 doesn't churn it |

## What's NOT in this PR

- Filesystem → S3 migration tooling
- Multi-bucket / multi-region setups
- Pre-signed URLs for direct uploads
- GCS, Azure Blob backends (follow the same abstraction)
- Slash-based key encoding (see ADR)

## Test plan

- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green (PlugwerkPropertiesS3ValidationTest, FilesystemArtifactStorageServiceTest, S3ArtifactStorageServiceTest)
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green (S3ArtifactStorageServiceIntegrationTest against MinIO Testcontainer, including the 1100-key pagination crossing)
- [x] Existing filesystem coverage continues to pass — `PluginReleaseService` / `NamespaceService` / `PluginService` are unchanged (they depend on the interface)
- [ ] **Reviewer manual smoke** (optional, if you have credentials): point `PLUGWERK_STORAGE_TYPE=s3` at AWS S3 / Cloudflare R2 / Hetzner with the env vars in `.env.example` and verify a plugin upload+download round-trip