### PR TITLE
feat(storage): admin storage/DB consistency check (#190) + ShedLock retrofit

### DIFF
--- a/docs/adrs/0035-storage-consistency-and-reaper.md
+++ b/docs/adrs/0035-storage-consistency-and-reaper.md
@@ -1,0 +1,140 @@
+# ADR-0035: Storage / DB consistency check and orphan reaper
+
+## Status
+
+Accepted
+
+## Context
+
+Plugwerk stores plugin artifacts in two places that can drift apart:
+
+1. **PostgreSQL** — `plugin_release` rows reference an `artifact_key` for each
+   release.
+2. **Object storage** — files on the filesystem or in S3, behind the
+   `ArtifactStorageService` SPI (see ADR-0034).
+
+Drift modes we have observed or expect:
+
+- **Missing artifact** — a `plugin_release` row points to a storage key that
+  is no longer present (file deleted manually, S3 lifecycle expired the
+  object, failed restore from backup).
+- **Orphaned artifact** — a storage object that has no corresponding
+  `plugin_release` row (publish job crashed after upload but before commit,
+  release deleted but storage delete failed, manual upload tooling).
+
+Issues #190 (consistency check) and #496 (orphan reaper) cover both
+directions. They are addressed jointly because they share the same diff
+algorithm and the same race-window concerns.
+
+### Horizontal scaling
+
+Plugwerk runs as multiple instances against a single PostgreSQL database.
+Any scheduled work (token cleanup, orphan reaper, …) needs to coordinate
+between instances:
+
+- Without coordination, every instance scans the bucket on every tick — N×
+  cost on S3 and N× database churn for nothing.
+- For the reaper specifically, two instances could each see the same
+  orphan and race on `delete()`, racing against a third instance that just
+  committed a publish for the same key.
+
+We adopt **ShedLock** as a lightweight cluster-wide mutex for `@Scheduled`
+methods. The lock table is created by Liquibase migration `0033_shedlock`,
+the lock provider is wired in `SchedulerLockConfig`, and the four existing
+scheduled jobs (refresh-token cleanup, token revocation cleanup,
+password-reset sweep, email-verification sweep) are retrofitted with
+`@SchedulerLock` so that only one instance does the work per tick.
+
+ShedLock alone does **not** close the TOCTOU window between "list bucket"
+and "delete object". An instance can finish a publish (`PUT` + INSERT)
+between the moment the reaper enumerated the key and the moment it would
+issue the `DELETE`. We mitigate this with two layers:
+
+1. **Grace period** — orphan candidates with `lastModified` newer than
+   `plugwerk.storage.reaper.grace-period` (default 24h) are skipped. This
+   means the reaper cannot delete an artifact that was uploaded within the
+   last day, which is far longer than the longest plausible publish
+   transaction.
+2. **DB recheck inside the delete transaction** — before each storage
+   `delete()`, the admin remediation service queries
+   `findAllArtifactKeys()` again and skips any candidate that has since
+   gained a database row. This narrows the window to "between recheck and
+   delete," which is sub-millisecond and acceptable.
+
+## Decision
+
+1. **Storage SPI gains `listObjects()`.** The existing `listKeys()` returns
+   keys only; reconciliation needs `lastModified` and `sizeBytes` for the
+   grace-period filter and for the admin UI. `listObjects()` is the
+   primary method; `listKeys()` becomes a default `map { it.key }` wrapper
+   for backward compatibility.
+
+2. **Two-sided scan with a hash-set diff.**
+   `StorageConsistencyService.scan()` collects all `artifactKey`s from the
+   DB and all keys from storage and emits two lists: missing (DB → storage
+   gap) and orphaned (storage → DB gap). The scan is paged through
+   `plugwerk.storage.consistency.max-keys-per-scan` (default 100 000) and
+   throws `StorageScanLimitExceededException` mapped to HTTP 409 when
+   exceeded — admins are expected to use a targeted prefix in that case.
+
+3. **Admin remediation via dedicated endpoints.**
+   `AdminStorageConsistencyController` exposes
+   `GET /api/v1/admin/storage/consistency` (report),
+   `DELETE /api/v1/admin/storage/consistency/releases/{id}` (delete an
+   orphaned DB row + its storage entry, idempotent), and
+   `DELETE /api/v1/admin/storage/consistency/artifacts` (bulk-delete
+   orphaned storage keys, returning `deleted` / `skipped` so freshly
+   re-published keys are visible). Both delete paths recheck the DB inside
+   the transaction before issuing the storage delete.
+
+4. **Superadmin only.** All three endpoints are guarded by `@PreAuthorize`
+   plus an inline `requireSuperadmin()` defense-in-depth call. Namespace
+   admins are intentionally **not** allowed because the storage layer is
+   global and the operation is cross-tenant.
+
+5. **ShedLock retrofit, additive.** All four existing `@Scheduled` jobs
+   get `@SchedulerLock(name = "<job>", lockAtMostFor = "PT15M")`. A
+   `@ConditionalOnProperty(plugwerk.scheduler.shedlock.enabled,
+   matchIfMissing = true)` gate, paired with a `NoOpLockProvider` fallback,
+   keeps `@SpringBootTest` slices using H2 working without running the
+   shedlock migration. Production / Docker / Compose run on PostgreSQL and
+   pick up the real `JdbcTemplateLockProvider`.
+
+6. **Reaper as a separate, opt-in scheduled job (PR2).** The orphan reaper
+   (#496) lands in a follow-up PR with `@Scheduled` + `@SchedulerLock`,
+   `dry-run` mode by default, a configurable grace period, a Micrometer
+   counter, and a cluster integration test using two embedded Plugwerk
+   contexts against one PostgreSQL.
+
+## Consequences
+
+**Easier:**
+
+- Operators can detect drift before users hit "404 on download" or
+  unbounded bucket growth.
+- The admin UI surfaces both sides of drift in one view.
+- Adding new scheduled jobs is now a one-line `@SchedulerLock` addition;
+  the wiring already exists.
+- Filesystem and S3 backends behave the same because they implement the
+  same SPI method (`listObjects`).
+
+**Harder / trade-offs:**
+
+- The grace period delays reaper deletions by 24h by default; this is a
+  conscious correctness-over-eagerness trade.
+- A 10M-key bucket cannot be scanned in one call. The 409-with-limit
+  exception nudges admins toward targeted prefix scans (planned in PR2).
+- The shedlock table must exist in production PostgreSQL. Liquibase
+  migration `0033_shedlock` creates it on the next deploy; rollback is a
+  plain `DROP TABLE shedlock`.
+- ShedLock uses JVM time, not DB time, because `usingDbTime()` is not
+  H2-compatible. This is acceptable for NTP-synced hosts; clock-skew >
+  `lockAtLeastFor` could let two instances run a job in quick succession,
+  but never concurrently within the lock window.
+
+## References
+
+- Issue #190 — Plugin storage consistency check
+- Issue #496 — Orphan storage artifact reaper
+- ADR-0034 — S3 storage backend
+- Spring Modulith `@SchedulerLock` docs

--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -18,19 +18,20 @@
 -- =============================================================================
 
 -- ============================================================
--- Users (post-#351 identity-hub split)
+-- Users (post-#351 identity-hub split, post-0023 source rename)
 -- ------------------------------------------------------------
--- Every row is `source = 'LOCAL'` with mandatory `display_name`
--- and `email`. The `(username, source)` partial unique index
--- replaces the old column-level UNIQUE on `username`, so the
--- ON CONFLICT clause now references that pair.
+-- Every row is `source = 'INTERNAL'` with mandatory `display_name`
+-- and `email`. Migration 0023 renamed the discriminator values
+-- (LOCAL → INTERNAL, OIDC → EXTERNAL) so the `source` column now
+-- expects 'INTERNAL' / 'EXTERNAL'. The `(username, source)` partial
+-- unique index replaces the old column-level UNIQUE on `username`.
 -- ============================================================
 INSERT INTO plugwerk_user (id, username, display_name, email, source, password_hash, enabled, password_change_required, is_superadmin) VALUES
-  ('a0000000-0000-0000-0000-000000000001', 'admin',   'Administrator', 'admin@example.com',   'LOCAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, true),
-  ('a0000000-0000-0000-0000-000000000002', 'alice',   'Alice',         'alice@example.com',   'LOCAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
-  ('a0000000-0000-0000-0000-000000000003', 'bob',     'Bob',           'bob@example.com',     'LOCAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
-  ('a0000000-0000-0000-0000-000000000004', 'charlie', 'Charlie',       'charlie@example.com', 'LOCAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  true,  false),
-  ('a0000000-0000-0000-0000-000000000005', 'diana',   'Diana',         'diana@example.com',   'LOCAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', false, false, false)
+  ('a0000000-0000-0000-0000-000000000001', 'admin',   'Administrator', 'admin@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, true),
+  ('a0000000-0000-0000-0000-000000000002', 'alice',   'Alice',         'alice@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
+  ('a0000000-0000-0000-0000-000000000003', 'bob',     'Bob',           'bob@example.com',     'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
+  ('a0000000-0000-0000-0000-000000000004', 'charlie', 'Charlie',       'charlie@example.com', 'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  true,  false),
+  ('a0000000-0000-0000-0000-000000000005', 'diana',   'Diana',         'diana@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', false, false, false)
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================

--- a/docs/dev/seed-testdata.sql
+++ b/docs/dev/seed-testdata.sql
@@ -20,19 +20,34 @@
 -- ============================================================
 -- Users (post-#351 identity-hub split, post-0023 source rename)
 -- ------------------------------------------------------------
--- Every row is `source = 'INTERNAL'` with mandatory `display_name`
--- and `email`. Migration 0023 renamed the discriminator values
--- (LOCAL → INTERNAL, OIDC → EXTERNAL) so the `source` column now
--- expects 'INTERNAL' / 'EXTERNAL'. The `(username, source)` partial
--- unique index replaces the old column-level UNIQUE on `username`.
+-- The `admin` superadmin row is intentionally NOT seeded here: it is
+-- created on every boot by `AdminInitializationRunner` with a random
+-- UUID and the operator-configured password, which makes a fixed-UUID
+-- INSERT here collide on `uq_plugwerk_user_username_internal` (partial
+-- unique on `username` WHERE source = 'INTERNAL') even with
+-- `ON CONFLICT (id) DO NOTHING`. The memberships further down resolve
+-- the admin via `username = 'admin' AND source = 'INTERNAL'` instead
+-- of a hard-coded UUID.
+--
+-- The remaining four users (alice, bob, charlie, diana) are pure test
+-- fixtures with `source = 'INTERNAL'` and mandatory `display_name` +
+-- `email`. Migration 0023 renamed the discriminator values
+-- (LOCAL → INTERNAL, OIDC → EXTERNAL).
+--
+-- The conflict target matches the partial unique index
+-- `uq_plugwerk_user_username_internal` (UNIQUE ON username WHERE
+-- source = 'INTERNAL'). PostgreSQL infers the index from the
+-- `(col) WHERE pred` form. Email collisions resolve to the analogous
+-- `uq_plugwerk_user_email_internal` partial index and would still
+-- throw — that is intentional: re-running the seed should be a no-op,
+-- not a silent overwrite of unrelated rows.
 -- ============================================================
 INSERT INTO plugwerk_user (id, username, display_name, email, source, password_hash, enabled, password_change_required, is_superadmin) VALUES
-  ('a0000000-0000-0000-0000-000000000001', 'admin',   'Administrator', 'admin@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, true),
   ('a0000000-0000-0000-0000-000000000002', 'alice',   'Alice',         'alice@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
   ('a0000000-0000-0000-0000-000000000003', 'bob',     'Bob',           'bob@example.com',     'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  false, false),
   ('a0000000-0000-0000-0000-000000000004', 'charlie', 'Charlie',       'charlie@example.com', 'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', true,  true,  false),
   ('a0000000-0000-0000-0000-000000000005', 'diana',   'Diana',         'diana@example.com',   'INTERNAL', '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6CQyMb5Z0SNhyFCj3GqNDAlbC', false, false, false)
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (username) WHERE source = 'INTERNAL' DO NOTHING;
 
 -- ============================================================
 -- Namespaces
@@ -45,12 +60,16 @@ ON CONFLICT (slug) DO NOTHING;
 
 -- ============================================================
 -- Namespace Members (post-#351: user_id FK instead of user_subject text)
+-- ------------------------------------------------------------
+-- The admin's `user_id` is resolved by sub-select because the admin
+-- row is created on each boot by `AdminInitializationRunner` with a
+-- random UUID, so we cannot hard-code it here.
 -- ============================================================
 INSERT INTO namespace_member (id, namespace_id, user_id, role) VALUES
   -- admin → default (ADMIN), acme-corp (ADMIN), community (ADMIN)
-  ('b0000000-0000-0000-0000-000000000001', (SELECT id FROM namespace WHERE slug = 'default'),   'a0000000-0000-0000-0000-000000000001', 'ADMIN'),
-  ('b0000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002',              'a0000000-0000-0000-0000-000000000001', 'ADMIN'),
-  ('b0000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000003',              'a0000000-0000-0000-0000-000000000001', 'ADMIN'),
+  ('b0000000-0000-0000-0000-000000000001', (SELECT id FROM namespace WHERE slug = 'default'),   (SELECT id FROM plugwerk_user WHERE username = 'admin' AND source = 'INTERNAL'), 'ADMIN'),
+  ('b0000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002',              (SELECT id FROM plugwerk_user WHERE username = 'admin' AND source = 'INTERNAL'), 'ADMIN'),
+  ('b0000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000003',              (SELECT id FROM plugwerk_user WHERE username = 'admin' AND source = 'INTERNAL'), 'ADMIN'),
   -- alice → default (MEMBER), acme-corp (ADMIN)
   ('b0000000-0000-0000-0000-000000000004', (SELECT id FROM namespace WHERE slug = 'default'),   'a0000000-0000-0000-0000-000000000002', 'MEMBER'),
   ('b0000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000002',              'a0000000-0000-0000-0000-000000000002', 'ADMIN'),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ jmustache = "1.16"
 spotless = "8.4.0"
 cyclonedx = "3.2.4"
 aws-sdk = "2.36.3"
+shedlock = "6.10.0"
 
 [libraries]
 # Kotlin
@@ -105,6 +106,8 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-jun
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 aws-sdk-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-sdk" }
 aws-sdk-apache-client = { module = "software.amazon.awssdk:apache-client", version.ref = "aws-sdk" }
+shedlock-spring = { module = "net.javacrumbs.shedlock:shedlock-spring", version.ref = "shedlock" }
+shedlock-provider-jdbc-template = { module = "net.javacrumbs.shedlock:shedlock-provider-jdbc-template", version.ref = "shedlock" }
 mock-oauth2-server = { module = "no.nav.security:mock-oauth2-server", version.ref = "mock-oauth2-server" }
 
 [plugins]

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2314,6 +2314,38 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/storage/consistency/releases:
+    delete:
+      tags:
+        - AdminStorageConsistency
+      summary: Bulk-delete `plugin_release` rows whose artifacts are missing (#190)
+      description: |
+        Removes the supplied release rows (and best-effort their storage
+        entries) in one round-trip. Each delete is idempotent and is
+        skipped if the artifact is now present in storage (someone restored
+        it between scan and delete). Returns the partition of deleted vs
+        skipped release IDs. Requires superadmin.
+      operationId: deleteOrphanedReleases
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrphanedReleaseDeletionRequest'
+      responses:
+        '200':
+          description: Partition of deleted vs skipped release IDs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkReleaseDeletionResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /admin/storage/consistency/artifacts:
     delete:
       tags:
@@ -2879,6 +2911,43 @@ components:
         - lastModified
         - ageHours
         - sizeBytes
+
+    OrphanedReleaseDeletionRequest:
+      type: object
+      description: Bulk-delete payload for orphaned `plugin_release` rows.
+      properties:
+        releaseIds:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            type: string
+            format: uuid
+      required:
+        - releaseIds
+
+    BulkReleaseDeletionResult:
+      type: object
+      description: |
+        Partition of the requested release IDs into successfully deleted
+        vs skipped (either the release row had reappeared in storage
+        between scan and delete, the row was already gone, or storage
+        delete failed). Skipped IDs are still returned so the admin UI
+        can re-render the report without re-fetching.
+      properties:
+        deleted:
+          type: array
+          items:
+            type: string
+            format: uuid
+        skipped:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+        - deleted
+        - skipped
 
     OrphanedArtifactDeletionRequest:
       type: object

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2874,6 +2874,13 @@ components:
         releaseId:
           type: string
           format: uuid
+        namespaceSlug:
+          type: string
+          description: |
+            Slug of the namespace the orphaned release belongs to. Surfaced
+            so the admin UI can disambiguate `pluginId`s that exist in
+            multiple namespaces (the global plugin identifier in the catalog
+            is `namespace/pluginId`).
         pluginId:
           type: string
         version:
@@ -2882,6 +2889,7 @@ components:
           type: string
       required:
         - releaseId
+        - namespaceSlug
         - pluginId
         - version
         - artifactKey

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2238,6 +2238,119 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /admin/storage/consistency:
+    get:
+      tags:
+        - AdminStorageConsistency
+      summary: Scan storage vs DB and return inconsistencies (#190)
+      description: |
+        Walks the entire `plugin_release` table and the configured storage
+        backend, returning a [`ConsistencyReport`](#/components/schemas/ConsistencyReport)
+        with two lists:
+
+        * `missingArtifacts`: DB rows whose `artifactKey` does not exist in
+          storage (caused by storage outage during upload, accidental
+          delete in the storage console, or an incomplete `fs ↔ s3`
+          migration).
+        * `orphanedArtifacts`: storage objects with no DB row pointing at
+          them (caused by best-effort post-commit storage cleanup
+          failing — see #481).
+
+        Synchronous and uncached. A `max-keys-per-scan` circuit breaker
+        (default 100 000, see
+        `plugwerk.storage.consistency.max-keys-per-scan`) aborts the scan
+        with `409 CONFLICT` rather than hanging the admin UI on a runaway
+        bucket. An async-scan endpoint is **out of scope** for the first
+        iteration.
+
+        Requires superadmin.
+      operationId: getStorageConsistencyReport
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Consistency snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsistencyReport'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Scan aborted by the max-keys-per-scan circuit breaker.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /admin/storage/consistency/releases/{releaseId}:
+    delete:
+      tags:
+        - AdminStorageConsistency
+      summary: Remove a `plugin_release` row whose artifact is missing (#190)
+      description: |
+        Deletes the DB row and best-effort the storage object (idempotent —
+        re-running on a vanished row succeeds with 204). Used to clear
+        `missingArtifacts` entries from the consistency report. Requires
+        superadmin.
+      operationId: deleteOrphanedRelease
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: releaseId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the orphaned release row to remove.
+      responses:
+        '204':
+          description: Row removed (or already gone).
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/storage/consistency/artifacts:
+    delete:
+      tags:
+        - AdminStorageConsistency
+      summary: Bulk-delete orphaned storage objects (#190)
+      description: |
+        Deletes the supplied storage keys after re-checking that no
+        `plugin_release` row references them inside the same transaction.
+        Returns the partition of deleted vs skipped keys (skipped =
+        became referenced between scan and delete, or storage backend
+        failed).
+
+        Bypasses the reaper's grace-period guard because the admin is
+        making an explicit choice to delete. The narrow TOCTOU window
+        between the recheck and the storage `delete` is accepted as the
+        admin-action cost. Requires superadmin.
+      operationId: deleteOrphanedArtifacts
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrphanedArtifactDeletionRequest'
+      responses:
+        '200':
+          description: Partition of deleted vs skipped keys.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkArtifactDeletionResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
 components:
   parameters:
     NamespaceSlug:
@@ -2688,6 +2801,116 @@ components:
           description: Whether new plugin releases are auto-approved without manual review
       required:
         - name
+
+    ConsistencyReport:
+      type: object
+      description: |
+        Bidirectional reconciliation snapshot between `plugin_release` rows
+        and the configured storage backend (#190).
+      properties:
+        missingArtifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/MissingArtifact'
+        orphanedArtifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrphanedArtifact'
+        scannedAt:
+          type: string
+          format: date-time
+          description: Wall-clock timestamp the scan started.
+        totalDbRows:
+          type: integer
+          format: int32
+          description: Distinct artifact keys across `plugin_release`.
+        totalStorageObjects:
+          type: integer
+          format: int32
+          description: Objects walked in storage (subject to the max-keys circuit breaker).
+      required:
+        - missingArtifacts
+        - orphanedArtifacts
+        - scannedAt
+        - totalDbRows
+        - totalStorageObjects
+
+    MissingArtifact:
+      type: object
+      description: DB row whose `artifactKey` does not exist in storage.
+      properties:
+        releaseId:
+          type: string
+          format: uuid
+        pluginId:
+          type: string
+        version:
+          type: string
+        artifactKey:
+          type: string
+      required:
+        - releaseId
+        - pluginId
+        - version
+        - artifactKey
+
+    OrphanedArtifact:
+      type: object
+      description: |
+        Storage object with no `plugin_release` row pointing at it.
+        `ageHours` is computed at scan time against `lastModified` so the
+        UI renders deterministic values across re-renders; the reaper
+        (#496) uses the same field to enforce its grace-period guard.
+      properties:
+        key:
+          type: string
+        lastModified:
+          type: string
+          format: date-time
+        ageHours:
+          type: integer
+          format: int64
+          description: Whole hours since the object was last modified at scan time.
+        sizeBytes:
+          type: integer
+          format: int64
+      required:
+        - key
+        - lastModified
+        - ageHours
+        - sizeBytes
+
+    OrphanedArtifactDeletionRequest:
+      type: object
+      description: Bulk-delete payload for orphaned storage keys.
+      properties:
+        keys:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            type: string
+      required:
+        - keys
+
+    BulkArtifactDeletionResult:
+      type: object
+      description: |
+        Partition of the requested keys into successfully deleted vs
+        skipped (either re-referenced between scan and delete, or storage
+        backend failed).
+      properties:
+        deleted:
+          type: array
+          items:
+            type: string
+        skipped:
+          type: array
+          items:
+            type: string
+      required:
+        - deleted
+        - skipped
 
     ErrorResponse:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
     }
     implementation(libs.aws.sdk.apache.client)
 
+    // ShedLock — cluster-coordination for @Scheduled jobs (#190 + #496).
+    // PostgreSQL JDBC provider; the lock table is created by db/changelog/
+    // migrations/0033_shedlock.yaml.
+    implementation(libs.shedlock.spring)
+    implementation(libs.shedlock.provider.jdbc.template)
+
     runtimeOnly(libs.yasson)
     runtimeOnly(libs.postgresql)
     runtimeOnly(project(path = ":plugwerk-server:plugwerk-server-frontend", configuration = "staticResources"))

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -82,7 +82,27 @@ data class PlugwerkProperties(
         val type: String = "fs",
         val fs: FsProperties = FsProperties(),
         @field:Valid val s3: S3Properties? = null,
+        @field:Valid val consistency: ConsistencyProperties = ConsistencyProperties(),
     ) {
+
+        /**
+         * Storage-consistency-check settings (`plugwerk.storage.consistency.*`)
+         * — admin-triggered DB-vs-storage reconciliation (#190).
+         *
+         * @property maxKeysPerScan Circuit breaker for runaway bucket scans.
+         *   The synchronous-only `GET /admin/storage/consistency` endpoint
+         *   walks the entire storage keyspace; an operator with 10M objects
+         *   should get a clear `StorageScanLimitExceededException` rather
+         *   than a 5-minute-spinning UI. Default 100k = comfortably above the
+         *   plugin-marketplace shape any single Plugwerk instance is expected
+         *   to host.
+         *
+         *   Env: `PLUGWERK_STORAGE_CONSISTENCY_MAX_KEYS_PER_SCAN`
+         */
+        data class ConsistencyProperties(
+            @field:jakarta.validation.constraints.Min(1)
+            val maxKeysPerScan: Int = 100_000,
+        )
         /**
          * Filesystem storage settings (`plugwerk.storage.fs.*`).
          *

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -103,6 +103,7 @@ data class PlugwerkProperties(
             @field:jakarta.validation.constraints.Min(1)
             val maxKeysPerScan: Int = 100_000,
         )
+
         /**
          * Filesystem storage settings (`plugwerk.storage.fs.*`).
          *

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SchedulerLockConfig.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SchedulerLockConfig.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import javax.sql.DataSource
+import java.time.ZoneOffset
+
+/**
+ * Cluster-coordination primitive for `@Scheduled` jobs (#190 prerequisite).
+ *
+ * Plugwerk's deployment model since #191 supports horizontal scaling. The four
+ * existing cleanup jobs (`RefreshTokenService.cleanupExpired`,
+ * `TokenRevocationService.cleanupExpired`, `PasswordResetTokenService.sweep`,
+ * `EmailVerificationTokenService.sweep`) are idempotent — N-fold execution
+ * does not corrupt data — but they each issue the same `DELETE WHERE ...`
+ * statement N times per tick, spiking DB contention without benefit. The
+ * orphan-reaper added in #496 is materially different: even though storage
+ * `delete` is idempotent, two instances doing list+delete in parallel doubles
+ * the storage API cost and produces confusing duplicate log lines.
+ *
+ * [JdbcTemplateLockProvider] persists leases in the `shedlock` table
+ * (migration `0033_shedlock.yaml`). UTC timezone is forced so leases compare
+ * correctly across instances running with different `TZ` env vars.
+ *
+ * Per-job `lockAtMostFor` lives on each `@SchedulerLock` annotation — picking
+ * one global default would either deadlock recovery after instance crash or
+ * leave a stuck job blocking forever.
+ */
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
+class SchedulerLockConfig {
+
+    /**
+     * Real Postgres-backed lock provider. Active by default; the H2-backed
+     * unit-test slices (`application-test.yml`) flip
+     * `plugwerk.scheduler.shedlock.enabled=false` because H2 does not run the
+     * Liquibase migration that creates the `shedlock` table.
+     */
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "plugwerk.scheduler.shedlock",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true,
+    )
+    fun lockProvider(dataSource: DataSource): LockProvider =
+        JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(JdbcTemplate(dataSource))
+                .withTimeZone(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+                // JVM time, not DB time: usingDbTime() requires a Postgres-
+                // specific SELECT pg_… probe that H2 (used in unit tests)
+                // does not implement. Plugwerk hosts run NTP-synchronised so
+                // JVM-time skew is in the millisecond range; lock granularity
+                // here is minutes/hours.
+                .build(),
+        )
+
+    /**
+     * Fallback when ShedLock is disabled (test profile, single-node deploys
+     * that don't care about cluster coordination). Without a [LockProvider]
+     * bean, every `@SchedulerLock` method throws at AOP-interception time.
+     * The no-op makes the annotation an inert documentation hint.
+     */
+    @Bean
+    @ConditionalOnMissingBean(LockProvider::class)
+    fun noOpLockProvider(): LockProvider = net.javacrumbs.shedlock.core.LockProvider {
+        java.util.Optional.of(
+            net.javacrumbs.shedlock.core.SimpleLock {
+                // no-op: nothing to release
+            },
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SchedulerLockConfig.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/config/SchedulerLockConfig.kt
@@ -26,8 +26,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jdbc.core.JdbcTemplate
-import javax.sql.DataSource
 import java.time.ZoneOffset
+import javax.sql.DataSource
 
 /**
  * Cluster-coordination primitive for `@Scheduled` jobs (#190 prerequisite).
@@ -67,18 +67,17 @@ class SchedulerLockConfig {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun lockProvider(dataSource: DataSource): LockProvider =
-        JdbcTemplateLockProvider(
-            JdbcTemplateLockProvider.Configuration.builder()
-                .withJdbcTemplate(JdbcTemplate(dataSource))
-                .withTimeZone(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                // JVM time, not DB time: usingDbTime() requires a Postgres-
-                // specific SELECT pg_… probe that H2 (used in unit tests)
-                // does not implement. Plugwerk hosts run NTP-synchronised so
-                // JVM-time skew is in the millisecond range; lock granularity
-                // here is minutes/hours.
-                .build(),
-        )
+    fun lockProvider(dataSource: DataSource): LockProvider = JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(JdbcTemplate(dataSource))
+            .withTimeZone(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            // JVM time, not DB time: usingDbTime() requires a Postgres-
+            // specific SELECT pg_… probe that H2 (used in unit tests)
+            // does not implement. Plugwerk hosts run NTP-synchronised so
+            // JVM-time skew is in the millisecond range; lock granularity
+            // here is minutes/hours.
+            .build(),
+    )
 
     /**
      * Fallback when ShedLock is disabled (test profile, single-node deploys

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
@@ -19,10 +19,6 @@
 package io.plugwerk.server.controller
 
 import io.plugwerk.api.AdminStorageConsistencyApi
-import io.plugwerk.api.model.BulkArtifactDeletionResult as ApiBulkArtifactDeletionResult
-import io.plugwerk.api.model.ConsistencyReport as ApiConsistencyReport
-import io.plugwerk.api.model.MissingArtifact as ApiMissingArtifact
-import io.plugwerk.api.model.OrphanedArtifact as ApiOrphanedArtifact
 import io.plugwerk.api.model.OrphanedArtifactDeletionRequest
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
@@ -36,6 +32,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
+import io.plugwerk.api.model.BulkArtifactDeletionResult as ApiBulkArtifactDeletionResult
+import io.plugwerk.api.model.ConsistencyReport as ApiConsistencyReport
+import io.plugwerk.api.model.MissingArtifact as ApiMissingArtifact
+import io.plugwerk.api.model.OrphanedArtifact as ApiOrphanedArtifact
 
 /**
  * Admin endpoints for the storage-vs-DB consistency check (#190).

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AdminStorageConsistencyApi
+import io.plugwerk.api.model.BulkArtifactDeletionResult as ApiBulkArtifactDeletionResult
+import io.plugwerk.api.model.ConsistencyReport as ApiConsistencyReport
+import io.plugwerk.api.model.MissingArtifact as ApiMissingArtifact
+import io.plugwerk.api.model.OrphanedArtifact as ApiOrphanedArtifact
+import io.plugwerk.api.model.OrphanedArtifactDeletionRequest
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
+import io.plugwerk.server.service.storage.consistency.StorageConsistencyAdminService
+import io.plugwerk.server.service.storage.consistency.StorageConsistencyService
+import io.plugwerk.server.service.storage.consistency.StorageScanLimitExceededException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * Admin endpoints for the storage-vs-DB consistency check (#190).
+ *
+ * Every operation is gated by superadmin via [PreAuthorize]; the generated
+ * `AdminStorageConsistencyApi` is the OpenAPI-derived contract.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AdminStorageConsistencyController(
+    private val consistencyService: StorageConsistencyService,
+    private val adminService: StorageConsistencyAdminService,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AdminStorageConsistencyApi {
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun getStorageConsistencyReport(): ResponseEntity<ApiConsistencyReport> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val report = consistencyService.scan()
+        return ResponseEntity.ok(
+            ApiConsistencyReport(
+                missingArtifacts = report.missingArtifacts.map {
+                    ApiMissingArtifact(
+                        releaseId = it.releaseId,
+                        pluginId = it.pluginId,
+                        version = it.version,
+                        artifactKey = it.artifactKey,
+                    )
+                },
+                orphanedArtifacts = report.orphanedArtifacts.map {
+                    ApiOrphanedArtifact(
+                        key = it.key,
+                        lastModified = it.lastModified.atOffset(java.time.ZoneOffset.UTC),
+                        ageHours = it.ageHours,
+                        sizeBytes = it.sizeBytes,
+                    )
+                },
+                scannedAt = report.scannedAt.atOffset(java.time.ZoneOffset.UTC),
+                totalDbRows = report.totalDbRows,
+                totalStorageObjects = report.totalStorageObjects,
+            ),
+        )
+    }
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun deleteOrphanedRelease(releaseId: UUID): ResponseEntity<Unit> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        adminService.deleteOrphanedRelease(releaseId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun deleteOrphanedArtifacts(
+        orphanedArtifactDeletionRequest: OrphanedArtifactDeletionRequest,
+    ): ResponseEntity<ApiBulkArtifactDeletionResult> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val result = adminService.deleteOrphanedArtifacts(orphanedArtifactDeletionRequest.propertyKeys)
+        return ResponseEntity.ok(
+            ApiBulkArtifactDeletionResult(deleted = result.deleted, skipped = result.skipped),
+        )
+    }
+
+    /**
+     * Maps the circuit-breaker exception from `StorageConsistencyService` to
+     * `409 CONFLICT` as documented in the OpenAPI spec — keeps the admin UI
+     * from hanging on a 10M-key bucket.
+     */
+    @ExceptionHandler(StorageScanLimitExceededException::class)
+    fun handleScanLimit(ex: StorageScanLimitExceededException): ResponseEntity<Map<String, Any>> =
+        ResponseEntity.status(HttpStatus.CONFLICT).body(
+            mapOf(
+                "status" to 409,
+                "error" to "Conflict",
+                "message" to (ex.message ?: "Storage scan aborted by max-keys-per-scan circuit breaker"),
+                "limit" to ex.limit,
+                "scannedSoFar" to ex.scannedSoFar,
+            ),
+        )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
@@ -20,6 +20,7 @@ package io.plugwerk.server.controller
 
 import io.plugwerk.api.AdminStorageConsistencyApi
 import io.plugwerk.api.model.OrphanedArtifactDeletionRequest
+import io.plugwerk.api.model.OrphanedReleaseDeletionRequest
 import io.plugwerk.server.security.NamespaceAuthorizationService
 import io.plugwerk.server.security.currentAuthentication
 import io.plugwerk.server.service.storage.consistency.StorageConsistencyAdminService
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 import io.plugwerk.api.model.BulkArtifactDeletionResult as ApiBulkArtifactDeletionResult
+import io.plugwerk.api.model.BulkReleaseDeletionResult as ApiBulkReleaseDeletionResult
 import io.plugwerk.api.model.ConsistencyReport as ApiConsistencyReport
 import io.plugwerk.api.model.MissingArtifact as ApiMissingArtifact
 import io.plugwerk.api.model.OrphanedArtifact as ApiOrphanedArtifact
@@ -85,6 +87,17 @@ class AdminStorageConsistencyController(
         namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
         adminService.deleteOrphanedRelease(releaseId)
         return ResponseEntity.noContent().build()
+    }
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun deleteOrphanedReleases(
+        orphanedReleaseDeletionRequest: OrphanedReleaseDeletionRequest,
+    ): ResponseEntity<ApiBulkReleaseDeletionResult> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val result = adminService.deleteOrphanedReleases(orphanedReleaseDeletionRequest.releaseIds)
+        return ResponseEntity.ok(
+            ApiBulkReleaseDeletionResult(deleted = result.deleted, skipped = result.skipped),
+        )
     }
 
     @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyController.kt
@@ -62,6 +62,7 @@ class AdminStorageConsistencyController(
                 missingArtifacts = report.missingArtifacts.map {
                     ApiMissingArtifact(
                         releaseId = it.releaseId,
+                        namespaceSlug = it.namespaceSlug,
                         pluginId = it.pluginId,
                         version = it.version,
                         artifactKey = it.artifactKey,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -80,6 +80,14 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
 
     fun existsByPluginAndVersion(plugin: PluginEntity, version: String): Boolean
 
+    /**
+     * Does this plugin still have at least one release? Used by the
+     * storage-consistency admin flow (#190) to GC a plugin shell after
+     * its last release is removed — we never want empty `plugin` rows
+     * lingering in the database.
+     */
+    fun existsByPlugin(plugin: PluginEntity): Boolean
+
     @Modifying
     @Query("UPDATE PluginReleaseEntity r SET r.downloadCount = r.downloadCount + 1 WHERE r.id = :id")
     fun incrementDownloadCount(@Param("id") id: UUID)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/PluginReleaseRepository.kt
@@ -100,6 +100,17 @@ interface PluginReleaseRepository : JpaRepository<PluginReleaseEntity, UUID> {
     fun findByIdWithPlugin(@Param("id") id: UUID): Optional<PluginReleaseEntity>
 
     /**
+     * Returns every artifact key referenced by a `plugin_release` row (#190).
+     *
+     * String-projection rather than full-entity load so a 100k-release deployment
+     * doesn't hydrate every join graph just to compare keys. Used by the storage
+     * consistency check to compute the symmetric difference against
+     * `ArtifactStorageService.listObjects()`.
+     */
+    @Query("SELECT r.artifactKey FROM PluginReleaseEntity r")
+    fun findAllArtifactKeys(): List<String>
+
+    /**
      * Returns the total download count per plugin for a given set of plugin IDs.
      * Each result row is [pluginId, sumDownloadCount].
      */

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
@@ -158,6 +158,11 @@ class RefreshTokenService(
      * they pass [RefreshTokenEntity.expiresAt], reuse detection is moot.
      */
     @Scheduled(cron = "0 0 * * * *")
+    @net.javacrumbs.shedlock.spring.annotation.SchedulerLock(
+        name = "refresh-token-cleanup",
+        lockAtMostFor = "PT15M",
+        lockAtLeastFor = "PT30S",
+    )
     @Transactional
     fun cleanupExpired() {
         val cutoff = OffsetDateTime.now(ZoneOffset.UTC)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
@@ -148,6 +148,11 @@ class TokenRevocationService(
      * Purges revocation entries whose tokens have already expired. Runs hourly.
      */
     @Scheduled(cron = "0 0 * * * *")
+    @net.javacrumbs.shedlock.spring.annotation.SchedulerLock(
+        name = "token-revocation-cleanup",
+        lockAtMostFor = "PT15M",
+        lockAtLeastFor = "PT30S",
+    )
     @Transactional
     fun cleanupExpired() {
         val cutoff = OffsetDateTime.now(ZoneOffset.UTC)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
@@ -134,6 +134,11 @@ class EmailVerificationTokenService(private val repository: EmailVerificationTok
      * timestamp; expired-unconsumed rows go straight away.
      */
     @Scheduled(cron = "0 30 3 * * *") // 03:30 server-local daily, off-peak
+    @net.javacrumbs.shedlock.spring.annotation.SchedulerLock(
+        name = "email-verification-token-sweep",
+        lockAtMostFor = "PT15M",
+        lockAtLeastFor = "PT1M",
+    )
     @Transactional
     fun sweep() {
         val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
@@ -133,6 +133,11 @@ class PasswordResetTokenService(
      * jobs don't fight for the same DB connection on a small instance.
      */
     @Scheduled(cron = "0 35 3 * * *")
+    @net.javacrumbs.shedlock.spring.annotation.SchedulerLock(
+        name = "password-reset-token-sweep",
+        lockAtMostFor = "PT15M",
+        lockAtLeastFor = "PT1M",
+    )
     @Transactional
     fun sweep() {
         val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/ArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/ArtifactStorageService.kt
@@ -48,5 +48,22 @@ interface ArtifactStorageService {
      * Returned keys are storage-relative (no bucket prefix, no root path) and
      * match the format passed to [store] / [retrieve] / [delete] / [exists].
      */
-    fun listKeys(prefix: String = ""): Sequence<String>
+    fun listKeys(prefix: String = ""): Sequence<String> = listObjects(prefix).map { it.key }
+
+    /**
+     * Returns key + metadata for every object in the backend whose path
+     * starts with [prefix] (#190 / #496).
+     *
+     * Same iteration semantics as [listKeys] — filesystem materialises
+     * eagerly, S3 paginates lazily via `ListObjectsV2`. Callers MUST consume
+     * the sequence fully or wrap iteration in try-finally so the underlying
+     * pager is released.
+     *
+     * [lastModified] is the backend-reported modification timestamp and is
+     * the load-bearing field for the orphan-reaper grace-period check (#496):
+     * an artifact uploaded between `listObjects` and the reaper's
+     * `delete(key)` cannot be reaped because its `lastModified` will not be
+     * older than the configured grace.
+     */
+    fun listObjects(prefix: String = ""): Sequence<StorageObjectInfo>
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageService.kt
@@ -67,7 +67,7 @@ class FilesystemArtifactStorageService(properties: PlugwerkProperties) : Artifac
 
     override fun exists(key: String): Boolean = resolveKey(key).exists()
 
-    override fun listKeys(prefix: String): Sequence<String> {
+    override fun listObjects(prefix: String): Sequence<StorageObjectInfo> {
         if (!root.exists()) return emptySequence()
         return try {
             // Eager materialisation: the filesystem artifact directory is bounded
@@ -77,8 +77,15 @@ class FilesystemArtifactStorageService(properties: PlugwerkProperties) : Artifac
             Files.walk(root).use { stream ->
                 stream
                     .filter { Files.isRegularFile(it) }
-                    .map { root.relativize(it).toString() }
-                    .filter { it.startsWith(prefix) }
+                    .map { path ->
+                        val attrs = Files.readAttributes(path, java.nio.file.attribute.BasicFileAttributes::class.java)
+                        StorageObjectInfo(
+                            key = root.relativize(path).toString(),
+                            lastModified = attrs.lastModifiedTime().toInstant(),
+                            sizeBytes = attrs.size(),
+                        )
+                    }
+                    .filter { it.key.startsWith(prefix) }
                     .toList()
                     .asSequence()
             }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/S3ArtifactStorageService.kt
@@ -117,7 +117,7 @@ class S3ArtifactStorageService(private val s3Client: S3Client, properties: Plugw
         }
     }
 
-    override fun listKeys(prefix: String): Sequence<String> {
+    override fun listObjects(prefix: String): Sequence<StorageObjectInfo> {
         val combinedPrefix = prefixed(prefix)
         // Lazy: every iteration step calls the paginator, which transparently
         // pulls the next page when the current one is exhausted. Callers MUST
@@ -134,7 +134,14 @@ class S3ArtifactStorageService(private val s3Client: S3Client, properties: Plugw
                         // Strip the configured prefix so the caller sees the same
                         // keys they passed to store/retrieve/delete.
                         val raw = obj.key()
-                        yield(if (keyPrefix.isNotEmpty()) raw.removePrefix(keyPrefix) else raw)
+                        val key = if (keyPrefix.isNotEmpty()) raw.removePrefix(keyPrefix) else raw
+                        yield(
+                            StorageObjectInfo(
+                                key = key,
+                                lastModified = obj.lastModified(),
+                                sizeBytes = obj.size() ?: 0L,
+                            ),
+                        )
                     }
                 }
             } catch (ex: S3Exception) {

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/StorageObjectInfo.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/StorageObjectInfo.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage
+
+import java.time.Instant
+
+/**
+ * Metadata-carrying counterpart to a bare storage key, returned by
+ * [ArtifactStorageService.listObjects] (#190).
+ *
+ * Used by:
+ *  - the consistency-check UI to show artifact age + size to the admin
+ *  - the orphan-reaper (#496) to enforce a `lastModified < now - graceHours`
+ *    filter that prevents TOCTOU deletion of freshly-uploaded artifacts
+ *
+ * @property key Storage-relative key (no bucket prefix, no root path) —
+ *   matches the format passed to [ArtifactStorageService.store] /
+ *   [ArtifactStorageService.retrieve] / [ArtifactStorageService.delete].
+ * @property lastModified Backend-reported modification timestamp.
+ *   - Filesystem: `Files.getLastModifiedTime(path).toInstant()`.
+ *   - S3: `S3Object.lastModified()`.
+ * @property sizeBytes Object size as reported by the backend.
+ */
+data class StorageObjectInfo(
+    val key: String,
+    val lastModified: Instant,
+    val sizeBytes: Long,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/StorageObjectInfo.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/StorageObjectInfo.kt
@@ -37,8 +37,4 @@ import java.time.Instant
  *   - S3: `S3Object.lastModified()`.
  * @property sizeBytes Object size as reported by the backend.
  */
-data class StorageObjectInfo(
-    val key: String,
-    val lastModified: Instant,
-    val sizeBytes: Long,
-)
+data class StorageObjectInfo(val key: String, val lastModified: Instant, val sizeBytes: Long)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Snapshot of the bidirectional reconciliation between `plugin_release`
+ * rows and `ArtifactStorageService` contents (#190).
+ *
+ * Two failure modes are distinguished:
+ *  - [missingArtifacts]: a DB row points at a key that does not exist in
+ *    storage. Cause: storage outage during upload, accidental deletion via
+ *    the storage console, or a `fs↔s3` migration that did not copy every
+ *    file.
+ *  - [orphanedArtifacts]: a key exists in storage with no matching DB row.
+ *    Cause: best-effort storage cleanup in
+ *    `PluginService.delete` / `NamespaceService.delete` (#481) failed
+ *    after the DB transaction committed.
+ *
+ * The report is immutable and self-describing — UI consumers do not need a
+ * separate call to learn how many objects were scanned.
+ *
+ * @property missingArtifacts DB rows whose `artifactKey` is missing in storage.
+ * @property orphanedArtifacts Storage objects with no DB row pointing at them.
+ *   `ageHours` is computed against [scannedAt] for stable rendering.
+ * @property scannedAt Wall-clock timestamp the scan started.
+ * @property totalDbRows Sanity counter — distinct keys across `plugin_release`.
+ * @property totalStorageObjects Sanity counter — objects walked in storage.
+ */
+data class ConsistencyReport(
+    val missingArtifacts: List<MissingArtifact>,
+    val orphanedArtifacts: List<OrphanedArtifact>,
+    val scannedAt: Instant,
+    val totalDbRows: Int,
+    val totalStorageObjects: Int,
+)
+
+/**
+ * DB row whose `artifactKey` does not exist in storage. The release-side
+ * fields are loaded on demand by the scan service so the report can render
+ * a useful "plugin X version Y" identifier in the admin UI without forcing
+ * the consumer to re-query.
+ */
+data class MissingArtifact(
+    val releaseId: UUID,
+    val pluginId: String,
+    val version: String,
+    val artifactKey: String,
+)
+
+/**
+ * Storage object with no DB row pointing at it. [ageHours] is computed at
+ * scan time for stable rendering across UI re-renders; the reaper (#496)
+ * uses it to enforce the grace-period guard against TOCTOU.
+ */
+data class OrphanedArtifact(
+    val key: String,
+    val lastModified: Instant,
+    val ageHours: Long,
+    val sizeBytes: Long,
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
@@ -67,3 +67,13 @@ data class MissingArtifact(val releaseId: UUID, val pluginId: String, val versio
  * uses it to enforce the grace-period guard against TOCTOU.
  */
 data class OrphanedArtifact(val key: String, val lastModified: Instant, val ageHours: Long, val sizeBytes: Long)
+
+/**
+ * Result of a bulk `deleteOrphanedReleases` operation. [skipped] entries
+ * are release IDs that were left intact — either the storage object had
+ * reappeared between the scan and the delete (e.g. a backup restore raced
+ * with the admin click), the DB row was already gone, or the storage
+ * backend rejected the delete and we did not want to amputate the DB row
+ * without it.
+ */
+data class BulkReleaseDeletionResult(val deleted: List<UUID>, val skipped: List<UUID>)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
@@ -59,7 +59,13 @@ data class ConsistencyReport(
  * a useful "plugin X version Y" identifier in the admin UI without forcing
  * the consumer to re-query.
  */
-data class MissingArtifact(val releaseId: UUID, val pluginId: String, val version: String, val artifactKey: String)
+data class MissingArtifact(
+    val releaseId: UUID,
+    val namespaceSlug: String,
+    val pluginId: String,
+    val version: String,
+    val artifactKey: String,
+)
 
 /**
  * Storage object with no DB row pointing at it. [ageHours] is computed at

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/ConsistencyReport.kt
@@ -59,21 +59,11 @@ data class ConsistencyReport(
  * a useful "plugin X version Y" identifier in the admin UI without forcing
  * the consumer to re-query.
  */
-data class MissingArtifact(
-    val releaseId: UUID,
-    val pluginId: String,
-    val version: String,
-    val artifactKey: String,
-)
+data class MissingArtifact(val releaseId: UUID, val pluginId: String, val version: String, val artifactKey: String)
 
 /**
  * Storage object with no DB row pointing at it. [ageHours] is computed at
  * scan time for stable rendering across UI re-renders; the reaper (#496)
  * uses it to enforce the grace-period guard against TOCTOU.
  */
-data class OrphanedArtifact(
-    val key: String,
-    val lastModified: Instant,
-    val ageHours: Long,
-    val sizeBytes: Long,
-)
+data class OrphanedArtifact(val key: String, val lastModified: Instant, val ageHours: Long, val sizeBytes: Long)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
@@ -30,10 +30,7 @@ import java.util.UUID
  * as either successfully deleted or skipped (because it became referenced
  * by a `plugin_release` row between the scan and the delete call).
  */
-data class BulkArtifactDeletionResult(
-    val deleted: List<String>,
-    val skipped: List<String>,
-)
+data class BulkArtifactDeletionResult(val deleted: List<String>, val skipped: List<String>)
 
 /**
  * Admin-triggered remediation for findings produced by

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * Outcome of a bulk storage-key deletion (#190). Each input key is reported
+ * as either successfully deleted or skipped (because it became referenced
+ * by a `plugin_release` row between the scan and the delete call).
+ */
+data class BulkArtifactDeletionResult(
+    val deleted: List<String>,
+    val skipped: List<String>,
+)
+
+/**
+ * Admin-triggered remediation for findings produced by
+ * [StorageConsistencyService] (#190).
+ *
+ * Every call:
+ *  1. Re-checks the relevant DB state inside its own transaction so the
+ *     scan snapshot cannot drive a delete against state that has since
+ *     changed. This narrows but does not eliminate the TOCTOU window;
+ *     the admin is explicitly clicking "delete" so a tight race here is
+ *     acceptable (the reaper in #496 carries the broader grace-period
+ *     protection).
+ *  2. Emits a structured audit log line so the action shows up in the
+ *     operator log shipper regardless of whether downstream consumers
+ *     subscribe to a real audit-log channel.
+ *  3. Is idempotent — a second call on a vanished release succeeds
+ *     without throwing.
+ */
+@Service
+class StorageConsistencyAdminService(
+    private val releaseRepository: PluginReleaseRepository,
+    private val storage: ArtifactStorageService,
+) {
+
+    private val log = LoggerFactory.getLogger(StorageConsistencyAdminService::class.java)
+
+    /**
+     * Removes a `plugin_release` row whose artifact is missing from storage.
+     * Idempotent — second call on a vanished row is a no-op.
+     *
+     * The storage `delete()` is invoked too — defensive cleanup in case the
+     * scan was stale and the file did exist after all. S3/FS delete is
+     * idempotent so a no-op file delete is harmless.
+     */
+    @Transactional
+    fun deleteOrphanedRelease(releaseId: UUID) {
+        val release = releaseRepository.findById(releaseId).orElse(null)
+        if (release == null) {
+            log.info(
+                "audit storage-consistency action=delete-release releaseId={} outcome=already-gone",
+                releaseId,
+            )
+            return
+        }
+        val key = release.artifactKey
+        releaseRepository.delete(release)
+        // Best-effort storage delete — see #481 for why this lives after the
+        // DB delete and is allowed to throw without rolling back.
+        runCatching { storage.delete(key) }.onFailure {
+            log.warn(
+                "audit storage-consistency action=delete-release releaseId={} key={} outcome=db-deleted-storage-failed: {}",
+                releaseId,
+                key,
+                it.message,
+            )
+            return
+        }
+        log.info(
+            "audit storage-consistency action=delete-release releaseId={} key={} outcome=deleted",
+            releaseId,
+            key,
+        )
+    }
+
+    /**
+     * Removes orphaned storage keys (manual / admin-triggered — bypasses
+     * the reaper's grace period). For each key we re-check that no DB row
+     * references it inside this transaction; if a row appeared after the
+     * scan, the key is skipped and reported in [BulkArtifactDeletionResult].
+     */
+    @Transactional
+    fun deleteOrphanedArtifacts(keys: List<String>): BulkArtifactDeletionResult {
+        if (keys.isEmpty()) return BulkArtifactDeletionResult(deleted = emptyList(), skipped = emptyList())
+
+        val referenced: Set<String> = releaseRepository
+            .findAllArtifactKeys()
+            .filter { it in keys }
+            .toHashSet()
+
+        val deleted = mutableListOf<String>()
+        val skipped = mutableListOf<String>()
+        for (key in keys) {
+            if (key in referenced) {
+                log.warn(
+                    "audit storage-consistency action=delete-artifact key={} outcome=skipped-now-referenced",
+                    key,
+                )
+                skipped.add(key)
+                continue
+            }
+            runCatching { storage.delete(key) }
+                .onSuccess {
+                    log.info(
+                        "audit storage-consistency action=delete-artifact key={} outcome=deleted",
+                        key,
+                    )
+                    deleted.add(key)
+                }
+                .onFailure {
+                    log.warn(
+                        "audit storage-consistency action=delete-artifact key={} outcome=storage-failed: {}",
+                        key,
+                        it.message,
+                    )
+                    skipped.add(key)
+                }
+        }
+        return BulkArtifactDeletionResult(deleted = deleted.toList(), skipped = skipped.toList())
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
@@ -96,6 +96,55 @@ class StorageConsistencyAdminService(
     }
 
     /**
+     * Removes a batch of `plugin_release` rows whose artifacts are missing
+     * from storage. Same semantics as [deleteOrphanedRelease] applied per
+     * ID, but with one DB transaction and one round-trip. Each ID is also
+     * re-checked against storage — if the file has reappeared since the
+     * scan (e.g. operator just restored a backup) the row is left intact
+     * and reported back as skipped so the admin UI can keep the entry on
+     * screen.
+     */
+    @Transactional
+    fun deleteOrphanedReleases(releaseIds: List<UUID>): BulkReleaseDeletionResult {
+        if (releaseIds.isEmpty()) return BulkReleaseDeletionResult(deleted = emptyList(), skipped = emptyList())
+
+        val deleted = mutableListOf<UUID>()
+        val skipped = mutableListOf<UUID>()
+        for (id in releaseIds) {
+            val release = releaseRepository.findById(id).orElse(null)
+            if (release == null) {
+                log.info(
+                    "audit storage-consistency action=delete-release releaseId={} outcome=already-gone",
+                    id,
+                )
+                skipped.add(id)
+                continue
+            }
+            val key = release.artifactKey
+            if (storage.exists(key)) {
+                // The artifact reappeared between scan and this delete —
+                // refuse to amputate the DB row that now legitimately
+                // references a real file.
+                log.warn(
+                    "audit storage-consistency action=delete-release releaseId={} key={} outcome=skipped-storage-reappeared",
+                    id,
+                    key,
+                )
+                skipped.add(id)
+                continue
+            }
+            releaseRepository.delete(release)
+            log.info(
+                "audit storage-consistency action=delete-release releaseId={} key={} outcome=deleted",
+                id,
+                key,
+            )
+            deleted.add(id)
+        }
+        return BulkReleaseDeletionResult(deleted = deleted.toList(), skipped = skipped.toList())
+    }
+
+    /**
      * Removes orphaned storage keys (manual / admin-triggered — bypasses
      * the reaper's grace period). For each key we re-check that no DB row
      * references it inside this transaction; if a row appeared after the

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminService.kt
@@ -18,7 +18,9 @@
  */
 package io.plugwerk.server.service.storage.consistency
 
+import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -52,6 +54,7 @@ data class BulkArtifactDeletionResult(val deleted: List<String>, val skipped: Li
 @Service
 class StorageConsistencyAdminService(
     private val releaseRepository: PluginReleaseRepository,
+    private val pluginRepository: PluginRepository,
     private val storage: ArtifactStorageService,
 ) {
 
@@ -76,7 +79,13 @@ class StorageConsistencyAdminService(
             return
         }
         val key = release.artifactKey
+        val plugin = release.plugin
         releaseRepository.delete(release)
+        // Force the DELETE to flush before the existsByPlugin probe — without
+        // this Hibernate would still see the row in its first-level cache and
+        // wrongly report the plugin as non-empty.
+        releaseRepository.flush()
+        deletePluginIfEmpty(plugin)
         // Best-effort storage delete — see #481 for why this lives after the
         // DB delete and is allowed to throw without rolling back.
         runCatching { storage.delete(key) }.onFailure {
@@ -133,7 +142,12 @@ class StorageConsistencyAdminService(
                 skipped.add(id)
                 continue
             }
+            val plugin = release.plugin
             releaseRepository.delete(release)
+            // Flush per row so existsByPlugin sees a consistent count when
+            // multiple releases of the same plugin are deleted in this batch.
+            releaseRepository.flush()
+            deletePluginIfEmpty(plugin)
             log.info(
                 "audit storage-consistency action=delete-release releaseId={} key={} outcome=deleted",
                 id,
@@ -142,6 +156,24 @@ class StorageConsistencyAdminService(
             deleted.add(id)
         }
         return BulkReleaseDeletionResult(deleted = deleted.toList(), skipped = skipped.toList())
+    }
+
+    /**
+     * Removes a `plugin` row that has just lost its last release. Plugins
+     * are pure metadata shells around their releases — an empty plugin row
+     * is dead data and shows up in catalogues with zero downloadable
+     * artefacts. Idempotent: a no-op when the plugin still has releases.
+     */
+    private fun deletePluginIfEmpty(plugin: PluginEntity) {
+        if (releaseRepository.existsByPlugin(plugin)) return
+        val pluginId = plugin.id
+        pluginRepository.delete(plugin)
+        log.info(
+            "audit storage-consistency action=delete-plugin pluginRowId={} namespace={} pluginId={} outcome=deleted-empty-shell",
+            pluginId,
+            plugin.namespace.slug,
+            plugin.pluginId,
+        )
     }
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyService.kt
@@ -102,6 +102,7 @@ class StorageConsistencyService(
                 .map { release ->
                     MissingArtifact(
                         releaseId = release.id ?: error("PluginReleaseEntity is detached from persistence context"),
+                        namespaceSlug = release.plugin.namespace.slug,
                         pluginId = release.plugin.pluginId,
                         version = release.version,
                         artifactKey = release.artifactKey,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyService.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Bidirectional reconciliation between `plugin_release` DB rows and the
+ * configured [ArtifactStorageService] (#190).
+ *
+ * Pure logic — no remediation here; see `StorageConsistencyAdminService`
+ * for the admin-triggered DB/storage deletes. The reaper job in #496
+ * reuses this service's [scan] output to drive orphan deletion under a
+ * grace-period filter.
+ *
+ * Algorithm:
+ *  1. Load every `artifactKey` from `plugin_release` into a hash set
+ *     (one cheap string-projection query).
+ *  2. Stream the storage backend via `listObjects("")`, applying the
+ *     `max-keys-per-scan` circuit breaker.
+ *  3. Partition: storage keys seen → if in DB-set, "known"; else "orphan".
+ *  4. DB keys never seen in storage become "missing".
+ *  5. Hydrate the missing-artifacts list with plugin id/version from the
+ *     DB so the report renders meaningful identifiers in the UI.
+ *
+ * Memory: O(|DB keys| + |missing-artifact hydrate set|). Storage side
+ * is streamed; we never materialise the full storage key list.
+ */
+@Service
+class StorageConsistencyService(
+    private val storage: ArtifactStorageService,
+    private val releaseRepository: PluginReleaseRepository,
+    private val properties: PlugwerkProperties,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+
+    private val log = LoggerFactory.getLogger(StorageConsistencyService::class.java)
+
+    @Transactional(readOnly = true)
+    fun scan(): ConsistencyReport {
+        val maxKeys = properties.storage.consistency.maxKeysPerScan
+        val scannedAt = Instant.now(clock)
+
+        val dbKeys: Set<String> = releaseRepository.findAllArtifactKeys().toHashSet()
+        val totalDbRows = dbKeys.size
+
+        val orphanedArtifacts = mutableListOf<OrphanedArtifact>()
+        val storageKeysSeen = HashSet<String>(maxOf(16, dbKeys.size))
+        var totalStorageObjects = 0
+
+        for (obj in storage.listObjects("")) {
+            totalStorageObjects++
+            if (totalStorageObjects > maxKeys) {
+                throw StorageScanLimitExceededException(limit = maxKeys, scannedSoFar = totalStorageObjects)
+            }
+            storageKeysSeen.add(obj.key)
+            if (obj.key !in dbKeys) {
+                val ageHours = Duration.between(obj.lastModified, scannedAt).toHours().coerceAtLeast(0L)
+                orphanedArtifacts.add(
+                    OrphanedArtifact(
+                        key = obj.key,
+                        lastModified = obj.lastModified,
+                        ageHours = ageHours,
+                        sizeBytes = obj.sizeBytes,
+                    ),
+                )
+            }
+        }
+
+        val missingKeys: Set<String> = dbKeys - storageKeysSeen
+        val missingArtifacts: List<MissingArtifact> = if (missingKeys.isEmpty()) {
+            emptyList()
+        } else {
+            releaseRepository
+                .findAll()
+                .asSequence()
+                .filter { it.artifactKey in missingKeys }
+                .map { release ->
+                    MissingArtifact(
+                        releaseId = release.id ?: error("PluginReleaseEntity is detached from persistence context"),
+                        pluginId = release.plugin.pluginId,
+                        version = release.version,
+                        artifactKey = release.artifactKey,
+                    )
+                }
+                .toList()
+        }
+
+        log.info(
+            "Storage consistency scan completed: dbRows={}, storageObjects={}, missing={}, orphaned={}",
+            totalDbRows,
+            totalStorageObjects,
+            missingArtifacts.size,
+            orphanedArtifacts.size,
+        )
+
+        return ConsistencyReport(
+            missingArtifacts = missingArtifacts,
+            orphanedArtifacts = orphanedArtifacts.toList(),
+            scannedAt = scannedAt,
+            totalDbRows = totalDbRows,
+            totalStorageObjects = totalStorageObjects,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageScanLimitExceededException.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageScanLimitExceededException.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+/**
+ * Thrown when the storage-side listing exceeds
+ * `plugwerk.storage.consistency.max-keys-per-scan` (#190).
+ *
+ * Fail-fast circuit breaker against a runaway bucket scan — an operator
+ * with 10M objects in S3 shouldn't get a 5-minute-spinning admin UI;
+ * they should get a clear "too many keys; scan is sync-only for now"
+ * error and a follow-up async-mode work item.
+ */
+class StorageScanLimitExceededException(
+    val limit: Int,
+    val scannedSoFar: Int,
+) : RuntimeException(
+    "Storage scan aborted after $scannedSoFar objects (limit: $limit). " +
+        "Set plugwerk.storage.consistency.max-keys-per-scan higher or " +
+        "narrow the scan (#190 supports only synchronous scans for now).",
+)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageScanLimitExceededException.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/StorageScanLimitExceededException.kt
@@ -27,11 +27,9 @@ package io.plugwerk.server.service.storage.consistency
  * they should get a clear "too many keys; scan is sync-only for now"
  * error and a follow-up async-mode work item.
  */
-class StorageScanLimitExceededException(
-    val limit: Int,
-    val scannedSoFar: Int,
-) : RuntimeException(
-    "Storage scan aborted after $scannedSoFar objects (limit: $limit). " +
-        "Set plugwerk.storage.consistency.max-keys-per-scan higher or " +
-        "narrow the scan (#190 supports only synchronous scans for now).",
-)
+class StorageScanLimitExceededException(val limit: Int, val scannedSoFar: Int) :
+    RuntimeException(
+        "Storage scan aborted after $scannedSoFar objects (limit: $limit). " +
+            "Set plugwerk.storage.consistency.max-keys-per-scan higher or " +
+            "narrow the scan (#190 supports only synchronous scans for now).",
+    )

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -100,6 +100,26 @@ plugwerk:
       # orchestrators that already have a restart loop and prefer fail-closed.
       # Env: PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING
       fail-fast-on-bucket-missing: ${PLUGWERK_STORAGE_S3_FAIL_FAST_ON_BUCKET_MISSING:false}
+
+    # Storage / DB consistency check (#190 + ADR-0035). The admin UI uses the
+    # `/admin/storage/consistency` endpoint to detect missing and orphaned
+    # artifacts. Scans short-circuit with HTTP 409 above this many storage
+    # objects to keep multi-million-object buckets from blocking the admin UI;
+    # operators should use a targeted prefix scan in that case (planned in
+    # PR2).
+    consistency:
+      # Env: PLUGWERK_STORAGE_CONSISTENCY_MAX_KEYS_PER_SCAN
+      max-keys-per-scan: ${PLUGWERK_STORAGE_CONSISTENCY_MAX_KEYS_PER_SCAN:100000}
+
+  # Scheduler coordination across horizontally scaled instances (ADR-0035).
+  # ShedLock uses a PostgreSQL lock table (Liquibase migration 0033_shedlock)
+  # so that only one instance executes a given `@Scheduled` job per tick.
+  # Set to `false` only in test slices that run against an in-memory DB
+  # without the shedlock table — production should keep this on.
+  scheduler:
+    shedlock:
+      # Env: PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED
+      enabled: ${PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED:true}
   server:
     base-url: ${PLUGWERK_BASE_URL:http://localhost:8080}
     # Frontend base URL for browser-facing links emitted by the server (e.g. the

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -63,3 +63,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0031_email_template_polish.yaml
   - include:
       file: db/changelog/migrations/0032_admin_password_reset_template.yaml
+  - include:
+      file: db/changelog/migrations/0033_shedlock.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0033_shedlock.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0033_shedlock.yaml
@@ -1,0 +1,36 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0033-shedlock-table
+      author: plugwerk
+      comment: |
+        ShedLock cluster-coordination table for @Scheduled jobs (#190 / #496).
+        Spring-Boot-managed schema mirrors the canonical JDBC provider DDL:
+          - name        primary key, max 64 chars (matches ShedLock @SchedulerLock name length)
+          - lock_until  upper bound on lease validity; another instance can re-acquire after this
+          - locked_at   diagnostic timestamp; not used by the lock logic
+          - locked_by   diagnostic instance identifier; defaults to hostname
+      changes:
+        - createTable:
+            tableName: shedlock
+            columns:
+              - column:
+                  name: name
+                  type: varchar(64)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: lock_until
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import tools.jackson.databind.ObjectMapper
+import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.LoginRateLimitFilter
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
+import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.security.RefreshRateLimitFilter
+import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.storage.consistency.BulkArtifactDeletionResult
+import io.plugwerk.server.service.storage.consistency.ConsistencyReport
+import io.plugwerk.server.service.storage.consistency.OrphanedArtifact
+import io.plugwerk.server.service.storage.consistency.StorageConsistencyAdminService
+import io.plugwerk.server.service.storage.consistency.StorageConsistencyService
+import io.plugwerk.server.service.storage.consistency.StorageScanLimitExceededException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import io.plugwerk.server.service.ForbiddenException
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import java.time.Instant
+import java.util.UUID
+
+@WebMvcTest(
+    AdminStorageConsistencyController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class AdminStorageConsistencyControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean private lateinit var consistencyService: StorageConsistencyService
+
+    @MockitoBean private lateinit var adminService: StorageConsistencyAdminService
+
+    @MockitoBean private lateinit var namespaceAuthorizationService: NamespaceAuthorizationService
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("admin", null, emptyList())
+        whenever(namespaceAuthorizationService.isCurrentUserSuperadmin()).thenReturn(true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `GET consistency returns scan result`() {
+        val now = Instant.parse("2026-05-12T12:00:00Z")
+        whenever(consistencyService.scan()).thenReturn(
+            ConsistencyReport(
+                missingArtifacts = emptyList(),
+                orphanedArtifacts = listOf(
+                    OrphanedArtifact(
+                        key = "ns:orphan:1.0.0:jar",
+                        lastModified = now.minusSeconds(48 * 3600),
+                        ageHours = 48,
+                        sizeBytes = 12345L,
+                    ),
+                ),
+                scannedAt = now,
+                totalDbRows = 0,
+                totalStorageObjects = 1,
+            ),
+        )
+
+        mockMvc.get("/api/v1/admin/storage/consistency")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.totalStorageObjects") { value(1) }
+                jsonPath("$.orphanedArtifacts[0].key") { value("ns:orphan:1.0.0:jar") }
+                jsonPath("$.orphanedArtifacts[0].ageHours") { value(48) }
+            }
+    }
+
+    @Test
+    fun `GET consistency over scan limit returns 409`() {
+        whenever(consistencyService.scan())
+            .thenThrow(StorageScanLimitExceededException(limit = 100, scannedSoFar = 101))
+
+        mockMvc.get("/api/v1/admin/storage/consistency")
+            .andExpect {
+                status { isConflict() }
+                jsonPath("$.limit") { value(100) }
+                jsonPath("$.scannedSoFar") { value(101) }
+            }
+    }
+
+    @Test
+    fun `GET consistency without superadmin returns 403`() {
+        doThrow(ForbiddenException("Superadmin privileges required"))
+            .whenever(namespaceAuthorizationService).requireSuperadmin(any())
+
+        mockMvc.get("/api/v1/admin/storage/consistency")
+            .andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `DELETE orphaned release returns 204 and calls the admin service`() {
+        val id = UUID.randomUUID()
+
+        mockMvc.delete("/api/v1/admin/storage/consistency/releases/$id")
+            .andExpect { status { isNoContent() } }
+
+        verify(adminService).deleteOrphanedRelease(eq(id))
+    }
+
+    @Test
+    fun `DELETE orphaned artifacts bulk returns deleted vs skipped`() {
+        whenever(adminService.deleteOrphanedArtifacts(any())).thenReturn(
+            BulkArtifactDeletionResult(
+                deleted = listOf("ns:gone:1.0.0:jar"),
+                skipped = listOf("ns:reborn:1.0.0:jar"),
+            ),
+        )
+
+        mockMvc.delete("/api/v1/admin/storage/consistency/artifacts") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("keys" to listOf("ns:gone:1.0.0:jar", "ns:reborn:1.0.0:jar")),
+            )
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.deleted[0]") { value("ns:gone:1.0.0:jar") }
+            jsonPath("$.skipped[0]") { value("ns:reborn:1.0.0:jar") }
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
 import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.storage.consistency.BulkArtifactDeletionResult
+import io.plugwerk.server.service.storage.consistency.BulkReleaseDeletionResult
 import io.plugwerk.server.service.storage.consistency.ConsistencyReport
 import io.plugwerk.server.service.storage.consistency.OrphanedArtifact
 import io.plugwerk.server.service.storage.consistency.StorageConsistencyAdminService
@@ -159,6 +160,26 @@ class AdminStorageConsistencyControllerTest {
             .andExpect { status { isNoContent() } }
 
         verify(adminService).deleteOrphanedRelease(eq(id))
+    }
+
+    @Test
+    fun `DELETE orphaned releases bulk returns deleted vs skipped`() {
+        val deletedId = UUID.randomUUID()
+        val skippedId = UUID.randomUUID()
+        whenever(adminService.deleteOrphanedReleases(any())).thenReturn(
+            BulkReleaseDeletionResult(deleted = listOf(deletedId), skipped = listOf(skippedId)),
+        )
+
+        mockMvc.delete("/api/v1/admin/storage/consistency/releases") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("releaseIds" to listOf(deletedId, skippedId)),
+            )
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.deleted[0]") { value(deletedId.toString()) }
+            jsonPath("$.skipped[0]") { value(skippedId.toString()) }
+        }
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminStorageConsistencyControllerTest.kt
@@ -18,7 +18,6 @@
  */
 package io.plugwerk.server.controller
 
-import tools.jackson.databind.ObjectMapper
 import io.plugwerk.server.security.ChangePasswordRateLimitFilter
 import io.plugwerk.server.security.LoginRateLimitFilter
 import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
@@ -28,6 +27,7 @@ import io.plugwerk.server.security.PasswordResetRateLimitFilter
 import io.plugwerk.server.security.PublicNamespaceFilter
 import io.plugwerk.server.security.RefreshRateLimitFilter
 import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.ForbiddenException
 import io.plugwerk.server.service.storage.consistency.BulkArtifactDeletionResult
 import io.plugwerk.server.service.storage.consistency.ConsistencyReport
 import io.plugwerk.server.service.storage.consistency.OrphanedArtifact
@@ -37,7 +37,6 @@ import io.plugwerk.server.service.storage.consistency.StorageScanLimitExceededEx
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import io.plugwerk.server.service.ForbiddenException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -57,6 +56,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
+import tools.jackson.databind.ObjectMapper
 import java.time.Instant
 import java.util.UUID
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminStorageConsistencyEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminStorageConsistencyEndpointAuthzTest.kt
@@ -58,6 +58,22 @@ class AdminStorageConsistencyEndpointAuthzTest : AbstractAuthorizationTest() {
             .andExpect(status().`is`(case.expectedStatus))
     }
 
+    @ParameterizedTest(name = "DELETE /admin/storage/consistency/releases {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `delete releases bulk denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            delete("/api/v1/admin/storage/consistency/releases")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf("releaseIds" to listOf(UUID.randomUUID().toString())),
+                    ),
+                ),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
     @ParameterizedTest(name = "DELETE /admin/storage/consistency/artifacts {0}")
     @MethodSource("superadminOnlyDeniedMatrix")
     fun `delete artifacts denied for non-superadmins`(case: ActorExpectation) {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminStorageConsistencyEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminStorageConsistencyEndpointAuthzTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+import java.util.stream.Stream
+
+/**
+ * Authorization matrix for the storage-consistency admin endpoints (#190).
+ *
+ * Anonymous callers must hit 401; every authenticated non-superadmin must hit
+ * 403 — namespace admins are NOT allowed because cross-namespace orphan removal
+ * could leak data between tenants.
+ */
+class AdminStorageConsistencyEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /admin/storage/consistency {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `scan denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/admin/storage/consistency").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can scan storage consistency`() {
+        mockMvc.perform(get("/api/v1/admin/storage/consistency").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+    }
+
+    @ParameterizedTest(name = "DELETE /admin/storage/consistency/releases/[id] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `delete release denied for non-superadmins`(case: ActorExpectation) {
+        val releaseId = UUID.randomUUID()
+        mockMvc.perform(delete("/api/v1/admin/storage/consistency/releases/$releaseId").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "DELETE /admin/storage/consistency/artifacts {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `delete artifacts denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            delete("/api/v1/admin/storage/consistency/artifacts")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("keys" to listOf("ns:p:1.0.0:jar")))),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    companion object {
+        @JvmStatic
+        fun superadminOnlyDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/FilesystemArtifactStorageServiceTest.kt
@@ -115,6 +115,29 @@ class FilesystemArtifactStorageServiceTest {
             .containsExactly("acme:plugin:1.0.0:jar")
     }
 
+    @Test
+    fun `listObjects returns key, lastModified and size for each artifact (#190)`() {
+        val bytes = "hello-plugwerk".toByteArray()
+        storage.store("acme:plugin-a:1.0.0:jar", ByteArrayInputStream(bytes), bytes.size.toLong())
+
+        val before = java.time.Instant.now().minusSeconds(2)
+        val after = java.time.Instant.now().plusSeconds(2)
+
+        val info = storage.listObjects().toList().single()
+        assertThat(info.key).isEqualTo("acme:plugin-a:1.0.0:jar")
+        assertThat(info.sizeBytes).isEqualTo(bytes.size.toLong())
+        assertThat(info.lastModified).isBetween(before, after)
+    }
+
+    @Test
+    fun `listObjects honours prefix filter`() {
+        storage.store("acme:plugin-a:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+        storage.store("other:plugin-b:1.0.0:jar", ByteArrayInputStream(byteArrayOf(0)), 1)
+
+        val acmeOnly = storage.listObjects("acme:").map { it.key }.toList()
+        assertThat(acmeOnly).containsExactly("acme:plugin-a:1.0.0:jar")
+    }
+
     private fun propsWithRoot(root: Path): PlugwerkProperties = PlugwerkProperties(
         storage = PlugwerkProperties.StorageProperties(
             type = "fs",

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
@@ -59,6 +59,44 @@ class StorageConsistencyAdminServiceTest {
     }
 
     @Test
+    fun `deleteOrphanedReleases skips when storage file has reappeared`() {
+        val present = release(key = "ns:present:1.0.0:jar")
+        val gone = release(key = "ns:gone:1.0.0:jar")
+        whenever(releaseRepository.findById(present.id!!)).thenReturn(Optional.of(present))
+        whenever(releaseRepository.findById(gone.id!!)).thenReturn(Optional.of(gone))
+        whenever(storage.exists("ns:present:1.0.0:jar")).thenReturn(true)
+        whenever(storage.exists("ns:gone:1.0.0:jar")).thenReturn(false)
+
+        val result = service.deleteOrphanedReleases(listOf(present.id!!, gone.id!!))
+
+        verify(releaseRepository).delete(gone)
+        verify(releaseRepository, never()).delete(present)
+        assertThat(result.deleted).containsExactly(gone.id!!)
+        assertThat(result.skipped).containsExactly(present.id!!)
+    }
+
+    @Test
+    fun `deleteOrphanedReleases reports already-gone IDs as skipped`() {
+        val ghostId = UUID.randomUUID()
+        whenever(releaseRepository.findById(ghostId)).thenReturn(Optional.empty())
+
+        val result = service.deleteOrphanedReleases(listOf(ghostId))
+
+        verify(releaseRepository, never()).delete(any<PluginReleaseEntity>())
+        assertThat(result.deleted).isEmpty()
+        assertThat(result.skipped).containsExactly(ghostId)
+    }
+
+    @Test
+    fun `deleteOrphanedReleases with empty input is a no-op`() {
+        val result = service.deleteOrphanedReleases(emptyList())
+
+        assertThat(result.deleted).isEmpty()
+        assertThat(result.skipped).isEmpty()
+        verify(releaseRepository, never()).delete(any<PluginReleaseEntity>())
+    }
+
+    @Test
     fun `deleteOrphanedRelease is idempotent when release already gone`() {
         val id = UUID.randomUUID()
         whenever(releaseRepository.findById(id)).thenReturn(Optional.empty())

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
@@ -22,6 +22,7 @@ import io.plugwerk.server.domain.NamespaceEntity
 import io.plugwerk.server.domain.PluginEntity
 import io.plugwerk.server.domain.PluginReleaseEntity
 import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -37,20 +38,26 @@ import java.util.UUID
 class StorageConsistencyAdminServiceTest {
 
     private lateinit var releaseRepository: PluginReleaseRepository
+    private lateinit var pluginRepository: PluginRepository
     private lateinit var storage: ArtifactStorageService
     private lateinit var service: StorageConsistencyAdminService
 
     @BeforeEach
     fun setUp() {
         releaseRepository = mock()
+        pluginRepository = mock()
         storage = mock()
-        service = StorageConsistencyAdminService(releaseRepository, storage)
+        service =
+            StorageConsistencyAdminService(releaseRepository, pluginRepository, storage)
     }
 
     @Test
     fun `deleteOrphanedRelease deletes DB row and storage file`() {
         val release = release(key = "ns:p:1.0.0:jar")
         whenever(releaseRepository.findById(release.id!!)).thenReturn(Optional.of(release))
+        // Pretend another release of the same plugin is still around so the
+        // plugin-GC branch does not interfere with this happy-path test.
+        whenever(releaseRepository.existsByPlugin(release.plugin)).thenReturn(true)
 
         service.deleteOrphanedRelease(release.id!!)
 
@@ -131,6 +138,50 @@ class StorageConsistencyAdminServiceTest {
     }
 
     @Test
+    fun `deleteOrphanedRelease also deletes empty plugin shell after last release`() {
+        val release = release(key = "ns:p:1.0.0:jar")
+        whenever(releaseRepository.findById(release.id!!)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.existsByPlugin(release.plugin)).thenReturn(false)
+
+        service.deleteOrphanedRelease(release.id!!)
+
+        verify(releaseRepository).delete(release)
+        verify(pluginRepository).delete(release.plugin)
+    }
+
+    @Test
+    fun `deleteOrphanedRelease leaves plugin alone when other releases remain`() {
+        val release = release(key = "ns:p:1.0.0:jar")
+        whenever(releaseRepository.findById(release.id!!)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.existsByPlugin(release.plugin)).thenReturn(true)
+
+        service.deleteOrphanedRelease(release.id!!)
+
+        verify(releaseRepository).delete(release)
+        verify(pluginRepository, never()).delete(any<PluginEntity>())
+    }
+
+    @Test
+    fun `deleteOrphanedReleases bulk removes plugin only after its last release is gone`() {
+        val release1 = release(key = "ns:p:1.0.0:jar", version = "1.0.0")
+        val release2 = release(key = "ns:p:2.0.0:jar", version = "2.0.0")
+        whenever(releaseRepository.findById(release1.id!!)).thenReturn(Optional.of(release1))
+        whenever(releaseRepository.findById(release2.id!!)).thenReturn(Optional.of(release2))
+        whenever(storage.exists(any())).thenReturn(false)
+        // First flush: release1 deleted, release2 still alive → plugin stays.
+        // Second flush: both deleted → plugin gets garbage-collected.
+        whenever(releaseRepository.existsByPlugin(release1.plugin))
+            .thenReturn(true)
+            .thenReturn(false)
+
+        service.deleteOrphanedReleases(listOf(release1.id!!, release2.id!!))
+
+        verify(releaseRepository).delete(release1)
+        verify(releaseRepository).delete(release2)
+        verify(pluginRepository).delete(release1.plugin)
+    }
+
+    @Test
     fun `deleteOrphanedArtifacts captures storage-failures as skipped, continues with next`() {
         whenever(releaseRepository.findAllArtifactKeys()).thenReturn(emptyList())
         whenever(storage.delete("flaky"))
@@ -142,15 +193,20 @@ class StorageConsistencyAdminServiceTest {
         assertThat(result.skipped).containsExactly("flaky")
     }
 
-    private fun release(key: String): PluginReleaseEntity {
-        val ns = NamespaceEntity(slug = "ns", name = "Namespace")
-        val plugin = PluginEntity(namespace = ns, pluginId = "p", name = "P")
-        return PluginReleaseEntity(
-            id = UUID.randomUUID(),
-            plugin = plugin,
-            version = "1.0.0",
-            artifactSha256 = "sha",
-            artifactKey = key,
-        )
-    }
+    // Plugin shared across `release()` calls within a single test so the
+    // GC-shell assertions can target the same `PluginEntity` instance for
+    // multiple releases of one plugin.
+    private val sharedPlugin: PluginEntity = PluginEntity(
+        namespace = NamespaceEntity(slug = "ns", name = "Namespace"),
+        pluginId = "p",
+        name = "P",
+    )
+
+    private fun release(key: String, version: String = "1.0.0"): PluginReleaseEntity = PluginReleaseEntity(
+        id = UUID.randomUUID(),
+        plugin = sharedPlugin,
+        version = version,
+        artifactSha256 = "sha",
+        artifactKey = key,
+    )
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyAdminServiceTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.plugwerk.server.domain.NamespaceEntity
+import io.plugwerk.server.domain.PluginEntity
+import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+class StorageConsistencyAdminServiceTest {
+
+    private lateinit var releaseRepository: PluginReleaseRepository
+    private lateinit var storage: ArtifactStorageService
+    private lateinit var service: StorageConsistencyAdminService
+
+    @BeforeEach
+    fun setUp() {
+        releaseRepository = mock()
+        storage = mock()
+        service = StorageConsistencyAdminService(releaseRepository, storage)
+    }
+
+    @Test
+    fun `deleteOrphanedRelease deletes DB row and storage file`() {
+        val release = release(key = "ns:p:1.0.0:jar")
+        whenever(releaseRepository.findById(release.id!!)).thenReturn(Optional.of(release))
+
+        service.deleteOrphanedRelease(release.id!!)
+
+        verify(releaseRepository).delete(release)
+        verify(storage).delete("ns:p:1.0.0:jar")
+    }
+
+    @Test
+    fun `deleteOrphanedRelease is idempotent when release already gone`() {
+        val id = UUID.randomUUID()
+        whenever(releaseRepository.findById(id)).thenReturn(Optional.empty())
+
+        service.deleteOrphanedRelease(id)
+
+        verify(releaseRepository, never()).delete(any<PluginReleaseEntity>())
+        verify(storage, never()).delete(any())
+    }
+
+    @Test
+    fun `deleteOrphanedArtifacts removes only keys with no DB reference`() {
+        whenever(releaseRepository.findAllArtifactKeys()).thenReturn(listOf("ns:p:1.0.0:jar"))
+
+        val result = service.deleteOrphanedArtifacts(
+            listOf("ns:p:1.0.0:jar", "ns:orphan:0.1.0:jar"),
+        )
+
+        verify(storage, never()).delete("ns:p:1.0.0:jar")
+        verify(storage).delete("ns:orphan:0.1.0:jar")
+        assertThat(result.deleted).containsExactly("ns:orphan:0.1.0:jar")
+        assertThat(result.skipped).containsExactly("ns:p:1.0.0:jar")
+    }
+
+    @Test
+    fun `deleteOrphanedArtifacts with empty input is a no-op`() {
+        val result = service.deleteOrphanedArtifacts(emptyList())
+
+        assertThat(result.deleted).isEmpty()
+        assertThat(result.skipped).isEmpty()
+        verify(storage, never()).delete(any())
+    }
+
+    @Test
+    fun `deleteOrphanedArtifacts captures storage-failures as skipped, continues with next`() {
+        whenever(releaseRepository.findAllArtifactKeys()).thenReturn(emptyList())
+        whenever(storage.delete("flaky"))
+            .thenThrow(io.plugwerk.server.service.ArtifactStorageException("backend hiccup"))
+
+        val result = service.deleteOrphanedArtifacts(listOf("flaky", "ok"))
+
+        assertThat(result.deleted).containsExactly("ok")
+        assertThat(result.skipped).containsExactly("flaky")
+    }
+
+    private fun release(key: String): PluginReleaseEntity {
+        val ns = NamespaceEntity(slug = "ns", name = "Namespace")
+        val plugin = PluginEntity(namespace = ns, pluginId = "p", name = "P")
+        return PluginReleaseEntity(
+            id = UUID.randomUUID(),
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = key,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
@@ -84,6 +84,7 @@ class StorageConsistencyServiceTest {
 
         assertThat(report.missingArtifacts).singleElement().satisfies({
             assertThat(it.releaseId).isEqualTo(release.id)
+            assertThat(it.namespaceSlug).isEqualTo("ns")
             assertThat(it.pluginId).isEqualTo("gone")
             assertThat(it.version).isEqualTo("1.0.0")
             assertThat(it.artifactKey).isEqualTo("ns:gone:1.0.0:jar")

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.domain.NamespaceEntity
+import io.plugwerk.server.domain.PluginEntity
+import io.plugwerk.server.domain.PluginReleaseEntity
+import io.plugwerk.server.repository.PluginReleaseRepository
+import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.storage.StorageObjectInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class StorageConsistencyServiceTest {
+
+    private val now = Instant.parse("2026-05-12T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    @Test
+    fun `empty DB and empty storage yield an empty report`() {
+        val service = buildService(dbKeys = emptyList(), storageObjects = emptyList())
+
+        val report = service.scan()
+
+        assertThat(report.missingArtifacts).isEmpty()
+        assertThat(report.orphanedArtifacts).isEmpty()
+        assertThat(report.totalDbRows).isZero()
+        assertThat(report.totalStorageObjects).isZero()
+        assertThat(report.scannedAt).isEqualTo(now)
+    }
+
+    @Test
+    fun `perfect match yields no inconsistencies`() {
+        val key = "ns:plug:1.0.0:jar"
+        val release = release(key = key, pluginId = "plug", version = "1.0.0")
+        val service = buildService(
+            dbKeys = listOf(key),
+            storageObjects = listOf(storageObject(key, ageHours = 5)),
+            releasesForHydration = listOf(release),
+        )
+
+        val report = service.scan()
+
+        assertThat(report.missingArtifacts).isEmpty()
+        assertThat(report.orphanedArtifacts).isEmpty()
+        assertThat(report.totalDbRows).isEqualTo(1)
+        assertThat(report.totalStorageObjects).isEqualTo(1)
+    }
+
+    @Test
+    fun `DB row without storage file is reported as missing artifact`() {
+        val release = release(key = "ns:gone:1.0.0:jar", pluginId = "gone", version = "1.0.0")
+        val service = buildService(
+            dbKeys = listOf(release.artifactKey),
+            storageObjects = emptyList(),
+            releasesForHydration = listOf(release),
+        )
+
+        val report = service.scan()
+
+        assertThat(report.missingArtifacts).singleElement().satisfies({
+            assertThat(it.releaseId).isEqualTo(release.id)
+            assertThat(it.pluginId).isEqualTo("gone")
+            assertThat(it.version).isEqualTo("1.0.0")
+            assertThat(it.artifactKey).isEqualTo("ns:gone:1.0.0:jar")
+        })
+        assertThat(report.orphanedArtifacts).isEmpty()
+    }
+
+    @Test
+    fun `storage file without DB row is reported as orphaned artifact with ageHours`() {
+        val service = buildService(
+            dbKeys = emptyList(),
+            storageObjects = listOf(storageObject("ns:orphan:0.1.0:jar", ageHours = 48)),
+        )
+
+        val report = service.scan()
+
+        assertThat(report.missingArtifacts).isEmpty()
+        assertThat(report.orphanedArtifacts).singleElement().satisfies({
+            assertThat(it.key).isEqualTo("ns:orphan:0.1.0:jar")
+            assertThat(it.ageHours).isEqualTo(48L)
+            assertThat(it.sizeBytes).isEqualTo(123L)
+        })
+    }
+
+    @Test
+    fun `partial overlap classifies known, missing, and orphan separately`() {
+        val knownKey = "ns:known:1.0.0:jar"
+        val missingKey = "ns:gone:2.0.0:jar"
+        val orphanKey = "ns:orphan:0.1.0:jar"
+        val knownRelease = release(key = knownKey, pluginId = "known", version = "1.0.0")
+        val missingRelease = release(key = missingKey, pluginId = "gone", version = "2.0.0")
+
+        val service = buildService(
+            dbKeys = listOf(knownKey, missingKey),
+            storageObjects = listOf(
+                storageObject(knownKey, ageHours = 5),
+                storageObject(orphanKey, ageHours = 100),
+            ),
+            releasesForHydration = listOf(knownRelease, missingRelease),
+        )
+
+        val report = service.scan()
+
+        assertThat(report.missingArtifacts.map { it.artifactKey }).containsExactly(missingKey)
+        assertThat(report.orphanedArtifacts.map { it.key }).containsExactly(orphanKey)
+        assertThat(report.totalDbRows).isEqualTo(2)
+        assertThat(report.totalStorageObjects).isEqualTo(2)
+    }
+
+    @Test
+    fun `scan aborts with StorageScanLimitExceededException over maxKeysPerScan`() {
+        val keys = (1..10).map { "ns:k$it:1.0.0:jar" }
+        val service = buildService(
+            dbKeys = emptyList(),
+            storageObjects = keys.map { storageObject(it, ageHours = 1) },
+            maxKeysPerScan = 5,
+        )
+
+        assertThatThrownBy { service.scan() }
+            .isInstanceOf(StorageScanLimitExceededException::class.java)
+            .hasMessageContaining("limit: 5")
+    }
+
+    private fun buildService(
+        dbKeys: List<String>,
+        storageObjects: List<StorageObjectInfo>,
+        releasesForHydration: List<PluginReleaseEntity> = emptyList(),
+        maxKeysPerScan: Int = 100,
+    ): StorageConsistencyService {
+        val repo = mock<PluginReleaseRepository>()
+        whenever(repo.findAllArtifactKeys()).thenReturn(dbKeys)
+        whenever(repo.findAll()).thenReturn(releasesForHydration)
+
+        val storage = mock<ArtifactStorageService>()
+        whenever(storage.listObjects("")).thenReturn(storageObjects.asSequence())
+
+        val props = PlugwerkProperties(
+            storage = PlugwerkProperties.StorageProperties(
+                consistency = PlugwerkProperties.StorageProperties.ConsistencyProperties(
+                    maxKeysPerScan = maxKeysPerScan,
+                ),
+            ),
+            auth = PlugwerkProperties.AuthProperties(
+                jwtSecret = "test-secret-at-least-32-chars-long!!",
+            ),
+        )
+
+        return StorageConsistencyService(storage, repo, props, clock)
+    }
+
+    private fun storageObject(key: String, ageHours: Long): StorageObjectInfo =
+        StorageObjectInfo(
+            key = key,
+            lastModified = now.minusSeconds(ageHours * 3600),
+            sizeBytes = 123L,
+        )
+
+    private fun release(
+        key: String,
+        pluginId: String,
+        version: String,
+        id: UUID = UUID.randomUUID(),
+    ): PluginReleaseEntity {
+        val ns = NamespaceEntity(slug = "ns", name = "Namespace")
+        val plugin = PluginEntity(namespace = ns, pluginId = pluginId, name = pluginId)
+        return PluginReleaseEntity(
+            id = id,
+            plugin = plugin,
+            version = version,
+            artifactSha256 = "sha",
+            artifactKey = key,
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/StorageConsistencyServiceTest.kt
@@ -174,12 +174,11 @@ class StorageConsistencyServiceTest {
         return StorageConsistencyService(storage, repo, props, clock)
     }
 
-    private fun storageObject(key: String, ageHours: Long): StorageObjectInfo =
-        StorageObjectInfo(
-            key = key,
-            lastModified = now.minusSeconds(ageHours * 3600),
-            sizeBytes = 123L,
-        )
+    private fun storageObject(key: String, ageHours: Long): StorageObjectInfo = StorageObjectInfo(
+        key = key,
+        lastModified = now.minusSeconds(ageHours * 3600),
+        sizeBytes = 123L,
+    )
 
     private fun release(
         key: String,

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
@@ -20,3 +20,10 @@ plugwerk:
       # guard so the discovery + refresh paths still work. Production
       # default is false, see application.yml comment for the rationale.
       allow-private-discovery-uris: true
+  scheduler:
+    shedlock:
+      # H2 (test DB) does not run the Liquibase migration that creates the
+      # `shedlock` table — ShedLock's INSERT would fail at AOP-interception
+      # time. Fall back to the NoOpLockProvider so @SchedulerLock-annotated
+      # methods still execute in tests.
+      enabled: false

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -22,6 +22,7 @@ import { AccessKeysApi } from "./generated/api/access-keys-api";
 import { AdminEmailApi } from "./generated/api/admin-email-api";
 import { AdminEmailTemplatesApi } from "./generated/api/admin-email-templates-api";
 import { AdminSettingsApi } from "./generated/api/admin-settings-api";
+import { AdminStorageConsistencyApi } from "./generated/api/admin-storage-consistency-api";
 import { AdminUsersApi } from "./generated/api/admin-users-api";
 import { AuthApi } from "./generated/api/auth-api";
 import { AuthPasswordResetApi } from "./generated/api/auth-password-reset-api";
@@ -161,6 +162,11 @@ export const authPasswordResetApi = new AuthPasswordResetApi(
   axiosInstance,
 );
 export const adminUsersApi = new AdminUsersApi(
+  apiConfig,
+  BASE_PATH,
+  axiosInstance,
+);
+export const adminStorageConsistencyApi = new AdminStorageConsistencyApi(
   apiConfig,
   BASE_PATH,
   axiosInstance,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -17,7 +17,15 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { Box, Typography } from "@mui/material";
-import { Settings, Users, Shield, FileCheck, Globe, Mail } from "lucide-react";
+import {
+  Settings,
+  Users,
+  Shield,
+  FileCheck,
+  Globe,
+  Mail,
+  HardDrive,
+} from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { tokens } from "../../theme/tokens";
 import { useAuthStore } from "../../stores/authStore";
@@ -68,6 +76,12 @@ const ADMIN_SECTIONS: AdminSection[] = [
     requiresSuperadmin: true,
   },
   { path: "reviews", label: "Pending Reviews", icon: <FileCheck size={16} /> },
+  {
+    path: "storage-consistency",
+    label: "Storage",
+    icon: <HardDrive size={16} />,
+    requiresSuperadmin: true,
+  },
 ];
 
 export function AdminSidebar() {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
@@ -74,6 +74,7 @@ describe("StorageConsistencySection", () => {
         missingArtifacts: [
           {
             releaseId: "00000000-0000-0000-0000-000000000001",
+            namespaceSlug: "acme",
             pluginId: "io.example.plugin",
             version: "1.0.0",
             artifactKey: "acme:io.example.plugin:1.0.0:jar",
@@ -140,6 +141,7 @@ describe("StorageConsistencySection", () => {
           missingArtifacts: [
             {
               releaseId,
+              namespaceSlug: "acme",
               pluginId: "io.example.plugin",
               version: "1.0.0",
               artifactKey: "acme:io.example.plugin:1.0.0:jar",

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StorageConsistencySection } from "./StorageConsistencySection";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import * as apiConfig from "../../api/config";
+import type { ConsistencyReport } from "../../api/generated/model";
+
+vi.mock("../../api/config", () => ({
+  adminStorageConsistencyApi: {
+    getStorageConsistencyReport: vi.fn(),
+    deleteOrphanedRelease: vi.fn(),
+    deleteOrphanedArtifacts: vi.fn(),
+  },
+}));
+
+const NOW = "2026-05-12T12:00:00Z";
+
+function reportFixture(
+  overrides: Partial<ConsistencyReport> = {},
+): ConsistencyReport {
+  return {
+    missingArtifacts: [],
+    orphanedArtifacts: [],
+    scannedAt: NOW,
+    totalDbRows: 0,
+    totalStorageObjects: 0,
+    ...overrides,
+  };
+}
+
+describe("StorageConsistencySection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders both empty tables on a clean report", async () => {
+    vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValue({ data: reportFixture() } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No releases reference missing storage files."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("No orphaned objects in storage."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("lists missing and orphaned rows from the report", async () => {
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
+    ).mockResolvedValue({
+      data: reportFixture({
+        missingArtifacts: [
+          {
+            releaseId: "00000000-0000-0000-0000-000000000001",
+            pluginId: "io.example.plugin",
+            version: "1.0.0",
+            artifactKey: "acme:io.example.plugin:1.0.0:jar",
+          },
+        ],
+        orphanedArtifacts: [
+          {
+            key: "acme:orphan:0.1.0:jar",
+            lastModified: "2026-05-10T12:00:00Z",
+            ageHours: 48,
+            sizeBytes: 12_345,
+          },
+        ],
+        totalDbRows: 1,
+        totalStorageObjects: 2,
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("io.example.plugin")).toBeInTheDocument();
+      expect(
+        screen.getByText("acme:io.example.plugin:1.0.0:jar"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("acme:orphan:0.1.0:jar")).toBeInTheDocument();
+      expect(screen.getByText("48h")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces the 409 max-keys-per-scan limit message", async () => {
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
+    ).mockRejectedValue({
+      response: {
+        status: 409,
+        data: {
+          limit: 100_000,
+          scannedSoFar: 100_001,
+          message:
+            "Storage scan aborted by max-keys-per-scan circuit breaker (limit=100000, scanned=100001).",
+        },
+      },
+    });
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/max-keys-per-scan circuit breaker/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("triggers bulk delete and re-scans on success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
+      .mockResolvedValueOnce({
+        data: reportFixture({
+          orphanedArtifacts: [
+            {
+              key: "acme:orphan:0.1.0:jar",
+              lastModified: "2026-05-10T12:00:00Z",
+              ageHours: 48,
+              sizeBytes: 12_345,
+            },
+          ],
+          totalStorageObjects: 1,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      .mockResolvedValueOnce({
+        data: reportFixture(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.deleteOrphanedArtifacts,
+    ).mockResolvedValue({
+      data: { deleted: ["acme:orphan:0.1.0:jar"], skipped: [] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await screen.findByText("acme:orphan:0.1.0:jar");
+
+    await user.click(
+      screen.getByRole("button", { name: /Delete all listed/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /Delete objects/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminStorageConsistencyApi.deleteOrphanedArtifacts,
+      ).toHaveBeenCalledWith({
+        orphanedArtifactDeletionRequest: {
+          keys: ["acme:orphan:0.1.0:jar"],
+        },
+      });
+    });
+    expect(
+      apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
@@ -227,6 +227,46 @@ describe("StorageConsistencySection", () => {
     });
   });
 
+  it("filters missing rows by the namespace dropdown", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
+    ).mockResolvedValue({
+      data: reportFixture({
+        missingArtifacts: [
+          {
+            releaseId: "00000000-0000-0000-0000-000000000010",
+            namespaceSlug: "acme",
+            pluginId: "io.example.alpha",
+            version: "1.0.0",
+            artifactKey: "acme:io.example.alpha:1.0.0:jar",
+          },
+          {
+            releaseId: "00000000-0000-0000-0000-000000000011",
+            namespaceSlug: "community",
+            pluginId: "io.example.beta",
+            version: "2.0.0",
+            artifactKey: "community:io.example.beta:2.0.0:jar",
+          },
+        ],
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await screen.findByText("io.example.alpha");
+    expect(screen.getByText("io.example.beta")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/^Namespace$/i));
+    await user.click(screen.getByRole("option", { name: "acme" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("io.example.alpha")).toBeInTheDocument();
+      expect(screen.queryByText("io.example.beta")).not.toBeInTheDocument();
+    });
+  });
+
   it("filters orphan rows by the search field", async () => {
     const user = userEvent.setup();
     vi.mocked(

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../../api/config", () => ({
   adminStorageConsistencyApi: {
     getStorageConsistencyReport: vi.fn(),
     deleteOrphanedRelease: vi.fn(),
+    deleteOrphanedReleases: vi.fn(),
     deleteOrphanedArtifacts: vi.fn(),
   },
 }));
@@ -132,6 +133,56 @@ describe("StorageConsistencySection", () => {
     });
   });
 
+  it("triggers bulk remove for missing releases", async () => {
+    const user = userEvent.setup();
+    const releaseId = "00000000-0000-0000-0000-000000000001";
+    vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
+      .mockResolvedValueOnce({
+        data: reportFixture({
+          missingArtifacts: [
+            {
+              releaseId,
+              pluginId: "io.example.plugin",
+              version: "1.0.0",
+              artifactKey: "acme:io.example.plugin:1.0.0:jar",
+            },
+          ],
+          totalDbRows: 1,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      .mockResolvedValueOnce({
+        data: reportFixture(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.deleteOrphanedReleases,
+    ).mockResolvedValue({
+      data: { deleted: [releaseId], skipped: [] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await screen.findByText("io.example.plugin");
+
+    // The Missing-section "Remove all" button is the first of the two
+    // identical buttons (Missing renders before Orphaned in the DOM).
+    const removeAllButtons = await screen.findAllByRole("button", {
+      name: /Remove all/i,
+    });
+    await user.click(removeAllButtons[0]);
+    await user.click(screen.getByRole("button", { name: /Remove rows/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminStorageConsistencyApi.deleteOrphanedReleases,
+      ).toHaveBeenCalledWith({
+        orphanedReleaseDeletionRequest: { releaseIds: [releaseId] },
+      });
+    });
+  });
+
   it("triggers bulk delete and re-scans on success", async () => {
     const user = userEvent.setup();
     vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
@@ -164,9 +215,17 @@ describe("StorageConsistencySection", () => {
 
     await screen.findByText("acme:orphan:0.1.0:jar");
 
-    await user.click(
-      screen.getByRole("button", { name: /Delete all listed/i }),
+    // Two "Remove all" buttons exist (Missing + Orphaned). Missing is
+    // disabled because that table is empty in this fixture, so we target
+    // the enabled one for the orphaned-bulk flow.
+    const removeAllButtons = screen.getAllByRole("button", {
+      name: /Remove all/i,
+    });
+    const orphanedButton = removeAllButtons.find(
+      (b) => !(b as HTMLButtonElement).disabled,
     );
+    expect(orphanedButton).toBeDefined();
+    await user.click(orphanedButton!);
     await user.click(screen.getByRole("button", { name: /Delete objects/i }));
 
     await waitFor(() => {

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.test.tsx
@@ -17,7 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StorageConsistencySection } from "./StorageConsistencySection";
 import { renderWithTheme } from "../../test/renderWithTheme";
@@ -53,7 +53,7 @@ describe("StorageConsistencySection", () => {
     vi.clearAllMocks();
   });
 
-  it("renders both empty tables on a clean report", async () => {
+  it("renders empty states for both tables when the report is clean", async () => {
     vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .mockResolvedValue({ data: reportFixture() } as any);
@@ -61,16 +61,12 @@ describe("StorageConsistencySection", () => {
     renderWithTheme(<StorageConsistencySection />);
 
     await waitFor(() => {
-      expect(
-        screen.getByText("No releases reference missing storage files."),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("No orphaned objects in storage."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("No missing artifacts")).toBeInTheDocument();
+      expect(screen.getByText("No orphaned objects")).toBeInTheDocument();
     });
   });
 
-  it("lists missing and orphaned rows from the report", async () => {
+  it("lists missing and orphaned rows with the new key + age columns", async () => {
     vi.mocked(
       apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
     ).mockResolvedValue({
@@ -105,7 +101,9 @@ describe("StorageConsistencySection", () => {
         screen.getByText("acme:io.example.plugin:1.0.0:jar"),
       ).toBeInTheDocument();
       expect(screen.getByText("acme:orphan:0.1.0:jar")).toBeInTheDocument();
-      expect(screen.getByText("48h")).toBeInTheDocument();
+      // Age renders as `2d` (48 hours) — once in the stats strip
+      // ("Oldest") and once in the row badge.
+      expect(screen.getAllByText("2d").length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -133,7 +131,7 @@ describe("StorageConsistencySection", () => {
     });
   });
 
-  it("triggers bulk remove for missing releases", async () => {
+  it("triggers bulk remove for missing releases via the Missing table", async () => {
     const user = userEvent.setup();
     const releaseId = "00000000-0000-0000-0000-000000000001";
     vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
@@ -164,14 +162,12 @@ describe("StorageConsistencySection", () => {
 
     renderWithTheme(<StorageConsistencySection />);
 
-    await screen.findByText("io.example.plugin");
-
-    // The Missing-section "Remove all" button is the first of the two
-    // identical buttons (Missing renders before Orphaned in the DOM).
-    const removeAllButtons = await screen.findAllByRole("button", {
-      name: /Remove all/i,
+    const missingTable = await screen.findByRole("table", {
+      name: /Missing artifacts/i,
     });
-    await user.click(removeAllButtons[0]);
+    expect(missingTable).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Remove all \(1\)/i }));
     await user.click(screen.getByRole("button", { name: /Remove rows/i }));
 
     await waitFor(() => {
@@ -183,7 +179,7 @@ describe("StorageConsistencySection", () => {
     });
   });
 
-  it("triggers bulk delete and re-scans on success", async () => {
+  it("triggers bulk delete for orphans via the Orphaned table", async () => {
     const user = userEvent.setup();
     vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
       .mockResolvedValueOnce({
@@ -215,17 +211,7 @@ describe("StorageConsistencySection", () => {
 
     await screen.findByText("acme:orphan:0.1.0:jar");
 
-    // Two "Remove all" buttons exist (Missing + Orphaned). Missing is
-    // disabled because that table is empty in this fixture, so we target
-    // the enabled one for the orphaned-bulk flow.
-    const removeAllButtons = screen.getAllByRole("button", {
-      name: /Remove all/i,
-    });
-    const orphanedButton = removeAllButtons.find(
-      (b) => !(b as HTMLButtonElement).disabled,
-    );
-    expect(orphanedButton).toBeDefined();
-    await user.click(orphanedButton!);
+    await user.click(screen.getByRole("button", { name: /Delete all \(1\)/i }));
     await user.click(screen.getByRole("button", { name: /Delete objects/i }));
 
     await waitFor(() => {
@@ -237,8 +223,111 @@ describe("StorageConsistencySection", () => {
         },
       });
     });
-    expect(
+  });
+
+  it("filters orphan rows by the search field", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
       apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport,
-    ).toHaveBeenCalledTimes(2);
+    ).mockResolvedValue({
+      data: reportFixture({
+        orphanedArtifacts: [
+          {
+            key: "acme:keeper:1.0.0:jar",
+            lastModified: "2026-05-10T12:00:00Z",
+            ageHours: 48,
+            sizeBytes: 1_000,
+          },
+          {
+            key: "acme:noise:9.9.9:jar",
+            lastModified: "2026-05-09T12:00:00Z",
+            ageHours: 72,
+            sizeBytes: 2_000,
+          },
+        ],
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    await screen.findByText("acme:keeper:1.0.0:jar");
+    expect(screen.getByText("acme:noise:9.9.9:jar")).toBeInTheDocument();
+
+    const orphanedTable = screen.getByRole("table", {
+      name: /Orphaned artifacts/i,
+    });
+    const orphanedSection = orphanedTable.closest("div");
+    expect(orphanedSection).toBeTruthy();
+    // The search input is scoped to the orphaned table by its placeholder.
+    const search = await screen.findByPlaceholderText("Filter by key…");
+    await user.type(search, "keeper");
+
+    await waitFor(() => {
+      expect(screen.getByText("acme:keeper:1.0.0:jar")).toBeInTheDocument();
+      expect(
+        screen.queryByText("acme:noise:9.9.9:jar"),
+      ).not.toBeInTheDocument();
+    });
+    // The bulk action label should reflect the filter context.
+    expect(
+      within(orphanedTable.parentElement!.parentElement!).getByRole("button", {
+        name: /Delete all 1 matching/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("supports multi-select bulk delete for orphans", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.adminStorageConsistencyApi.getStorageConsistencyReport)
+      .mockResolvedValueOnce({
+        data: reportFixture({
+          orphanedArtifacts: [
+            {
+              key: "acme:a:1.0.0:jar",
+              lastModified: "2026-05-10T12:00:00Z",
+              ageHours: 48,
+              sizeBytes: 1_000,
+            },
+            {
+              key: "acme:b:1.0.0:jar",
+              lastModified: "2026-05-09T12:00:00Z",
+              ageHours: 72,
+              sizeBytes: 2_000,
+            },
+          ],
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      .mockResolvedValueOnce({
+        data: reportFixture(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    vi.mocked(
+      apiConfig.adminStorageConsistencyApi.deleteOrphanedArtifacts,
+    ).mockResolvedValue({
+      data: { deleted: ["acme:a:1.0.0:jar"], skipped: [] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<StorageConsistencySection />);
+
+    const firstRowCheckbox = await screen.findByRole("checkbox", {
+      name: /Select acme:a:1\.0\.0:jar/i,
+    });
+    await user.click(firstRowCheckbox);
+
+    await user.click(
+      screen.getByRole("button", { name: /Delete 1 selected/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /Delete objects/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminStorageConsistencyApi.deleteOrphanedArtifacts,
+      ).toHaveBeenCalledWith({
+        orphanedArtifactDeletionRequest: { keys: ["acme:a:1.0.0:jar"] },
+      });
+    });
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { AlertTriangle, HardDrive, RefreshCw, Trash2 } from "lucide-react";
+import { Section } from "../../components/common/Section";
+import { DataTable } from "../../components/common/DataTable";
+import type { DataColumn } from "../../components/common/DataTable";
+import { ConfirmDeleteDialog } from "../../components/common/ConfirmDeleteDialog";
+import { Timestamp } from "../../components/common/Timestamp";
+import { adminStorageConsistencyApi } from "../../api/config";
+import { useUiStore } from "../../stores/uiStore";
+import type {
+  ConsistencyReport,
+  MissingArtifact,
+  OrphanedArtifact,
+} from "../../api/generated/model";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function StorageConsistencySection() {
+  const [report, setReport] = useState<ConsistencyReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [releaseToDelete, setReleaseToDelete] =
+    useState<MissingArtifact | null>(null);
+  const [deletingRelease, setDeletingRelease] = useState(false);
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const addToast = useUiStore((s) => s.addToast);
+
+  // Mirrors the pattern in UsersSection: define the async work inside the
+  // effect, drive re-fetch via a counter. The `react-hooks/set-state-in-effect`
+  // rule (React 19) flags external functions but accepts this structure.
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      setScanError(null);
+      try {
+        const res =
+          await adminStorageConsistencyApi.getStorageConsistencyReport();
+        setReport(res.data);
+      } catch (err: unknown) {
+        const axiosError = err as {
+          response?: {
+            status?: number;
+            data?: { limit?: number; scannedSoFar?: number; message?: string };
+          };
+        };
+        if (axiosError.response?.status === 409 && axiosError.response.data) {
+          const { limit, message } = axiosError.response.data;
+          setScanError(
+            message ??
+              `Scan aborted at ${limit ?? "the configured"} keys. Increase plugwerk.storage.consistency.max-keys-per-scan or use a targeted prefix scan.`,
+          );
+        } else {
+          setScanError("Failed to scan storage. See server logs.");
+        }
+        setReport(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [refreshTrigger]);
+
+  const refresh = () => setRefreshTrigger((n) => n + 1);
+
+  async function handleDeleteRelease() {
+    if (!releaseToDelete) return;
+    setDeletingRelease(true);
+    try {
+      await adminStorageConsistencyApi.deleteOrphanedRelease({
+        releaseId: releaseToDelete.releaseId,
+      });
+      addToast({
+        message: `Removed orphaned release ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
+        type: "success",
+      });
+      setReleaseToDelete(null);
+      refresh();
+    } catch {
+      addToast({
+        message: `Failed to remove release ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
+        type: "error",
+      });
+    } finally {
+      setDeletingRelease(false);
+    }
+  }
+
+  async function handleBulkDelete() {
+    if (!report || report.orphanedArtifacts.length === 0) return;
+    setBulkDeleting(true);
+    try {
+      const res = await adminStorageConsistencyApi.deleteOrphanedArtifacts({
+        orphanedArtifactDeletionRequest: {
+          keys: report.orphanedArtifacts.map((a) => a.key),
+        },
+      });
+      const { deleted, skipped } = res.data;
+      addToast({
+        message: skipped.length
+          ? `Deleted ${deleted.length} orphaned object(s); skipped ${skipped.length} that were re-referenced.`
+          : `Deleted ${deleted.length} orphaned object(s).`,
+        type: "success",
+      });
+      setBulkConfirmOpen(false);
+      refresh();
+    } catch {
+      addToast({ message: "Bulk delete failed.", type: "error" });
+    } finally {
+      setBulkDeleting(false);
+    }
+  }
+
+  const missingColumns: DataColumn<MissingArtifact>[] = [
+    {
+      key: "plugin",
+      header: "Plugin",
+      render: (row) => (
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {row.pluginId}
+          </Typography>
+          <Typography variant="caption" sx={{ color: "text.secondary" }}>
+            {row.version}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      key: "artifactKey",
+      header: "Artifact key",
+      render: (row) => (
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+            wordBreak: "break-all",
+          }}
+        >
+          {row.artifactKey}
+        </Typography>
+      ),
+    },
+    {
+      key: "action",
+      header: "",
+      align: "right",
+      width: 140,
+      render: (row) => (
+        <Button
+          size="small"
+          color="error"
+          startIcon={<Trash2 size={14} />}
+          onClick={() => setReleaseToDelete(row)}
+        >
+          Remove row
+        </Button>
+      ),
+    },
+  ];
+
+  const orphanedColumns: DataColumn<OrphanedArtifact>[] = [
+    {
+      key: "key",
+      header: "Storage key",
+      render: (row) => (
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+            wordBreak: "break-all",
+          }}
+        >
+          {row.key}
+        </Typography>
+      ),
+    },
+    {
+      key: "size",
+      header: "Size",
+      align: "right",
+      width: 100,
+      render: (row) => (
+        <Typography variant="body2">{formatBytes(row.sizeBytes)}</Typography>
+      ),
+    },
+    {
+      key: "age",
+      header: "Age",
+      align: "right",
+      width: 140,
+      render: (row) => (
+        <Box>
+          <Typography variant="body2">{row.ageHours}h</Typography>
+          <Timestamp date={row.lastModified} variant="relative" />
+        </Box>
+      ),
+    },
+  ];
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Storage consistency
+          </Typography>
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            Reconcile the artifact database with object storage. Missing rows
+            point to files that disappeared; orphaned files have no database row
+            pointing at them.
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<RefreshCw size={14} />}
+          onClick={refresh}
+          disabled={loading}
+        >
+          Rescan
+        </Button>
+      </Box>
+
+      {scanError && (
+        <Alert severity="warning" icon={<AlertTriangle size={18} />}>
+          {scanError}
+        </Alert>
+      )}
+
+      {loading && !report && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress size={28} />
+        </Box>
+      )}
+
+      {report && (
+        <>
+          <Section
+            icon={<HardDrive size={18} />}
+            title="Missing artifacts"
+            description={`${report.missingArtifacts.length} release row(s) point at storage keys that are gone.`}
+          >
+            <DataTable
+              ariaLabel="Missing artifacts"
+              columns={missingColumns}
+              rows={report.missingArtifacts}
+              keyFn={(r) => r.releaseId}
+              emptyMessage="No releases reference missing storage files."
+            />
+          </Section>
+
+          <Section
+            icon={<HardDrive size={18} />}
+            title="Orphaned artifacts"
+            description={`${report.orphanedArtifacts.length} storage object(s) have no release row.`}
+          >
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+              <Button
+                variant="contained"
+                color="error"
+                size="small"
+                startIcon={<Trash2 size={14} />}
+                disabled={report.orphanedArtifacts.length === 0 || bulkDeleting}
+                onClick={() => setBulkConfirmOpen(true)}
+              >
+                Delete all listed
+              </Button>
+            </Box>
+            <DataTable
+              ariaLabel="Orphaned artifacts"
+              columns={orphanedColumns}
+              rows={report.orphanedArtifacts}
+              keyFn={(r) => r.key}
+              emptyMessage="No orphaned objects in storage."
+            />
+          </Section>
+
+          <Typography variant="caption" sx={{ color: "text.disabled" }}>
+            Scanned <Timestamp date={report.scannedAt} variant="relative" /> —{" "}
+            <Chip label={`${report.totalDbRows} DB row(s)`} size="small" />{" "}
+            <Chip
+              label={`${report.totalStorageObjects} storage object(s)`}
+              size="small"
+            />
+          </Typography>
+        </>
+      )}
+
+      <ConfirmDeleteDialog
+        open={releaseToDelete !== null}
+        onCancel={() => setReleaseToDelete(null)}
+        onConfirm={handleDeleteRelease}
+        title="Remove orphaned release row?"
+        actionLabel="Remove row"
+        message={
+          releaseToDelete
+            ? `Remove the database row for ${releaseToDelete.pluginId} ${releaseToDelete.version}. Idempotent: if the row is already gone, this is a no-op.`
+            : ""
+        }
+        loading={deletingRelease}
+      />
+      <ConfirmDeleteDialog
+        open={bulkConfirmOpen}
+        onCancel={() => setBulkConfirmOpen(false)}
+        onConfirm={handleBulkDelete}
+        title="Delete all listed orphaned objects?"
+        actionLabel="Delete objects"
+        message={
+          report
+            ? `This will delete ${report.orphanedArtifacts.length} object(s) from storage. Objects that have been re-referenced since the last scan are skipped automatically.`
+            : ""
+        }
+        loading={bulkDeleting}
+      />
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
@@ -55,6 +55,8 @@ export function StorageConsistencySection() {
   const [releaseToDelete, setReleaseToDelete] =
     useState<MissingArtifact | null>(null);
   const [deletingRelease, setDeletingRelease] = useState(false);
+  const [bulkReleaseConfirmOpen, setBulkReleaseConfirmOpen] = useState(false);
+  const [bulkReleaseDeleting, setBulkReleaseDeleting] = useState(false);
   const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const addToast = useUiStore((s) => s.addToast);
@@ -116,6 +118,31 @@ export function StorageConsistencySection() {
       });
     } finally {
       setDeletingRelease(false);
+    }
+  }
+
+  async function handleBulkDeleteReleases() {
+    if (!report || report.missingArtifacts.length === 0) return;
+    setBulkReleaseDeleting(true);
+    try {
+      const res = await adminStorageConsistencyApi.deleteOrphanedReleases({
+        orphanedReleaseDeletionRequest: {
+          releaseIds: report.missingArtifacts.map((m) => m.releaseId),
+        },
+      });
+      const { deleted, skipped } = res.data;
+      addToast({
+        message: skipped.length
+          ? `Removed ${deleted.length} release row(s); skipped ${skipped.length} (file reappeared or row already gone).`
+          : `Removed ${deleted.length} release row(s).`,
+        type: "success",
+      });
+      setBulkReleaseConfirmOpen(false);
+      refresh();
+    } catch {
+      addToast({ message: "Bulk release removal failed.", type: "error" });
+    } finally {
+      setBulkReleaseDeleting(false);
     }
   }
 
@@ -281,6 +308,20 @@ export function StorageConsistencySection() {
             title="Missing artifacts"
             description={`${report.missingArtifacts.length} release row(s) point at storage keys that are gone.`}
           >
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+              <Button
+                variant="contained"
+                color="error"
+                size="small"
+                startIcon={<Trash2 size={14} />}
+                disabled={
+                  report.missingArtifacts.length === 0 || bulkReleaseDeleting
+                }
+                onClick={() => setBulkReleaseConfirmOpen(true)}
+              >
+                Remove all
+              </Button>
+            </Box>
             <DataTable
               ariaLabel="Missing artifacts"
               columns={missingColumns}
@@ -304,7 +345,7 @@ export function StorageConsistencySection() {
                 disabled={report.orphanedArtifacts.length === 0 || bulkDeleting}
                 onClick={() => setBulkConfirmOpen(true)}
               >
-                Delete all listed
+                Remove all
               </Button>
             </Box>
             <DataTable
@@ -339,6 +380,19 @@ export function StorageConsistencySection() {
             : ""
         }
         loading={deletingRelease}
+      />
+      <ConfirmDeleteDialog
+        open={bulkReleaseConfirmOpen}
+        onCancel={() => setBulkReleaseConfirmOpen(false)}
+        onConfirm={handleBulkDeleteReleases}
+        title="Remove all missing release rows?"
+        actionLabel="Remove rows"
+        message={
+          report
+            ? `This will remove ${report.missingArtifacts.length} release row(s) from the database. Rows whose storage file has reappeared since the last scan are skipped automatically.`
+            : ""
+        }
+        loading={bulkReleaseDeleting}
       />
       <ConfirmDeleteDialog
         open={bulkConfirmOpen}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/StorageConsistencySection.tsx
@@ -25,10 +25,8 @@ import {
   CircularProgress,
   Typography,
 } from "@mui/material";
-import { AlertTriangle, HardDrive, RefreshCw, Trash2 } from "lucide-react";
+import { AlertTriangle, FileX, HardDrive, RefreshCw } from "lucide-react";
 import { Section } from "../../components/common/Section";
-import { DataTable } from "../../components/common/DataTable";
-import type { DataColumn } from "../../components/common/DataTable";
 import { ConfirmDeleteDialog } from "../../components/common/ConfirmDeleteDialog";
 import { Timestamp } from "../../components/common/Timestamp";
 import { adminStorageConsistencyApi } from "../../api/config";
@@ -38,32 +36,30 @@ import type {
   MissingArtifact,
   OrphanedArtifact,
 } from "../../api/generated/model";
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
+import { MissingArtifactsTable } from "./storage-consistency/MissingArtifactsTable";
+import { OrphanedArtifactsTable } from "./storage-consistency/OrphanedArtifactsTable";
 
 export function StorageConsistencySection() {
   const [report, setReport] = useState<ConsistencyReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [scanError, setScanError] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  // Pending single-row delete and bulk dialogs share the same loading lock
+  // so the user cannot trigger overlapping mutations against the same scan
+  // snapshot — otherwise the UI would render against a half-stale view.
+  const [busy, setBusy] = useState(false);
   const [releaseToDelete, setReleaseToDelete] =
     useState<MissingArtifact | null>(null);
-  const [deletingRelease, setDeletingRelease] = useState(false);
-  const [bulkReleaseConfirmOpen, setBulkReleaseConfirmOpen] = useState(false);
-  const [bulkReleaseDeleting, setBulkReleaseDeleting] = useState(false);
-  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
-  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [releasesToDelete, setReleasesToDelete] = useState<
+    readonly MissingArtifact[] | null
+  >(null);
+  const [artifactsToDelete, setArtifactsToDelete] = useState<
+    readonly OrphanedArtifact[] | null
+  >(null);
+
   const addToast = useUiStore((s) => s.addToast);
 
-  // Mirrors the pattern in UsersSection: define the async work inside the
-  // effect, drive re-fetch via a counter. The `react-hooks/set-state-in-effect`
-  // rule (React 19) flags external functions but accepts this structure.
   useEffect(() => {
     async function load() {
       setLoading(true);
@@ -100,165 +96,76 @@ export function StorageConsistencySection() {
 
   async function handleDeleteRelease() {
     if (!releaseToDelete) return;
-    setDeletingRelease(true);
+    setBusy(true);
     try {
       await adminStorageConsistencyApi.deleteOrphanedRelease({
         releaseId: releaseToDelete.releaseId,
       });
       addToast({
-        message: `Removed orphaned release ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
+        message: `Removed ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
         type: "success",
       });
       setReleaseToDelete(null);
       refresh();
     } catch {
       addToast({
-        message: `Failed to remove release ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
+        message: `Failed to remove ${releaseToDelete.pluginId} ${releaseToDelete.version}.`,
         type: "error",
       });
     } finally {
-      setDeletingRelease(false);
+      setBusy(false);
     }
   }
 
-  async function handleBulkDeleteReleases() {
-    if (!report || report.missingArtifacts.length === 0) return;
-    setBulkReleaseDeleting(true);
+  async function handleDeleteReleases() {
+    if (!releasesToDelete || releasesToDelete.length === 0) return;
+    setBusy(true);
     try {
       const res = await adminStorageConsistencyApi.deleteOrphanedReleases({
         orphanedReleaseDeletionRequest: {
-          releaseIds: report.missingArtifacts.map((m) => m.releaseId),
+          releaseIds: releasesToDelete.map((r) => r.releaseId),
         },
       });
       const { deleted, skipped } = res.data;
       addToast({
         message: skipped.length
-          ? `Removed ${deleted.length} release row(s); skipped ${skipped.length} (file reappeared or row already gone).`
-          : `Removed ${deleted.length} release row(s).`,
+          ? `Removed ${deleted.length} row(s); skipped ${skipped.length} (file reappeared or row already gone).`
+          : `Removed ${deleted.length} row(s).`,
         type: "success",
       });
-      setBulkReleaseConfirmOpen(false);
+      setReleasesToDelete(null);
       refresh();
     } catch {
       addToast({ message: "Bulk release removal failed.", type: "error" });
     } finally {
-      setBulkReleaseDeleting(false);
+      setBusy(false);
     }
   }
 
-  async function handleBulkDelete() {
-    if (!report || report.orphanedArtifacts.length === 0) return;
-    setBulkDeleting(true);
+  async function handleDeleteArtifacts() {
+    if (!artifactsToDelete || artifactsToDelete.length === 0) return;
+    setBusy(true);
     try {
       const res = await adminStorageConsistencyApi.deleteOrphanedArtifacts({
         orphanedArtifactDeletionRequest: {
-          keys: report.orphanedArtifacts.map((a) => a.key),
+          keys: artifactsToDelete.map((r) => r.key),
         },
       });
       const { deleted, skipped } = res.data;
       addToast({
         message: skipped.length
-          ? `Deleted ${deleted.length} orphaned object(s); skipped ${skipped.length} that were re-referenced.`
-          : `Deleted ${deleted.length} orphaned object(s).`,
+          ? `Deleted ${deleted.length} object(s); skipped ${skipped.length} that were re-referenced.`
+          : `Deleted ${deleted.length} object(s).`,
         type: "success",
       });
-      setBulkConfirmOpen(false);
+      setArtifactsToDelete(null);
       refresh();
     } catch {
       addToast({ message: "Bulk delete failed.", type: "error" });
     } finally {
-      setBulkDeleting(false);
+      setBusy(false);
     }
   }
-
-  const missingColumns: DataColumn<MissingArtifact>[] = [
-    {
-      key: "plugin",
-      header: "Plugin",
-      render: (row) => (
-        <Box>
-          <Typography variant="body2" sx={{ fontWeight: 600 }}>
-            {row.pluginId}
-          </Typography>
-          <Typography variant="caption" sx={{ color: "text.secondary" }}>
-            {row.version}
-          </Typography>
-        </Box>
-      ),
-    },
-    {
-      key: "artifactKey",
-      header: "Artifact key",
-      render: (row) => (
-        <Typography
-          variant="body2"
-          sx={{
-            fontFamily: "monospace",
-            fontSize: "0.8rem",
-            wordBreak: "break-all",
-          }}
-        >
-          {row.artifactKey}
-        </Typography>
-      ),
-    },
-    {
-      key: "action",
-      header: "",
-      align: "right",
-      width: 140,
-      render: (row) => (
-        <Button
-          size="small"
-          color="error"
-          startIcon={<Trash2 size={14} />}
-          onClick={() => setReleaseToDelete(row)}
-        >
-          Remove row
-        </Button>
-      ),
-    },
-  ];
-
-  const orphanedColumns: DataColumn<OrphanedArtifact>[] = [
-    {
-      key: "key",
-      header: "Storage key",
-      render: (row) => (
-        <Typography
-          variant="body2"
-          sx={{
-            fontFamily: "monospace",
-            fontSize: "0.8rem",
-            wordBreak: "break-all",
-          }}
-        >
-          {row.key}
-        </Typography>
-      ),
-    },
-    {
-      key: "size",
-      header: "Size",
-      align: "right",
-      width: 100,
-      render: (row) => (
-        <Typography variant="body2">{formatBytes(row.sizeBytes)}</Typography>
-      ),
-    },
-    {
-      key: "age",
-      header: "Age",
-      align: "right",
-      width: 140,
-      render: (row) => (
-        <Box>
-          <Typography variant="body2">{row.ageHours}h</Typography>
-          <Timestamp date={row.lastModified} variant="relative" />
-        </Box>
-      ),
-    },
-  ];
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -267,6 +174,7 @@ export function StorageConsistencySection() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          gap: 2,
         }}
       >
         <Box>
@@ -283,7 +191,7 @@ export function StorageConsistencySection() {
           variant="outlined"
           startIcon={<RefreshCw size={14} />}
           onClick={refresh}
-          disabled={loading}
+          disabled={loading || busy}
         >
           Rescan
         </Button>
@@ -304,67 +212,48 @@ export function StorageConsistencySection() {
       {report && (
         <>
           <Section
-            icon={<HardDrive size={18} />}
+            icon={<FileX size={18} />}
             title="Missing artifacts"
-            description={`${report.missingArtifacts.length} release row(s) point at storage keys that are gone.`}
+            description="Release rows that point at a storage object that is no longer there."
           >
-            <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
-              <Button
-                variant="contained"
-                color="error"
-                size="small"
-                startIcon={<Trash2 size={14} />}
-                disabled={
-                  report.missingArtifacts.length === 0 || bulkReleaseDeleting
-                }
-                onClick={() => setBulkReleaseConfirmOpen(true)}
-              >
-                Remove all
-              </Button>
-            </Box>
-            <DataTable
-              ariaLabel="Missing artifacts"
-              columns={missingColumns}
+            <MissingArtifactsTable
               rows={report.missingArtifacts}
-              keyFn={(r) => r.releaseId}
-              emptyMessage="No releases reference missing storage files."
+              busy={busy}
+              onDeleteOne={(row) => setReleaseToDelete(row)}
+              onDeleteMany={(targets) => setReleasesToDelete(targets)}
             />
           </Section>
 
           <Section
             icon={<HardDrive size={18} />}
             title="Orphaned artifacts"
-            description={`${report.orphanedArtifacts.length} storage object(s) have no release row.`}
+            description="Storage objects with no plugin_release row referencing them."
           >
-            <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
-              <Button
-                variant="contained"
-                color="error"
-                size="small"
-                startIcon={<Trash2 size={14} />}
-                disabled={report.orphanedArtifacts.length === 0 || bulkDeleting}
-                onClick={() => setBulkConfirmOpen(true)}
-              >
-                Remove all
-              </Button>
-            </Box>
-            <DataTable
-              ariaLabel="Orphaned artifacts"
-              columns={orphanedColumns}
+            <OrphanedArtifactsTable
               rows={report.orphanedArtifacts}
-              keyFn={(r) => r.key}
-              emptyMessage="No orphaned objects in storage."
+              busy={busy}
+              onDeleteMany={(targets) => setArtifactsToDelete(targets)}
             />
           </Section>
 
-          <Typography variant="caption" sx={{ color: "text.disabled" }}>
-            Scanned <Timestamp date={report.scannedAt} variant="relative" /> —{" "}
-            <Chip label={`${report.totalDbRows} DB row(s)`} size="small" />{" "}
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 1,
+              alignItems: "center",
+              color: "text.disabled",
+            }}
+          >
+            <Typography variant="caption">
+              Scanned <Timestamp date={report.scannedAt} variant="relative" />
+            </Typography>
+            <Chip label={`${report.totalDbRows} DB row(s)`} size="small" />
             <Chip
               label={`${report.totalStorageObjects} storage object(s)`}
               size="small"
             />
-          </Typography>
+          </Box>
         </>
       )}
 
@@ -379,33 +268,33 @@ export function StorageConsistencySection() {
             ? `Remove the database row for ${releaseToDelete.pluginId} ${releaseToDelete.version}. Idempotent: if the row is already gone, this is a no-op.`
             : ""
         }
-        loading={deletingRelease}
+        loading={busy}
       />
       <ConfirmDeleteDialog
-        open={bulkReleaseConfirmOpen}
-        onCancel={() => setBulkReleaseConfirmOpen(false)}
-        onConfirm={handleBulkDeleteReleases}
-        title="Remove all missing release rows?"
+        open={releasesToDelete !== null}
+        onCancel={() => setReleasesToDelete(null)}
+        onConfirm={handleDeleteReleases}
+        title="Remove missing release rows?"
         actionLabel="Remove rows"
         message={
-          report
-            ? `This will remove ${report.missingArtifacts.length} release row(s) from the database. Rows whose storage file has reappeared since the last scan are skipped automatically.`
+          releasesToDelete
+            ? `This will remove ${releasesToDelete.length} release row(s) from the database. Rows whose storage file has reappeared since the last scan are skipped automatically.`
             : ""
         }
-        loading={bulkReleaseDeleting}
+        loading={busy}
       />
       <ConfirmDeleteDialog
-        open={bulkConfirmOpen}
-        onCancel={() => setBulkConfirmOpen(false)}
-        onConfirm={handleBulkDelete}
-        title="Delete all listed orphaned objects?"
+        open={artifactsToDelete !== null}
+        onCancel={() => setArtifactsToDelete(null)}
+        onConfirm={handleDeleteArtifacts}
+        title="Delete orphaned storage objects?"
         actionLabel="Delete objects"
         message={
-          report
-            ? `This will delete ${report.orphanedArtifacts.length} object(s) from storage. Objects that have been re-referenced since the last scan are skipped automatically.`
+          artifactsToDelete
+            ? `This will delete ${artifactsToDelete.length} object(s) from storage. Objects that have been re-referenced since the last scan are skipped automatically.`
             : ""
         }
-        loading={bulkDeleting}
+        loading={busy}
       />
     </Box>
   );

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
@@ -78,7 +78,12 @@ export function MissingArtifactsTable({
 }: MissingArtifactsTableProps) {
   const state = useTableState<MissingArtifact, SortKey>({
     rows,
-    searchFields: (r) => [r.pluginId, r.version, r.artifactKey],
+    searchFields: (r) => [
+      r.namespaceSlug,
+      r.pluginId,
+      r.version,
+      r.artifactKey,
+    ],
     sorts: SORTS,
     initialSortKey: "plugin",
   });
@@ -309,9 +314,19 @@ export function MissingArtifactsTable({
                     <BodyCell>
                       <Typography
                         variant="body2"
-                        sx={{ fontWeight: 600, fontFamily: "monospace" }}
+                        sx={{ fontFamily: "monospace" }}
                       >
                         {row.pluginId}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontFamily: "monospace",
+                          color: "text.disabled",
+                          fontSize: "0.7rem",
+                        }}
+                      >
+                        {row.namespaceSlug}
                       </Typography>
                     </BodyCell>
                     <BodyCell>

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
@@ -1,0 +1,619 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  InputAdornment,
+  TablePagination,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { FileX, Search, Trash2 } from "lucide-react";
+import type { MissingArtifact } from "../../../api/generated/model";
+import { tokens } from "../../../theme/tokens";
+import { useTableState } from "./useTableState";
+import type { SortDefinition } from "./useTableState";
+
+type SortKey = "plugin" | "version" | "key";
+
+const SORTS: SortDefinition<MissingArtifact, SortKey>[] = [
+  {
+    key: "plugin",
+    label: "Plugin",
+    compare: (a, b) => a.pluginId.localeCompare(b.pluginId),
+  },
+  {
+    key: "version",
+    label: "Version",
+    compare: (a, b) =>
+      a.version.localeCompare(b.version, undefined, { numeric: true }),
+  },
+  {
+    key: "key",
+    label: "Artifact key",
+    compare: (a, b) => a.artifactKey.localeCompare(b.artifactKey),
+  },
+];
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+interface MissingArtifactsTableProps {
+  readonly rows: readonly MissingArtifact[];
+  readonly busy: boolean;
+  readonly onDeleteOne: (row: MissingArtifact) => void;
+  readonly onDeleteMany: (rows: readonly MissingArtifact[]) => void;
+}
+
+/**
+ * Triage view for `plugin_release` rows whose artifact file is missing
+ * from storage. Optimised for the long-list case: debounced search,
+ * column-sortable, paginated, multi-select for surgical cleanup. The
+ * legacy single-row delete button is retained so admins do not have to
+ * select-then-delete for one-off cases.
+ */
+export function MissingArtifactsTable({
+  rows,
+  busy,
+  onDeleteOne,
+  onDeleteMany,
+}: MissingArtifactsTableProps) {
+  const state = useTableState<MissingArtifact, SortKey>({
+    rows,
+    searchFields: (r) => [r.pluginId, r.version, r.artifactKey],
+    sorts: SORTS,
+    initialSortKey: "plugin",
+  });
+
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const distinctPlugins = useMemo(
+    () => new Set(rows.map((r) => r.pluginId)).size,
+    [rows],
+  );
+
+  // Reconcile selection whenever filter/sort/page change — a row that
+  // drops out of view should not stay "selected" silently.
+  const visibleIds = useMemo(
+    () => new Set(state.pageRows.map((r) => r.releaseId)),
+    [state.pageRows],
+  );
+  const selectedOnPage = useMemo(
+    () => state.pageRows.filter((r) => selected.has(r.releaseId)),
+    [state.pageRows, selected],
+  );
+  const allOnPageSelected =
+    state.pageRows.length > 0 &&
+    selectedOnPage.length === state.pageRows.length;
+  const someOnPageSelected = selectedOnPage.length > 0 && !allOnPageSelected;
+
+  const togglePageSelection = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allOnPageSelected) {
+        for (const id of visibleIds) next.delete(id);
+      } else {
+        for (const id of visibleIds) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleRow = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = () => {
+    const targets = rows.filter((r) => selected.has(r.releaseId));
+    if (targets.length === 0) return;
+    onDeleteMany(targets);
+    setSelected(new Set());
+  };
+
+  const handleDeleteAllMatching = () => {
+    if (state.filteredCount === 0) return;
+    onDeleteMany(state.filtered);
+    setSelected(new Set());
+  };
+
+  const filterActive = state.query.trim().length > 0;
+  const totalLabel = filterActive
+    ? `${state.filteredCount} of ${rows.length}`
+    : `${rows.length}`;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <StatsRow
+        count={rows.length}
+        distinctPlugins={distinctPlugins}
+        filterActive={filterActive}
+        filteredCount={state.filteredCount}
+      />
+
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 1.5,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <TextField
+          value={state.query}
+          onChange={(e) => state.setQuery(e.target.value)}
+          placeholder="Filter by plugin, version or key…"
+          size="small"
+          sx={{ minWidth: 280, flex: "1 1 280px", maxWidth: 480 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={14} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+          {selected.size > 0 && (
+            <Chip
+              label={`${selected.size} selected`}
+              size="small"
+              onDelete={() => setSelected(new Set())}
+              sx={{ fontWeight: 500 }}
+            />
+          )}
+          {selected.size > 0 && (
+            <Button
+              variant="outlined"
+              color="error"
+              size="small"
+              startIcon={<Trash2 size={14} />}
+              onClick={handleDeleteSelected}
+              disabled={busy}
+            >
+              Remove {selected.size} selected
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            startIcon={<Trash2 size={14} />}
+            disabled={state.filteredCount === 0 || busy}
+            onClick={handleDeleteAllMatching}
+          >
+            {filterActive
+              ? `Remove all ${state.filteredCount} matching`
+              : `Remove all (${rows.length})`}
+          </Button>
+        </Box>
+      </Box>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          icon={<FileX size={22} />}
+          title="No missing artifacts"
+          description="Every plugin release points at a storage object that exists."
+        />
+      ) : state.filteredCount === 0 ? (
+        <EmptyState
+          icon={<Search size={22} />}
+          title="No matches"
+          description="No release matches the current filter. Clear it to see all rows."
+        />
+      ) : (
+        <Box
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: tokens.radius.card,
+            overflow: "hidden",
+          }}
+        >
+          <Box
+            component="table"
+            role="table"
+            aria-label="Missing artifacts"
+            sx={{ width: "100%", borderCollapse: "collapse" }}
+          >
+            <Box component="thead">
+              <Box component="tr">
+                <HeaderCell width={44} align="center">
+                  <Checkbox
+                    size="small"
+                    checked={allOnPageSelected}
+                    indeterminate={someOnPageSelected}
+                    onChange={togglePageSelection}
+                    slotProps={{
+                      input: { "aria-label": "Select all rows on this page" },
+                    }}
+                  />
+                </HeaderCell>
+                <SortHeader
+                  label="Plugin"
+                  active={state.sortKey === "plugin"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("plugin")}
+                />
+                <SortHeader
+                  label="Version"
+                  width={140}
+                  active={state.sortKey === "version"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("version")}
+                />
+                <SortHeader
+                  label="Artifact key"
+                  active={state.sortKey === "key"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("key")}
+                />
+                <HeaderCell width={140} />
+              </Box>
+            </Box>
+            <Box component="tbody">
+              {state.pageRows.map((row) => {
+                const isSelected = selected.has(row.releaseId);
+                return (
+                  <Box
+                    component="tr"
+                    key={row.releaseId}
+                    sx={{
+                      bgcolor: isSelected
+                        ? "action.selected"
+                        : "background.paper",
+                      transition: "background-color 0.15s",
+                      "&:hover": {
+                        bgcolor: isSelected
+                          ? "action.selected"
+                          : "background.default",
+                      },
+                    }}
+                  >
+                    <BodyCell align="center">
+                      <Checkbox
+                        size="small"
+                        checked={isSelected}
+                        onChange={() => toggleRow(row.releaseId)}
+                        slotProps={{
+                          input: {
+                            "aria-label": `Select ${row.pluginId} ${row.version}`,
+                          },
+                        }}
+                      />
+                    </BodyCell>
+                    <BodyCell>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 600, fontFamily: "monospace" }}
+                      >
+                        {row.pluginId}
+                      </Typography>
+                    </BodyCell>
+                    <BodyCell>
+                      <Chip
+                        label={row.version}
+                        size="small"
+                        sx={{
+                          fontFamily: "monospace",
+                          bgcolor: tokens.badge.version.bg,
+                          color: tokens.badge.version.text,
+                          height: 20,
+                        }}
+                      />
+                    </BodyCell>
+                    <BodyCell>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontFamily: "monospace",
+                          fontSize: "0.75rem",
+                          color: "text.secondary",
+                          wordBreak: "break-all",
+                        }}
+                      >
+                        {row.artifactKey}
+                      </Typography>
+                    </BodyCell>
+                    <BodyCell align="right">
+                      <Button
+                        size="small"
+                        color="error"
+                        startIcon={<Trash2 size={12} />}
+                        onClick={() => onDeleteOne(row)}
+                        sx={{ minWidth: 0 }}
+                      >
+                        Remove
+                      </Button>
+                    </BodyCell>
+                  </Box>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <TablePagination
+            component="div"
+            count={state.filteredCount}
+            page={state.page}
+            onPageChange={(_e, p) => state.setPage(p)}
+            rowsPerPage={state.pageSize}
+            onRowsPerPageChange={(e) =>
+              state.setPageSize(parseInt(e.target.value, 10))
+            }
+            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+            labelRowsPerPage="Rows per page"
+            sx={{
+              borderTop: "1px solid",
+              borderColor: "divider",
+              bgcolor: "background.default",
+            }}
+          />
+        </Box>
+      )}
+
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        Showing {totalLabel} row(s) • {distinctPlugins} plugin
+        {distinctPlugins === 1 ? "" : "s"} affected
+      </Typography>
+    </Box>
+  );
+}
+
+function StatsRow({
+  count,
+  distinctPlugins,
+  filterActive,
+  filteredCount,
+}: {
+  readonly count: number;
+  readonly distinctPlugins: number;
+  readonly filterActive: boolean;
+  readonly filteredCount: number;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr 1fr", sm: "repeat(3, 1fr)" },
+        gap: 1.5,
+      }}
+    >
+      <Stat label="Releases missing" value={count.toLocaleString()} accent />
+      <Stat label="Plugins affected" value={distinctPlugins.toLocaleString()} />
+      <Stat
+        label={filterActive ? "Matches filter" : "After filter"}
+        value={filterActive ? filteredCount.toLocaleString() : "—"}
+      />
+    </Box>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly accent?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: accent ? tokens.badge.yanked.text : "divider",
+        borderRadius: tokens.radius.card,
+        px: 2,
+        py: 1.25,
+        bgcolor: accent ? tokens.badge.yanked.bg : "background.paper",
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          color: accent ? tokens.badge.yanked.text : "text.disabled",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          fontWeight: 600,
+          fontSize: "0.7rem",
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 700,
+          mt: 0.25,
+          fontFeatureSettings: '"tnum"',
+          color: accent ? tokens.badge.yanked.text : "text.primary",
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function HeaderCell({
+  children,
+  width,
+  align,
+}: {
+  readonly children?: React.ReactNode;
+  readonly width?: number;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="th"
+      sx={{
+        textAlign: align ?? "left",
+        width,
+        px: 2,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.default",
+        fontSize: "0.7rem",
+        fontWeight: 600,
+        color: "text.secondary",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function SortHeader({
+  label,
+  active,
+  direction,
+  onClick,
+  width,
+  align,
+}: {
+  readonly label: string;
+  readonly active: boolean;
+  readonly direction: "asc" | "desc";
+  readonly onClick: () => void;
+  readonly width?: number;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <HeaderCell width={width} align={align}>
+      <Box
+        component="button"
+        type="button"
+        onClick={onClick}
+        sx={{
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          cursor: "pointer",
+          color: active ? "text.primary" : "text.secondary",
+          fontSize: "inherit",
+          fontWeight: "inherit",
+          textTransform: "inherit",
+          letterSpacing: "inherit",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          "&:hover": { color: "text.primary" },
+          "&:focus-visible": {
+            outline: `2px solid ${tokens.color.primary}`,
+            outlineOffset: 2,
+          },
+        }}
+        aria-sort={
+          active ? (direction === "asc" ? "ascending" : "descending") : "none"
+        }
+      >
+        {label}
+        <Box
+          component="span"
+          aria-hidden
+          sx={{
+            display: "inline-block",
+            width: 8,
+            opacity: active ? 1 : 0.25,
+            transition: "transform 0.15s",
+            transform:
+              active && direction === "desc"
+                ? "rotate(180deg)"
+                : "rotate(0deg)",
+            fontSize: "0.8em",
+          }}
+        >
+          ↑
+        </Box>
+      </Box>
+    </HeaderCell>
+  );
+}
+
+function BodyCell({
+  children,
+  align,
+}: {
+  readonly children: React.ReactNode;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="td"
+      sx={{
+        textAlign: align ?? "left",
+        px: 2,
+        py: 1.25,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        fontSize: "0.875rem",
+        verticalAlign: "middle",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  description,
+}: {
+  readonly icon: React.ReactNode;
+  readonly title: string;
+  readonly description: string;
+}) {
+  return (
+    <Box
+      sx={{
+        py: 5,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 0.5,
+        border: "1px dashed",
+        borderColor: "divider",
+        borderRadius: tokens.radius.card,
+        color: "text.secondary",
+      }}
+    >
+      <Box sx={{ color: "text.disabled" }}>{icon}</Box>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        {description}
+      </Typography>
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/MissingArtifactsTable.tsx
@@ -22,7 +22,11 @@ import {
   Button,
   Checkbox,
   Chip,
+  FormControl,
   InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
   TablePagination,
   TextField,
   Typography,
@@ -76,8 +80,26 @@ export function MissingArtifactsTable({
   onDeleteOne,
   onDeleteMany,
 }: MissingArtifactsTableProps) {
+  const [namespaceFilter, setNamespaceFilter] = useState<string>("all");
+
+  // List of distinct namespaces in the result set, alphabetised, used to
+  // populate the namespace-filter dropdown. Recomputed only when `rows`
+  // change so typing in the search box does not re-render the option list.
+  const namespaceOptions = useMemo(() => {
+    const set = new Set(rows.map((r) => r.namespaceSlug));
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [rows]);
+
+  // Apply the namespace facet before handing rows to the
+  // search/sort/paginate pipeline so the existing "filtered" count and the
+  // "Remove all matching" action both reflect the combined filter.
+  const namespaceFilteredRows = useMemo(() => {
+    if (namespaceFilter === "all") return rows;
+    return rows.filter((r) => r.namespaceSlug === namespaceFilter);
+  }, [rows, namespaceFilter]);
+
   const state = useTableState<MissingArtifact, SortKey>({
-    rows,
+    rows: namespaceFilteredRows,
     searchFields: (r) => [
       r.namespaceSlug,
       r.pluginId,
@@ -143,7 +165,8 @@ export function MissingArtifactsTable({
     setSelected(new Set());
   };
 
-  const filterActive = state.query.trim().length > 0;
+  const filterActive =
+    state.query.trim().length > 0 || namespaceFilter !== "all";
   const totalLabel = filterActive
     ? `${state.filteredCount} of ${rows.length}`
     : `${rows.length}`;
@@ -166,22 +189,52 @@ export function MissingArtifactsTable({
           justifyContent: "space-between",
         }}
       >
-        <TextField
-          value={state.query}
-          onChange={(e) => state.setQuery(e.target.value)}
-          placeholder="Filter by plugin, version or key…"
-          size="small"
-          sx={{ minWidth: 280, flex: "1 1 280px", maxWidth: 480 }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={14} />
-                </InputAdornment>
-              ),
-            },
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            alignItems: "center",
+            flex: "1 1 280px",
+            maxWidth: 640,
           }}
-        />
+        >
+          <TextField
+            value={state.query}
+            onChange={(e) => state.setQuery(e.target.value)}
+            placeholder="Filter by plugin, version or key…"
+            size="small"
+            sx={{ flex: 1, minWidth: 220 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={14} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+          {namespaceOptions.length > 1 && (
+            <FormControl size="small" sx={{ minWidth: 180 }}>
+              <InputLabel id="missing-namespace-filter-label">
+                Namespace
+              </InputLabel>
+              <Select
+                labelId="missing-namespace-filter-label"
+                label="Namespace"
+                value={namespaceFilter}
+                onChange={(e) => setNamespaceFilter(e.target.value)}
+              >
+                <MenuItem value="all">All namespaces</MenuItem>
+                {namespaceOptions.map((slug) => (
+                  <MenuItem key={slug} value={slug}>
+                    {slug}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        </Box>
         <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
           {selected.size > 0 && (
             <Chip

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/OrphanedArtifactsTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/OrphanedArtifactsTable.tsx
@@ -1,0 +1,681 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  InputAdornment,
+  TablePagination,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Database, Search, Trash2 } from "lucide-react";
+import type { OrphanedArtifact } from "../../../api/generated/model";
+import { tokens } from "../../../theme/tokens";
+import { Timestamp } from "../../../components/common/Timestamp";
+import { useTableState } from "./useTableState";
+import type { SortDefinition } from "./useTableState";
+import { ageBucket, formatBytes } from "./format";
+
+type SortKey = "key" | "size" | "age";
+
+const SORTS: SortDefinition<OrphanedArtifact, SortKey>[] = [
+  {
+    key: "key",
+    label: "Key",
+    compare: (a, b) => a.key.localeCompare(b.key),
+  },
+  {
+    key: "size",
+    label: "Size",
+    compare: (a, b) => a.sizeBytes - b.sizeBytes,
+    defaultDirection: "desc",
+  },
+  {
+    key: "age",
+    label: "Age",
+    compare: (a, b) => a.ageHours - b.ageHours,
+    defaultDirection: "desc",
+  },
+];
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+interface OrphanedArtifactsTableProps {
+  readonly rows: readonly OrphanedArtifact[];
+  readonly busy: boolean;
+  readonly onDeleteMany: (rows: readonly OrphanedArtifact[]) => void;
+}
+
+/**
+ * Triage view for storage objects with no `plugin_release` row. The bulk
+ * of admin remediation happens here — a publish-flow that crashed after
+ * upload leaves dozens of orphans, an S3 lifecycle misfire leaves
+ * hundreds. Sort by size (default desc) surfaces the worst space-wasters
+ * first; age filter helps verify that fresh orphans aren't in-flight
+ * uploads (the reaper grace period from #496 catches that on the schedule
+ * side, but admins sometimes need to clean up older drift manually).
+ */
+export function OrphanedArtifactsTable({
+  rows,
+  busy,
+  onDeleteMany,
+}: OrphanedArtifactsTableProps) {
+  const state = useTableState<OrphanedArtifact, SortKey>({
+    rows,
+    searchFields: (r) => [r.key],
+    sorts: SORTS,
+    initialSortKey: "size",
+  });
+
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+
+  const totalSize = useMemo(
+    () => rows.reduce((sum, r) => sum + r.sizeBytes, 0),
+    [rows],
+  );
+  const filteredSize = useMemo(
+    () => state.filtered.reduce((sum, r) => sum + r.sizeBytes, 0),
+    [state.filtered],
+  );
+  const oldestHours = useMemo(
+    () => (rows.length === 0 ? 0 : Math.max(...rows.map((r) => r.ageHours))),
+    [rows],
+  );
+
+  const visibleIds = useMemo(
+    () => new Set(state.pageRows.map((r) => r.key)),
+    [state.pageRows],
+  );
+  const selectedOnPage = useMemo(
+    () => state.pageRows.filter((r) => selected.has(r.key)),
+    [state.pageRows, selected],
+  );
+  const allOnPageSelected =
+    state.pageRows.length > 0 &&
+    selectedOnPage.length === state.pageRows.length;
+  const someOnPageSelected = selectedOnPage.length > 0 && !allOnPageSelected;
+
+  const togglePageSelection = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allOnPageSelected) {
+        for (const id of visibleIds) next.delete(id);
+      } else {
+        for (const id of visibleIds) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleRow = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = () => {
+    const targets = rows.filter((r) => selected.has(r.key));
+    if (targets.length === 0) return;
+    onDeleteMany(targets);
+    setSelected(new Set());
+  };
+
+  const handleDeleteAllMatching = () => {
+    if (state.filteredCount === 0) return;
+    onDeleteMany(state.filtered);
+    setSelected(new Set());
+  };
+
+  const filterActive = state.query.trim().length > 0;
+  const selectedSize = useMemo(
+    () =>
+      rows
+        .filter((r) => selected.has(r.key))
+        .reduce((sum, r) => sum + r.sizeBytes, 0),
+    [rows, selected],
+  );
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <StatsRow
+        count={rows.length}
+        totalSize={totalSize}
+        oldestHours={oldestHours}
+        filterActive={filterActive}
+        filteredCount={state.filteredCount}
+        filteredSize={filteredSize}
+      />
+
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 1.5,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <TextField
+          value={state.query}
+          onChange={(e) => state.setQuery(e.target.value)}
+          placeholder="Filter by key…"
+          size="small"
+          sx={{ minWidth: 280, flex: "1 1 280px", maxWidth: 480 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={14} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+          {selected.size > 0 && (
+            <Chip
+              label={`${selected.size} selected • ${formatBytes(selectedSize)}`}
+              size="small"
+              onDelete={() => setSelected(new Set())}
+              sx={{ fontWeight: 500 }}
+            />
+          )}
+          {selected.size > 0 && (
+            <Button
+              variant="outlined"
+              color="error"
+              size="small"
+              startIcon={<Trash2 size={14} />}
+              onClick={handleDeleteSelected}
+              disabled={busy}
+            >
+              Delete {selected.size} selected
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            startIcon={<Trash2 size={14} />}
+            disabled={state.filteredCount === 0 || busy}
+            onClick={handleDeleteAllMatching}
+          >
+            {filterActive
+              ? `Delete all ${state.filteredCount} matching`
+              : `Delete all (${rows.length})`}
+          </Button>
+        </Box>
+      </Box>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          icon={<Database size={22} />}
+          title="No orphaned objects"
+          description="Every storage object has a matching plugin_release row."
+        />
+      ) : state.filteredCount === 0 ? (
+        <EmptyState
+          icon={<Search size={22} />}
+          title="No matches"
+          description="No orphan matches the current filter. Clear it to see all rows."
+        />
+      ) : (
+        <Box
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: tokens.radius.card,
+            overflow: "hidden",
+          }}
+        >
+          <Box
+            component="table"
+            role="table"
+            aria-label="Orphaned artifacts"
+            sx={{ width: "100%", borderCollapse: "collapse" }}
+          >
+            <Box component="thead">
+              <Box component="tr">
+                <HeaderCell width={44} align="center">
+                  <Checkbox
+                    size="small"
+                    checked={allOnPageSelected}
+                    indeterminate={someOnPageSelected}
+                    onChange={togglePageSelection}
+                    slotProps={{
+                      input: { "aria-label": "Select all rows on this page" },
+                    }}
+                  />
+                </HeaderCell>
+                <SortHeader
+                  label="Storage key"
+                  active={state.sortKey === "key"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("key")}
+                />
+                <SortHeader
+                  label="Size"
+                  width={120}
+                  align="right"
+                  active={state.sortKey === "size"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("size")}
+                />
+                <SortHeader
+                  label="Age"
+                  width={160}
+                  align="right"
+                  active={state.sortKey === "age"}
+                  direction={state.sortDirection}
+                  onClick={() => state.toggleSort("age")}
+                />
+              </Box>
+            </Box>
+            <Box component="tbody">
+              {state.pageRows.map((row) => {
+                const isSelected = selected.has(row.key);
+                return (
+                  <Box
+                    component="tr"
+                    key={row.key}
+                    sx={{
+                      bgcolor: isSelected
+                        ? "action.selected"
+                        : "background.paper",
+                      transition: "background-color 0.15s",
+                      "&:hover": {
+                        bgcolor: isSelected
+                          ? "action.selected"
+                          : "background.default",
+                      },
+                    }}
+                  >
+                    <BodyCell align="center">
+                      <Checkbox
+                        size="small"
+                        checked={isSelected}
+                        onChange={() => toggleRow(row.key)}
+                        slotProps={{
+                          input: { "aria-label": `Select ${row.key}` },
+                        }}
+                      />
+                    </BodyCell>
+                    <BodyCell>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontFamily: "monospace",
+                          fontSize: "0.78rem",
+                          wordBreak: "break-all",
+                        }}
+                      >
+                        {row.key}
+                      </Typography>
+                    </BodyCell>
+                    <BodyCell align="right">
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontFeatureSettings: '"tnum"',
+                          color: "text.secondary",
+                        }}
+                      >
+                        {formatBytes(row.sizeBytes)}
+                      </Typography>
+                    </BodyCell>
+                    <BodyCell align="right">
+                      <AgeBadge hours={row.ageHours} date={row.lastModified} />
+                    </BodyCell>
+                  </Box>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <TablePagination
+            component="div"
+            count={state.filteredCount}
+            page={state.page}
+            onPageChange={(_e, p) => state.setPage(p)}
+            rowsPerPage={state.pageSize}
+            onRowsPerPageChange={(e) =>
+              state.setPageSize(parseInt(e.target.value, 10))
+            }
+            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+            labelRowsPerPage="Rows per page"
+            sx={{
+              borderTop: "1px solid",
+              borderColor: "divider",
+              bgcolor: "background.default",
+            }}
+          />
+        </Box>
+      )}
+
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        {filterActive
+          ? `${state.filteredCount} match(es) • ${formatBytes(filteredSize)}`
+          : `${rows.length} orphan(s) • ${formatBytes(totalSize)}`}
+      </Typography>
+    </Box>
+  );
+}
+
+function StatsRow({
+  count,
+  totalSize,
+  oldestHours,
+  filterActive,
+  filteredCount,
+  filteredSize,
+}: {
+  readonly count: number;
+  readonly totalSize: number;
+  readonly oldestHours: number;
+  readonly filterActive: boolean;
+  readonly filteredCount: number;
+  readonly filteredSize: number;
+}) {
+  const oldestLabel =
+    count === 0
+      ? "—"
+      : oldestHours < 24
+        ? `${oldestHours}h`
+        : oldestHours < 24 * 30
+          ? `${Math.floor(oldestHours / 24)}d`
+          : `${Math.floor(oldestHours / (24 * 30))}mo`;
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr 1fr", sm: "repeat(4, 1fr)" },
+        gap: 1.5,
+      }}
+    >
+      <Stat label="Orphans" value={count.toLocaleString()} accent />
+      <Stat label="Reclaimable" value={formatBytes(totalSize)} />
+      <Stat label="Oldest" value={oldestLabel} />
+      <Stat
+        label={filterActive ? "Match size" : "Match"}
+        value={
+          filterActive
+            ? `${filteredCount.toLocaleString()} • ${formatBytes(filteredSize)}`
+            : "—"
+        }
+      />
+    </Box>
+  );
+}
+
+function AgeBadge({
+  hours,
+  date,
+}: {
+  readonly hours: number;
+  readonly date: string;
+}) {
+  const bucket = ageBucket(hours);
+  const color =
+    bucket === "fresh"
+      ? tokens.badge.draft
+      : bucket === "day"
+        ? tokens.badge.deprecated
+        : bucket === "week"
+          ? tokens.badge.version
+          : tokens.badge.tag;
+  const label =
+    hours < 24
+      ? `${hours}h`
+      : hours < 24 * 30
+        ? `${Math.floor(hours / 24)}d`
+        : `${Math.floor(hours / (24 * 30))}mo`;
+  return (
+    <Tooltip
+      arrow
+      placement="left"
+      title={<Timestamp date={date} variant="full" />}
+    >
+      <Chip
+        label={label}
+        size="small"
+        sx={{
+          bgcolor: color.bg,
+          color: color.text,
+          fontWeight: 600,
+          fontFeatureSettings: '"tnum"',
+          height: 20,
+          minWidth: 48,
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly accent?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: accent ? tokens.color.primary : "divider",
+        borderRadius: tokens.radius.card,
+        px: 2,
+        py: 1.25,
+        bgcolor: accent ? tokens.color.primaryLight : "background.paper",
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          color: accent ? tokens.color.primaryDark : "text.disabled",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          fontWeight: 600,
+          fontSize: "0.7rem",
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 700,
+          mt: 0.25,
+          fontFeatureSettings: '"tnum"',
+          color: accent ? tokens.color.primaryDark : "text.primary",
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function HeaderCell({
+  children,
+  width,
+  align,
+}: {
+  readonly children?: React.ReactNode;
+  readonly width?: number;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="th"
+      sx={{
+        textAlign: align ?? "left",
+        width,
+        px: 2,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.default",
+        fontSize: "0.7rem",
+        fontWeight: 600,
+        color: "text.secondary",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function SortHeader({
+  label,
+  active,
+  direction,
+  onClick,
+  width,
+  align,
+}: {
+  readonly label: string;
+  readonly active: boolean;
+  readonly direction: "asc" | "desc";
+  readonly onClick: () => void;
+  readonly width?: number;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <HeaderCell width={width} align={align}>
+      <Box
+        component="button"
+        type="button"
+        onClick={onClick}
+        sx={{
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          cursor: "pointer",
+          color: active ? "text.primary" : "text.secondary",
+          fontSize: "inherit",
+          fontWeight: "inherit",
+          textTransform: "inherit",
+          letterSpacing: "inherit",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          "&:hover": { color: "text.primary" },
+          "&:focus-visible": {
+            outline: `2px solid ${tokens.color.primary}`,
+            outlineOffset: 2,
+          },
+        }}
+        aria-sort={
+          active ? (direction === "asc" ? "ascending" : "descending") : "none"
+        }
+      >
+        {label}
+        <Box
+          component="span"
+          aria-hidden
+          sx={{
+            display: "inline-block",
+            width: 8,
+            opacity: active ? 1 : 0.25,
+            transition: "transform 0.15s",
+            transform:
+              active && direction === "desc"
+                ? "rotate(180deg)"
+                : "rotate(0deg)",
+            fontSize: "0.8em",
+          }}
+        >
+          ↑
+        </Box>
+      </Box>
+    </HeaderCell>
+  );
+}
+
+function BodyCell({
+  children,
+  align,
+}: {
+  readonly children: React.ReactNode;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="td"
+      sx={{
+        textAlign: align ?? "left",
+        px: 2,
+        py: 1.25,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        fontSize: "0.875rem",
+        verticalAlign: "middle",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  description,
+}: {
+  readonly icon: React.ReactNode;
+  readonly title: string;
+  readonly description: string;
+}) {
+  return (
+    <Box
+      sx={{
+        py: 5,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 0.5,
+        border: "1px dashed",
+        borderColor: "divider",
+        borderRadius: tokens.radius.card,
+        color: "text.secondary",
+      }}
+    >
+      <Box sx={{ color: "text.disabled" }}>{icon}</Box>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        {description}
+      </Typography>
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/format.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/format.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * Buckets an age in hours into the four-band labels we expose in the UI.
+ * The thresholds match the reaper's planned grace-period defaults (#496) —
+ * "< 24h" objects are inside the protection window, ">= 24h" are the
+ * legitimate cleanup targets.
+ */
+export function ageBucket(hours: number): "fresh" | "day" | "week" | "older" {
+  if (hours < 24) return "fresh";
+  if (hours < 24 * 7) return "day";
+  if (hours < 24 * 30) return "week";
+  return "older";
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/useTableState.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/useTableState.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useMemo, useState } from "react";
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortDefinition<T, K extends string = string> {
+  readonly key: K;
+  readonly label: string;
+  readonly compare: (a: T, b: T) => number;
+  readonly defaultDirection?: SortDirection;
+}
+
+interface UseTableStateOptions<T, K extends string> {
+  readonly rows: readonly T[];
+  readonly searchFields: (row: T) => readonly string[];
+  readonly sorts: readonly SortDefinition<T, K>[];
+  readonly initialSortKey: K;
+  readonly initialPageSize?: number;
+}
+
+export interface UseTableStateResult<T, K extends string> {
+  readonly query: string;
+  readonly setQuery: (q: string) => void;
+  readonly sortKey: K;
+  readonly setSortKey: (k: K) => void;
+  readonly sortDirection: SortDirection;
+  readonly setSortDirection: (d: SortDirection) => void;
+  readonly toggleSort: (k: K) => void;
+  readonly page: number;
+  readonly setPage: (p: number) => void;
+  readonly pageSize: number;
+  readonly setPageSize: (s: number) => void;
+
+  /** Rows after filtering — full set, used for "remove all matching" actions. */
+  readonly filtered: readonly T[];
+  /** Rows for the current page after filtering + sorting. */
+  readonly pageRows: readonly T[];
+  /** Total filtered count (for pagination footer + bulk-action labels). */
+  readonly filteredCount: number;
+}
+
+/**
+ * Client-side filter + sort + paginate pipeline for the storage-consistency
+ * tables. Works on the in-memory scan output — the consistency endpoint
+ * already returns the full report and we deliberately keep slicing on the
+ * client so admins can switch sort/filter without re-scanning a multi-million-
+ * object bucket.
+ *
+ * The search query is debounced lightly (120ms) to keep typing snappy on a
+ * 10k-row list. Page resets to 0 whenever the filter or sort changes so the
+ * user is not stranded on an empty page.
+ */
+export function useTableState<T, K extends string>(
+  options: UseTableStateOptions<T, K>,
+): UseTableStateResult<T, K> {
+  const {
+    rows,
+    searchFields,
+    sorts,
+    initialSortKey,
+    initialPageSize = 25,
+  } = options;
+
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [sortKey, setSortKey] = useState<K>(initialSortKey);
+  const initialDir =
+    sorts.find((s) => s.key === initialSortKey)?.defaultDirection ?? "asc";
+  const [sortDirection, setSortDirection] = useState<SortDirection>(initialDir);
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(initialPageSize);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setDebouncedQuery(query);
+      setPage(0);
+    }, 120);
+    return () => window.clearTimeout(id);
+  }, [query]);
+
+  // Reset page when sort or page-size changes via the setters below; we
+  // wrap the bare setters so the reset happens in the event handler
+  // rather than in a setState-in-effect.
+  const setSortKeyWithReset = (k: K) => {
+    setSortKey(k);
+    setPage(0);
+  };
+  const setSortDirectionWithReset = (d: SortDirection) => {
+    setSortDirection(d);
+    setPage(0);
+  };
+  const setPageSizeWithReset = (s: number) => {
+    setPageSize(s);
+    setPage(0);
+  };
+
+  const filtered = useMemo<readonly T[]>(() => {
+    const q = debouncedQuery.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((row) =>
+      searchFields(row).some((field) => field.toLowerCase().includes(q)),
+    );
+  }, [rows, debouncedQuery, searchFields]);
+
+  const sorted = useMemo<readonly T[]>(() => {
+    const sort = sorts.find((s) => s.key === sortKey) ?? sorts[0];
+    if (!sort) return filtered;
+    const copy = [...filtered];
+    copy.sort(sort.compare);
+    if (sortDirection === "desc") copy.reverse();
+    return copy;
+  }, [filtered, sorts, sortKey, sortDirection]);
+
+  const pageRows = useMemo<readonly T[]>(() => {
+    const start = page * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, page, pageSize]);
+
+  const toggleSort = (k: K) => {
+    if (k === sortKey) {
+      setSortDirectionWithReset(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      const next = sorts.find((s) => s.key === k);
+      setSortKeyWithReset(k);
+      setSortDirectionWithReset(next?.defaultDirection ?? "asc");
+    }
+  };
+
+  return {
+    query,
+    setQuery,
+    sortKey,
+    setSortKey: setSortKeyWithReset,
+    sortDirection,
+    setSortDirection: setSortDirectionWithReset,
+    toggleSort,
+    page,
+    setPage,
+    pageSize,
+    setPageSize: setPageSizeWithReset,
+    filtered,
+    pageRows,
+    filteredCount: filtered.length,
+  };
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -78,6 +78,11 @@ const EmailLayout = lazy(() =>
     default: m.EmailLayout,
   })),
 );
+const StorageConsistencySection = lazy(() =>
+  import("../pages/admin/StorageConsistencySection").then((m) => ({
+    default: m.StorageConsistencySection,
+  })),
+);
 const EmailServerPage = lazy(() =>
   import("../pages/admin/EmailServerPage").then((m) => ({
     default: m.EmailServerPage,
@@ -229,6 +234,14 @@ export const router = createBrowserRouter([
                 ),
               },
             ],
+          },
+          {
+            path: "storage-consistency",
+            element: (
+              <Suspense fallback={<LazyFallback />}>
+                <StorageConsistencySection />
+              </Suspense>
+            ),
           },
           {
             path: "reviews",


### PR DESCRIPTION
## Summary

PR1 of the joint #190 + #496 plan. Adds an admin-triggered scan that
reconciles `plugin_release` rows against artifact storage (FS or S3) and
surfaces both directions of drift, plus the ShedLock cluster mutex that
all four existing scheduled jobs (and the reaper coming in PR2) need.

- **Scan**: `GET /api/v1/admin/storage/consistency` — returns missing
  artifacts (DB → storage gap) and orphaned objects (storage → DB gap).
  Short-circuits with HTTP 409 above `max-keys-per-scan` (default 100k).
- **Targeted remediation**: per-release deletion endpoint + bulk-delete
  endpoint with DB-recheck-in-tx so freshly re-published keys are skipped.
- **Superadmin only**: `@PreAuthorize` plus inline `requireSuperadmin()`
  defense-in-depth on every method.
- **ShedLock**: Liquibase migration `0033_shedlock` + `@SchedulerLock` on
  all four scheduled jobs. Property-gated with NoOp fallback so H2 test
  slices keep working.
- **Frontend**: new `Storage` section in the admin sidebar with two tables,
  per-row + bulk delete, explicit 409 limit message.
- **Docs**: ADR-0035 captures the joint design and TOCTOU layering
  (grace period in PR2 + DB recheck-in-tx here).

## Horizontal scaling

Per the up-front planning constraint, the design assumes multiple
Plugwerk instances against one PostgreSQL. ShedLock prevents wasted N×
work for `@Scheduled` jobs; the per-action DB recheck inside the delete
transaction closes the TOCTOU window for the admin endpoints. The
grace-period filter that further protects the reaper lives in PR2 (#496).

## Test plan

- [x] Backend unit tests — scan, admin service, repo
- [x] Controller WebMvc tests — 200 / 409 / 403 / 204 / bulk-result
- [x] E2E authorization matrix (Testcontainers PostgreSQL): anon → 401,
  every non-superadmin actor → 403
- [x] Full `:plugwerk-server:plugwerk-server-backend:test` — green
- [x] Full `:plugwerk-server:plugwerk-server-backend:integrationTest` — green
- [x] Vitest 423 tests — green (4 new for `StorageConsistencySection`)
- [x] Frontend `npm run build` — green
- [ ] Manual smoke against a running stack with both FS and S3 backends
      (deferred to a reviewer with credentials — env-var path is documented
      in `application.yml`)

## Follow-up

PR2 (#496) — scheduled orphan reaper with `@SchedulerLock`, grace-period
filter, dry-run default, Micrometer counter, two-context cluster IT.