### PR TITLE
feat(admin): read-only display of plugwerk.* effective configuration (#522)

### DIFF
--- a/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
+++ b/plugwerk-api/src/main/resources/openapi/plugwerk-api.yaml
@@ -2383,6 +2383,40 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/configuration:
+    get:
+      tags:
+        - AdminConfiguration
+      summary: Effective plugwerk.* configuration tree (#522)
+      description: |
+        Read-only snapshot of the bound `PlugwerkProperties` bean for the
+        admin dashboard. The tree mirrors the yaml hierarchy. Sensitive
+        fields (jwt-secret, S3 access/secret key, scrape-password, …) are
+        replaced by an object `{ "_secret": true, "configured": <bool> }`
+        — the plaintext is never sent over the wire. Requires superadmin.
+
+        Values cannot be edited via this endpoint; operators must change
+        `application.yml` / `PLUGWERK_*` env vars and restart.
+      operationId: getEffectiveConfiguration
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Effective plugwerk.* configuration tree.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: |
+                  Nested object that mirrors the `plugwerk.*` yaml
+                  hierarchy. Leaf values are primitives or the redacted
+                  marker for sensitive fields.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /admin/scheduler/jobs:
     get:
       tags:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminConfigurationController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/AdminConfigurationController.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.api.AdminConfigurationApi
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.currentAuthentication
+import io.plugwerk.server.service.configuration.ConfigurationTreeBuilder
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Read-only admin endpoint that surfaces the effective `plugwerk.*`
+ * configuration tree for the dashboard (#522). Superadmin-only with
+ * the usual `@PreAuthorize` + inline `requireSuperadmin`
+ * defense-in-depth pair.
+ *
+ * The endpoint is purely informational — operators change values in
+ * `application.yml` / env-vars and restart the server.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AdminConfigurationController(
+    private val treeBuilder: ConfigurationTreeBuilder,
+    private val objectMapper: ObjectMapper,
+    private val namespaceAuthorizationService: NamespaceAuthorizationService,
+) : AdminConfigurationApi {
+
+    @PreAuthorize("@namespaceAuthorizationService.isCurrentUserSuperadmin()")
+    override fun getEffectiveConfiguration(): ResponseEntity<Map<String, Any>> {
+        namespaceAuthorizationService.requireSuperadmin(currentAuthentication())
+        val tree = treeBuilder.build()
+
+        // Convert the redacted ObjectNode into the contract type
+        // (`Map<String, Any>`) so the generated DTO and the response
+        // match without an extra type-cast on the wire.
+        @Suppress("UNCHECKED_CAST")
+        val asMap = objectMapper.treeToValue(tree, Map::class.java) as Map<String, Any>
+        return ResponseEntity.ok(asMap)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactor.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactor.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.configuration
+
+/**
+ * Decides whether a config property name carries a sensitive value that
+ * must NOT leak into the read-only admin configuration view (#522).
+ *
+ * The strategy is **by construction**: any property whose terminal name
+ * token ends in one of the configured suffixes is treated as a secret,
+ * regardless of how new the field is. Adding a new sensitive field to
+ * `PlugwerkProperties` does not require remembering to extend a list —
+ * as long as the name follows the project's existing convention
+ * (`jwt-secret`, `access-key`, `secret-key`, `scrape-password`, …), the
+ * redactor catches it automatically.
+ *
+ * The terminal-token rule prevents false positives like `keyPrefix`,
+ * `keyLookupHash`, or `passwordChangeRequired`, where the segment that
+ * looks sensitive sits inside a longer compound word. Only the final
+ * dash- or camelCase-separated word participates in the suffix match.
+ */
+object ConfigurationKeyRedactor {
+
+    /**
+     * Suffix tokens that mark a property as secret. Matched against the
+     * last word of the kebab-case or camelCase name, case-insensitively.
+     */
+    private val SENSITIVE_SUFFIXES = setOf("secret", "password", "key", "token")
+
+    /**
+     * Explicit allow-list — names that look sensitive by the suffix rule
+     * but are operational metadata, not credentials. Keeps the rule
+     * mechanical while documenting the deliberate exemptions.
+     */
+    private val ALLOW_LIST = setOf(
+        // Public key-prefix the operator picks for namespace access keys.
+        // Stored as plaintext so the UI can show the leading characters
+        // of a key without exposing the bearer half.
+        "key-prefix",
+        "keyprefix",
+    )
+
+    fun isSensitive(propertyName: String): Boolean {
+        val normalised = propertyName.lowercase()
+        if (normalised in ALLOW_LIST) return false
+        val lastWord = lastWord(normalised)
+        return lastWord in SENSITIVE_SUFFIXES
+    }
+
+    /**
+     * Extracts the final word of a kebab-case or camelCase identifier.
+     * `accessKey` → `key`, `jwt-secret` → `secret`, `scrapePassword` →
+     * `password`, `keyPrefix` → `prefix`.
+     */
+    private fun lastWord(normalised: String): String {
+        // kebab-case takes precedence: split on dash, take last segment
+        if ('-' in normalised) {
+            return normalised.substringAfterLast('-')
+        }
+        // camelCase fallback: split on the last capital boundary. Because
+        // we lowercased the input already, we cannot use the case directly
+        // — instead split on the original casing's word boundaries before
+        // lowercasing. The caller passes lowercase; we keep both lowercase
+        // and camelCase tokens by relying on the structural distinction
+        // that camelCase names never contain dashes.
+        return normalised
+    }
+
+    /**
+     * camelCase-aware overload: takes the raw (un-lowercased) identifier
+     * and splits on the uppercase-letter boundary. Used by the tree
+     * builder which has access to the raw JSON node names.
+     */
+    fun isSensitiveCamel(rawName: String): Boolean {
+        if (rawName.lowercase() in ALLOW_LIST) return false
+        // Pick the last camelCase segment. `accessKey` → `Key`, `jwtSecret` → `Secret`.
+        val lastSegment = rawName.split(Regex("(?=[A-Z])")).lastOrNull()?.lowercase()
+            ?: return false
+        if (lastSegment in SENSITIVE_SUFFIXES) return true
+        // Fall back to the kebab-case rule for properties whose JSON name
+        // happens to be lowercase-only (rare; defensive).
+        return isSensitive(rawName)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.configuration
+
+import io.plugwerk.server.PlugwerkProperties
+import org.springframework.stereotype.Service
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.ObjectNode
+
+/**
+ * Builds a read-only JSON tree of the effective `plugwerk.*` configuration
+ * for the admin UI (#522).
+ *
+ * The body of the tree is whatever Jackson produces for
+ * [PlugwerkProperties] — the same bean Spring Boot has bound at startup.
+ * A recursive walker then replaces any leaf whose property name is
+ * classified sensitive by [ConfigurationKeyRedactor] with the redacted
+ * marker `{ "_secret": true, "configured": <bool> }` so the dashboard
+ * can render a "configured / not configured" chip without ever seeing
+ * the value.
+ */
+@Service
+class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private val properties: PlugwerkProperties) {
+    /**
+     * Returns the redacted tree, ready to serialise as the admin
+     * endpoint's response.
+     */
+    fun build(): ObjectNode {
+        val raw = objectMapper.valueToTree<JsonNode>(properties)
+        require(raw is ObjectNode) {
+            "PlugwerkProperties must serialise to an object, got ${raw.nodeType}"
+        }
+        return redact(raw) as ObjectNode
+    }
+
+    private fun redact(node: JsonNode): JsonNode = when (node) {
+        is ObjectNode -> {
+            val replacement = objectMapper.createObjectNode()
+            node.propertyNames().forEach { fieldName ->
+                val value = node.get(fieldName)
+                replacement.set(
+                    fieldName,
+                    if (ConfigurationKeyRedactor.isSensitiveCamel(fieldName)) {
+                        redactedLeaf(value)
+                    } else {
+                        redact(value)
+                    },
+                )
+            }
+            replacement
+        }
+
+        is ArrayNode -> {
+            val replacement = objectMapper.createArrayNode()
+            for (i in 0 until node.size()) {
+                replacement.add(redact(node.get(i)))
+            }
+            replacement
+        }
+
+        else -> node
+    }
+
+    /**
+     * Replaces a sensitive leaf with the redacted marker. "Configured"
+     * means the value is present and non-empty; null and the empty
+     * string both count as "not configured" so an operator can tell at
+     * a glance whether the deployment ever set the credential.
+     */
+    private fun redactedLeaf(value: JsonNode?): ObjectNode {
+        val configured = value != null &&
+            !value.isNull &&
+            !(value.isTextual && value.textValue().isBlank())
+        val node = objectMapper.createObjectNode()
+        node.put("_secret", true)
+        node.put("configured", configured)
+        return node
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
@@ -39,9 +39,13 @@ import tools.jackson.databind.node.ObjectNode
  */
 @Service
 class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private val properties: PlugwerkProperties) {
+
     /**
      * Returns the redacted tree, ready to serialise as the admin
-     * endpoint's response.
+     * endpoint's response. Field names are converted to kebab-case
+     * during the walk so the rendered paths match the yaml the
+     * operator actually edits (`path-style-access` instead of
+     * `pathStyleAccess`).
      */
     fun build(): ObjectNode {
         val raw = objectMapper.valueToTree<JsonNode>(properties)
@@ -56,8 +60,14 @@ class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private v
             val replacement = objectMapper.createObjectNode()
             node.propertyNames().forEach { fieldName ->
                 val value = node.get(fieldName)
+                // Convert camelCase property names to kebab-case so the
+                // rendered path matches the yaml the operator edits.
+                // Redaction is decided against the original (camelCase)
+                // name because the suffix rule has both shapes covered
+                // anyway and the original keeps the intent obvious.
+                val renderedName = toKebabCase(fieldName)
                 replacement.set(
-                    fieldName,
+                    renderedName,
                     if (ConfigurationKeyRedactor.isSensitiveCamel(fieldName)) {
                         redactedLeaf(value)
                     } else {
@@ -78,6 +88,15 @@ class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private v
 
         else -> node
     }
+
+    /**
+     * Converts a camelCase identifier to kebab-case
+     * (`pathStyleAccess` → `path-style-access`). Identifiers that are
+     * already kebab-case or single-word are returned unchanged.
+     */
+    private fun toKebabCase(camel: String): String = camel
+        .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
+        .lowercase()
 
     /**
      * Replaces a sensitive leaf with the redacted marker. "Configured"

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
@@ -19,11 +19,16 @@
 package io.plugwerk.server.service.configuration
 
 import io.plugwerk.server.PlugwerkProperties
+import jakarta.validation.constraints.AssertTrue
 import org.springframework.stereotype.Service
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.node.ArrayNode
 import tools.jackson.databind.node.ObjectNode
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.findAnnotation
 
 /**
  * Builds a read-only JSON tree of the effective `plugwerk.*` configuration
@@ -39,6 +44,17 @@ import tools.jackson.databind.node.ObjectNode
  */
 @Service
 class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private val properties: PlugwerkProperties) {
+
+    /**
+     * JSON field names produced by Jackson for Bean-Validation methods
+     * (`@AssertTrue fun isFoo(): Boolean` → JSON field `foo`). These
+     * are validation checks, not configurable properties, so they must
+     * not surface in the admin UI tree. Computed once at bean
+     * construction by walking `PlugwerkProperties` and every nested
+     * `@ConfigurationProperties`-style data class via Kotlin reflection.
+     */
+    private val hiddenFieldNames: Set<String> =
+        collectAssertTrueFieldNames(PlugwerkProperties::class)
 
     /**
      * Returns the redacted tree, ready to serialise as the admin
@@ -59,6 +75,12 @@ class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private v
         is ObjectNode -> {
             val replacement = objectMapper.createObjectNode()
             node.propertyNames().forEach { fieldName ->
+                // Skip @AssertTrue validation methods serialised as
+                // is*() getters — they are checks, not configuration,
+                // and would otherwise pollute the admin UI with
+                // pseudo-properties like
+                // `is-s3-config-present-when-s3-selected`.
+                if (fieldName in hiddenFieldNames) return@forEach
                 val value = node.get(fieldName)
                 // Convert camelCase property names to kebab-case so the
                 // rendered path matches the yaml the operator edits.
@@ -97,6 +119,41 @@ class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private v
     private fun toKebabCase(camel: String): String = camel
         .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
         .lowercase()
+
+    /**
+     * Walks the `@ConfigurationProperties` class graph starting at
+     * [root] and collects the JSON field names that correspond to
+     * `@AssertTrue` Bean-Validation methods. The Jackson convention
+     * for `isFoo()` → JSON `foo`; we honour that so a Set lookup on
+     * the raw field name works in [redact].
+     *
+     * Only types in the `io.plugwerk.` package family are recursed
+     * into so we don't drift into JDK / library types like `Duration`.
+     */
+    private fun collectAssertTrueFieldNames(root: KClass<*>): Set<String> {
+        val seen = mutableSetOf<KClass<*>>()
+        val hidden = mutableSetOf<String>()
+        fun visit(klass: KClass<*>) {
+            if (!seen.add(klass)) return
+            for (fn in klass.declaredMemberFunctions) {
+                if (fn.findAnnotation<AssertTrue>() == null) continue
+                val name = fn.name
+                // Jackson strips a leading `is` and lowercases the
+                // first remaining char: `isFooBar` → `fooBar`.
+                if (name.length > 2 && name.startsWith("is") && name[2].isUpperCase()) {
+                    hidden += name[2].lowercaseChar() + name.substring(3)
+                }
+            }
+            for (prop in klass.declaredMemberProperties) {
+                val type = prop.returnType.classifier as? KClass<*> ?: continue
+                if (type.qualifiedName?.startsWith("io.plugwerk.") == true) {
+                    visit(type)
+                }
+            }
+        }
+        visit(root)
+        return hidden
+    }
 
     /**
      * Replaces a sensitive leaf with the redacted marker. "Configured"

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilder.kt
@@ -138,8 +138,12 @@ class ConfigurationTreeBuilder(private val objectMapper: ObjectMapper, private v
             for (fn in klass.declaredMemberFunctions) {
                 if (fn.findAnnotation<AssertTrue>() == null) continue
                 val name = fn.name
-                // Jackson strips a leading `is` and lowercases the
-                // first remaining char: `isFooBar` → `fooBar`.
+                // Add both the with-`is`-prefix form (Jackson's
+                // Kotlin-module default for `isFooBar()` keeps the
+                // method name verbatim) and the bean-convention
+                // stripped form (`fooBar`). Whichever shape Jackson
+                // emits at runtime is then in the hidden set.
+                hidden += name
                 if (name.length > 2 && name.startsWith("is") && name[2].isUpperCase()) {
                     hidden += name[2].lowercaseChar() + name.substring(3)
                 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminConfigurationControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminConfigurationControllerTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.LoginRateLimitFilter
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.NamespaceAuthorizationService
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
+import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.security.RefreshRateLimitFilter
+import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.ForbiddenException
+import io.plugwerk.server.service.configuration.ConfigurationTreeBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import tools.jackson.databind.ObjectMapper
+
+@WebMvcTest(
+    AdminConfigurationController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class AdminConfigurationControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean private lateinit var treeBuilder: ConfigurationTreeBuilder
+
+    @MockitoBean private lateinit var namespaceAuthorizationService: NamespaceAuthorizationService
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("admin", null, emptyList())
+        whenever(namespaceAuthorizationService.isCurrentUserSuperadmin()).thenReturn(true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `GET configuration returns the redacted tree for superadmin`() {
+        val tree = objectMapper.createObjectNode().apply {
+            putObject("storage").put("type", "fs")
+            putObject("auth").set(
+                "jwtSecret",
+                objectMapper.createObjectNode().put("_secret", true).put("configured", true),
+            )
+        }
+        whenever(treeBuilder.build()).thenReturn(tree)
+
+        mockMvc.get("/api/v1/admin/configuration")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.storage.type") { value("fs") }
+                jsonPath("$.auth.jwtSecret._secret") { value(true) }
+                jsonPath("$.auth.jwtSecret.configured") { value(true) }
+            }
+    }
+
+    @Test
+    fun `GET configuration without superadmin returns 403`() {
+        doThrow(ForbiddenException("Superadmin privileges required"))
+            .whenever(namespaceAuthorizationService).requireSuperadmin(any())
+
+        mockMvc.get("/api/v1/admin/configuration")
+            .andExpect { status { isForbidden() } }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminConfigurationControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/AdminConfigurationControllerTest.kt
@@ -92,7 +92,7 @@ class AdminConfigurationControllerTest {
         val tree = objectMapper.createObjectNode().apply {
             putObject("storage").put("type", "fs")
             putObject("auth").set(
-                "jwtSecret",
+                "jwt-secret",
                 objectMapper.createObjectNode().put("_secret", true).put("configured", true),
             )
         }
@@ -102,8 +102,8 @@ class AdminConfigurationControllerTest {
             .andExpect {
                 status { isOk() }
                 jsonPath("$.storage.type") { value("fs") }
-                jsonPath("$.auth.jwtSecret._secret") { value(true) }
-                jsonPath("$.auth.jwtSecret.configured") { value(true) }
+                jsonPath("$.auth['jwt-secret']._secret") { value(true) }
+                jsonPath("$.auth['jwt-secret'].configured") { value(true) }
             }
     }
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminConfigurationEndpointAuthzTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/AdminConfigurationEndpointAuthzTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
+
+/**
+ * Authorization matrix for the read-only configuration endpoint (#522).
+ * Superadmin-only — the response carries operational metadata (storage
+ * paths, OIDC settings, …) that namespace admins have no business
+ * with, even though no secrets are leaked.
+ */
+class AdminConfigurationEndpointAuthzTest : AbstractAuthorizationTest() {
+
+    @ParameterizedTest(name = "GET /admin/configuration {0}")
+    @MethodSource("superadminOnlyDeniedMatrix")
+    fun `configuration denied for non-superadmins`(case: ActorExpectation) {
+        mockMvc.perform(get("/api/v1/admin/configuration").actAs(case.actor))
+            .andExpect(status().`is`(case.expectedStatus))
+    }
+
+    @Test
+    fun `superadmin can read configuration`() {
+        mockMvc.perform(get("/api/v1/admin/configuration").actAs(Actor.SUPERADMIN))
+            .andExpect(status().isOk)
+    }
+
+    companion object {
+        @JvmStatic
+        fun superadminOnlyDeniedMatrix(): Stream<ActorExpectation> = Stream.of(
+            ActorExpectation(Actor.ANONYMOUS, 401),
+            ActorExpectation(Actor.NS1_ADMIN, 403),
+            ActorExpectation(Actor.NS1_READ_ONLY, 403),
+            ActorExpectation(Actor.NS2_ADMIN, 403),
+            ActorExpectation(Actor.UNRELATED, 403),
+            ActorExpectation(Actor.API_KEY_NS1, 403),
+        )
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactorTest.kt
@@ -99,11 +99,13 @@ class ConfigurationKeyRedactorTest {
             results += prop.name
             val returnType = prop.returnType.classifier as? kotlin.reflect.KClass<*> ?: continue
             // Recurse into nested data classes inside the same package family.
-            if (returnType.qualifiedName?.startsWith("io.plugwerk.server.PlugwerkProperties") == true ||
+            val isPlugwerkPropertiesInner =
+                returnType.qualifiedName?.startsWith("io.plugwerk.server.PlugwerkProperties") == true
+            val isPlugwerkDataClass =
                 returnType.isSubclassOf(Any::class) &&
-                returnType.qualifiedName?.startsWith("io.plugwerk.") == true &&
-                returnType.isData
-            ) {
+                    returnType.qualifiedName?.startsWith("io.plugwerk.") == true &&
+                    returnType.isData
+            if (isPlugwerkPropertiesInner || isPlugwerkDataClass) {
                 results += collectPropertyNames(returnType, seen)
             }
         }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationKeyRedactorTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.configuration
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.isSubclassOf
+
+class ConfigurationKeyRedactorTest {
+
+    @Test
+    fun `flags the four canonical credential-suffix shapes`() {
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("jwtSecret")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("accessKey")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("secretKey")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("scrapePassword")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("authToken")).isTrue
+    }
+
+    @Test
+    fun `does not flag compound names whose sensitive-looking segment is not the last word`() {
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("keyPrefix")).isFalse
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("keyLookupHash")).isFalse
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("passwordChangeRequired")).isFalse
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("tokenValidityMinutes")).isFalse
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("secretManagerEnabled")).isFalse
+    }
+
+    @Test
+    fun `kebab-case input also routes through the suffix rule`() {
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("jwt-secret")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("access-key")).isTrue
+        assertThat(ConfigurationKeyRedactor.isSensitiveCamel("key-prefix")).isFalse
+    }
+
+    /**
+     * The whole point of the redactor (#522) is that adding a new
+     * sensitive field to `PlugwerkProperties` does not require remembering
+     * to extend an allow-list. This test walks the declared properties of
+     * `PlugwerkProperties` and every nested @ConfigurationProperties data
+     * class and asserts that every field name ending in one of the four
+     * suffix tokens is recognised as sensitive. If someone adds a new
+     * credential without the conventional naming, this test stays green
+     * but the redactor will leak the value — so the convention itself is
+     * also documented in [ConfigurationKeyRedactor].
+     */
+    @Test
+    fun `every PlugwerkProperties field whose last word matches a sensitive suffix is redacted`() {
+        val suffixes = listOf("Secret", "Password", "Key", "Token")
+        val offenders = collectPropertyNames(PlugwerkProperties::class)
+            .filter { name ->
+                // Last camelCase word is one of the sensitive suffixes …
+                val lastWord = name.split(Regex("(?=[A-Z])")).last()
+                lastWord in suffixes
+            }
+            .filter { name ->
+                // … but the redactor does NOT classify it as sensitive.
+                !ConfigurationKeyRedactor.isSensitiveCamel(name)
+            }
+            // The compound names we explicitly allow-listed are expected
+            // here (e.g. `keyPrefix`); they must be the only survivors.
+            .filter { it.lowercase() !in setOf("keyprefix") }
+
+        assertThat(offenders)
+            .withFailMessage(
+                "These PlugwerkProperties fields look sensitive by name but " +
+                    "ConfigurationKeyRedactor does not redact them — either " +
+                    "extend the redactor or rename the field: %s",
+                offenders,
+            )
+            .isEmpty()
+    }
+
+    private fun collectPropertyNames(
+        klass: kotlin.reflect.KClass<*>,
+        seen: MutableSet<kotlin.reflect.KClass<*>> = mutableSetOf(),
+    ): List<String> {
+        if (!seen.add(klass)) return emptyList()
+        val results = mutableListOf<String>()
+        for (prop in klass.declaredMemberProperties) {
+            results += prop.name
+            val returnType = prop.returnType.classifier as? kotlin.reflect.KClass<*> ?: continue
+            // Recurse into nested data classes inside the same package family.
+            if (returnType.qualifiedName?.startsWith("io.plugwerk.server.PlugwerkProperties") == true ||
+                returnType.isSubclassOf(Any::class) &&
+                returnType.qualifiedName?.startsWith("io.plugwerk.") == true &&
+                returnType.isData
+            ) {
+                results += collectPropertyNames(returnType, seen)
+            }
+        }
+        return results
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
@@ -72,9 +72,15 @@ class ConfigurationTreeBuilderTest {
         // S3Properties would otherwise surface as pseudo-properties
         // because Jackson treats `isFooBar()` as a bean getter.
         val asString = tree.toString()
+        // The Kotlin Jackson module keeps `isFooBar` as a method name —
+        // hide both shapes so neither leaks.
+        assertThat(asString).doesNotContain("isS3ConfigPresentWhenS3Selected")
+        assertThat(asString).doesNotContain("is-s3-config-present-when-s3-selected")
         assertThat(asString).doesNotContain("s3-config-present-when-s3-selected")
         assertThat(asString).doesNotContain("s3ConfigPresentWhenS3Selected")
+        assertThat(asString).doesNotContain("isCredentialsConsistent")
         assertThat(asString).doesNotContain("credentials-consistent")
+        assertThat(asString).doesNotContain("isKeyPrefixWellFormed")
         assertThat(asString).doesNotContain("key-prefix-well-formed")
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.configuration
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+
+class ConfigurationTreeBuilderTest {
+
+    private val mapper = JsonMapper.builder().build()
+
+    @Test
+    fun `redacts jwt secret as a configured-flag marker`() {
+        val props = PlugwerkProperties(
+            auth = PlugwerkProperties.AuthProperties(jwtSecret = "do-not-leak"),
+        )
+        val tree = ConfigurationTreeBuilder(mapper, props).build()
+
+        val jwtSecret = tree.get("auth")?.get("jwtSecret")
+        assertThat(jwtSecret).isNotNull
+        assertThat(jwtSecret!!.get("_secret").booleanValue()).isTrue
+        assertThat(jwtSecret.get("configured").booleanValue()).isTrue
+        // The plaintext must not appear anywhere in the rendered tree.
+        assertThat(tree.toString()).doesNotContain("do-not-leak")
+    }
+
+    @Test
+    fun `marks an empty secret as not configured`() {
+        val props = PlugwerkProperties(
+            auth = PlugwerkProperties.AuthProperties(jwtSecret = ""),
+        )
+        val tree = ConfigurationTreeBuilder(mapper, props).build()
+
+        val jwtSecret = tree.get("auth")?.get("jwtSecret")
+        assertThat(jwtSecret?.get("configured")?.booleanValue()).isFalse
+    }
+
+    @Test
+    fun `non-secret leafs pass through untouched`() {
+        val props = PlugwerkProperties(
+            storage = PlugwerkProperties.StorageProperties(type = "fs"),
+        )
+        val tree = ConfigurationTreeBuilder(mapper, props).build()
+
+        assertThat(tree.get("storage")?.get("type")?.textValue()).isEqualTo("fs")
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
@@ -62,4 +62,19 @@ class ConfigurationTreeBuilderTest {
 
         assertThat(tree.get("storage")?.get("type")?.textValue()).isEqualTo("fs")
     }
+
+    @Test
+    fun `bean-validation methods are hidden from the rendered tree`() {
+        val props = PlugwerkProperties()
+        val tree = ConfigurationTreeBuilder(mapper, props).build()
+
+        // @AssertTrue methods on PlugwerkProperties.StorageProperties /
+        // S3Properties would otherwise surface as pseudo-properties
+        // because Jackson treats `isFooBar()` as a bean getter.
+        val asString = tree.toString()
+        assertThat(asString).doesNotContain("s3-config-present-when-s3-selected")
+        assertThat(asString).doesNotContain("s3ConfigPresentWhenS3Selected")
+        assertThat(asString).doesNotContain("credentials-consistent")
+        assertThat(asString).doesNotContain("key-prefix-well-formed")
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/configuration/ConfigurationTreeBuilderTest.kt
@@ -34,7 +34,7 @@ class ConfigurationTreeBuilderTest {
         )
         val tree = ConfigurationTreeBuilder(mapper, props).build()
 
-        val jwtSecret = tree.get("auth")?.get("jwtSecret")
+        val jwtSecret = tree.get("auth")?.get("jwt-secret")
         assertThat(jwtSecret).isNotNull
         assertThat(jwtSecret!!.get("_secret").booleanValue()).isTrue
         assertThat(jwtSecret.get("configured").booleanValue()).isTrue
@@ -49,7 +49,7 @@ class ConfigurationTreeBuilderTest {
         )
         val tree = ConfigurationTreeBuilder(mapper, props).build()
 
-        val jwtSecret = tree.get("auth")?.get("jwtSecret")
+        val jwtSecret = tree.get("auth")?.get("jwt-secret")
         assertThat(jwtSecret?.get("configured")?.booleanValue()).isFalse
     }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.ts
@@ -21,6 +21,7 @@ import { Configuration } from "./generated/configuration";
 import { AccessKeysApi } from "./generated/api/access-keys-api";
 import { AdminEmailApi } from "./generated/api/admin-email-api";
 import { AdminEmailTemplatesApi } from "./generated/api/admin-email-templates-api";
+import { AdminConfigurationApi } from "./generated/api/admin-configuration-api";
 import { AdminSchedulerApi } from "./generated/api/admin-scheduler-api";
 import { AdminSettingsApi } from "./generated/api/admin-settings-api";
 import { AdminStorageConsistencyApi } from "./generated/api/admin-storage-consistency-api";
@@ -173,6 +174,11 @@ export const adminStorageConsistencyApi = new AdminStorageConsistencyApi(
   axiosInstance,
 );
 export const adminSchedulerApi = new AdminSchedulerApi(
+  apiConfig,
+  BASE_PATH,
+  axiosInstance,
+);
+export const adminConfigurationApi = new AdminConfigurationApi(
   apiConfig,
   BASE_PATH,
   axiosInstance,

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -58,6 +58,12 @@ const ADMIN_SECTIONS: AdminSection[] = [
     icon: <Settings size={16} />,
     requiresSuperadmin: true,
   },
+  {
+    path: "configuration",
+    label: "Configuration",
+    icon: <SlidersHorizontal size={16} />,
+    requiresSuperadmin: true,
+  },
   { path: "namespaces", label: "Namespaces", icon: <Globe size={16} /> },
   {
     path: "users",
@@ -88,12 +94,6 @@ const ADMIN_SECTIONS: AdminSection[] = [
     path: "scheduler",
     label: "Scheduler",
     icon: <Clock size={16} />,
-    requiresSuperadmin: true,
-  },
-  {
-    path: "configuration",
-    label: "Configuration",
-    icon: <SlidersHorizontal size={16} />,
     requiresSuperadmin: true,
   },
 ];

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/AdminSidebar.tsx
@@ -26,6 +26,7 @@ import {
   Mail,
   HardDrive,
   Clock,
+  SlidersHorizontal,
 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { tokens } from "../../theme/tokens";
@@ -87,6 +88,12 @@ const ADMIN_SECTIONS: AdminSection[] = [
     path: "scheduler",
     label: "Scheduler",
     icon: <Clock size={16} />,
+    requiresSuperadmin: true,
+  },
+  {
+    path: "configuration",
+    label: "Configuration",
+    icon: <SlidersHorizontal size={16} />,
     requiresSuperadmin: true,
   },
 ];

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.test.tsx
@@ -41,8 +41,8 @@ describe("ConfigurationSection", () => {
       data: {
         storage: { type: "fs" },
         auth: {
-          jwtSecret: { _secret: true, configured: true },
-          accessTokenValidityMinutes: 480,
+          "jwt-secret": { _secret: true, configured: true },
+          "access-token-validity-minutes": 480,
         },
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,8 +67,11 @@ describe("ConfigurationSection", () => {
       apiConfig.adminConfigurationApi.getEffectiveConfiguration,
     ).mockResolvedValue({
       data: {
-        storage: { type: "fs", consistency: { maxKeysPerScan: 100000 } },
-        auth: { accessTokenValidityMinutes: 480 },
+        storage: {
+          type: "fs",
+          consistency: { "max-keys-per-scan": 100000 },
+        },
+        auth: { "access-token-validity-minutes": 480 },
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
@@ -82,7 +85,7 @@ describe("ConfigurationSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("plugwerk.auth.accessTokenValidityMinutes"),
+        screen.getByText("plugwerk.auth.access-token-validity-minutes"),
       ).toBeInTheDocument();
       expect(
         screen.queryByText("plugwerk.storage.type"),
@@ -95,7 +98,7 @@ describe("ConfigurationSection", () => {
       apiConfig.adminConfigurationApi.getEffectiveConfiguration,
     ).mockResolvedValue({
       data: {
-        auth: { jwtSecret: { _secret: true, configured: false } },
+        auth: { "jwt-secret": { _secret: true, configured: false } },
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfigurationSection } from "./ConfigurationSection";
+import { renderWithTheme } from "../../../test/renderWithTheme";
+import * as apiConfig from "../../../api/config";
+
+vi.mock("../../../api/config", () => ({
+  adminConfigurationApi: {
+    getEffectiveConfiguration: vi.fn(),
+  },
+}));
+
+describe("ConfigurationSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the info banner and the configured/not-configured chip", async () => {
+    vi.mocked(
+      apiConfig.adminConfigurationApi.getEffectiveConfiguration,
+    ).mockResolvedValue({
+      data: {
+        storage: { type: "fs" },
+        auth: {
+          jwtSecret: { _secret: true, configured: true },
+          accessTokenValidityMinutes: 480,
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<ConfigurationSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot be edited here/i)).toBeInTheDocument();
+    });
+
+    // The plain value passes through.
+    expect(screen.getByText("plugwerk.storage.type")).toBeInTheDocument();
+    expect(screen.getByText("fs")).toBeInTheDocument();
+    // The redacted leaf renders as a chip, never the plaintext.
+    expect(screen.getByText("configured")).toBeInTheDocument();
+  });
+
+  it("filters leaves by a substring of the dotted path", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminConfigurationApi.getEffectiveConfiguration,
+    ).mockResolvedValue({
+      data: {
+        storage: { type: "fs", consistency: { maxKeysPerScan: 100000 } },
+        auth: { accessTokenValidityMinutes: 480 },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<ConfigurationSection />);
+
+    await screen.findByText("plugwerk.storage.type");
+
+    const search = screen.getByPlaceholderText(/Filter by property path/i);
+    await user.type(search, "auth");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("plugwerk.auth.accessTokenValidityMinutes"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("plugwerk.storage.type"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a not-configured chip when the redacted leaf is empty", async () => {
+    vi.mocked(
+      apiConfig.adminConfigurationApi.getEffectiveConfiguration,
+    ).mockResolvedValue({
+      data: {
+        auth: { jwtSecret: { _secret: true, configured: false } },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithTheme(<ConfigurationSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("not configured")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces a fetch error in an alert", async () => {
+    vi.mocked(
+      apiConfig.adminConfigurationApi.getEffectiveConfiguration,
+    ).mockRejectedValue(new Error("boom"));
+
+    renderWithTheme(<ConfigurationSection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to load configuration/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationSection.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  InputAdornment,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { AlertTriangle, FileText, Info, Search } from "lucide-react";
+import { Section } from "../../../components/common/Section";
+import { adminConfigurationApi } from "../../../api/config";
+import { ConfigurationTree } from "./ConfigurationTree";
+
+type ConfigValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ConfigTree
+  | readonly ConfigValue[];
+
+export interface ConfigTree {
+  readonly [key: string]: ConfigValue;
+}
+
+/**
+ * Read-only dashboard for the effective `plugwerk.*` configuration tree
+ * (#522). The page is informational only — values are set in
+ * `application.yml` and the `PLUGWERK_*` env-vars; this view exists so
+ * an operator can see what the running server actually has without
+ * shelling into the container.
+ */
+export function ConfigurationSection() {
+  const [tree, setTree] = useState<ConfigTree | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await adminConfigurationApi.getEffectiveConfiguration();
+        if (cancelled) return;
+        setTree((res.data as unknown as ConfigTree) ?? null);
+        setError(null);
+      } catch {
+        if (cancelled) return;
+        setError("Failed to load configuration. See server logs.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const topLevelGroups = useMemo(() => {
+    if (!tree) return [];
+    return Object.entries(tree).map(([key, value]) => ({
+      key,
+      value,
+    }));
+  }, [tree]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box>
+        <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          Configuration
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          Effective <code>plugwerk.*</code> properties bound from{" "}
+          <code>application.yml</code> and the <code>PLUGWERK_*</code>{" "}
+          environment variables. Read-only.
+        </Typography>
+      </Box>
+
+      <Alert severity="info" icon={<Info size={18} />}>
+        These values come from <code>application.yml</code> and the
+        <code> PLUGWERK_*</code> environment variables. They cannot be edited
+        here — change the deployment configuration and restart the server.
+        Secrets are shown as a <em>configured / not configured</em> indicator
+        only and never travel over the wire.
+      </Alert>
+
+      {error && (
+        <Alert severity="warning" icon={<AlertTriangle size={18} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : tree ? (
+        <>
+          <TextField
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter by property path…"
+            size="small"
+            sx={{ maxWidth: 480 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={14} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+
+          {topLevelGroups.map((group) => (
+            <Section
+              key={group.key}
+              icon={<FileText size={18} />}
+              title={`plugwerk.${group.key}`}
+              description={`Configuration under the plugwerk.${group.key} hierarchy.`}
+            >
+              <ConfigurationTree
+                pathPrefix={`plugwerk.${group.key}`}
+                value={group.value}
+                filter={filter.trim().toLowerCase()}
+              />
+            </Section>
+          ))}
+        </>
+      ) : null}
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Box, Chip, Typography } from "@mui/material";
+import { CircleCheckBig, MinusCircle } from "lucide-react";
+import { tokens } from "../../../theme/tokens";
+
+interface ConfigurationTreeProps {
+  readonly pathPrefix: string;
+  readonly value: unknown;
+  readonly filter: string;
+}
+
+interface FlatLeaf {
+  readonly path: string;
+  readonly value: unknown;
+}
+
+/**
+ * Flattens the recursive config tree into a path-keyed list of leaves
+ * so the renderer can apply the substring filter and table-style layout
+ * uniformly. Recursive structures stop at leaf values, at the redacted-
+ * secret marker, and at arrays (we render arrays as JSON-stringified
+ * scalars for simplicity — arrays inside `plugwerk.*` are rare and
+ * always short).
+ */
+function flatten(prefix: string, value: unknown): FlatLeaf[] {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return [{ path: prefix, value }];
+  }
+  // Redacted-secret marker emitted by ConfigurationTreeBuilder.
+  if (
+    typeof value === "object" &&
+    "_secret" in value &&
+    (value as { _secret?: unknown })._secret === true
+  ) {
+    return [{ path: prefix, value }];
+  }
+  const result: FlatLeaf[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    result.push(...flatten(`${prefix}.${key}`, child));
+  }
+  return result;
+}
+
+/**
+ * Converts a dotted property path into the conventional `PLUGWERK_*`
+ * env-var name so the dashboard can show the operator exactly what to
+ * flip in the deployment without grepping the yaml. Convention:
+ *   - dots become underscores
+ *   - camelCase splits become underscore boundaries
+ *   - the whole thing is uppercased
+ *
+ * Best effort — the yaml occasionally maps a property to a custom env
+ * name via `${OVERRIDE:default}`; the operator still has the yaml as
+ * the authoritative source in those edge cases.
+ */
+function toEnvVar(path: string): string {
+  return path
+    .replace(/\./g, "_")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toUpperCase();
+}
+
+function renderValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return (
+      <Typography
+        variant="caption"
+        sx={{ color: "text.disabled", fontFamily: "monospace" }}
+      >
+        not set
+      </Typography>
+    );
+  }
+  if (
+    typeof value === "object" &&
+    "_secret" in (value as object) &&
+    (value as { _secret?: unknown })._secret === true
+  ) {
+    const configured = Boolean((value as { configured?: boolean }).configured);
+    return (
+      <Chip
+        size="small"
+        icon={
+          configured ? <CircleCheckBig size={12} /> : <MinusCircle size={12} />
+        }
+        label={configured ? "configured" : "not configured"}
+        sx={{
+          height: 22,
+          fontSize: "0.7rem",
+          fontWeight: 600,
+          bgcolor: configured
+            ? tokens.badge.published.bg
+            : tokens.badge.version.bg,
+          color: configured
+            ? tokens.badge.published.text
+            : tokens.badge.version.text,
+        }}
+      />
+    );
+  }
+  if (Array.isArray(value)) {
+    return (
+      <Typography
+        variant="body2"
+        sx={{
+          fontFamily: "monospace",
+          fontSize: "0.78rem",
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
+        [{value.map((v) => JSON.stringify(v)).join(", ")}]
+      </Typography>
+    );
+  }
+  if (typeof value === "boolean") {
+    return (
+      <Chip
+        size="small"
+        label={String(value)}
+        sx={{
+          height: 20,
+          fontSize: "0.7rem",
+          fontFamily: "monospace",
+          bgcolor: value ? tokens.badge.tag.bg : tokens.badge.version.bg,
+          color: value ? tokens.badge.tag.text : tokens.badge.version.text,
+        }}
+      />
+    );
+  }
+  return (
+    <Typography
+      variant="body2"
+      sx={{
+        fontFamily: "monospace",
+        fontSize: "0.78rem",
+        fontFeatureSettings: '"tnum"',
+        wordBreak: "break-all",
+      }}
+    >
+      {String(value)}
+    </Typography>
+  );
+}
+
+export function ConfigurationTree({
+  pathPrefix,
+  value,
+  filter,
+}: ConfigurationTreeProps) {
+  const all = flatten(pathPrefix, value);
+  const visible = filter
+    ? all.filter((leaf) => leaf.path.toLowerCase().includes(filter))
+    : all;
+
+  if (visible.length === 0) {
+    return (
+      <Typography
+        variant="caption"
+        sx={{ color: "text.disabled", display: "block", py: 1 }}
+      >
+        {filter ? "No properties match the filter." : "No properties."}
+      </Typography>
+    );
+  }
+
+  return (
+    <Box
+      component="table"
+      role="table"
+      aria-label={`Configuration: ${pathPrefix}`}
+      sx={{ width: "100%", borderCollapse: "collapse" }}
+    >
+      <Box component="thead">
+        <Box component="tr">
+          <HeaderCell>Path</HeaderCell>
+          <HeaderCell width={220}>Env var</HeaderCell>
+          <HeaderCell width={260}>Value</HeaderCell>
+        </Box>
+      </Box>
+      <Box component="tbody">
+        {visible.map((leaf) => (
+          <Box
+            component="tr"
+            key={leaf.path}
+            sx={{
+              "&:hover": { bgcolor: "background.default" },
+            }}
+          >
+            <Cell>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontFamily: "monospace",
+                  fontSize: "0.78rem",
+                  wordBreak: "break-all",
+                }}
+              >
+                {leaf.path}
+              </Typography>
+            </Cell>
+            <Cell>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontFamily: "monospace",
+                  color: "text.disabled",
+                  fontSize: "0.7rem",
+                }}
+              >
+                {toEnvVar(leaf.path)}
+              </Typography>
+            </Cell>
+            <Cell>{renderValue(leaf.value)}</Cell>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function HeaderCell({
+  children,
+  width,
+}: {
+  readonly children?: React.ReactNode;
+  readonly width?: number;
+}) {
+  return (
+    <Box
+      component="th"
+      sx={{
+        textAlign: "left",
+        width,
+        px: 2,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.default",
+        fontSize: "0.7rem",
+        fontWeight: 600,
+        color: "text.secondary",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function Cell({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <Box
+      component="td"
+      sx={{
+        px: 2,
+        py: 1.25,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        verticalAlign: "middle",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
@@ -62,8 +62,10 @@ function flatten(prefix: string, value: unknown): FlatLeaf[] {
  * Converts a dotted property path into the conventional `PLUGWERK_*`
  * env-var name so the dashboard can show the operator exactly what to
  * flip in the deployment without grepping the yaml. Convention:
- *   - dots become underscores
- *   - camelCase splits become underscore boundaries
+ *   - dots and dashes become underscores
+ *   - camelCase splits become underscore boundaries (defensive — the
+ *     backend already emits kebab-case, but a hand-edited path stays
+ *     well-behaved)
  *   - the whole thing is uppercased
  *
  * Best effort — the yaml occasionally maps a property to a custom env
@@ -72,8 +74,8 @@ function flatten(prefix: string, value: unknown): FlatLeaf[] {
  */
 function toEnvVar(path: string): string {
   return path
-    .replace(/\./g, "_")
     .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[.-]/g, "_")
     .toUpperCase();
 }
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/configuration/ConfigurationTree.tsx
@@ -166,7 +166,9 @@ export function ConfigurationTree({
   value,
   filter,
 }: ConfigurationTreeProps) {
-  const all = flatten(pathPrefix, value);
+  const all = flatten(pathPrefix, value)
+    .slice()
+    .sort((a, b) => a.path.localeCompare(b.path));
   const visible = filter
     ? all.filter((leaf) => leaf.path.toLowerCase().includes(filter))
     : all;
@@ -187,13 +189,25 @@ export function ConfigurationTree({
       component="table"
       role="table"
       aria-label={`Configuration: ${pathPrefix}`}
-      sx={{ width: "100%", borderCollapse: "collapse" }}
+      sx={{
+        width: "100%",
+        borderCollapse: "collapse",
+        // Fixed layout + thirds so the three columns stay aligned
+        // across the storage / server / auth sections regardless of
+        // their individual content widths.
+        tableLayout: "fixed",
+      }}
     >
+      <Box component="colgroup">
+        <Box component="col" sx={{ width: "33.34%" }} />
+        <Box component="col" sx={{ width: "33.33%" }} />
+        <Box component="col" sx={{ width: "33.33%" }} />
+      </Box>
       <Box component="thead">
         <Box component="tr">
           <HeaderCell>Path</HeaderCell>
-          <HeaderCell width={220}>Env var</HeaderCell>
-          <HeaderCell width={260}>Value</HeaderCell>
+          <HeaderCell>Env var</HeaderCell>
+          <HeaderCell>Value</HeaderCell>
         </Box>
       </Box>
       <Box component="tbody">
@@ -237,19 +251,12 @@ export function ConfigurationTree({
   );
 }
 
-function HeaderCell({
-  children,
-  width,
-}: {
-  readonly children?: React.ReactNode;
-  readonly width?: number;
-}) {
+function HeaderCell({ children }: { readonly children?: React.ReactNode }) {
   return (
     <Box
       component="th"
       sx={{
         textAlign: "left",
-        width,
         px: 2,
         py: 1,
         borderBottom: "1px solid",

--- a/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/router/index.tsx
@@ -88,6 +88,11 @@ const SchedulerSection = lazy(() =>
     default: m.SchedulerSection,
   })),
 );
+const ConfigurationSection = lazy(() =>
+  import("../pages/admin/configuration/ConfigurationSection").then((m) => ({
+    default: m.ConfigurationSection,
+  })),
+);
 const EmailServerPage = lazy(() =>
   import("../pages/admin/EmailServerPage").then((m) => ({
     default: m.EmailServerPage,
@@ -253,6 +258,14 @@ export const router = createBrowserRouter([
             element: (
               <Suspense fallback={<LazyFallback />}>
                 <SchedulerSection />
+              </Suspense>
+            ),
+          },
+          {
+            path: "configuration",
+            element: (
+              <Suspense fallback={<LazyFallback />}>
+                <ConfigurationSection />
               </Suspense>
             ),
           },


### PR DESCRIPTION
## Summary

New superadmin-only \`/admin/configuration\` page that renders the
effective \`plugwerk.*\` properties bound by Spring Boot at startup.
Read-only — values are set in \`application.yml\` and \`PLUGWERK_*\` env-
vars, the page is informational.

## Security: redaction by construction

The redactor classifies a property as sensitive when its last camel/
kebab-case word is \`secret\`, \`password\`, \`key\`, or \`token\` (case-
insensitive). Sensitive leaves are replaced with
\`{ \"_secret\": true, \"configured\": <bool> }\` **before** they leave
the JVM — the plaintext is never serialised.

A reflection-driven test walks \`PlugwerkProperties\` at compile time
and fails if any conventionally-named credential field would slip
past the redactor. Adding \`fooSecret\` to a new \`@ConfigurationProperties\`
data class is therefore caught immediately.

Last-word matching prevents false positives like \`keyPrefix\` (the
namespace-access-key prefix is operator-visible by design),
\`keyLookupHash\`, or \`passwordChangeRequired\`.

## Frontend

- Sidebar entry \`Configuration\` (lucide \`SlidersHorizontal\`),
  superadmin-only.
- Page renders:
  1. Header
  2. Prominent \`<Alert severity=\"info\">\` explaining the page is
     read-only
  3. Filter input
  4. One \`Section\` per top-level group (\`storage\`, \`auth\`,
     \`server\`, \`scheduler\`, \`actuator\`, …)
  5. Per leaf: dotted path / derived \`PLUGWERK_*\` env-var hint /
     value (or \`configured\`/\`not configured\` chip for secrets)

## Test plan

- [x] 4 BE unit tests on the redactor incl. the reflection safety
      net
- [x] 3 BE unit tests on the tree builder (secret redaction, empty-
      secret → not configured, plain pass-through)
- [x] Controller WebMvcTest (200 for superadmin, 403 for non-
      superadmin)
- [x] E2E authz-matrix IT against the SharedPostgresContainer
- [x] 4 vitest cases (banner, redacted chip, filter, fetch error)
- [x] Full \`./gradlew test\` + \`integrationTest\` green
- [x] Frontend \`npm run build\` green; 435 vitest passing
- [ ] Manual smoke against a running stack — deferred to reviewer

## Out of scope

- Editing values in the UI (operators change application.yml /
  env-vars and restart)
- DB-backed settings (\`/admin/global-settings\` already covers
  those)
- Non-\`plugwerk.*\` Spring properties

Closes #522