### PR TITLE
feat: wire general.site_name through UI (#234)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -3881,8 +3881,18 @@ components:
                 `Europe/Berlin`). Used as the display-time fallback for any user who has
                 not set a personal timezone preference.
               example: "UTC"
+            siteName:
+              type: string
+              description: |
+                Operator-branded display name surfaced by the UI in the browser tab
+                title, top bar, footer, and onboarding (#234). DB-backed via
+                `general.site_name` in `application_setting` (ADR-0016); the admin
+                write path validates length 1..255. The frontend falls back to
+                `Plugwerk` if the value is empty.
+              example: "Plugwerk"
           required:
             - defaultTimezone
+            - siteName
         auth:
           type: object
           description: |

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/ConfigController.kt
@@ -46,7 +46,10 @@ class ConfigController(
         ServerConfigResponse(
             version = versionProvider.getVersion(),
             upload = ServerConfigResponseUpload(maxFileSizeMb = settingsService.maxUploadSizeMb()),
-            general = ServerConfigResponseGeneral(defaultTimezone = settingsService.defaultTimezone()),
+            general = ServerConfigResponseGeneral(
+                defaultTimezone = settingsService.defaultTimezone(),
+                siteName = settingsService.siteName(),
+            ),
             auth = ServerConfigResponseAuth(
                 oidcProviders = enabledOidcProviderLoginInfo(),
                 selfRegistrationEnabled = settingsService.selfRegistrationEnabled(),

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/ConfigControllerTest.kt
@@ -71,10 +71,20 @@ class ConfigControllerTest {
 
     @Autowired private lateinit var mockMvc: MockMvc
 
+    @org.junit.jupiter.api.BeforeEach
+    fun setUpDefaultStubs() {
+        // siteName() is called by every getServerConfig() invocation — stub a
+        // sensible default so individual tests only override when they assert
+        // on the value. Mockito's lenient mode is the project default for these
+        // controller slices; #234.
+        whenever(settingsService.siteName()).thenReturn("Plugwerk")
+    }
+
     @Test
-    fun `GET config returns upload limits, version, and default timezone`() {
+    fun `GET config returns upload limits, version, default timezone, and site name`() {
         whenever(settingsService.maxUploadSizeMb()).thenReturn(200)
         whenever(settingsService.defaultTimezone()).thenReturn("Europe/Berlin")
+        whenever(settingsService.siteName()).thenReturn("Acme Plugin Hub")
         whenever(versionProvider.getVersion()).thenReturn("1.2.3")
         whenever(oidcProviderRepository.findAllByEnabledTrue()).thenReturn(emptyList())
 
@@ -84,6 +94,7 @@ class ConfigControllerTest {
                 jsonPath("$.version") { value("1.2.3") }
                 jsonPath("$.upload.maxFileSizeMb") { value(200) }
                 jsonPath("$.general.defaultTimezone") { value("Europe/Berlin") }
+                jsonPath("$.general.siteName") { value("Acme Plugin Hub") }
             }
     }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/App.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/App.tsx
@@ -16,11 +16,23 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 import { AuthHydrationBoundary } from "./components/auth/AuthHydrationBoundary";
+import { useConfigStore } from "./stores/configStore";
 
 export default function App() {
+  // Keep document.title in sync with the operator-configured site name (#234).
+  // The static <title> in index.html stays as the SEO/no-JS fallback; this
+  // effect overrides it once /config has resolved. Footer already triggers
+  // fetchConfig() — the loaded guard in the store prevents a duplicate
+  // request, so reading siteName here is enough.
+  const siteName = useConfigStore((s) => s.siteName);
+  useEffect(() => {
+    document.title = `${siteName} – Plugin Catalog`;
+  }, [siteName]);
+
   return (
     <AuthHydrationBoundary>
       <RouterProvider router={router} />

--- a/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/auth/AuthCard.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Paper, Typography } from "@mui/material";
 import type { ReactNode } from "react";
+import { useConfigStore } from "../../stores/configStore";
 
 interface AuthCardProps {
   title: string;
@@ -26,6 +27,7 @@ interface AuthCardProps {
 }
 
 export function AuthCard({ title, subtitle, children }: AuthCardProps) {
+  const siteName = useConfigStore((s) => s.siteName);
   return (
     <Box
       component="main"
@@ -58,7 +60,7 @@ export function AuthCard({ title, subtitle, children }: AuthCardProps) {
           <Box
             component="img"
             src="/logomark.svg"
-            alt="Plugwerk"
+            alt={siteName}
             sx={{ height: 64, width: "auto" }}
           />
         </Box>

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/Footer.tsx
@@ -24,6 +24,7 @@ import { tokens } from "../../theme/tokens";
 
 export function Footer() {
   const version = useConfigStore((s) => s.version);
+  const siteName = useConfigStore((s) => s.siteName);
   const fetchConfig = useConfigStore((s) => s.fetchConfig);
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export function Footer() {
               fontWeight: 700,
             }}
           >
-            Plugwerk
+            {siteName}
           </Typography>
           <Typography
             variant="caption"

--- a/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/layout/TopBar.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useUiStore } from "../../stores/uiStore";
+import { useConfigStore } from "../../stores/configStore";
 import { UploadModal } from "../upload/UploadModal";
 import { UploadProgressPanel } from "../upload/UploadProgressPanel";
 import { useAuthStore } from "../../stores/authStore";
@@ -50,6 +51,7 @@ export function TopBar() {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const { toggleTheme, openUploadModal } = useUiStore();
+  const siteName = useConfigStore((s) => s.siteName);
   const { isAuthenticated, logout, namespace, setNamespace, isSuperadmin } =
     useAuthStore();
   const { data: namespaces = [] } = useNamespaces();
@@ -105,7 +107,7 @@ export function TopBar() {
           <Box
             component={Link}
             to="/"
-            aria-label="Plugwerk – back to catalog"
+            aria-label={`${siteName} – back to catalog`}
             sx={{
               display: "flex",
               alignItems: "center",
@@ -118,7 +120,7 @@ export function TopBar() {
             <Box
               component="img"
               src={isDark ? "/logo-dark.svg" : "/logo-light.svg"}
-              alt="Plugwerk"
+              alt={siteName}
               sx={{
                 height: 48,
                 width: "auto",

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/OnboardingPage.tsx
@@ -21,6 +21,7 @@ import { Box, Button, Container, Typography } from "@mui/material";
 import { Puzzle, Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
+import { useConfigStore } from "../stores/configStore";
 import { CreateNamespaceDialog } from "../components/admin/CreateNamespaceDialog";
 import type { NamespaceSummary } from "../api/generated/model";
 
@@ -28,6 +29,7 @@ export function OnboardingPage() {
   const navigate = useNavigate();
   const setNamespace = useAuthStore((s) => s.setNamespace);
   const isSuperadmin = useAuthStore((s) => s.isSuperadmin);
+  const siteName = useConfigStore((s) => s.siteName);
   const [createOpen, setCreateOpen] = useState(false);
 
   function handleCreated(ns: NamespaceSummary) {
@@ -52,7 +54,7 @@ export function OnboardingPage() {
         </Box>
 
         <Typography variant="h1" sx={{ fontSize: "2rem", mb: 2 }}>
-          Welcome to Plugwerk
+          Welcome to {siteName}
         </Typography>
 
         {isSuperadmin ? (
@@ -107,7 +109,7 @@ export function OnboardingPage() {
               mx: "auto",
             }}
           >
-            You don't have access to any namespace yet. Ask a Plugwerk
+            You don't have access to any namespace yet. Ask a {siteName}{" "}
             administrator to add you to one.
           </Typography>
         )}

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.test.ts
@@ -33,6 +33,7 @@ describe("configStore", () => {
       version: "…",
       maxFileSizeMb: 100,
       defaultTimezone: "UTC",
+      siteName: "Plugwerk",
       loaded: false,
     });
     vi.mocked(apiConfig.axiosInstance.get).mockReset();
@@ -74,6 +75,48 @@ describe("configStore", () => {
     await useConfigStore.getState().fetchConfig();
 
     expect(useConfigStore.getState().defaultTimezone).toBe("UTC");
+  });
+
+  it("parses siteName from response when present (#234)", async () => {
+    vi.mocked(apiConfig.axiosInstance.get).mockResolvedValue({
+      data: {
+        version: "1.0.0",
+        upload: { maxFileSizeMb: 100 },
+        general: { defaultTimezone: "UTC", siteName: "Acme Plugin Hub" },
+      },
+    });
+
+    await useConfigStore.getState().fetchConfig();
+
+    expect(useConfigStore.getState().siteName).toBe("Acme Plugin Hub");
+  });
+
+  it("falls back to Plugwerk when siteName is empty (#234)", async () => {
+    vi.mocked(apiConfig.axiosInstance.get).mockResolvedValue({
+      data: {
+        version: "1.0.0",
+        upload: { maxFileSizeMb: 100 },
+        general: { defaultTimezone: "UTC", siteName: "" },
+      },
+    });
+
+    await useConfigStore.getState().fetchConfig();
+
+    expect(useConfigStore.getState().siteName).toBe("Plugwerk");
+  });
+
+  it("falls back to Plugwerk when siteName is missing from response (#234)", async () => {
+    vi.mocked(apiConfig.axiosInstance.get).mockResolvedValue({
+      data: {
+        version: "1.0.0",
+        upload: { maxFileSizeMb: 100 },
+        general: { defaultTimezone: "UTC" },
+      },
+    });
+
+    await useConfigStore.getState().fetchConfig();
+
+    expect(useConfigStore.getState().siteName).toBe("Plugwerk");
   });
 
   it("sets version to unknown on fetch error", async () => {

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.ts
@@ -88,6 +88,14 @@ interface ConfigState {
   readonly version: string;
   readonly maxFileSizeMb: number;
   readonly defaultTimezone: string;
+  /**
+   * Operator-branded display name surfaced by the UI in the browser-tab
+   * title, top bar, footer, and onboarding (#234). Backed by the
+   * `general.site_name` admin setting (ADR-0016). Falls back to
+   * `"Plugwerk"` when the response is missing or empty so user-visible
+   * surfaces never render an empty string.
+   */
+  readonly siteName: string;
   /** OIDC providers currently enabled by the operator. Empty when none. */
   readonly oidcProviders: readonly OidcProviderLoginInfo[];
   /**
@@ -123,6 +131,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   version: "…",
   maxFileSizeMb: 100,
   defaultTimezone: "UTC",
+  siteName: "Plugwerk",
   oidcProviders: [],
   selfRegistrationEnabled: false,
   passwordResetEnabled: false,
@@ -143,6 +152,11 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
           res.data.general.defaultTimezone.length > 0
             ? res.data.general.defaultTimezone
             : "UTC",
+        siteName:
+          typeof res.data?.general?.siteName === "string" &&
+          res.data.general.siteName.length > 0
+            ? res.data.general.siteName
+            : "Plugwerk",
         oidcProviders: parseOidcProviders(res.data?.auth?.oidcProviders),
         selfRegistrationEnabled:
           res.data?.auth?.selfRegistrationEnabled === true,
@@ -152,6 +166,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
     } catch {
       set({
         version: "unknown",
+        siteName: "Plugwerk",
         oidcProviders: [],
         selfRegistrationEnabled: false,
         passwordResetEnabled: false,


### PR DESCRIPTION
## Summary

Closes #234. The `general.site_name` admin setting (added in #208 / ADR-0016) was DB-backed and operator-editable but never consumed in the UI. This change pipes the value end-to-end: DB → `/config` → Zustand store → 5 user-visible surfaces + `document.title`.

## What changed

**Backend** (smallest possible touch):
- OpenAPI `ServerConfigResponse.general.siteName: string` (required). Description points at the 1..255 validator on the write path; the schema itself does not duplicate that constraint.
- `ConfigController.getServerConfig` calls `ApplicationSettingsService.siteName()`.
- `ConfigControllerTest`: one new assertion on the happy-path response; shared `@BeforeEach` default-stubs `siteName()` so the other 11 tests stay unchanged.

**Frontend store**:
- `siteName: string` on `ConfigState`, default `"Plugwerk"`.
- Same empty-string-fallback pattern as `defaultTimezone`.
- 3 new tests (happy parse, empty fallback, missing fallback).

**Five UI touchpoints**:
| Surface | Change |
|---|---|
| `document.title` | `useEffect` in `App.tsx` → `\`${siteName} – Plugin Catalog\`` |
| `TopBar` logo | `alt` + `aria-label` read `siteName` |
| `AuthCard` login logo | `alt` reads `siteName` |
| `Footer` brand line | reads `siteName` |
| `OnboardingPage` | welcome headline + no-namespace hint |

`index.html` static `<title>` is intentionally unchanged — stays as the SEO / no-JS fallback.

## Acceptance criteria (from issue)

- [x] Changing `general.site_name` to "ACME Plugin Hub" + page reload shows it in tab title, top bar `alt`, footer, onboarding.
- [x] Login page shows the custom name before authentication (AuthCard reads from public `/config`).
- [x] Empty / missing value falls back to `"Plugwerk"` (3 store tests pin this).
- [x] Existing tests updated to verify dynamic rendering.

## What's out of scope (per issue body)

- Custom logo upload — logos remain the default Plugwerk logos.
- Backend-side usage (email templates, API responses) — separate work when those features exist.
- License headers + code comments — stay literal "Plugwerk" by design.

## Propagation model

Full reload picks up the new value. No real-time push from settings-save → store. The `loaded` guard on `configStore.fetchConfig` prevents redundant requests; the new `App.tsx` effect just reads from the store.

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:test` — green
- [x] `./gradlew :plugwerk-server:plugwerk-server-backend:integrationTest` — green
- [x] `npx vitest run src/stores/configStore.test.ts` — 9/9 green (3 new + 6 existing)
- [x] `npm run build` — green (Vite + strict `tsc --noEmit`)