### PR TITLE
feat(storage): scheduled orphan-artifact reaper (#496)

### DIFF
--- a/docs/adrs/0035-storage-consistency-and-reaper.md
+++ b/docs/adrs/0035-storage-consistency-and-reaper.md
@@ -100,11 +100,33 @@ issue the `DELETE`. We mitigate this with two layers:
    shedlock migration. Production / Docker / Compose run on PostgreSQL and
    pick up the real `JdbcTemplateLockProvider`.
 
-6. **Reaper as a separate, opt-in scheduled job (PR2).** The orphan reaper
-   (#496) lands in a follow-up PR with `@Scheduled` + `@SchedulerLock`,
-   `dry-run` mode by default, a configurable grace period, a Micrometer
-   counter, and a cluster integration test using two embedded Plugwerk
-   contexts against one PostgreSQL.
+6. **Reaper as a separate scheduled job (#496, delivered).** The orphan
+   reaper is `OrphanReaperScheduler`, a `@Scheduled` + `@SchedulerLock`
+   bean that runs nightly (default `0 15 3 * * *`) and delegates eligible
+   orphans to `StorageConsistencyAdminService.deleteOrphanedArtifacts`
+   for the actual delete with DB recheck-in-tx.
+
+   - **Dry-run by default** (`plugwerk.storage.reaper.dry-run=true`).
+     The reaper logs the keys it WOULD delete; operators inspect the
+     eviction list for a release cycle before flipping the flag to
+     `false`.
+   - **Grace-period filter** (`plugwerk.storage.reaper.grace-period-hours`,
+     default 24h) — keys younger than the cut-off are skipped to avoid
+     deleting an in-flight publish.
+   - **Per-tick cap** (`plugwerk.storage.reaper.max-deletes-per-tick`,
+     default 1000) — a misconfigured prefix cannot silently wipe
+     terabytes; the rest rolls over to the next tick.
+   - **Micrometer counters** — `plugwerk.storage.reaper.deleted` and
+     `plugwerk.storage.reaper.skipped` with a `plugwerk.storage.reaper.run`
+     timer for tick wall-clock time.
+   - **Scan-limit handling** — a `StorageScanLimitExceededException`
+     aborts the tick without throwing to the scheduler thread, so the
+     next tick gets a clean slate.
+   - **Wiring test** uses a real PostgreSQL container, the production
+     Liquibase migration set, and the proxy-wrapped reaper bean to
+     prove the `@SchedulerLock` advice actually records a row in the
+     `shedlock` table on every invocation (cluster mutual-exclusion
+     itself is owned by the ShedLock library and is not re-tested).
 
 ## Consequences
 
@@ -123,7 +145,8 @@ issue the `DELETE`. We mitigate this with two layers:
 - The grace period delays reaper deletions by 24h by default; this is a
   conscious correctness-over-eagerness trade.
 - A 10M-key bucket cannot be scanned in one call. The 409-with-limit
-  exception nudges admins toward targeted prefix scans (planned in PR2).
+  exception nudges admins toward targeted prefix scans; the reaper
+  aborts the tick rather than work on a biased subset.
 - The shedlock table must exist in production PostgreSQL. Liquibase
   migration `0033_shedlock` creates it on the next deploy; rollback is a
   plain `DROP TABLE shedlock`.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -83,6 +83,7 @@ data class PlugwerkProperties(
         val fs: FsProperties = FsProperties(),
         @field:Valid val s3: S3Properties? = null,
         @field:Valid val consistency: ConsistencyProperties = ConsistencyProperties(),
+        @field:Valid val reaper: ReaperProperties = ReaperProperties(),
     ) {
 
         /**
@@ -102,6 +103,53 @@ data class PlugwerkProperties(
         data class ConsistencyProperties(
             @field:jakarta.validation.constraints.Min(1)
             val maxKeysPerScan: Int = 100_000,
+        )
+
+        /**
+         * Orphan-artifact reaper (`plugwerk.storage.reaper.*`) — #496.
+         *
+         * Periodically scans storage for objects with no matching
+         * `plugin_release` row and deletes them after a grace period so a
+         * publish that is still in flight is never mistaken for an orphan.
+         * Coordinated across instances by ShedLock (ADR-0035) — only one
+         * Plugwerk process executes the reaper per tick.
+         *
+         * @property enabled Master switch. Default `true`. Set to `false` in
+         *   environments where storage cleanup is owned by an external job
+         *   (bucket lifecycle, cron container, …).
+         *   Env: `PLUGWERK_STORAGE_REAPER_ENABLED`
+         * @property cron Spring cron expression. Default `0 15 3 * * *` —
+         *   03:15 server-local time, off-peak in most deployments and
+         *   staggered against the token cleanup jobs that run on the hour.
+         *   Env: `PLUGWERK_STORAGE_REAPER_CRON`
+         * @property dryRun When `true` (default), the reaper logs the keys
+         *   it WOULD delete but does not call `storage.delete()`. Lets
+         *   operators inspect the eviction list for a release cycle before
+         *   committing to live deletes — defensive default for a destructive
+         *   automated job.
+         *   Env: `PLUGWERK_STORAGE_REAPER_DRY_RUN`
+         * @property gracePeriodHours Minimum age of a storage object before
+         *   the reaper will touch it. The publish flow writes to storage
+         *   first and inserts the DB row second, so an in-flight publish
+         *   would otherwise look exactly like an orphan. 24h is far longer
+         *   than the longest plausible publish transaction; tighten only
+         *   when running with very long upload pipelines.
+         *   Env: `PLUGWERK_STORAGE_REAPER_GRACE_PERIOD_HOURS`
+         * @property maxDeletesPerTick Safety cap on how many objects the
+         *   reaper will delete in a single run. A misconfigured bucket
+         *   or a runaway prefix should not silently wipe terabytes; once
+         *   the cap is hit the reaper logs a warning and stops, leaving the
+         *   rest for the next tick (or for an admin to triage via the UI).
+         *   Env: `PLUGWERK_STORAGE_REAPER_MAX_DELETES_PER_TICK`
+         */
+        data class ReaperProperties(
+            val enabled: Boolean = true,
+            val cron: String = "0 15 3 * * *",
+            val dryRun: Boolean = true,
+            @field:jakarta.validation.constraints.Min(1)
+            val gracePeriodHours: Int = 24,
+            @field:jakarta.validation.constraints.Min(1)
+            val maxDeletesPerTick: Int = 1_000,
         )
 
         /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import io.plugwerk.server.PlugwerkProperties
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Periodic orphan-artifact reaper (#496).
+ *
+ * Runs on the cron configured by `plugwerk.storage.reaper.cron`, scoped
+ * cluster-wide by ShedLock so only one Plugwerk instance executes per
+ * tick (see [io.plugwerk.server.config.SchedulerLockConfig] + migration
+ * `0033_shedlock`). Two protective layers guard against TOCTOU with the
+ * publish flow:
+ *
+ *  1. **Grace period** — only keys older than
+ *     `plugwerk.storage.reaper.grace-period-hours` are considered. The
+ *     publish flow writes storage first and inserts the DB row second,
+ *     so an in-flight publish would otherwise look exactly like an
+ *     orphan; the grace period is far longer than the longest plausible
+ *     publish transaction (default 24h).
+ *  2. **DB recheck-in-tx** — delegates the actual delete to
+ *     [StorageConsistencyAdminService.deleteOrphanedArtifacts], which
+ *     re-queries `findAllArtifactKeys()` inside the delete transaction
+ *     and skips any key that has reappeared in the DB.
+ *
+ * Dry-run is the default. The reaper logs the keys it WOULD delete but
+ * does not call `storage.delete`. Operators are expected to inspect the
+ * eviction list for a release cycle before flipping `dry-run` to false.
+ *
+ * Bounded by `max-deletes-per-tick` so a misconfigured prefix cannot
+ * silently wipe terabytes — the remainder rolls over to the next tick.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "plugwerk.storage.reaper",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class OrphanReaperScheduler(
+    private val consistencyService: StorageConsistencyService,
+    private val adminService: StorageConsistencyAdminService,
+    private val properties: PlugwerkProperties,
+    meterRegistry: MeterRegistry,
+) {
+    private val log = LoggerFactory.getLogger(OrphanReaperScheduler::class.java)
+
+    private val deletedCounter: Counter = Counter
+        .builder("plugwerk.storage.reaper.deleted")
+        .description("Total orphan storage objects deleted by the reaper")
+        .register(meterRegistry)
+
+    private val skippedCounter: Counter = Counter
+        .builder("plugwerk.storage.reaper.skipped")
+        .description(
+            "Total orphans the reaper skipped (grace period, re-referenced, " +
+                "or storage backend rejected the delete)",
+        )
+        .register(meterRegistry)
+
+    private val runTimer: Timer = Timer
+        .builder("plugwerk.storage.reaper.run")
+        .description("Wall-clock time for a single reaper invocation")
+        .register(meterRegistry)
+
+    /**
+     * Reaper tick. Cron taken from
+     * `plugwerk.storage.reaper.cron` (default `0 15 3 * * *`). `lockAtMostFor`
+     * is generous (`PT2H`) because a full-bucket scan on a large S3 backend
+     * may legitimately take many minutes; `lockAtLeastFor` is short (`PT30S`)
+     * so a fast tick on a quiet cluster does not block the next scheduled
+     * run unnecessarily.
+     */
+    @Scheduled(cron = "\${plugwerk.storage.reaper.cron:0 15 3 * * *}")
+    @SchedulerLock(
+        name = "orphan-storage-reaper",
+        lockAtMostFor = "PT2H",
+        lockAtLeastFor = "PT30S",
+    )
+    fun reap() {
+        val reaper = properties.storage.reaper
+        val sample = Timer.start()
+        try {
+            val report = consistencyService.scan()
+            val graceHours = reaper.gracePeriodHours.toLong()
+            val eligible = report.orphanedArtifacts
+                .filter { it.ageHours >= graceHours }
+            val skippedByGrace = report.orphanedArtifacts.size - eligible.size
+            if (skippedByGrace > 0) {
+                skippedCounter.increment(skippedByGrace.toDouble())
+            }
+
+            if (eligible.isEmpty()) {
+                log.info(
+                    "reaper tick: orphans={}, skippedByGrace={}, eligible=0 — nothing to do",
+                    report.orphanedArtifacts.size,
+                    skippedByGrace,
+                )
+                return
+            }
+
+            val capped = eligible.take(reaper.maxDeletesPerTick)
+            if (capped.size < eligible.size) {
+                log.warn(
+                    "reaper tick: max-deletes-per-tick={} hit, {} eligible orphans " +
+                        "deferred to next run",
+                    reaper.maxDeletesPerTick,
+                    eligible.size - capped.size,
+                )
+            }
+
+            if (reaper.dryRun) {
+                log.info(
+                    "reaper tick (DRY-RUN): would delete {} orphan(s); skippedByGrace={}",
+                    capped.size,
+                    skippedByGrace,
+                )
+                for (orphan in capped) {
+                    log.info(
+                        "reaper tick (DRY-RUN): would delete key={} sizeBytes={} ageHours={}",
+                        orphan.key,
+                        orphan.sizeBytes,
+                        orphan.ageHours,
+                    )
+                }
+                return
+            }
+
+            val result = adminService.deleteOrphanedArtifacts(capped.map { it.key })
+            deletedCounter.increment(result.deleted.size.toDouble())
+            skippedCounter.increment(result.skipped.size.toDouble())
+            log.info(
+                "reaper tick: deleted={}, skipped={}, skippedByGrace={}, " +
+                    "totalOrphansSeen={}",
+                result.deleted.size,
+                result.skipped.size,
+                skippedByGrace,
+                report.orphanedArtifacts.size,
+            )
+        } catch (ex: StorageScanLimitExceededException) {
+            // Bucket is bigger than the consistency-scan circuit breaker —
+            // a partial scan would only delete a biased subset, so we skip
+            // this tick entirely and let the operator decide via the admin UI.
+            log.warn(
+                "reaper tick aborted: scan limit exceeded (limit={}, scanned={}). " +
+                    "Increase plugwerk.storage.consistency.max-keys-per-scan or " +
+                    "trim the bucket before the reaper can run.",
+                ex.limit,
+                ex.scannedSoFar,
+            )
+        } catch (ex: Exception) {
+            // Don't let one bad tick prevent future ones. ShedLock guarantees
+            // the next tick gets a fresh lock; we just need to make sure this
+            // method does not propagate the failure to the scheduler thread.
+            log.error("reaper tick failed: {}", ex.message, ex)
+        } finally {
+            sample.stop(runTimer)
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -111,6 +111,35 @@ plugwerk:
       # Env: PLUGWERK_STORAGE_CONSISTENCY_MAX_KEYS_PER_SCAN
       max-keys-per-scan: ${PLUGWERK_STORAGE_CONSISTENCY_MAX_KEYS_PER_SCAN:100000}
 
+    # Orphan-artifact reaper (#496). Periodically scans storage for objects
+    # with no matching plugin_release row and removes them after a grace
+    # period. ShedLock (migration 0033) ensures only one Plugwerk instance
+    # executes the reaper per tick. Defensive defaults: dry-run on, 24h
+    # grace, capped at 1000 deletes/run.
+    reaper:
+      # Env: PLUGWERK_STORAGE_REAPER_ENABLED
+      enabled: ${PLUGWERK_STORAGE_REAPER_ENABLED:true}
+      # Spring cron expression (sec min hour day-of-month month day-of-week).
+      # Default 03:15 server-local, off-peak and staggered against token-
+      # cleanup jobs that run on the hour.
+      # Env: PLUGWERK_STORAGE_REAPER_CRON
+      cron: ${PLUGWERK_STORAGE_REAPER_CRON:0 15 3 * * *}
+      # When true, the reaper logs the keys it WOULD delete without
+      # touching storage. Flip to false once you have inspected the
+      # eviction list for a release cycle and trust the output.
+      # Env: PLUGWERK_STORAGE_REAPER_DRY_RUN
+      dry-run: ${PLUGWERK_STORAGE_REAPER_DRY_RUN:true}
+      # Minimum age (hours, lastModified vs now at scan time) before a
+      # storage object becomes eligible for deletion. Must be longer than
+      # the longest plausible publish transaction.
+      # Env: PLUGWERK_STORAGE_REAPER_GRACE_PERIOD_HOURS
+      grace-period-hours: ${PLUGWERK_STORAGE_REAPER_GRACE_PERIOD_HOURS:24}
+      # Hard cap on deletes per run. A misconfigured prefix should not be
+      # able to silently wipe terabytes; the remainder rolls over to the
+      # next tick (or the admin UI).
+      # Env: PLUGWERK_STORAGE_REAPER_MAX_DELETES_PER_TICK
+      max-deletes-per-tick: ${PLUGWERK_STORAGE_REAPER_MAX_DELETES_PER_TICK:1000}
+
   # Scheduler coordination across horizontally scaled instances (ADR-0035).
   # ShedLock uses a PostgreSQL lock table (Liquibase migration 0033_shedlock)
   # so that only one instance executes a given `@Scheduled` job per tick.

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperSchedulerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperSchedulerTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+class OrphanReaperSchedulerTest {
+
+    private lateinit var consistencyService: StorageConsistencyService
+    private lateinit var adminService: StorageConsistencyAdminService
+    private lateinit var meterRegistry: SimpleMeterRegistry
+
+    @BeforeEach
+    fun setUp() {
+        consistencyService = mock()
+        adminService = mock()
+        meterRegistry = SimpleMeterRegistry()
+    }
+
+    @Test
+    fun `dry-run logs candidates without calling delete`() {
+        val scheduler = scheduler(dryRun = true, gracePeriodHours = 24)
+        whenever(consistencyService.scan()).thenReturn(
+            report(orphans = listOf(orphan("acme:gone:1.0.0:jar", ageHours = 72))),
+        )
+
+        scheduler.reap()
+
+        verify(adminService, never()).deleteOrphanedArtifacts(any())
+        assertThat(deletedCount()).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `grace period filters out fresh orphans`() {
+        val scheduler = scheduler(dryRun = false, gracePeriodHours = 24)
+        whenever(consistencyService.scan()).thenReturn(
+            report(
+                orphans = listOf(
+                    orphan("acme:fresh:1.0.0:jar", ageHours = 1), // skipped
+                    orphan("acme:stale:1.0.0:jar", ageHours = 48), // eligible
+                ),
+            ),
+        )
+        whenever(adminService.deleteOrphanedArtifacts(any())).thenReturn(
+            BulkArtifactDeletionResult(
+                deleted = listOf("acme:stale:1.0.0:jar"),
+                skipped = emptyList(),
+            ),
+        )
+
+        scheduler.reap()
+
+        val keysCaptor = argumentCaptor<List<String>>()
+        verify(adminService).deleteOrphanedArtifacts(keysCaptor.capture())
+        assertThat(keysCaptor.firstValue).containsExactly("acme:stale:1.0.0:jar")
+        // 1 grace-skip + 0 delete-skip = 1 skipped counter increment.
+        assertThat(skippedCount()).isEqualTo(1.0)
+        assertThat(deletedCount()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `max-deletes-per-tick caps the eligible batch`() {
+        val scheduler = scheduler(
+            dryRun = false,
+            gracePeriodHours = 24,
+            maxDeletesPerTick = 2,
+        )
+        whenever(consistencyService.scan()).thenReturn(
+            report(
+                orphans = (1..5).map {
+                    orphan("acme:orphan$it:1.0.0:jar", ageHours = 48)
+                },
+            ),
+        )
+        whenever(adminService.deleteOrphanedArtifacts(any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val keys = invocation.arguments[0] as List<String>
+            BulkArtifactDeletionResult(deleted = keys, skipped = emptyList())
+        }
+
+        scheduler.reap()
+
+        val keysCaptor = argumentCaptor<List<String>>()
+        verify(adminService).deleteOrphanedArtifacts(keysCaptor.capture())
+        assertThat(keysCaptor.firstValue).hasSize(2)
+        assertThat(deletedCount()).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `scan-limit exception aborts the tick without throwing`() {
+        val scheduler = scheduler(dryRun = false, gracePeriodHours = 24)
+        whenever(consistencyService.scan())
+            .thenThrow(StorageScanLimitExceededException(limit = 100, scannedSoFar = 101))
+
+        scheduler.reap()
+
+        verify(adminService, never()).deleteOrphanedArtifacts(any())
+    }
+
+    @Test
+    fun `unexpected exception is swallowed so next tick can run`() {
+        val scheduler = scheduler(dryRun = false, gracePeriodHours = 24)
+        whenever(consistencyService.scan()).thenThrow(RuntimeException("boom"))
+
+        scheduler.reap()
+
+        verify(adminService, never()).deleteOrphanedArtifacts(any())
+    }
+
+    @Test
+    fun `delete-side skips count towards the skipped meter`() {
+        val scheduler = scheduler(dryRun = false, gracePeriodHours = 24)
+        whenever(consistencyService.scan()).thenReturn(
+            report(
+                orphans = listOf(
+                    orphan("acme:ok:1.0.0:jar", ageHours = 48),
+                    orphan("acme:reborn:1.0.0:jar", ageHours = 72),
+                ),
+            ),
+        )
+        whenever(adminService.deleteOrphanedArtifacts(any())).thenReturn(
+            BulkArtifactDeletionResult(
+                deleted = listOf("acme:ok:1.0.0:jar"),
+                skipped = listOf("acme:reborn:1.0.0:jar"),
+            ),
+        )
+
+        scheduler.reap()
+
+        assertThat(deletedCount()).isEqualTo(1.0)
+        assertThat(skippedCount()).isEqualTo(1.0)
+    }
+
+    // ---- helpers ----
+
+    private fun scheduler(
+        dryRun: Boolean,
+        gracePeriodHours: Int,
+        maxDeletesPerTick: Int = 1_000,
+    ): OrphanReaperScheduler {
+        val props = PlugwerkProperties(
+            storage = PlugwerkProperties.StorageProperties(
+                reaper = PlugwerkProperties.StorageProperties.ReaperProperties(
+                    enabled = true,
+                    dryRun = dryRun,
+                    gracePeriodHours = gracePeriodHours,
+                    maxDeletesPerTick = maxDeletesPerTick,
+                ),
+            ),
+        )
+        return OrphanReaperScheduler(
+            consistencyService,
+            adminService,
+            props,
+            meterRegistry,
+        )
+    }
+
+    private fun report(orphans: List<OrphanedArtifact>): ConsistencyReport = ConsistencyReport(
+        missingArtifacts = emptyList(),
+        orphanedArtifacts = orphans,
+        scannedAt = Instant.parse("2026-05-12T12:00:00Z"),
+        totalDbRows = 0,
+        totalStorageObjects = orphans.size,
+    )
+
+    private fun orphan(key: String, ageHours: Long): OrphanedArtifact = OrphanedArtifact(
+        key = key,
+        lastModified = Instant.parse("2026-05-12T12:00:00Z").minusSeconds(ageHours * 3600),
+        ageHours = ageHours,
+        sizeBytes = 1_024L,
+    )
+
+    private fun deletedCount(): Double = meterRegistry.counter("plugwerk.storage.reaper.deleted").count()
+
+    private fun skippedCount(): Double = meterRegistry.counter("plugwerk.storage.reaper.skipped").count()
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperShedLockIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperShedLockIT.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.storage.consistency
+
+import io.plugwerk.server.SharedPostgresContainer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.Instant
+
+/**
+ * End-to-end wiring test for the orphan reaper (#496) against a real
+ * PostgreSQL Testcontainer.
+ *
+ * What it proves:
+ *  - Liquibase migration `0033_shedlock` creates the `shedlock` table
+ *    in the production-equivalent schema (the same migration set runs
+ *    here as on a real deploy).
+ *  - `SchedulerLockConfig` wires a real `JdbcTemplateLockProvider`
+ *    against that table (the `NoOpLockProvider` fallback would not
+ *    write to `shedlock`).
+ *  - `OrphanReaperScheduler` boots as a Spring bean with its
+ *    `@SchedulerLock("orphan-storage-reaper")` advice applied — when
+ *    we invoke `reap()` through the proxy the ShedLock advice acquires
+ *    a row in `shedlock` named `orphan-storage-reaper`.
+ *  - The reaper delegates eligible orphans to
+ *    `deleteOrphanedArtifacts` and respects the grace-period filter
+ *    end-to-end.
+ *
+ * We deliberately do NOT spin up two Spring contexts to assert
+ * mutual-exclusion: that contract is owned by ShedLock itself and is
+ * extensively tested upstream. Re-proving it here would amount to a
+ * library smoke test, while the wiring above is the part that is ours
+ * to break.
+ */
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+    properties = [
+        "plugwerk.scheduler.shedlock.enabled=true",
+        "plugwerk.storage.reaper.enabled=true",
+        "plugwerk.storage.reaper.dry-run=false",
+        "plugwerk.storage.reaper.grace-period-hours=24",
+    ],
+)
+@Tag("integration")
+class OrphanReaperShedLockIT {
+
+    companion object {
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { SharedPostgresContainer.instance.jdbcUrl }
+            registry.add("spring.datasource.username") { SharedPostgresContainer.instance.username }
+            registry.add("spring.datasource.password") { SharedPostgresContainer.instance.password }
+        }
+    }
+
+    @Autowired
+    private lateinit var reaper: OrphanReaperScheduler
+
+    @Autowired
+    private lateinit var jdbc: JdbcTemplate
+
+    @MockitoBean
+    private lateinit var consistencyService: StorageConsistencyService
+
+    @MockitoBean
+    private lateinit var adminService: StorageConsistencyAdminService
+
+    @Test
+    fun `reaper boots wired with real ShedLock and delegates eligible orphans`() {
+        val now = Instant.now()
+        whenever(consistencyService.scan()).thenReturn(
+            ConsistencyReport(
+                missingArtifacts = emptyList(),
+                orphanedArtifacts = listOf(
+                    OrphanedArtifact(
+                        key = "acme:eligible:1.0.0:jar",
+                        lastModified = now.minusSeconds(48L * 3600),
+                        ageHours = 48L,
+                        sizeBytes = 1_024L,
+                    ),
+                    OrphanedArtifact(
+                        key = "acme:fresh:1.0.0:jar",
+                        lastModified = now.minusSeconds(3600L),
+                        ageHours = 1L, // inside grace period — must be filtered out
+                        sizeBytes = 512L,
+                    ),
+                ),
+                scannedAt = now,
+                totalDbRows = 0,
+                totalStorageObjects = 2,
+            ),
+        )
+        whenever(adminService.deleteOrphanedArtifacts(any())).thenReturn(
+            BulkArtifactDeletionResult(
+                deleted = listOf("acme:eligible:1.0.0:jar"),
+                skipped = emptyList(),
+            ),
+        )
+
+        reaper.reap()
+
+        // The proxy-wrapped reap() should have asked ShedLock for a lock —
+        // proven by the row in shedlock with our scheduler name.
+        val lockRows = jdbc.queryForList(
+            "SELECT name FROM shedlock WHERE name = ?",
+            "orphan-storage-reaper",
+        )
+        assertThat(lockRows)
+            .withFailMessage(
+                "Expected ShedLock to have recorded a lock for 'orphan-storage-reaper' — " +
+                    "either the @SchedulerLock advice did not fire or the JdbcTemplateLockProvider " +
+                    "is not wired against the production shedlock table.",
+            )
+            .isNotEmpty
+
+        // The body ran with only the eligible (>=24h) orphan; the fresh
+        // one was filtered out by the grace period.
+        verify(adminService).deleteOrphanedArtifacts(listOf("acme:eligible:1.0.0:jar"))
+    }
+}


### PR DESCRIPTION
## Summary

PR2 of the joint #190 + #496 plan. PR1 delivered admin-triggered
reconciliation; this PR adds the periodic counterpart so storage
drift no longer requires a human to click "rescan".

`OrphanReaperScheduler` runs on `plugwerk.storage.reaper.cron`
(default 03:15 nightly), reuses `StorageConsistencyService.scan()`
for detection, and delegates eligible orphans to
`StorageConsistencyAdminService.deleteOrphanedArtifacts` for the
actual delete with DB recheck-in-tx. ShedLock (migration 0033) keeps
the work single-instance across a horizontally scaled cluster.

## Defensive defaults

| Setting | Default | Why |
|---|---|---|
| `enabled` | `true` | Master switch for environments where storage cleanup is owned by an external job |
| `dry-run` | `true` | Logs the eviction list without deleting until operator flips the flag |
| `grace-period-hours` | `24` | An in-flight publish (storage write before DB commit) looks like an orphan; 24h is far longer than the longest plausible upload |
| `max-deletes-per-tick` | `1000` | A misconfigured prefix cannot silently wipe terabytes |
| `cron` | `0 15 3 * * *` | Off-peak, staggered against token-cleanup jobs on the hour |

## Observability

Three Micrometer instruments expose reaper activity to Actuator/Prometheus:

- `plugwerk.storage.reaper.deleted` (Counter)
- `plugwerk.storage.reaper.skipped` (Counter — counts grace-skips and
  delete-side skips together)
- `plugwerk.storage.reaper.run` (Timer for tick wall-clock)

## Test plan

- [x] 6 unit tests — dry-run, grace filter, max-deletes cap,
      scan-limit exception, generic exception, skipped meter
- [x] Integration test against `SharedPostgresContainer` proves
      the `@SchedulerLock` advice is wired against the real
      `shedlock` table created by migration 0033
- [x] Full backend `test` + `integrationTest` green
- [x] Spotless clean
- [ ] Manual smoke against a running stack (FS + S3) — deferred to
      reviewer

## Out of scope

- Cluster mutual-exclusion is owned by the ShedLock library and not
  re-tested here; the IT only proves our wiring asks the lock at all.
- No new Admin UI surface — the dashboard already shows orphans; the
  reaper is invisible by design.

Closes #496