### PR TITLE
ci: dispatch .env.example to website on release (#526)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,14 @@ jobs:
           event-type: docker-compose-update
           client-payload: '{"version": "${{ steps.version.outputs.VERSION }}"}'
 
+      - name: Sync .env.example to website
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          repository: plugwerk/website
+          event-type: env-example-update
+          client-payload: '{"version": "${{ steps.version.outputs.VERSION }}"}'
+
   docker-publish:
     name: Build and push Docker image
     needs: publish


### PR DESCRIPTION
## Summary
- Adds a third \`repository_dispatch\` step to \`release.yml\` (\`env-example-update\`), placed immediately after the existing \`openapi-update\` and \`docker-compose-update\` steps.
- Byte-identical shape to the two existing steps — same SHA-pinned action, same \`RELEASE_TOKEN\`, same \`{"version": …}\` payload.
- Fire-and-forget: if no website-side workflow listens, the event is silently dropped. The consuming workflow is tracked in plugwerk/website#101 and ships independently.

## Test plan
- [x] YAML structure verified — 14 steps in \`publish\` job, new step is the last one before \`docker-publish\`
- [ ] After merge: trigger \`gh workflow run release.yml\` manually and confirm the step reports "Repository Dispatch successful"
- [ ] After merge: cross-check on \`plugwerk/website\` Actions tab that an \`env-example-update\` event was received

Closes #526