### PR TITLE
docs(env): sync .env.example with token-validity and register/reset rate-limit vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,22 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # server on reload and forces the user back to /login. See ADR-0027.
 # PLUGWERK_AUTH_COOKIE_SECURE=false
 
+# --- Token validity ---
+
+# Legacy self-issued JWT access-token lifetime in hours. Default 8.
+# PLUGWERK_TOKEN_VALIDITY_HOURS=8
+
+# Short-lived access-token lifetime in minutes. 1..1440. Default 15.
+# PLUGWERK_AUTH_ACCESS_TOKEN_VALIDITY_MINUTES=15
+
+# Refresh-token lifetime in hours. 1..8760 (one year). Default 168 (7 days).
+# PLUGWERK_AUTH_REFRESH_TOKEN_VALIDITY_HOURS=168
+
+# Comma-separated hostnames (no scheme, no port) that the artifact download
+# endpoint may proxy through. Empty default = downloads served from the
+# server's own origin only.
+# PLUGWERK_AUTH_DOWNLOAD_ALLOWED_HOSTS=
+
 # Reverse-proxy trust list for X-Forwarded-For (SBS-006 / #265).
 # Comma-separated CIDR ranges of trusted proxies. The leftmost X-Forwarded-For
 # value is honoured ONLY when the request's remoteAddr matches one of these
@@ -55,6 +71,23 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # the login limit above). Default: 5 attempts / 300s.
 # PLUGWERK_AUTH_RATE_LIMIT_CHANGE_PASSWORD_MAX_ATTEMPTS=5
 # PLUGWERK_AUTH_RATE_LIMIT_CHANGE_PASSWORD_WINDOW_SECONDS=300
+
+# Self-registration rate limits. IP bucket and email bucket are independent so a
+# single abuser cannot exhaust the per-email cap for a victim's address.
+# Defaults: 10 IP-attempts / 60s, 5 email-attempts / 60s (email is SHA-256-hashed
+# before bucketing — the address itself is never used as a cache key).
+# PLUGWERK_AUTH_RATE_LIMIT_REGISTER_IP_MAX_ATTEMPTS=10
+# PLUGWERK_AUTH_RATE_LIMIT_REGISTER_IP_WINDOW_SECONDS=60
+# PLUGWERK_AUTH_RATE_LIMIT_REGISTER_EMAIL_MAX_ATTEMPTS=5
+# PLUGWERK_AUTH_RATE_LIMIT_REGISTER_EMAIL_WINDOW_SECONDS=60
+
+# Password-reset rate limits. IP bucket caps reset-request bursts; token bucket
+# caps consume-attempts per reset-token-hash. Defaults: 5 IP-attempts / 900s,
+# 10 token-attempts / 3600s.
+# PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_IP_MAX_ATTEMPTS=5
+# PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_IP_WINDOW_SECONDS=900
+# PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_TOKEN_MAX_ATTEMPTS=10
+# PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_TOKEN_WINDOW_SECONDS=3600
 
 # --- OIDC hardening (#479 SSRF guard + #501 startup safety) ---
 


### PR DESCRIPTION
## Summary

`.env.example` drifted from `PlugwerkProperties.kt` over several earlier PRs. This adds the missing operator-tunable knobs so the file matches the live property surface.

Builds on the recent #510 sync (which covered OIDC + login rate-limit). PR #511 (S3 backend) will add its own S3 block on top of this.

## Added (11 vars, all commented; defaults sensible)

**Token validity** (new section between admin/cookie and the proxy block):
- `PLUGWERK_TOKEN_VALIDITY_HOURS` (default 8)
- `PLUGWERK_AUTH_ACCESS_TOKEN_VALIDITY_MINUTES` (default 15, 1..1440)
- `PLUGWERK_AUTH_REFRESH_TOKEN_VALIDITY_HOURS` (default 168 / 7 days, 1..8760)
- `PLUGWERK_AUTH_DOWNLOAD_ALLOWED_HOSTS` (default empty)

**Rate limiting** (extending the existing section):
- `PLUGWERK_AUTH_RATE_LIMIT_REGISTER_IP_MAX_ATTEMPTS` / `_WINDOW_SECONDS`
- `PLUGWERK_AUTH_RATE_LIMIT_REGISTER_EMAIL_MAX_ATTEMPTS` / `_WINDOW_SECONDS`
- `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_IP_MAX_ATTEMPTS` / `_WINDOW_SECONDS`
- `PLUGWERK_AUTH_RATE_LIMIT_PASSWORD_RESET_TOKEN_MAX_ATTEMPTS` / `_WINDOW_SECONDS`

## Test plan

- [x] `diff <(grep -oE 'PLUGWERK_[A-Z_0-9]+' .env.example | sort -u) <(grep -oE 'PLUGWERK_[A-Z_0-9]+' plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt | sort -u)` shows only the expected residuals (OIDC vars wired via `OidcSsrfPolicy` rather than `PlugwerkProperties`, and Spring's `spring.datasource.*` env-var binding for DB).