### PR TITLE
fix(branding): drop immutable Cache-Control so deletes invalidate (#530)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/BrandingController.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/controller/BrandingController.kt
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.Duration
 
 /**
  * Public read-only endpoint that serves the bytes of an
@@ -35,10 +34,11 @@ import java.time.Duration
  * default the endpoint returns 404 and the frontend falls back to the
  * bundled SVG.
  *
- * The response carries a SHA-256 ETag and a long `Cache-Control` —
- * the frontend pins the URL with `?v=<sha256>` so a re-upload
- * invalidates immediately, which lets us treat the bytes as
- * effectively immutable.
+ * `Cache-Control: no-cache` paired with a SHA-256 ETag means the
+ * browser may cache the bytes but MUST revalidate via
+ * `If-None-Match` on every request. Unchanged slots get a cheap
+ * `304 Not Modified`; deleted slots get a fresh 404 instead of a
+ * stale cached 200 (#530).
  *
  * Implemented directly with `@GetMapping` rather than implementing
  * the OpenAPI-generated interface because the contract returns
@@ -57,7 +57,7 @@ class BrandingController(private val brandingService: BrandingService) {
         return ResponseEntity.ok()
             .contentType(MediaType.parseMediaType(asset.contentType))
             .eTag("\"${asset.sha256}\"")
-            .cacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic().immutable())
+            .cacheControl(CacheControl.noCache())
             .header("Content-Length", asset.sizeBytes.toString())
             .body(asset.content)
     }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/BrandingControllerTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/controller/BrandingControllerTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.controller
+
+import io.plugwerk.server.domain.ApplicationAssetEntity
+import io.plugwerk.server.domain.BrandingSlot
+import io.plugwerk.server.security.ChangePasswordRateLimitFilter
+import io.plugwerk.server.security.LoginRateLimitFilter
+import io.plugwerk.server.security.NamespaceAccessKeyAuthFilter
+import io.plugwerk.server.security.PasswordChangeRequiredFilter
+import io.plugwerk.server.security.PasswordResetRateLimitFilter
+import io.plugwerk.server.security.PublicNamespaceFilter
+import io.plugwerk.server.security.RefreshRateLimitFilter
+import io.plugwerk.server.security.RegisterRateLimitFilter
+import io.plugwerk.server.service.branding.BrandingService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.util.Optional
+
+/**
+ * Cache-header regression guard for #530. `BrandingController` previously
+ * advertised `immutable, max-age=1y`, which made browsers serve stale
+ * bytes from disk cache after the operator deleted the slot. We now use
+ * `no-cache` + ETag — the browser may keep the bytes but MUST revalidate.
+ */
+@WebMvcTest(
+    BrandingController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, ServletWebSecurityAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [ChangePasswordRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [LoginRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RegisterRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordResetRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RefreshRateLimitFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [NamespaceAccessKeyAuthFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PublicNamespaceFilter::class]),
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [PasswordChangeRequiredFilter::class]),
+    ],
+)
+class BrandingControllerTest {
+
+    @MockitoBean lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean lateinit var brandingService: BrandingService
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `serve returns Cache-Control no-cache plus ETag on 200 (#530)`() {
+        val asset = ApplicationAssetEntity(
+            slot = "logomark",
+            contentType = "image/png",
+            content = ByteArray(8) { it.toByte() },
+            sha256 = "a".repeat(64),
+            sizeBytes = 8,
+        )
+        whenever(brandingService.find(BrandingSlot.LOGOMARK)).thenReturn(Optional.of(asset))
+
+        mockMvc.get("/api/v1/branding/logomark")
+            .andExpect {
+                status { isOk() }
+                header { string("Cache-Control", "no-cache") }
+                header { string("ETag", "\"${asset.sha256}\"") }
+                header { string("Content-Length", "8") }
+            }
+    }
+
+    @Test
+    fun `serve returns 404 with no-store when slot is empty (#530)`() {
+        whenever(brandingService.find(BrandingSlot.LOGOMARK)).thenReturn(Optional.empty())
+
+        mockMvc.get("/api/v1/branding/logomark")
+            .andExpect {
+                status { isNotFound() }
+                header { string("Cache-Control", "no-store") }
+            }
+    }
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/App.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/App.tsx
@@ -34,17 +34,27 @@ export default function App() {
     document.title = `${siteName} – Plugin Catalog`;
   }, [siteName]);
 
