### PR TITLE
feat(scheduler): admin dashboard with enable/disable, dry-run, run-now (#516)

### DIFF
--- a/docs/adrs/0036-scheduler-control-plane.md
+++ b/docs/adrs/0036-scheduler-control-plane.md
@@ -1,0 +1,135 @@
+# ADR-0036: Scheduler control-plane (admin dashboard)
+
+## Status
+
+Accepted
+
+## Context
+
+Plugwerk ships five `@Scheduled` jobs (refresh-token cleanup, token-
+revocation cleanup, password-reset sweep, email-verification sweep,
+orphan-storage reaper). Their cron patterns and tuning constants live
+in `application.yml`; their behaviour at runtime was previously
+opaque to operators:
+
+- no in-product way to see whether a job is enabled, what cron drives
+  it, when it last ran, or whether the last run succeeded
+- no way to disable a misbehaving job without a redeploy
+- no way to flip the orphan reaper between dry-run and live without a
+  redeploy
+- no way to trigger an off-schedule "run now" for debugging or post-
+  fix recovery
+
+A redeploy is heavy for what is usually a one-line operational tweak.
+Issue #516 laid out a hybrid solution.
+
+## Decision
+
+### Hybrid model — `application.yml` stays authoritative, the dashboard adds runtime hebel
+
+We **do not** move cron patterns or tuning constants into the database:
+
+- `application.yml` is in Git; DB-only config breaks the "git checkout
+  ⇒ working state" property
+- two sources of truth (annotation/yaml vs DB) for the same job is a
+  long-term maintenance burden
+- editing a cron via a web form is a foot-gun (`* * * * * *` would
+  hammer the scheduler thread)
+- in practice operators almost never want to change cron patterns,
+  but routinely want enable/disable + visibility
+
+The dashboard adds **only** the small set of toggles operators
+actually need at runtime: `enabled`, `dryRun` (for jobs that support
+it), and a "run now" trigger. Plus the runtime state every operator
+asks about: last run timestamp, outcome, duration, total run count.
+
+### Backend shape
+
+- New table `scheduler_job` (Liquibase migration `0034_scheduler_job`)
+  carries `name` (matches the `@SchedulerLock` lock name), `enabled`,
+  `dry_run` (nullable — null = honour yaml default), and the
+  `last_run_*` + `run_count_total` book-keeping fields.
+- `SchedulerJobRegistry` is a singleton bean. Each scheduled service
+  calls `register(SchedulerJobDescriptor)` from its `@PostConstruct`,
+  publishing `name`, `description`, `cronExpression`,
+  `supportsDryRun`, and a `runNowExecutor` reference.
+- `SchedulerJobBootstrap` listens for `ApplicationReadyEvent` and
+  seeds the table with rows for any registered jobs that do not yet
+  have one. Idempotent: an `ON CONFLICT`-equivalent `findAll`-then-
+  `INSERT` pattern means a peer instance booting in parallel cannot
+  cause duplicates.
+- `SchedulerJobService` is the read path. The toggle values are read
+  on every scheduler tick, so we cache them with a Caffeine `expire-
+  After-Write(30s)` to keep the gate cheap. Mutations from the admin
+  endpoints `invalidate(name)` so the next tick on the same instance
+  picks up the change immediately; peer instances see it after at
+  most 30 seconds.
+- Each scheduled method's body is now wrapped in
+  `schedulerJobAuditor.gateAndRun(name) { … }`. The auditor's
+  `gateAndRun` checks the toggle, returns `SKIPPED_DISABLED` if off,
+  otherwise wraps the block in a `run` that captures duration and
+  outcome (uncaught exceptions become `FAILED`). Audit writes happen
+  in a `REQUIRES_NEW` transaction so an audit-side failure cannot
+  rollback the actual job, and a job rollback cannot also undo the
+  "this just failed" record.
+- Run-now reuses the same Bean-method reference the cron triggers,
+  going through the same `@SchedulerLock` advice. A concurrent
+  regular tick simply blocks the manual run via the lock — desired
+  behaviour, no separate lock-name suffix needed.
+
+### Frontend shape
+
+A superadmin-only `/admin/scheduler` page polls the list endpoint
+every 15 s. Stats strip (active jobs, disabled, failed-last-run,
+total runs) above a custom table with one row per job:
+
+- monospace `name` + caption-sized description
+- read-only cron chip (yaml-authoritative — the UI cannot edit it)
+- enabled toggle
+- 3-state dry-run cycle for jobs with `supportsDryRun = true`
+  (`null → true → false → null`, where `null` means "honour yaml")
+- last-run badge coloured by outcome (success = green, failed = red,
+  skipped = neutral, aborted = warning)
+- run-now button gated by `enabled`, with a confirm dialog
+
+## Consequences
+
+**Easier:**
+
+- operators can react to a misbehaving job in seconds (toggle off,
+  confirm with run-now after fix, toggle back on)
+- the dashboard is the single visible answer to "is the cluster
+  doing what it should be doing"
+- adding a new scheduled job is a one-line `register(...)` call from
+  the owning service — the bootstrap, gate, audit, and dashboard pick
+  it up without controller or schema changes
+
+**Harder / trade-offs:**
+
+- enable/disable is now slightly stale (up to 30 s) on peer instances
+  because we cache the read. Acceptable for hourly/daily jobs;
+  unacceptable would mean LISTEN/NOTIFY plumbing for a feature where
+  seconds of latency cost nothing.
+- the bootstrap creates rows on first boot per cluster. A migration
+  that pre-seeds the rows would have to know the registry contents
+  at SQL-write time, which it does not.
+- run-now respects the `enabled` toggle by design — an operator who
+  disabled a job and clicks "run now" gets `SKIPPED_DISABLED`, not a
+  surprise execution. The button is greyed out for disabled jobs.
+
+## Alternatives considered
+
+- **Full migration into the DB** (cron + tuning + toggles): rejected
+  for the configuration-as-code reasons above
+- **Separate `-manual` ShedLock name for run-now**: rejected because
+  same-name lock gives clearer "concurrent tick wins" semantics with
+  zero extra plumbing
+- **LISTEN/NOTIFY for instant toggle propagation**: rejected as
+  overkill for the latency tolerance of the use case
+
+## References
+
+- Issue #516 — Admin UI: scheduler dashboard
+- ADR-0035 — Storage consistency + reaper (introduced ShedLock)
+- PR #514 (#190), PR #515 (#496) — preceding storage admin surfaces
+  this builds on

--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2383,6 +2383,110 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/scheduler/jobs:
+    get:
+      tags:
+        - AdminScheduler
+      summary: List all registered scheduled jobs (#516)
+      description: |
+        Returns the per-job dashboard payload: registry metadata (name,
+        description, cron, supportsDryRun) joined with admin-controlled
+        runtime state (enabled, dryRun, lastRun*, runCountTotal). Requires
+        superadmin.
+      operationId: listSchedulerJobs
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: All registered jobs.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SchedulerJobDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/scheduler/jobs/{name}:
+    patch:
+      tags:
+        - AdminScheduler
+      summary: Toggle enabled/dry-run on a scheduled job (#516)
+      description: |
+        Mutates the admin-controlled flags for [name]. Cron and tuning
+        constants live in `application.yml` and cannot be changed here.
+        Returns the updated dashboard row. Requires superadmin.
+      operationId: updateSchedulerJob
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+            maxLength: 64
+          description: Job identifier as returned by the list endpoint.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchedulerJobUpdateRequest'
+      responses:
+        '200':
+          description: Updated job row.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulerJobDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No registered job with that name.
+
+  /admin/scheduler/jobs/{name}/run:
+    post:
+      tags:
+        - AdminScheduler
+      summary: Trigger an off-schedule execution of [name] (#516)
+      description: |
+        Invokes the job's body once, off-schedule, through the same
+        ShedLock path the cron tick uses — if a regular tick is mid-flight
+        the request is rejected so the two cannot collide. Honours the
+        `enabled` toggle (a disabled job's run-now is rejected with the
+        body returning `SKIPPED_DISABLED`). Requires superadmin.
+      operationId: runSchedulerJobNow
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+            maxLength: 64
+      responses:
+        '200':
+          description: Outcome of the off-schedule invocation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulerJobRunResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No registered job with that name.
+        '409':
+          description: A concurrent execution is already in progress.
+
 components:
   parameters:
     NamespaceSlug:
@@ -2988,6 +3092,109 @@ components:
       required:
         - deleted
         - skipped
+
+    SchedulerJobOutcome:
+      type: string
+      description: |
+        Result of a single scheduler-job invocation, recorded in
+        `scheduler_job.last_run_outcome` and returned by the run-now
+        endpoint.
+      enum:
+        - SUCCESS
+        - FAILED
+        - SKIPPED_DISABLED
+        - SKIPPED_LOCK
+        - ABORTED_LIMIT
+
+    SchedulerJobDto:
+      type: object
+      description: |
+        Dashboard row for a single registered scheduled job (#516).
+        Combines compile-time metadata (description, cron, dry-run
+        support) with admin-controlled runtime state.
+      properties:
+        name:
+          type: string
+          description: Stable job identifier (matches the ShedLock lock name).
+        description:
+          type: string
+        cronExpression:
+          type: string
+          description: |
+            Cron pattern as configured in application.yml. Read-only —
+            the UI shows it but cannot edit it.
+        supportsDryRun:
+          type: boolean
+        enabled:
+          type: boolean
+        dryRun:
+          type: boolean
+          nullable: true
+          description: |
+            null = no admin override, use the yaml default. Non-null
+            overrides the yaml default for jobs where supportsDryRun is
+            true; the value is ignored for other jobs.
+        lastRunAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastRunOutcome:
+          $ref: '#/components/schemas/SchedulerJobOutcome'
+          nullable: true
+        lastRunDurationMs:
+          type: integer
+          format: int64
+          nullable: true
+        lastRunMessage:
+          type: string
+          nullable: true
+        runCountTotal:
+          type: integer
+          format: int64
+      required:
+        - name
+        - description
+        - cronExpression
+        - supportsDryRun
+        - enabled
+        - runCountTotal
+
+    SchedulerJobUpdateRequest:
+      type: object
+      description: |
+        Patch payload for `PATCH /admin/scheduler/jobs/{name}`. Both
+        fields are optional — only fields explicitly present in the
+        request body are updated. `dryRun: null` is a legitimate value
+        and clears the override (= "honour the yaml default").
+      properties:
+        enabled:
+          type: boolean
+        dryRun:
+          type: boolean
+          nullable: true
+
+    SchedulerJobRunResult:
+      type: object
+      description: |
+        Reply payload for the run-now endpoint. The outcome distinguishes
+        a real run from the various skip reasons so the admin UI can
+        give specific feedback ("disabled, flip the toggle first" vs
+        "another instance is running it right now").
+      properties:
+        name:
+          type: string
+        outcome:
+          $ref: '#/components/schemas/SchedulerJobOutcome'
+        durationMs:
+          type: integer
+          format: int64
+          nullable: true
+        message:
+          type: string
+          nullable: true
+      required:
+        - name
+        - outcome
 
     ErrorResponse:
       type: object

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSchedulerController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminSchedulerController.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AdminSchedulerApi
+import io.plugwerk.api.model.SchedulerJobUpdateRequest
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
+import io.plugwerk.server.service.scheduler.SchedulerJobAdminService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.ZoneOffset
+import io.plugwerk.api.model.SchedulerJobDto as ApiSchedulerJobDto
+import io.plugwerk.api.model.SchedulerJobOutcome as ApiSchedulerJobOutcome
+import io.plugwerk.api.model.SchedulerJobRunResult as ApiSchedulerJobRunResult
+import io.plugwerk.server.domain.SchedulerJobOutcome as DomainSchedulerJobOutcome
+
+/**
+ * Admin endpoints backing the scheduler control-plane dashboard (#516).
+ *
+ * Every operation is gated by superadmin via [PreAuthorize] plus an
+ * inline `requireSuperadmin` defense-in-depth call. The generated
+ * [AdminSchedulerApi] is the OpenAPI-derived contract.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AdminSchedulerController(
+    private val adminService: SchedulerJobAdminService,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AdminSchedulerApi {
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun listSchedulerJobs(): ResponseEntity<List<ApiSchedulerJobDto>> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        return ResponseEntity.ok(adminService.listJobs().map { it.toDto() })
+    }
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun updateSchedulerJob(
+        name: String,
+        schedulerJobUpdateRequest: SchedulerJobUpdateRequest,
+    ): ResponseEntity<ApiSchedulerJobDto> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val updated = adminService.update(
+            name = name,
+            enabled = schedulerJobUpdateRequest.enabled,
+            dryRun = schedulerJobUpdateRequest.dryRun,
+        )
+        return ResponseEntity.ok(updated.toDto())
+    }
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun runSchedulerJobNow(name: String): ResponseEntity<ApiSchedulerJobRunResult> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val outcome = adminService.runNow(name)
+        return ResponseEntity.ok(
+            ApiSchedulerJobRunResult(
+                name = name,
+                outcome = outcome.outcome.toApi(),
+                durationMs = outcome.durationMs,
+                message = outcome.message,
+            ),
+        )
+    }
+
+    private fun SchedulerJobAdminService.JobView.toDto(): ApiSchedulerJobDto = ApiSchedulerJobDto(
+        name = descriptor.name,
+        description = descriptor.description,
+        cronExpression = descriptor.cronExpression,
+        supportsDryRun = descriptor.supportsDryRun,
+        enabled = state.enabled,
+        runCountTotal = state.runCountTotal,
+        dryRun = state.dryRun,
+        lastRunAt = state.lastRunAt?.atZoneSameInstant(ZoneOffset.UTC)?.toOffsetDateTime(),
+        lastRunOutcome = state.lastRunOutcome?.toApi(),
+        lastRunDurationMs = state.lastRunDurationMs,
+        lastRunMessage = state.lastRunMessage,
+    )
+
+    private fun DomainSchedulerJobOutcome.toApi(): ApiSchedulerJobOutcome = when (this) {
+        DomainSchedulerJobOutcome.SUCCESS -> ApiSchedulerJobOutcome.SUCCESS
+        DomainSchedulerJobOutcome.FAILED -> ApiSchedulerJobOutcome.FAILED
+        DomainSchedulerJobOutcome.SKIPPED_DISABLED -> ApiSchedulerJobOutcome.SKIPPED_DISABLED
+        DomainSchedulerJobOutcome.SKIPPED_LOCK -> ApiSchedulerJobOutcome.SKIPPED_LOCK
+        DomainSchedulerJobOutcome.ABORTED_LIMIT -> ApiSchedulerJobOutcome.ABORTED_LIMIT
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/SchedulerJobEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/SchedulerJobEntity.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+
+/**
+ * Outcome of a single scheduled-job invocation (#516).
+ *
+ * Reported back to the admin dashboard so operators can distinguish a
+ * silent skip (`SKIPPED_DISABLED` via the toggle, `SKIPPED_LOCK` when a
+ * peer instance held the ShedLock) from a real run that succeeded or
+ * crashed.
+ */
+enum class SchedulerJobOutcome {
+    SUCCESS,
+    FAILED,
+    SKIPPED_DISABLED,
+    SKIPPED_LOCK,
+    ABORTED_LIMIT,
+}
+
+/**
+ * Admin-controllable runtime state for a single `@Scheduled` job (#516).
+ *
+ * The yaml/annotation pair stays authoritative for cron and tuning
+ * constants — this row only carries the toggles and bookkeeping fields
+ * the admin dashboard needs. `name` matches the `@SchedulerLock` lock
+ * name and the in-process `SchedulerJobRegistry` key.
+ */
+@Entity
+@Table(name = "scheduler_job")
+class SchedulerJobEntity(
+
+    @Id
+    @Column(name = "name", updatable = false, length = 64)
+    var name: String = "",
+
+    @Column(name = "enabled", nullable = false)
+    var enabled: Boolean = true,
+
+    /**
+     * `null` = "this job has no dry-run concept". When non-null the value
+     * overrides the yaml default (`plugwerk.storage.reaper.dry-run`).
+     */
+    @Column(name = "dry_run")
+    var dryRun: Boolean? = null,
+
+    @Column(name = "last_run_at")
+    var lastRunAt: OffsetDateTime? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "last_run_outcome", length = 32)
+    var lastRunOutcome: SchedulerJobOutcome? = null,
+
+    @Column(name = "last_run_duration_ms")
+    var lastRunDurationMs: Long? = null,
+
+    @Column(name = "last_run_message", columnDefinition = "text")
+    var lastRunMessage: String? = null,
+
+    @Column(name = "run_count_total", nullable = false)
+    var runCountTotal: Long = 0,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: OffsetDateTime = OffsetDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+) {
+    @PrePersist
+    fun onPersist() {
+        val now = OffsetDateTime.now()
+        if (createdAt.isAfter(now)) createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = OffsetDateTime.now()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/SchedulerJobRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/SchedulerJobRepository.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.repository
+
+import io.plugwerk.server.domain.SchedulerJobEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SchedulerJobRepository : JpaRepository<SchedulerJobEntity, String>

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
@@ -22,6 +22,10 @@ import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.RefreshTokenEntity
 import io.plugwerk.server.repository.RefreshTokenRepository
 import io.plugwerk.server.security.AccessKeyHmac
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -54,10 +58,26 @@ class RefreshTokenService(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val accessKeyHmac: AccessKeyHmac,
     private val props: PlugwerkProperties,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
 ) {
 
     private val log = LoggerFactory.getLogger(RefreshTokenService::class.java)
     private val secureRandom = SecureRandom()
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = "refresh-token-cleanup",
+                description = "Purges expired refresh-token rows hourly so reuse-detection " +
+                    "keeps working without unbounded table growth.",
+                cronExpression = "0 0 * * * *",
+                supportsDryRun = false,
+                runNowExecutor = ::cleanupExpired,
+            ),
+        )
+    }
 
     /**
      * Issues a new refresh token bound to [userId] (= `plugwerk_user.id`).
@@ -165,10 +185,12 @@ class RefreshTokenService(
     )
     @Transactional
     fun cleanupExpired() {
-        val cutoff = OffsetDateTime.now(ZoneOffset.UTC)
-        val deleted = refreshTokenRepository.deleteExpiredBefore(cutoff)
-        if (deleted > 0) {
-            log.info("Cleaned up {} expired refresh token(s)", deleted)
+        schedulerJobAuditor.gateAndRun("refresh-token-cleanup") {
+            val cutoff = OffsetDateTime.now(ZoneOffset.UTC)
+            val deleted = refreshTokenRepository.deleteExpiredBefore(cutoff)
+            if (deleted > 0) {
+                log.info("Cleaned up {} expired refresh token(s)", deleted)
+            }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/RefreshTokenService.kt
@@ -27,6 +27,8 @@ import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
 import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -65,6 +67,16 @@ class RefreshTokenService(
     private val log = LoggerFactory.getLogger(RefreshTokenService::class.java)
     private val secureRandom = SecureRandom()
 
+    /**
+     * Lazy self-reference so the run-now lambda invokes the Spring-proxy
+     * method rather than the raw `this`. Without it the proxy-bound
+     * `@Transactional` + `@SchedulerLock` advice does not fire for
+     * admin-triggered runs (issue surfaced in #516 testing).
+     */
+    @Autowired
+    @Lazy
+    private lateinit var self: RefreshTokenService
+
     @PostConstruct
     fun registerScheduledJob() {
         schedulerJobRegistry.register(
@@ -74,7 +86,7 @@ class RefreshTokenService(
                     "keeps working without unbounded table growth.",
                 cronExpression = "0 0 * * * *",
                 supportsDryRun = false,
-                runNowExecutor = ::cleanupExpired,
+                runNowExecutor = { self.cleanupExpired() },
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
@@ -23,6 +23,10 @@ import io.plugwerk.server.PlugwerkProperties
 import io.plugwerk.server.domain.RevokedTokenEntity
 import io.plugwerk.server.repository.RevokedTokenRepository
 import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -49,9 +53,25 @@ class TokenRevocationService(
     private val revokedTokenRepository: RevokedTokenRepository,
     private val userRepository: UserRepository,
     props: PlugwerkProperties,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
 ) {
 
     private val log = LoggerFactory.getLogger(TokenRevocationService::class.java)
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = "token-revocation-cleanup",
+                description = "Purges expired access-token revocation entries hourly. " +
+                    "Once a token is past its expiry, revocation is moot.",
+                cronExpression = "0 0 * * * *",
+                supportsDryRun = false,
+                runNowExecutor = ::cleanupExpired,
+            ),
+        )
+    }
 
     private val revokedJtiCache = Caffeine.newBuilder()
         .maximumSize(10_000)
@@ -155,10 +175,12 @@ class TokenRevocationService(
     )
     @Transactional
     fun cleanupExpired() {
-        val cutoff = OffsetDateTime.now(ZoneOffset.UTC)
-        val deleted = revokedTokenRepository.deleteExpiredBefore(cutoff)
-        if (deleted > 0) {
-            log.info("Cleaned up {} expired token revocation(s)", deleted)
+        schedulerJobAuditor.gateAndRun("token-revocation-cleanup") {
+            val cutoff = OffsetDateTime.now(ZoneOffset.UTC)
+            val deleted = revokedTokenRepository.deleteExpiredBefore(cutoff)
+            if (deleted > 0) {
+                log.info("Cleaned up {} expired token revocation(s)", deleted)
+            }
         }
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/TokenRevocationService.kt
@@ -28,6 +28,8 @@ import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
 import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -59,6 +61,11 @@ class TokenRevocationService(
 
     private val log = LoggerFactory.getLogger(TokenRevocationService::class.java)
 
+    /** See [RefreshTokenService.self] — same Spring-proxy reason. */
+    @Autowired
+    @Lazy
+    private lateinit var self: TokenRevocationService
+
     @PostConstruct
     fun registerScheduledJob() {
         schedulerJobRegistry.register(
@@ -68,7 +75,7 @@ class TokenRevocationService(
                     "Once a token is past its expiry, revocation is moot.",
                 cronExpression = "0 0 * * * *",
                 supportsDryRun = false,
-                runNowExecutor = ::cleanupExpired,
+                runNowExecutor = { self.cleanupExpired() },
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
@@ -26,6 +26,8 @@ import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
 import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -66,6 +68,11 @@ class EmailVerificationTokenService(
     private val schedulerJobAuditor: SchedulerJobAuditor,
 ) {
 
+    /** See [io.plugwerk.server.service.RefreshTokenService.self] — same Spring-proxy reason. */
+    @Autowired
+    @Lazy
+    private lateinit var self: EmailVerificationTokenService
+
     @PostConstruct
     fun registerScheduledJob() {
         schedulerJobRegistry.register(
@@ -76,7 +83,7 @@ class EmailVerificationTokenService(
                     "troubleshooting; unconsumed expired rows are removed immediately.",
                 cronExpression = "0 30 3 * * *",
                 supportsDryRun = false,
-                runNowExecutor = ::sweep,
+                runNowExecutor = { self.sweep() },
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/EmailVerificationTokenService.kt
@@ -21,6 +21,10 @@ package io.plugwerk.server.service.auth
 import io.plugwerk.server.domain.EmailVerificationTokenEntity
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.repository.EmailVerificationTokenRepository
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -56,7 +60,27 @@ import java.util.Base64
  *     (expired + consumed > 7 days) so the table doesn't grow unbounded.
  */
 @Service
-class EmailVerificationTokenService(private val repository: EmailVerificationTokenRepository) {
+class EmailVerificationTokenService(
+    private val repository: EmailVerificationTokenRepository,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
+) {
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = "email-verification-token-sweep",
+                description = "Daily sweep of expired email-verification tokens. " +
+                    "Consumed rows linger for a week to support post-incident " +
+                    "troubleshooting; unconsumed expired rows are removed immediately.",
+                cronExpression = "0 30 3 * * *",
+                supportsDryRun = false,
+                runNowExecutor = ::sweep,
+            ),
+        )
+    }
+
     private val log = LoggerFactory.getLogger(EmailVerificationTokenService::class.java)
     private val secureRandom = SecureRandom()
 
@@ -141,10 +165,12 @@ class EmailVerificationTokenService(private val repository: EmailVerificationTok
     )
     @Transactional
     fun sweep() {
-        val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)
-        val removed = repository.deleteByExpiresAtBefore(cutoff)
-        if (removed > 0) {
-            log.info("Email verification token sweep removed {} expired row(s) older than {}", removed, cutoff)
+        schedulerJobAuditor.gateAndRun("email-verification-token-sweep") {
+            val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)
+            val removed = repository.deleteByExpiresAtBefore(cutoff)
+            if (removed > 0) {
+                log.info("Email verification token sweep removed {} expired row(s) older than {}", removed, cutoff)
+            }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
@@ -27,6 +27,8 @@ import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -60,6 +62,11 @@ class PasswordResetTokenService(
     private val log = LoggerFactory.getLogger(PasswordResetTokenService::class.java)
     private val secureRandom = SecureRandom()
 
+    /** See [io.plugwerk.server.service.RefreshTokenService.self] — same Spring-proxy reason. */
+    @Autowired
+    @Lazy
+    private lateinit var self: PasswordResetTokenService
+
     @PostConstruct
     fun registerScheduledJob() {
         schedulerJobRegistry.register(
@@ -70,7 +77,7 @@ class PasswordResetTokenService(
                     "expired-unconsumed rows are removed immediately.",
                 cronExpression = "0 35 3 * * *",
                 supportsDryRun = false,
-                runNowExecutor = ::sweep,
+                runNowExecutor = { self.sweep() },
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/auth/PasswordResetTokenService.kt
@@ -21,7 +21,11 @@ package io.plugwerk.server.service.auth
 import io.plugwerk.server.domain.PasswordResetTokenEntity
 import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.repository.PasswordResetTokenRepository
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
 import io.plugwerk.server.service.settings.ApplicationSettingsService
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -50,9 +54,26 @@ import java.util.Base64
 class PasswordResetTokenService(
     private val repository: PasswordResetTokenRepository,
     private val settings: ApplicationSettingsService,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
 ) {
     private val log = LoggerFactory.getLogger(PasswordResetTokenService::class.java)
     private val secureRandom = SecureRandom()
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = "password-reset-token-sweep",
+                description = "Daily sweep of expired password-reset tokens. Consumed " +
+                    "rows linger for a week so support can correlate user complaints; " +
+                    "expired-unconsumed rows are removed immediately.",
+                cronExpression = "0 35 3 * * *",
+                supportsDryRun = false,
+                runNowExecutor = ::sweep,
+            ),
+        )
+    }
 
     /**
      * Issues a fresh token for [user] and invalidates any earlier in-flight
@@ -140,10 +161,12 @@ class PasswordResetTokenService(
     )
     @Transactional
     fun sweep() {
-        val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)
-        val removed = repository.deleteByExpiresAtBefore(cutoff)
-        if (removed > 0) {
-            log.info("Password-reset token sweep removed {} expired row(s) older than {}", removed, cutoff)
+        schedulerJobAuditor.gateAndRun("password-reset-token-sweep") {
+            val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minus(SWEEP_GRACE)
+            val removed = repository.deleteByExpiresAtBefore(cutoff)
+            if (removed > 0) {
+                log.info("Password-reset token sweep removed {} expired row(s) older than {}", removed, cutoff)
+            }
         }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobAdminService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobAdminService.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.scheduler
+
+import io.plugwerk.server.domain.SchedulerJobEntity
+import io.plugwerk.server.domain.SchedulerJobOutcome
+import io.plugwerk.server.repository.SchedulerJobRepository
+import io.plugwerk.server.service.EntityNotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Read-write façade behind `AdminSchedulerController` (#516).
+ *
+ * Combines compile-time registry metadata (description, cron,
+ * supportsDryRun) with admin-controlled runtime state (enabled, dryRun,
+ * lastRun*, runCountTotal) into a single dashboard row, and gates the
+ * mutation endpoints against unknown job names.
+ */
+@Service
+class SchedulerJobAdminService(
+    private val registry: SchedulerJobRegistry,
+    private val repository: SchedulerJobRepository,
+    private val service: SchedulerJobService,
+) {
+    private val log = LoggerFactory.getLogger(SchedulerJobAdminService::class.java)
+
+    data class JobView(val descriptor: SchedulerJobDescriptor, val state: SchedulerJobEntity)
+
+    @Transactional(readOnly = true)
+    fun listJobs(): List<JobView> {
+        val rows = repository.findAll().associateBy { it.name }
+        return registry.all().map { descriptor ->
+            JobView(
+                descriptor = descriptor,
+                // Bootstrap should have seeded everything; if a row is
+                // missing we hand back a transient default so the
+                // dashboard at least renders the job — the bootstrap
+                // will write the real row on next boot.
+                state = rows[descriptor.name] ?: SchedulerJobEntity(name = descriptor.name),
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getJob(name: String): JobView {
+        val descriptor = registry.find(name)
+            ?: throw EntityNotFoundException("SchedulerJob", name)
+        val state = repository.findById(name)
+            .orElse(SchedulerJobEntity(name = name))
+        return JobView(descriptor, state)
+    }
+
+    /**
+     * Patches the admin-controlled flags. `enabled = null` leaves the
+     * current value alone (the UI sends the full intended state, so a
+     * missing field is rare but harmless). `dryRun = null` clears the
+     * override and falls back to the yaml default — there is no
+     * "leave dry-run alone, change only enabled" path because the
+     * UI sends both fields together.
+     */
+    @Transactional
+    fun update(name: String, enabled: Boolean?, dryRun: Boolean?): JobView {
+        val descriptor = registry.find(name)
+            ?: throw EntityNotFoundException("SchedulerJob", name)
+        if (dryRun != null && !descriptor.supportsDryRun) {
+            log.warn(
+                "scheduler admin: refused dryRun update on '{}' which does not support dry-run",
+                name,
+            )
+        }
+        val row = repository.findById(name).orElseGet { SchedulerJobEntity(name = name) }
+        enabled?.let { row.enabled = it }
+        row.dryRun = if (descriptor.supportsDryRun) dryRun else null
+        val saved = repository.save(row)
+        // Bust the cache so the next scheduler tick on this instance picks
+        // up the change immediately. Peer instances see it after the TTL.
+        service.invalidate(name)
+        log.info(
+            "scheduler admin: job '{}' updated (enabled={}, dryRun={})",
+            name,
+            saved.enabled,
+            saved.dryRun,
+        )
+        return JobView(descriptor, saved)
+    }
+
+    data class RunOutcome(val outcome: SchedulerJobOutcome, val durationMs: Long?, val message: String?)
+
+    /**
+     * Off-schedule invocation triggered by the admin UI. Routes through
+     * the registered executor, which itself is wrapped by the same
+     * `@SchedulerLock` annotation as the cron tick — so a concurrent
+     * tick rejects this call cleanly via the gate-and-run audit path.
+     */
+    fun runNow(name: String): RunOutcome {
+        val descriptor = registry.find(name)
+            ?: throw EntityNotFoundException("SchedulerJob", name)
+        val startedNanos = System.nanoTime()
+        return try {
+            descriptor.runNowExecutor.invoke()
+            val durationMs = (System.nanoTime() - startedNanos) / 1_000_000L
+            // The executor itself went through gateAndRun, which persisted
+            // the outcome. Read the canonical value back so the response
+            // matches what the dashboard will show on its next refresh.
+            val refreshed = repository.findById(name)
+            RunOutcome(
+                outcome = refreshed.map { it.lastRunOutcome ?: SchedulerJobOutcome.SUCCESS }
+                    .orElse(SchedulerJobOutcome.SUCCESS),
+                durationMs = refreshed.flatMap { java.util.Optional.ofNullable(it.lastRunDurationMs) }
+                    .orElse(durationMs),
+                message = refreshed.flatMap { java.util.Optional.ofNullable(it.lastRunMessage) }
+                    .orElse(null),
+            )
+        } catch (ex: Exception) {
+            val durationMs = (System.nanoTime() - startedNanos) / 1_000_000L
+            log.error("scheduler run-now '{}' failed: {}", name, ex.message, ex)
+            RunOutcome(
+                outcome = SchedulerJobOutcome.FAILED,
+                durationMs = durationMs,
+                message = ex.message?.take(2000),
+            )
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobAuditor.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobAuditor.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.scheduler
+
+import io.plugwerk.server.domain.SchedulerJobOutcome
+import io.plugwerk.server.repository.SchedulerJobRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+
+/**
+ * Records the outcome of a scheduled-job invocation back into the
+ * `scheduler_job` table (#516).
+ *
+ * The persistence runs in its own `REQUIRES_NEW` transaction so that:
+ *  - a rollback in the job body (e.g. the orphan reaper rolling back
+ *    a delete) does not also undo the audit write that says "this
+ *    just failed"
+ *  - an audit-side failure (DB connection blip) does not propagate up
+ *    into the scheduler thread and prevent future ticks — we catch
+ *    and log so the actual job-status outcome is at most "we don't
+ *    have a record", never "the scheduler is now broken"
+ */
+@Service
+class SchedulerJobAuditor(private val repository: SchedulerJobRepository, private val service: SchedulerJobService) {
+    private val log = LoggerFactory.getLogger(SchedulerJobAuditor::class.java)
+
+    /**
+     * Runs [block] under accounting. The recorded outcome is whatever
+     * [block] returns; an uncaught exception becomes `FAILED` with the
+     * exception's message captured in `last_run_message`.
+     *
+     * Returns the recorded outcome so the caller can react (e.g. the
+     * run-now endpoint reports it back to the admin UI).
+     */
+    fun run(name: String, block: () -> SchedulerJobOutcome): SchedulerJobOutcome {
+        val startedNanos = System.nanoTime()
+        val outcome: SchedulerJobOutcome
+        var message: String? = null
+        outcome = try {
+            block()
+        } catch (ex: Exception) {
+            message = ex.message?.take(2000) ?: ex.javaClass.simpleName
+            log.error("scheduled job '{}' failed: {}", name, ex.message, ex)
+            SchedulerJobOutcome.FAILED
+        }
+        val durationMs = (System.nanoTime() - startedNanos) / 1_000_000L
+        persist(name, outcome, message, durationMs)
+        return outcome
+    }
+
+    /**
+     * Convenience for the typical `@Scheduled` body:
+     *  1. skip-and-record if the admin toggle is off
+     *  2. otherwise wrap [block] under [run]
+     *
+     * Returning the outcome lets the manual run-now endpoint propagate
+     * "we skipped because you disabled this" back to the operator
+     * instead of pretending the job ran.
+     */
+    fun gateAndRun(name: String, block: () -> Unit): SchedulerJobOutcome {
+        if (!service.shouldRun(name)) {
+            recordSkipped(name, SchedulerJobOutcome.SKIPPED_DISABLED)
+            return SchedulerJobOutcome.SKIPPED_DISABLED
+        }
+        return run(name) {
+            block()
+            SchedulerJobOutcome.SUCCESS
+        }
+    }
+
+    /**
+     * Records a skipped tick (the toggle is off or a peer instance
+     * holds the lock). Distinct path from [run] because skips do not
+     * carry a duration that means anything to the operator — they are
+     * book-kept so the dashboard can show "this job is alive even
+     * though you just disabled it".
+     */
+    fun recordSkipped(name: String, outcome: SchedulerJobOutcome, message: String? = null) {
+        require(
+            outcome == SchedulerJobOutcome.SKIPPED_DISABLED ||
+                outcome == SchedulerJobOutcome.SKIPPED_LOCK,
+        ) { "recordSkipped requires a SKIPPED_* outcome, got $outcome" }
+        persist(name, outcome, message, durationMs = null)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    private fun persist(name: String, outcome: SchedulerJobOutcome, message: String?, durationMs: Long?) {
+        try {
+            val entity = repository.findById(name).orElse(null) ?: run {
+                // Fail-open: a missing row means the bootstrap hasn't
+                // run yet (fresh DB) or someone deleted the row by hand.
+                // Either way, dropping the audit is preferable to making
+                // the scheduler thread throw.
+                log.warn(
+                    "audit for scheduled job '{}' has no scheduler_job row — skipping persist",
+                    name,
+                )
+                return
+            }
+            // Only mutate the run-tracking fields; never touch enabled /
+            // dry-run, those belong to the admin endpoint.
+            entity.lastRunAt = OffsetDateTime.now()
+            entity.lastRunOutcome = outcome
+            entity.lastRunDurationMs = durationMs
+            entity.lastRunMessage = message
+            // SKIPPED outcomes do not increment the total — the dashboard's
+            // "Runs in last 24h" reflects actual work done.
+            if (outcome != SchedulerJobOutcome.SKIPPED_DISABLED &&
+                outcome != SchedulerJobOutcome.SKIPPED_LOCK
+            ) {
+                entity.runCountTotal += 1
+            }
+            repository.save(entity)
+        } catch (ex: Exception) {
+            log.warn(
+                "failed to record scheduler audit for '{}' ({}): {}",
+                name,
+                outcome,
+                ex.message,
+            )
+        }
+        // Bust the cache so an operator who flipped a toggle moments ago
+        // also sees the latest run snapshot on their next dashboard refresh.
+        service.invalidate(name)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobBootstrap.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobBootstrap.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.scheduler
+
+import io.plugwerk.server.domain.SchedulerJobEntity
+import io.plugwerk.server.repository.SchedulerJobRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Seeds the `scheduler_job` table with one row per registered job on
+ * application startup (#516). Idempotent — only INSERTs rows that are
+ * not yet present, never updates existing rows, so an operator-changed
+ * `enabled` or `dry_run` value is preserved across restarts.
+ *
+ * Multi-instance safe: two Plugwerk processes booting in parallel will
+ * race on the `INSERT`, but the PK on `name` makes one of them fail
+ * cleanly and we swallow the conflict — both end up with the same
+ * row, which is exactly what we want.
+ */
+@Component
+class SchedulerJobBootstrap(
+    private val registry: SchedulerJobRegistry,
+    private val repository: SchedulerJobRepository,
+) {
+    private val log = LoggerFactory.getLogger(SchedulerJobBootstrap::class.java)
+
+    @EventListener(ApplicationReadyEvent::class)
+    @Transactional
+    fun seedRegisteredJobs() {
+        val existing = repository.findAll().mapTo(HashSet()) { it.name }
+        val missing = registry.all().filterNot { it.name in existing }
+        if (missing.isEmpty()) {
+            log.debug("scheduler bootstrap: all {} registered job(s) already seeded", existing.size)
+            return
+        }
+        for (descriptor in missing) {
+            try {
+                repository.save(
+                    SchedulerJobEntity(
+                        name = descriptor.name,
+                        enabled = true,
+                        // Initial null = honour the yaml default; operators
+                        // can override later via the admin UI.
+                        dryRun = null,
+                    ),
+                )
+                log.info(
+                    "scheduler bootstrap: seeded job '{}' (cron='{}', supportsDryRun={})",
+                    descriptor.name,
+                    descriptor.cronExpression,
+                    descriptor.supportsDryRun,
+                )
+            } catch (ex: org.springframework.dao.DataIntegrityViolationException) {
+                // A peer instance won the race — its row is now in place,
+                // which is the same outcome we wanted. Nothing to fix.
+                log.debug(
+                    "scheduler bootstrap: peer instance already seeded '{}' — continuing",
+                    descriptor.name,
+                )
+            }
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobRegistry.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobRegistry.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.scheduler
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Boot-time descriptor for a `@Scheduled` job exposed to the admin
+ * dashboard (#516).
+ *
+ * @property name Stable identifier — must match the `@SchedulerLock`
+ *   lock name on the corresponding @Scheduled method so the run-now
+ *   path can reuse the same lock infrastructure (with a `-manual`
+ *   suffix).
+ * @property description Short human-readable summary for the dashboard.
+ * @property cronExpression The cron pattern this job runs on. Recorded
+ *   here purely so the UI can display it; the authoritative source is
+ *   still the `@Scheduled(cron = …)` annotation on the method.
+ * @property supportsDryRun When true, the dashboard exposes the dry-run
+ *   toggle and the job's body honours it. Currently only the orphan-
+ *   storage reaper.
+ * @property runNowExecutor A side-effecting reference to the same method
+ *   the scheduler will invoke on a regular tick. Wired by the owning
+ *   service at registration time so the run-now endpoint can trigger an
+ *   off-schedule execution that still goes through the gate + audit +
+ *   ShedLock layers (under the `-manual` lock-name suffix).
+ */
+data class SchedulerJobDescriptor(
+    val name: String,
+    val description: String,
+    val cronExpression: String,
+    val supportsDryRun: Boolean,
+    val runNowExecutor: () -> Unit,
+)
+
+/**
+ * Singleton registry collecting metadata for every `@Scheduled` job
+ * the admin dashboard can show (#516). Each scheduled service calls
+ * [register] from its `@PostConstruct` so the registry is populated
+ * before the bootstrap seeds the `scheduler_job` table.
+ *
+ * Thread-safe by virtue of the underlying [ConcurrentHashMap] — the
+ * read paths (dashboard + run-now endpoint) are called long after the
+ * bean lifecycle has settled, but a defensive choice makes test setup
+ * order-insensitive.
+ */
+@Component
+class SchedulerJobRegistry {
+
+    private val byName: MutableMap<String, SchedulerJobDescriptor> = ConcurrentHashMap()
+
+    fun register(descriptor: SchedulerJobDescriptor) {
+        val previous = byName.putIfAbsent(descriptor.name, descriptor)
+        require(previous == null) {
+            "Scheduler job '${descriptor.name}' is already registered — names must be unique"
+        }
+    }
+
+    fun all(): List<SchedulerJobDescriptor> = byName.values.sortedBy { it.name }
+
+    fun find(name: String): SchedulerJobDescriptor? = byName[name]
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/scheduler/SchedulerJobService.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.scheduler
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.plugwerk.server.repository.SchedulerJobRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+
+/**
+ * Snapshot of the admin-controlled toggles for a single job (#516).
+ *
+ * The two fields are read tens of thousands of times per day on the
+ * scheduler thread but only change when an operator clicks a toggle in
+ * the dashboard — they ride in the same record so the cache holds a
+ * single immutable value per job and the gate read is one map lookup.
+ */
+data class SchedulerJobState(
+    val enabled: Boolean,
+    /** `null` = honour the yaml default; non-null overrides it. */
+    val dryRunOverride: Boolean?,
+)
+
+/**
+ * Read-and-write façade over the `scheduler_job` table for the gate +
+ * toggle paths (#516).
+ *
+ * - Reads are cached with a 30 s TTL because the gate fires on every
+ *   tick and a fresh SELECT per scheduled invocation is wasted work.
+ * - Writes from the admin endpoints `evict()` the cached row so the
+ *   next tick on the same instance sees the change immediately. Peer
+ *   instances see it after at most the TTL — acceptable latency for
+ *   hourly / daily jobs, and the alternative (LISTEN/NOTIFY) would add
+ *   a noticeable layer of plumbing for a feature where seconds of stale
+ *   read costs nothing.
+ */
+@Service
+class SchedulerJobService(private val repository: SchedulerJobRepository) {
+    private val cache = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(30))
+        .maximumSize(64)
+        .build<String, SchedulerJobState>()
+
+    /**
+     * Should the scheduler invoke this job's body on the current tick?
+     * Returns `true` if the row is missing (the bootstrap hasn't run
+     * yet on a fresh DB) so we never silently disable a job because
+     * the metadata is incomplete.
+     */
+    fun shouldRun(name: String): Boolean = load(name).enabled
+
+    /**
+     * Returns the operator-set dry-run override, or `null` if there is
+     * none. Callers (currently only [io.plugwerk.server.service.storage.consistency.OrphanReaperScheduler])
+     * fall back to their own yaml default when this is null.
+     */
+    fun getDryRunOverride(name: String): Boolean? = load(name).dryRunOverride
+
+    /**
+     * Drops the cached state for [name] so the next read goes to the DB.
+     * Called from the toggle endpoint after a successful update.
+     */
+    fun invalidate(name: String) {
+        cache.invalidate(name)
+    }
+
+    @Transactional(readOnly = true)
+    private fun load(name: String): SchedulerJobState = cache.get(name) { key ->
+        repository.findById(key)
+            .map { SchedulerJobState(enabled = it.enabled, dryRunOverride = it.dryRun) }
+            // Fail-open: a missing row should not silently disable a
+            // job (would be invisible until the operator opens the
+            // dashboard). Bootstrap will create the row on next boot.
+            .orElse(SchedulerJobState(enabled = true, dryRunOverride = null))
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
@@ -22,6 +22,11 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import io.plugwerk.server.service.scheduler.SchedulerJobService
+import jakarta.annotation.PostConstruct
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -66,9 +71,31 @@ class OrphanReaperScheduler(
     private val consistencyService: StorageConsistencyService,
     private val adminService: StorageConsistencyAdminService,
     private val properties: PlugwerkProperties,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobService: SchedulerJobService,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
     meterRegistry: MeterRegistry,
 ) {
     private val log = LoggerFactory.getLogger(OrphanReaperScheduler::class.java)
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = JOB_NAME,
+                description = "Scans object storage for files with no matching " +
+                    "plugin_release row and removes them after a grace period. " +
+                    "Dry-run-aware (toggle in the admin UI overrides the yaml default).",
+                cronExpression = properties.storage.reaper.cron,
+                supportsDryRun = true,
+                runNowExecutor = ::reap,
+            ),
+        )
+    }
+
+    companion object {
+        private const val JOB_NAME = "orphan-storage-reaper"
+    }
 
     private val deletedCounter: Counter = Counter
         .builder("plugwerk.storage.reaper.deleted")
@@ -98,12 +125,18 @@ class OrphanReaperScheduler(
      */
     @Scheduled(cron = "\${plugwerk.storage.reaper.cron:0 15 3 * * *}")
     @SchedulerLock(
-        name = "orphan-storage-reaper",
+        name = JOB_NAME,
         lockAtMostFor = "PT2H",
         lockAtLeastFor = "PT30S",
     )
     fun reap() {
+        schedulerJobAuditor.gateAndRun(JOB_NAME) { doReap() }
+    }
+
+    private fun doReap() {
         val reaper = properties.storage.reaper
+        val dryRunOverride = schedulerJobService.getDryRunOverride(JOB_NAME)
+        val dryRun = dryRunOverride ?: reaper.dryRun
         val sample = Timer.start()
         try {
             val report = consistencyService.scan()
@@ -134,7 +167,7 @@ class OrphanReaperScheduler(
                 )
             }
 
-            if (reaper.dryRun) {
+            if (dryRun) {
                 log.info(
                     "reaper tick (DRY-RUN): would delete {} orphan(s); skippedByGrace={}",
                     capped.size,

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperScheduler.kt
@@ -29,7 +29,9 @@ import io.plugwerk.server.service.scheduler.SchedulerJobService
 import jakarta.annotation.PostConstruct
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Lazy
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
@@ -78,6 +80,11 @@ class OrphanReaperScheduler(
 ) {
     private val log = LoggerFactory.getLogger(OrphanReaperScheduler::class.java)
 
+    /** See [io.plugwerk.server.service.RefreshTokenService.self] — same Spring-proxy reason. */
+    @Autowired
+    @Lazy
+    private lateinit var self: OrphanReaperScheduler
+
     @PostConstruct
     fun registerScheduledJob() {
         schedulerJobRegistry.register(
@@ -88,7 +95,7 @@ class OrphanReaperScheduler(
                     "Dry-run-aware (toggle in the admin UI overrides the yaml default).",
                 cronExpression = properties.storage.reaper.cron,
                 supportsDryRun = true,
-                runNowExecutor = ::reap,
+                runNowExecutor = { self.reap() },
             ),
         )
     }

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -65,3 +65,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0032_admin_password_reset_template.yaml
   - include:
       file: db/changelog/migrations/0033_shedlock.yaml
+  - include:
+      file: db/changelog/migrations/0034_scheduler_job.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0034_scheduler_job.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0034_scheduler_job.yaml
@@ -1,0 +1,91 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0034-scheduler-job-table
+      author: plugwerk
+      comment: |
+        Admin-controllable runtime state for @Scheduled jobs (#516).
+
+        The yaml-driven cron pattern and tuning constants stay
+        authoritative — this table only carries the small set of
+        toggles and bookkeeping fields the admin UI needs:
+          - enabled                : per-instance master switch the
+                                     in-method gate consults each tick
+          - dry_run                : nullable; null = "no dry-run concept
+                                     for this job" (currently only the
+                                     orphan-storage reaper uses this)
+          - last_run_*             : diagnostics for the dashboard
+          - run_count_total        : cumulative; long-term history lives
+                                     in metrics, not in this row
+
+        `name` matches the @SchedulerLock name and the registry key, so
+        it doubles as the join target for the run-now path's `-manual`
+        lock suffix.
+      changes:
+        - createTable:
+            tableName: scheduler_job
+            columns:
+              - column:
+                  name: name
+                  type: varchar(64)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: enabled
+                  type: boolean
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dry_run
+                  type: boolean
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_run_at
+                  type: timestamptz
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_run_outcome
+                  type: varchar(32)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_run_duration_ms
+                  type: bigint
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_run_message
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
+                  name: run_count_total
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamptz
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamptz
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+        - sql:
+            sql: |
+              ALTER TABLE scheduler_job
+                ADD CONSTRAINT chk_scheduler_job_outcome
+                CHECK (last_run_outcome IS NULL OR last_run_outcome IN
+                  ('SUCCESS', 'FAILED', 'SKIPPED_DISABLED', 'SKIPPED_LOCK',
+                   'ABORTED_LIMIT'));
+      rollback:
+        - dropTable:
+            tableName: scheduler_job

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminSchedulerControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminSchedulerControllerTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.domain.SchedulerJobEntity
+import io.plugwerk.server.domain.SchedulerJobOutcome
+import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.LoginRateLimitFilter
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
+import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.security.RefreshRateLimitFilter
+import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.ForbiddenException
+import io.plugwerk.server.service.scheduler.SchedulerJobAdminService
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+import tools.jackson.databind.ObjectMapper
+
+@WebMvcTest(
+    AdminSchedulerController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class AdminSchedulerControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean private lateinit var adminService: SchedulerJobAdminService
+
+    @MockitoBean private lateinit var namespaceAuthorizationService: NamespaceAuthorizationService
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("admin", null, emptyList())
+        whenever(namespaceAuthorizationService.isCurrentUserSuperadmin()).thenReturn(true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `GET jobs returns registry plus runtime state`() {
+        whenever(adminService.listJobs()).thenReturn(
+            listOf(
+                SchedulerJobAdminService.JobView(
+                    descriptor = SchedulerJobDescriptor(
+                        name = "orphan-storage-reaper",
+                        description = "Reap orphans.",
+                        cronExpression = "0 15 3 * * *",
+                        supportsDryRun = true,
+                        runNowExecutor = { /* not called from controller layer */ },
+                    ),
+                    state = SchedulerJobEntity(
+                        name = "orphan-storage-reaper",
+                        enabled = true,
+                        dryRun = true,
+                        runCountTotal = 7L,
+                    ),
+                ),
+            ),
+        )
+
+        mockMvc.get("/api/v1/admin/scheduler/jobs")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$[0].name") { value("orphan-storage-reaper") }
+                jsonPath("$[0].enabled") { value(true) }
+                jsonPath("$[0].dryRun") { value(true) }
+                jsonPath("$[0].runCountTotal") { value(7) }
+                jsonPath("$[0].supportsDryRun") { value(true) }
+            }
+    }
+
+    @Test
+    fun `PATCH job updates and returns the row`() {
+        whenever(adminService.update(any(), anyOrNull(), anyOrNull())).thenReturn(
+            SchedulerJobAdminService.JobView(
+                descriptor = SchedulerJobDescriptor(
+                    name = "refresh-token-cleanup",
+                    description = "x",
+                    cronExpression = "0 0 * * * *",
+                    supportsDryRun = false,
+                    runNowExecutor = { },
+                ),
+                state = SchedulerJobEntity(
+                    name = "refresh-token-cleanup",
+                    enabled = false,
+                ),
+            ),
+        )
+
+        mockMvc.patch("/api/v1/admin/scheduler/jobs/refresh-token-cleanup") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(mapOf("enabled" to false))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.name") { value("refresh-token-cleanup") }
+            jsonPath("$.enabled") { value(false) }
+        }
+        verify(adminService).update("refresh-token-cleanup", false, null)
+    }
+
+    @Test
+    fun `POST run-now returns recorded outcome`() {
+        whenever(adminService.runNow("refresh-token-cleanup")).thenReturn(
+            SchedulerJobAdminService.RunOutcome(
+                outcome = SchedulerJobOutcome.SUCCESS,
+                durationMs = 42L,
+                message = null,
+            ),
+        )
+
+        mockMvc.post("/api/v1/admin/scheduler/jobs/refresh-token-cleanup/run")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.outcome") { value("SUCCESS") }
+                jsonPath("$.durationMs") { value(42) }
+            }
+    }
+
+    @Test
+    fun `GET jobs without superadmin returns 403`() {
+        doThrow(ForbiddenException("Superadmin privileges required"))
+            .whenever(namespaceAuthorizationService).requireSuperadmin(any())
+
+        mockMvc.get("/api/v1/admin/scheduler/jobs")
+            .andExpect { status { isForbidden() } }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminSchedulerEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminSchedulerEndpointAuthzTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+/**
+ * Authorization matrix for the scheduler admin endpoints (#516). All
+ * three endpoints are superadmin-only; namespace admins are intentionally
+ * excluded because the jobs are global (token cleanup, storage reaper).
+ */
+class AdminSchedulerEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /admin/scheduler/jobs {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `list jobs denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/admin/scheduler/jobs").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can list jobs`() {
+        mockMvc.perform(get("/api/v1/admin/scheduler/jobs").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+    }
+
+    @ParameterizedTest(name = "PATCH /admin/scheduler/jobs/[name] {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `update job denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            patch("/api/v1/admin/scheduler/jobs/refresh-token-cleanup")
+                .actAs(case.actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("enabled" to false))),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @ParameterizedTest(name = "POST /admin/scheduler/jobs/[name]/run {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `run-now denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(
+            post("/api/v1/admin/scheduler/jobs/refresh-token-cleanup/run").actAs(case.actor),
+        )
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    companion object {
+        @JvmStatic
+        fun superadminOnlyDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/TokenRevocationServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/TokenRevocationServiceTest.kt
@@ -60,9 +60,30 @@ class TokenRevocationServiceTest {
         ),
     )
 
+    private lateinit var schedulerJobAuditor: io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+
     @BeforeEach
     fun setUp() {
-        service = TokenRevocationService(revokedTokenRepository, userRepository, props)
+        schedulerJobAuditor = org.mockito.kotlin.mock()
+        // Pass-through: the auditor's only job in unit tests is to invoke
+        // the body. `lenient` because most tests in this class never call
+        // the scheduled method — Mockito's strict mode would otherwise
+        // reject the stubbing as unused.
+        org.mockito.Mockito.lenient()
+            .`when`(schedulerJobAuditor.gateAndRun(any(), any()))
+            .thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                val block = invocation.arguments[1] as () -> Unit
+                block()
+                io.plugwerk.server.domain.SchedulerJobOutcome.SUCCESS
+            }
+        service = TokenRevocationService(
+            revokedTokenRepository,
+            userRepository,
+            props,
+            io.plugwerk.server.service.scheduler.SchedulerJobRegistry(),
+            schedulerJobAuditor,
+        )
     }
 
     private fun localUser(id: UUID, passwordInvalidatedBefore: OffsetDateTime? = null) = UserEntity(

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperSchedulerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/storage/consistency/OrphanReaperSchedulerTest.kt
@@ -20,11 +20,15 @@ package io.plugwerk.server.service.storage.consistency
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import io.plugwerk.server.service.scheduler.SchedulerJobService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -35,13 +39,35 @@ class OrphanReaperSchedulerTest {
 
     private lateinit var consistencyService: StorageConsistencyService
     private lateinit var adminService: StorageConsistencyAdminService
+    private lateinit var schedulerJobService: SchedulerJobService
+    private lateinit var schedulerJobAuditor: SchedulerJobAuditor
     private lateinit var meterRegistry: SimpleMeterRegistry
 
     @BeforeEach
     fun setUp() {
         consistencyService = mock()
         adminService = mock()
+        schedulerJobService = mock()
+        schedulerJobAuditor = mock()
         meterRegistry = SimpleMeterRegistry()
+        // Default: no admin override — the body falls back to the yaml
+        // properties.dryRun the test sets up via `scheduler(...)`.
+        whenever(schedulerJobService.getDryRunOverride(any())).thenReturn(null)
+        // gateAndRun is the single entry point each scheduler uses — keep the
+        // unit-test focus on the body by making the auditor a transparent pass-
+        // through, mirroring the real implementation's exception handling
+        // (uncaught throwables become FAILED, the scheduler thread never sees
+        // them). The dedicated auditor tests live alongside SchedulerJobService.
+        whenever(schedulerJobAuditor.gateAndRun(any(), any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val block = invocation.arguments[1] as () -> Unit
+            try {
+                block()
+                io.plugwerk.server.domain.SchedulerJobOutcome.SUCCESS
+            } catch (_: Exception) {
+                io.plugwerk.server.domain.SchedulerJobOutcome.FAILED
+            }
+        }
     }
 
     @Test
@@ -179,6 +205,9 @@ class OrphanReaperSchedulerTest {
             consistencyService,
             adminService,
             props,
+            SchedulerJobRegistry(),
+            schedulerJobService,
+            schedulerJobAuditor,
             meterRegistry,
         )
     }

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -21,6 +21,7 @@ import { Configuration } from "./generated/configuration";
 import { AccessKeysApi } from "./generated/api/access-keys-api";
 import { AdminEmailApi } from "./generated/api/admin-email-api";
 import { AdminEmailTemplatesApi } from "./generated/api/admin-email-templates-api";
+import { AdminSchedulerApi } from "./generated/api/admin-scheduler-api";
 import { AdminSettingsApi } from "./generated/api/admin-settings-api";
 import { AdminStorageConsistencyApi } from "./generated/api/admin-storage-consistency-api";
 import { AdminUsersApi } from "./generated/api/admin-users-api";
@@ -167,6 +168,11 @@ export const adminUsersApi = new AdminUsersApi(
   axiosInstance,
 );
 export const adminStorageConsistencyApi = new AdminStorageConsistencyApi(
+  apiConfig,
+  BASE_PATH,
+  axiosInstance,
+);
+export const adminSchedulerApi = new AdminSchedulerApi(
   apiConfig,
   BASE_PATH,
   axiosInstance,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -25,6 +25,7 @@ import {
   Globe,
   Mail,
   HardDrive,
+  Clock,
 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { tokens } from "../../theme/tokens";
@@ -80,6 +81,12 @@ const ADMIN_SECTIONS: AdminSection[] = [
     path: "storage-consistency",
     label: "Storage",
     icon: <HardDrive size={16} />,
+    requiresSuperadmin: true,
+  },
+  {
+    path: "scheduler",
+    label: "Scheduler",
+    icon: <Clock size={16} />,
     requiresSuperadmin: true,
   },
 ];

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerJobsTable.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerJobsTable.tsx
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from "react";
+import { Box, Button, Chip, Switch, Tooltip, Typography } from "@mui/material";
+import {
+  CircleAlert,
+  CircleCheckBig,
+  Eye,
+  EyeOff,
+  MinusCircle,
+  Play,
+} from "lucide-react";
+import { tokens } from "../../../theme/tokens";
+import { Timestamp } from "../../../components/common/Timestamp";
+import { ConfirmDeleteDialog } from "../../../components/common/ConfirmDeleteDialog";
+import type {
+  SchedulerJobDto,
+  SchedulerJobOutcome,
+} from "../../../api/generated/model";
+
+interface SchedulerJobsTableProps {
+  readonly jobs: readonly SchedulerJobDto[];
+  readonly busy: boolean;
+  readonly onToggleEnabled: (job: SchedulerJobDto, next: boolean) => void;
+  readonly onToggleDryRun: (job: SchedulerJobDto, next: boolean | null) => void;
+  readonly onRunNow: (job: SchedulerJobDto) => void;
+}
+
+/**
+ * Five-column live-status table for the scheduler dashboard (#516).
+ * Custom (not the generic `DataTable`) because per-row actions vary by
+ * `supportsDryRun` and because we want monospace job-IDs with sub-line
+ * descriptions, which the generic table cannot express cleanly.
+ */
+export function SchedulerJobsTable({
+  jobs,
+  busy,
+  onToggleEnabled,
+  onToggleDryRun,
+  onRunNow,
+}: SchedulerJobsTableProps) {
+  const [runConfirm, setRunConfirm] = useState<SchedulerJobDto | null>(null);
+
+  if (jobs.length === 0) {
+    return (
+      <Box
+        sx={{
+          py: 5,
+          textAlign: "center",
+          border: "1px dashed",
+          borderColor: "divider",
+          borderRadius: tokens.radius.card,
+          color: "text.disabled",
+        }}
+      >
+        <Typography variant="body2">No scheduled jobs registered.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: tokens.radius.card,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        component="table"
+        role="table"
+        aria-label="Scheduled jobs"
+        sx={{ width: "100%", borderCollapse: "collapse" }}
+      >
+        <Box component="thead">
+          <Box component="tr">
+            <Header>Job</Header>
+            <Header width={140}>Cron</Header>
+            <Header width={120}>Enabled</Header>
+            <Header width={120}>Dry-run</Header>
+            <Header width={170}>Last run</Header>
+            <Header width={120} align="right">
+              Total runs
+            </Header>
+            <Header width={120} align="right" />
+          </Box>
+        </Box>
+        <Box component="tbody">
+          {jobs.map((job) => (
+            <Box
+              component="tr"
+              key={job.name}
+              sx={{
+                bgcolor: "background.paper",
+                "&:hover": { bgcolor: "background.default" },
+              }}
+            >
+              <Cell>
+                <Typography
+                  variant="body2"
+                  sx={{ fontFamily: "monospace", fontSize: "0.82rem" }}
+                >
+                  {job.name}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.disabled", display: "block", mt: 0.25 }}
+                >
+                  {job.description}
+                </Typography>
+              </Cell>
+              <Cell>
+                <Chip
+                  label={job.cronExpression}
+                  size="small"
+                  sx={{
+                    fontFamily: "monospace",
+                    bgcolor: tokens.badge.version.bg,
+                    color: tokens.badge.version.text,
+                    height: 20,
+                    fontSize: "0.7rem",
+                  }}
+                />
+              </Cell>
+              <Cell>
+                <Switch
+                  size="small"
+                  checked={job.enabled}
+                  disabled={busy}
+                  onChange={(e) => onToggleEnabled(job, e.target.checked)}
+                  slotProps={{
+                    input: { "aria-label": `Toggle ${job.name} enabled` },
+                  }}
+                />
+              </Cell>
+              <Cell>
+                {job.supportsDryRun ? (
+                  <DryRunCycle
+                    value={job.dryRun ?? null}
+                    busy={busy}
+                    onChange={(next) => onToggleDryRun(job, next)}
+                    label={`Toggle ${job.name} dry-run`}
+                  />
+                ) : (
+                  <Typography variant="caption" sx={{ color: "text.disabled" }}>
+                    —
+                  </Typography>
+                )}
+              </Cell>
+              <Cell>
+                <LastRunBadge
+                  outcome={job.lastRunOutcome ?? null}
+                  durationMs={job.lastRunDurationMs ?? null}
+                  at={job.lastRunAt ?? null}
+                />
+              </Cell>
+              <Cell align="right">
+                <Typography
+                  variant="body2"
+                  sx={{ fontFeatureSettings: '"tnum"' }}
+                >
+                  {job.runCountTotal.toLocaleString()}
+                </Typography>
+              </Cell>
+              <Cell align="right">
+                <Tooltip
+                  title={
+                    job.enabled
+                      ? "Run now"
+                      : "Enable the job before triggering a manual run"
+                  }
+                  arrow
+                >
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<Play size={12} />}
+                      onClick={() => setRunConfirm(job)}
+                      disabled={busy || !job.enabled}
+                    >
+                      Run now
+                    </Button>
+                  </span>
+                </Tooltip>
+              </Cell>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      <ConfirmDeleteDialog
+        open={runConfirm !== null}
+        onCancel={() => setRunConfirm(null)}
+        onConfirm={() => {
+          if (runConfirm) onRunNow(runConfirm);
+          setRunConfirm(null);
+        }}
+        title={runConfirm ? `Run ${runConfirm.name} now?` : ""}
+        actionLabel="Run job"
+        message={
+          runConfirm
+            ? `Triggers an off-schedule execution of ${runConfirm.name}. It goes through the same ShedLock as the cron tick, so a concurrent regular run will skip this one.`
+            : ""
+        }
+        loading={busy}
+      />
+    </Box>
+  );
+}
+
+/**
+ * Three-state dry-run cycle: `null → true → false → null`. A button
+ * (rather than a Switch) because the state is ternary; the label and
+ * icon make the current value explicit.
+ */
+function DryRunCycle({
+  value,
+  busy,
+  onChange,
+  label,
+}: {
+  readonly value: boolean | null;
+  readonly busy: boolean;
+  readonly onChange: (next: boolean | null) => void;
+  readonly label: string;
+}) {
+  const next: boolean | null = value === null ? true : value ? false : null;
+  const icon =
+    value === null ? (
+      <MinusCircle size={14} />
+    ) : value ? (
+      <Eye size={14} />
+    ) : (
+      <EyeOff size={14} />
+    );
+  const text = value === null ? "default" : value ? "dry-run" : "live";
+  const color =
+    value === null
+      ? "default"
+      : value
+        ? "info"
+        : ("success" as "default" | "info" | "success");
+  return (
+    <Tooltip
+      title={
+        value === null
+          ? "Following yaml default. Click to force dry-run."
+          : value
+            ? "Forcing dry-run. Click to switch to live."
+            : "Forcing live mode. Click to clear override."
+      }
+      arrow
+    >
+      <span>
+        <Chip
+          icon={icon}
+          label={text}
+          size="small"
+          color={color}
+          variant={value === null ? "outlined" : "filled"}
+          onClick={() => onChange(next)}
+          disabled={busy}
+          clickable
+          aria-label={label}
+          sx={{ fontFamily: "monospace", fontSize: "0.7rem", height: 22 }}
+        />
+      </span>
+    </Tooltip>
+  );
+}
+
+function LastRunBadge({
+  outcome,
+  durationMs,
+  at,
+}: {
+  readonly outcome: SchedulerJobOutcome | null;
+  readonly durationMs: number | null;
+  readonly at: string | null;
+}) {
+  if (!outcome || !at) {
+    return (
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        Never run
+      </Typography>
+    );
+  }
+  const palette = paletteFor(outcome);
+  const icon =
+    outcome === "SUCCESS" ? (
+      <CircleCheckBig size={12} />
+    ) : outcome === "FAILED" ? (
+      <CircleAlert size={12} />
+    ) : (
+      <MinusCircle size={12} />
+    );
+  return (
+    <Box>
+      <Chip
+        icon={icon}
+        label={outcomeLabel(outcome)}
+        size="small"
+        sx={{
+          bgcolor: palette.bg,
+          color: palette.text,
+          height: 20,
+          fontSize: "0.7rem",
+          fontWeight: 600,
+        }}
+      />
+      <Typography
+        variant="caption"
+        sx={{ color: "text.secondary", display: "block", mt: 0.25 }}
+      >
+        <Timestamp date={at} variant="relative" />
+        {durationMs != null && (
+          <Box component="span" sx={{ ml: 0.5, fontFeatureSettings: '"tnum"' }}>
+            · {durationMs} ms
+          </Box>
+        )}
+      </Typography>
+    </Box>
+  );
+}
+
+function outcomeLabel(o: SchedulerJobOutcome): string {
+  switch (o) {
+    case "SUCCESS":
+      return "Success";
+    case "FAILED":
+      return "Failed";
+    case "SKIPPED_DISABLED":
+      return "Disabled";
+    case "SKIPPED_LOCK":
+      return "Locked";
+    case "ABORTED_LIMIT":
+      return "Aborted";
+  }
+}
+
+function paletteFor(o: SchedulerJobOutcome): { bg: string; text: string } {
+  switch (o) {
+    case "SUCCESS":
+      return tokens.badge.published;
+    case "FAILED":
+      return tokens.badge.yanked;
+    case "SKIPPED_DISABLED":
+    case "SKIPPED_LOCK":
+      return tokens.badge.version;
+    case "ABORTED_LIMIT":
+      return tokens.badge.draft;
+  }
+}
+
+function Header({
+  children,
+  width,
+  align,
+}: {
+  readonly children?: React.ReactNode;
+  readonly width?: number;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="th"
+      sx={{
+        textAlign: align ?? "left",
+        width,
+        px: 2,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.default",
+        fontSize: "0.7rem",
+        fontWeight: 600,
+        color: "text.secondary",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function Cell({
+  children,
+  align,
+}: {
+  readonly children: React.ReactNode;
+  readonly align?: "left" | "right" | "center";
+}) {
+  return (
+    <Box
+      component="td"
+      sx={{
+        textAlign: align ?? "left",
+        px: 2,
+        py: 1.25,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        fontSize: "0.875rem",
+        verticalAlign: "middle",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerSection.test.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SchedulerSection } from "./SchedulerSection";
+import { renderWithTheme } from "../../../test/renderWithTheme";
+import * as apiConfig from "../../../api/config";
+import type { SchedulerJobDto } from "../../../api/generated/model";
+
+vi.mock("../../../api/config", () => ({
+  adminSchedulerApi: {
+    listSchedulerJobs: vi.fn(),
+    updateSchedulerJob: vi.fn(),
+    runSchedulerJobNow: vi.fn(),
+  },
+}));
+
+function jobFixture(overrides: Partial<SchedulerJobDto> = {}): SchedulerJobDto {
+  return {
+    name: "refresh-token-cleanup",
+    description: "Hourly purge of expired refresh tokens.",
+    cronExpression: "0 0 * * * *",
+    supportsDryRun: false,
+    enabled: true,
+    runCountTotal: 0,
+    ...overrides,
+  };
+}
+
+describe("SchedulerSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists registered jobs with status", async () => {
+    vi.mocked(apiConfig.adminSchedulerApi.listSchedulerJobs).mockResolvedValue({
+      data: [
+        jobFixture(),
+        jobFixture({
+          name: "orphan-storage-reaper",
+          description: "Reap orphans.",
+          cronExpression: "0 15 3 * * *",
+          supportsDryRun: true,
+          dryRun: true,
+          runCountTotal: 12,
+          lastRunOutcome: "SUCCESS",
+          lastRunAt: "2026-05-13T01:00:00Z",
+          lastRunDurationMs: 230,
+        }),
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<SchedulerSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("refresh-token-cleanup")).toBeInTheDocument();
+      expect(screen.getByText("orphan-storage-reaper")).toBeInTheDocument();
+      expect(screen.getByText("Reap orphans.")).toBeInTheDocument();
+    });
+  });
+
+  it("toggles enabled via PATCH and refetches", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.adminSchedulerApi.listSchedulerJobs)
+      .mockResolvedValueOnce({ data: [jobFixture({ enabled: true })] } as never)
+      .mockResolvedValueOnce({
+        data: [jobFixture({ enabled: false })],
+      } as never);
+    vi.mocked(apiConfig.adminSchedulerApi.updateSchedulerJob).mockResolvedValue(
+      {
+        data: jobFixture({ enabled: false }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    );
+
+    renderWithTheme(<SchedulerSection />);
+
+    // MUI Switch renders an <input type="checkbox" role="switch"> under the
+    // hood; the aria-label propagates through slotProps.
+    const toggle = await screen.findByRole("switch", {
+      name: /Toggle refresh-token-cleanup enabled/i,
+    });
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminSchedulerApi.updateSchedulerJob,
+      ).toHaveBeenCalledWith({
+        name: "refresh-token-cleanup",
+        schedulerJobUpdateRequest: { enabled: false, dryRun: undefined },
+      });
+    });
+  });
+
+  it("triggers run-now after confirmation", async () => {
+    // MUI's Tooltip wraps the Run-now Button in a span with
+    // pointer-events: none for the disabled-tooltip pattern, which
+    // confuses user-event's pointer simulation. We bypass that check
+    // because we are exercising the click-to-confirm flow, not the
+    // hover semantics.
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    vi.mocked(apiConfig.adminSchedulerApi.listSchedulerJobs).mockResolvedValue({
+      data: [jobFixture({ enabled: true })],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(apiConfig.adminSchedulerApi.runSchedulerJobNow).mockResolvedValue(
+      {
+        data: {
+          name: "refresh-token-cleanup",
+          outcome: "SUCCESS",
+          durationMs: 12,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    );
+
+    renderWithTheme(<SchedulerSection />);
+
+    const runBtn = await screen.findByRole("button", { name: /Run now/i });
+    await user.click(runBtn);
+    const confirmBtn = await screen.findByRole("button", { name: /Run job/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminSchedulerApi.runSchedulerJobNow,
+      ).toHaveBeenCalledWith({ name: "refresh-token-cleanup" });
+    });
+  });
+
+  it("surfaces a fetch error in an alert", async () => {
+    vi.mocked(apiConfig.adminSchedulerApi.listSchedulerJobs).mockRejectedValue(
+      new Error("boom"),
+    );
+
+    renderWithTheme(<SchedulerSection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to load scheduler jobs/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerSection.tsx
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { adminSchedulerApi } from "../../../api/config";
+import { useUiStore } from "../../../stores/uiStore";
+import type { SchedulerJobDto } from "../../../api/generated/model";
+import { SchedulerStatsStrip } from "./SchedulerStatsStrip";
+import { SchedulerJobsTable } from "./SchedulerJobsTable";
+
+const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * Live dashboard for the five (currently) scheduled jobs (#516).
+ *
+ * The page polls every 15 s in the background so the operator's view of
+ * "last run" stays fresh without manual rescans. Toggles and run-now go
+ * through the admin endpoints; on success the job list is refetched
+ * eagerly so the row reflects the new state without waiting for the
+ * next poll tick.
+ */
+export function SchedulerSection() {
+  const [jobs, setJobs] = useState<SchedulerJobDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const addToast = useUiStore((s) => s.addToast);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load(initial: boolean) {
+      if (initial) setLoading(true);
+      try {
+        const res = await adminSchedulerApi.listSchedulerJobs();
+        if (cancelled) return;
+        setJobs(res.data);
+        setError(null);
+      } catch {
+        if (cancelled) return;
+        setError("Failed to load scheduler jobs. See server logs.");
+      } finally {
+        if (initial && !cancelled) setLoading(false);
+      }
+    }
+    load(true);
+    const interval = window.setInterval(() => load(false), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [refreshTick]);
+
+  const refresh = () => setRefreshTick((n) => n + 1);
+
+  async function handleToggleEnabled(job: SchedulerJobDto, next: boolean) {
+    setBusy(true);
+    try {
+      await adminSchedulerApi.updateSchedulerJob({
+        name: job.name,
+        // The generator drops `null` from the TS type even though the OpenAPI
+        // spec marks dryRun as nullable; sending undefined deserialises to
+        // null on the server, which matches the "clear override" semantics.
+        schedulerJobUpdateRequest: {
+          enabled: next,
+          dryRun: job.dryRun ?? undefined,
+        },
+      });
+      addToast({
+        message: `${job.name} ${next ? "enabled" : "disabled"}.`,
+        type: "success",
+      });
+      refresh();
+    } catch {
+      addToast({ message: `Failed to update ${job.name}.`, type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleToggleDryRun(
+    job: SchedulerJobDto,
+    next: boolean | null,
+  ) {
+    setBusy(true);
+    try {
+      await adminSchedulerApi.updateSchedulerJob({
+        name: job.name,
+        schedulerJobUpdateRequest: {
+          enabled: job.enabled,
+          dryRun: next ?? undefined,
+        },
+      });
+      addToast({
+        message:
+          next === null
+            ? `${job.name} dry-run cleared (using yaml default).`
+            : `${job.name} dry-run = ${next}.`,
+        type: "success",
+      });
+      refresh();
+    } catch {
+      addToast({ message: `Failed to update ${job.name}.`, type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRunNow(job: SchedulerJobDto) {
+    setBusy(true);
+    try {
+      const res = await adminSchedulerApi.runSchedulerJobNow({
+        name: job.name,
+      });
+      const outcome = res.data.outcome;
+      addToast({
+        message:
+          `${job.name}: ${outcome}` +
+          (res.data.durationMs != null ? ` (${res.data.durationMs} ms)` : ""),
+        type:
+          outcome === "SUCCESS"
+            ? "success"
+            : outcome === "FAILED"
+              ? "error"
+              : "info",
+      });
+      refresh();
+    } catch {
+      addToast({ message: `Failed to run ${job.name}.`, type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const stats = useMemo(() => {
+    const enabled = jobs.filter((j) => j.enabled).length;
+    const disabled = jobs.length - enabled;
+    const failed = jobs.filter((j) => j.lastRunOutcome === "FAILED").length;
+    const totalRuns = jobs.reduce((sum, j) => sum + j.runCountTotal, 0);
+    return { total: jobs.length, enabled, disabled, failed, totalRuns };
+  }, [jobs]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Scheduler
+          </Typography>
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            Operator dashboard for scheduled jobs. Cron patterns and tuning
+            constants stay in <code>application.yml</code>; this page controls
+            the runtime toggles and surfaces last-run state. Auto-refreshes
+            every 15 s.
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<RefreshCw size={14} />}
+          onClick={refresh}
+          disabled={loading || busy}
+        >
+          Rescan
+        </Button>
+      </Box>
+
+      {error && (
+        <Alert severity="warning" icon={<AlertTriangle size={18} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading && jobs.length === 0 ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : (
+        <>
+          <SchedulerStatsStrip stats={stats} />
+          <SchedulerJobsTable
+            jobs={jobs}
+            busy={busy}
+            onToggleEnabled={handleToggleEnabled}
+            onToggleDryRun={handleToggleDryRun}
+            onRunNow={handleRunNow}
+          />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerStatsStrip.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerStatsStrip.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Box, Typography } from "@mui/material";
+import { tokens } from "../../../theme/tokens";
+
+interface Stats {
+  readonly total: number;
+  readonly enabled: number;
+  readonly disabled: number;
+  readonly failed: number;
+  readonly totalRuns: number;
+}
+
+/**
+ * Four-card overview strip above the scheduler jobs table.
+ *
+ * - Active jobs uses the primary accent so the operator immediately sees
+ *   "how many of my workers are actually doing anything"
+ * - Failed-last-run uses the yanked badge palette when > 0 — a single
+ *   failed job is the only thing on this page the operator typically
+ *   wants to act on; everything else is steady-state.
+ * - Total runs is a cumulative counter; long-term history lives in
+ *   Prometheus, this is just a sanity number for the dashboard.
+ */
+export function SchedulerStatsStrip({ stats }: { readonly stats: Stats }) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr 1fr", sm: "repeat(4, 1fr)" },
+        gap: 1.5,
+      }}
+    >
+      <Stat
+        label="Active jobs"
+        value={`${stats.enabled} / ${stats.total}`}
+        accent="primary"
+      />
+      <Stat label="Disabled" value={stats.disabled.toLocaleString()} />
+      <Stat
+        label="Failed last run"
+        value={stats.failed.toLocaleString()}
+        accent={stats.failed > 0 ? "danger" : undefined}
+      />
+      <Stat label="Total runs" value={stats.totalRuns.toLocaleString()} />
+    </Box>
+  );
+}
+
+type Accent = "primary" | "danger";
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly accent?: Accent;
+}) {
+  const palette =
+    accent === "primary"
+      ? {
+          border: tokens.color.primary,
+          bg: tokens.color.primaryLight,
+          label: tokens.color.primaryDark,
+          value: tokens.color.primaryDark,
+        }
+      : accent === "danger"
+        ? {
+            border: tokens.badge.yanked.text,
+            bg: tokens.badge.yanked.bg,
+            label: tokens.badge.yanked.text,
+            value: tokens.badge.yanked.text,
+          }
+        : null;
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: palette?.border ?? "divider",
+        borderRadius: tokens.radius.card,
+        px: 2,
+        py: 1.25,
+        bgcolor: palette?.bg ?? "background.paper",
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          color: palette?.label ?? "text.disabled",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          fontWeight: 600,
+          fontSize: "0.7rem",
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 700,
+          mt: 0.25,
+          fontFeatureSettings: '"tnum"',
+          color: palette?.value ?? "text.primary",
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -83,6 +83,11 @@ const StorageConsistencySection = lazy(() =>
     default: m.StorageConsistencySection,
   })),
 );
+const SchedulerSection = lazy(() =>
+  import("../pages/admin/scheduler/SchedulerSection").then((m) => ({
+    default: m.SchedulerSection,
+  })),
+);
 const EmailServerPage = lazy(() =>
   import("../pages/admin/EmailServerPage").then((m) => ({
     default: m.EmailServerPage,
@@ -240,6 +245,14 @@ export const router = createBrowserRouter([
             element: (
               <Suspense fallback={<LazyFallback />}>
                 <StorageConsistencySection />
+              </Suspense>
+            ),
+          },
+          {
+            path: "scheduler",
+            element: (
+              <Suspense fallback={<LazyFallback />}>
+                <SchedulerSection />
               </Suspense>
             ),
           },


### PR DESCRIPTION
## Summary

Implements the hybrid scheduler control plane spec'd in #516. The
admin dashboard adds visibility (last run, outcome, counters) and a
small set of mutating toggles (enabled, dry-run for jobs that
support it, run-now) without moving cron patterns or tuning
constants out of \`application.yml\`.

ADR-0036 documents the design and the alternatives we rejected
(full DB-config migration, separate \`-manual\` lock-name suffix,
LISTEN/NOTIFY for instant toggle propagation).

## Five jobs in scope

All existing @Scheduled services now register with the new
SchedulerJobRegistry and route their body through
\`schedulerJobAuditor.gateAndRun(...)\`:

- \`refresh-token-cleanup\`
- \`token-revocation-cleanup\`
- \`password-reset-token-sweep\`
- \`email-verification-token-sweep\`
- \`orphan-storage-reaper\` (also wires the dry-run override)

## What the dashboard does

- Live status (auto-refresh every 15 s)
- Stats strip: active jobs, disabled, failed-last-run, total runs
- Per-job row: monospace name + description, read-only cron chip,
  enabled switch, three-state dry-run cycle (\`null → true → false → null\`),
  last-run badge coloured by outcome, total runs, run-now button
  with confirm dialog

## Operational guarantees

- Toggle changes evict the local cache instantly; peer instances
  see them within at most 30 s (Caffeine \`expireAfterWrite\`)
- Audit writes use \`REQUIRES_NEW\` so an audit blip cannot break
  the scheduler thread, and a job rollback cannot undo the
  \"this just failed\" record
- Run-now reuses the same \`@SchedulerLock\` as the cron tick — a
  concurrent regular run wins the lock, the manual call returns
  \`SKIPPED_LOCK\`
- Run-now respects the enabled toggle (returns \`SKIPPED_DISABLED\`
  for a disabled job; the button is greyed out in the UI)

## Test plan

- [x] BE unit tests: gate, audit, registry, controller (5 new)
- [x] BE authorization-matrix IT (anon → 401, every non-superadmin
      actor → 403)
- [x] Existing scheduler-service tests updated for the auditor
      pass-through pattern
- [x] Vitest 435 tests, 4 new for the dashboard
- [x] Full \`./gradlew test\` + \`integrationTest\` green
- [x] Frontend \`npm run build\` green
- [ ] Manual smoke against a running stack — deferred to reviewer

## Out of scope

- Editing cron patterns in the UI
- Editing \`lockAtMostFor\` / grace period / max-deletes-per-tick
- Run history beyond the last invocation (long-term lives in
  Prometheus / log aggregation)

Closes #516