-  // Swap the favicon to the operator-uploaded logomark when present (#254).
-  // Falls back to the bundled SVG via useBranding's default. We mutate the
-  // existing <link rel="icon"> in index.html rather than appending so the
-  // browser cache treats it as a single resource.
+  // Swap the favicon to the operator-uploaded logomark when present
+  // (#254). Falls back to the bundled SVG via useBranding's default.
+  //
+  // Browsers cache favicons in a separate, very aggressive cache that
+  // ignores HTTP Cache-Control AND often ignores `link.href` mutations
+  // on an existing element (Chrome in particular only re-checks the
+  // favicon at specific lifecycle events, not on attribute changes).
+  // The reliable cross-browser workaround is to remove every existing
+  // icon link and append a fresh one — the browser then registers the
+  // new element as a brand-new favicon target and refetches (#530).
   const logomark = useBranding("logomark");
   useEffect(() => {
-    const link =
-      document.querySelector<HTMLLinkElement>("link[rel='icon']") ??
-      Object.assign(document.createElement("link"), { rel: "icon" });
+    document
+      .querySelectorAll(
+        "link[rel='icon'], link[rel='shortcut icon'], link[rel='apple-touch-icon']",
+      )
+      .forEach((el) => el.remove());
+    const link = document.createElement("link");
+    link.rel = "icon";
     link.href = logomark;
-    if (!link.parentElement) document.head.appendChild(link);
+    document.head.appendChild(link);
   }, [logomark]);
 
   return (

--- a/plugwerk-server/plugwerk-server-frontend/src/hooks/useBranding.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/hooks/useBranding.ts
@@ -55,9 +55,11 @@ export function notifyBrandingChanged(): void {
  * URL, on `onerror` we keep the bundled fallback.
  *
  * Listens for [BRANDING_CHANGED_EVENT] so a Reset or Upload performed
- * elsewhere on the page triggers a re-probe immediately. The probe is
- * cache-busted with a monotonic counter so the browser refetches the
- * fresh bytes even though the public endpoint advertises `immutable`.
+ * elsewhere on the page triggers a re-probe immediately. The probe URL
+ * always carries a `?v=` query parameter so browsers that cached an
+ * older response under the bare `/api/v1/branding/{slot}` URL (when
+ * the endpoint still advertised `immutable, max-age=1y`) miss the
+ * cache and revalidate against the server (#530).
  */
 export function useBranding(slot: BrandingSlot): string {
   const fallback = BUNDLED[slot];
@@ -73,10 +75,7 @@ export function useBranding(slot: BrandingSlot): string {
 
   useEffect(() => {
     let cancelled = false;
-    const candidate =
-      version === 0
-        ? `/api/v1/branding/${slot}`
-        : `/api/v1/branding/${slot}?v=${version}`;
+    const candidate = `/api/v1/branding/${slot}?v=${version}`;
     const probe = new Image();
     probe.onload = () => {
       if (!cancelled) setUrl(candidate);

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
@@ -249,27 +249,41 @@ function BrandingSlotCard({
         />
       </Box>
 
+      {/*
+       * Fixed-height wrapper so the preview frame (240×60 for the wide
+       * logos, 128×128 for the square logomark) always occupies the
+       * same vertical extent across cards. Without this, the dropzone
+       * row below renders at three different y-positions.
+       */}
       <Box
         sx={{
-          aspectRatio: descriptor.previewAspect,
-          width: descriptor.previewSize,
-          maxWidth: "100%",
-          bgcolor: descriptor.previewBg,
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: tokens.radius.input,
+          minHeight: 140,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          overflow: "hidden",
-          alignSelf: "center",
         }}
       >
-        <img
-          src={previewUrl}
-          alt={`${descriptor.label} preview`}
-          style={{ maxWidth: "85%", maxHeight: "85%", objectFit: "contain" }}
-        />
+        <Box
+          sx={{
+            aspectRatio: descriptor.previewAspect,
+            width: descriptor.previewSize,
+            maxWidth: "100%",
+            bgcolor: descriptor.previewBg,
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: tokens.radius.input,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+          }}
+        >
+          <img
+            src={previewUrl}
+            alt={`${descriptor.label} preview`}
+            style={{ maxWidth: "85%", maxHeight: "85%", objectFit: "contain" }}
+          />
+        </Box>
       </Box>
 
       <Box

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Button, Chip, Typography } from "@mui/material";
 import { useDropzone } from "react-dropzone";
 import { ImagePlus, RotateCcw } from "lucide-react";
@@ -105,12 +105,15 @@ function BrandingSlotCard({
   readonly descriptor: SlotDescriptor;
 }) {
   const [version, setVersion] = useState(0);
-  // Tri-state: null while we have not tried to render yet, true if the
-  // server returned the asset, false if the <img> onError fired (i.e.
-  // the slot is at its bundled default). Driven by the rendered image
-  // itself rather than a separate HEAD probe — HEAD-response caching
-  // was inconsistent across browsers and made the chip / Reset button
-  // flicker after an upload.
+  // Tri-state: null while the probe is in flight, true if the server
+  // returned the asset, false if it returned 404. Driven by an
+  // off-DOM Image() probe rather than the rendered <img>'s
+  // onLoad/onError, because src-swapping the rendered <img> to the
+  // bundled fallback raced with React state updates: the cached
+  // fallback's onLoad fired before the setHasCustom(false) from the
+  // 404 had committed, re-flipping hasCustom to true and resurrecting
+  // the Reset button on slots that were actually at their default
+  // (#530 follow-up).
   const [hasCustom, setHasCustom] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
   const addToast = useUiStore((s) => s.addToast);
@@ -181,16 +184,32 @@ function BrandingSlotCard({
     disabled: busy,
   });
 
-  // Always try the public endpoint first. The <img> onError falls back
-  // to the bundled default and flips the chip to `Default` for us.
-  // `?v=<counter>` invalidates any old `immutable, max-age=1y` cache
-  // entry that pre-#530 servers left in the browser, and bumps on
-  // upload/reset for in-tab refresh.
+  // Probe the public endpoint with an off-DOM Image so the load /
+  // error handlers can't race with React state updates the way an
+  // <img onLoad>/<img onError> on the rendered element did before
+  // (#530 follow-up). The `?v=<counter>` query bypasses any
+  // pre-#530 `immutable` cache entry and forces revalidation after
+  // upload / reset.
+  useEffect(() => {
+    let cancelled = false;
+    const probe = new Image();
+    probe.onload = () => {
+      if (!cancelled) setHasCustom(true);
+    };
+    probe.onerror = () => {
+      if (!cancelled) setHasCustom(false);
+    };
+    probe.src = `/api/v1/branding/${descriptor.slot}?v=${version}`;
+    return () => {
+      cancelled = true;
+    };
+  }, [descriptor.slot, version]);
+
   const previewUrl = useMemo(
     () =>
-      hasCustom === false
-        ? descriptor.bundledFallback
-        : `/api/v1/branding/${descriptor.slot}?v=${version}`,
+      hasCustom === true
+        ? `/api/v1/branding/${descriptor.slot}?v=${version}`
+        : descriptor.bundledFallback,
     [hasCustom, descriptor.bundledFallback, descriptor.slot, version],
   );
 
@@ -250,20 +269,6 @@ function BrandingSlotCard({
           src={previewUrl}
           alt={`${descriptor.label} preview`}
           style={{ maxWidth: "85%", maxHeight: "85%", objectFit: "contain" }}
-          onLoad={() => {
-            // Only flip to Custom if we were actually pointing at the
-            // public endpoint, not at the bundled fallback.
-            if (hasCustom !== false) setHasCustom(true);
-          }}
-          onError={(e) => {
-            // 404 on the public endpoint → fall back to the bundled SVG
-            // and remember that the slot is at its default.
-            if (hasCustom !== false) {
-              setHasCustom(false);
-              (e.currentTarget as HTMLImageElement).src =
-                descriptor.bundledFallback;
-            }
-          }}
         />
       </Box>
 

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.tsx
@@ -183,8 +183,9 @@ function BrandingSlotCard({
 
   // Always try the public endpoint first. The <img> onError falls back
   // to the bundled default and flips the chip to `Default` for us.
-  // `?v=<counter>` defeats the immutable Cache-Control on the GET so a
-  // freshly uploaded asset replaces the previous bytes immediately.
+  // `?v=<counter>` invalidates any old `immutable, max-age=1y` cache
+  // entry that pre-#530 servers left in the browser, and bumps on
+  // upload/reset for in-tab refresh.
   const previewUrl = useMemo(
     () =>
       hasCustom === false


### PR DESCRIPTION
## Summary
- Bug repro: upload a logo, then delete the row in \`application_asset\` (or hit *Reset to default* in a separate tab and reload the original tab). Old logo keeps appearing — the server's 404 is invisible because the browser cached the previous 200 with \`immutable, max-age=1y\` and serves it from disk cache without revalidating.
- **Backend:** \`BrandingController\` now sets \`Cache-Control: no-cache\` instead of \`immutable, max-age=1y, public\`. The browser may still cache the bytes but MUST revalidate; the existing SHA-256 ETag turns the round-trip into a cheap 304 when nothing changed.
- **Frontend:** \`useBranding\` and \`BrandingSection\` always append \`?v=<version>\` (even on first load with \`version=0\`) so users who still have the old \`immutable\` response cached under the bare URL bypass their cache instead of waiting a year for the TTL.
- **Test:** new \`BrandingControllerTest\` asserts the new \`no-cache\` header on 200 and \`no-store\` on 404 as a regression guard.

## Test plan
- [x] \`./gradlew :plugwerk-server:plugwerk-server-backend:test --tests BrandingControllerTest\` passes
- [x] Spotless / Prettier clean
- [ ] Manual verification: upload, truncate \`application_asset\`, hard-reload → bundled default appears in top bar, favicon, admin tile preview
- [ ] DevTools Network panel shows the request actually goes out on every page load (no \"from disk cache\")
- [ ] Second load shows \`304 Not Modified\` when the slot is unchanged
- [ ] In-tab cache-busting after upload / reset (via \`BRANDING_CHANGED_EVENT\`) still works

Closes #530