### PR TITLE
fix(deps): override Spring-managed Tomcat to 11.0.22 — close 5 CVEs (#538)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,11 @@
 kotlin = "2.3.21"
 spring-boot = "4.0.6"
 spring-dependency-management = "1.1.7"
+# Security override: Spring Boot 4.0.6 manages tomcat-embed-* 11.0.21, which has
+# 5 CVEs (CVE-2026-41293/43512 CRITICAL, -41284/42498/43513 HIGH). Pinned to the
+# patched 11.0.22 via the `tomcat.version` BOM property in the backend build.
+# Remove once Spring Boot >= 4.0.7 carries the fix (#538 / follow-up #539).
+tomcat = "11.0.22"
 openapi-generator = "7.22.0"
 pf4j = "3.15.0"
 okhttp = "5.3.2"
@@ -36,6 +41,10 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 
 # Spring Boot
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+# Not declared as a dependency — only present so Renovate's gradle version-catalog
+# manager tracks the `tomcat` version key and proposes the next patch. The actual
+# override is applied via the `tomcat.version` BOM property in the backend build.
+tomcat-embed-core = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -9,6 +9,17 @@ plugins {
     signing
 }
 
+// Security: override the Spring Boot-managed Apache Tomcat version. Spring Boot
+// 4.0.6 manages tomcat-embed-* 11.0.21, which carries 5 fixed CVEs
+// (CVE-2026-41293 / CVE-2026-43512 CRITICAL; CVE-2026-41284 / CVE-2026-42498 /
+// CVE-2026-43513 HIGH) and fails the required backend SBOM scan. No stable
+// Spring Boot 4.0.x ships the patched Tomcat yet, so the `tomcat.version` BOM
+// property is overridden here — it propagates to every tomcat-embed-* artifact
+// via the io.spring.dependency-management plugin. Remove this override and the
+// libs.versions.toml `tomcat` key once Spring Boot >= 4.0.7 carries the fix
+// (tracked in #538; cleanup follow-up #539).
+extra["tomcat.version"] = libs.versions.tomcat.get()
+
 // CycloneDX SBOM generation for CI vulnerability scanning (issue #297, ADR-0030).
 // Restricted to runtimeClasspath: only deps that ship in the production artefact
 // are security-relevant. Test/compile-only deps would add false-positive noise.


### PR DESCRIPTION
## Summary

The required **"Backend SBOM vulnerability scan"** check is red on `main` and blocks every open PR (including Renovate #536/#537, whose own diffs are unrelated). Root cause: Spring Boot `4.0.6` transitively manages `org.apache.tomcat.embed:tomcat-embed-*` at `11.0.21`, which has 5 fixed CVEs:

| CVE | Severity |
|-----|----------|
| CVE-2026-41293 | CRITICAL — Improper Input Validation |
| CVE-2026-43512 | CRITICAL — Authentication Bypass (digest auth) |
| CVE-2026-41284 | HIGH — Resource allocation without throttling (DoS) |
| CVE-2026-42498 | HIGH — HTTP auth header exposure (WebSocket) |
| CVE-2026-43513 | HIGH — Case-sensitivity handling in LockOutRealm |

No stable Spring Boot 4.0.x ships the patched Tomcat yet (`4.0.6` is the latest stable; `4.1.0-RC1` is an RC). This PR overrides the BOM-managed `tomcat.version` to **`11.0.22`** (current Maven Central release) via the `io.spring.dependency-management` extra property — it propagates to all `tomcat-embed-*` artifacts. A non-declared `libs.versions.toml` entry keeps the pin Renovate-trackable. Interim mitigation; reverted by follow-up #539 once Spring Boot ≥ 4.0.7 carries the fix.

Change is +20/-0: a `tomcat` version key + tracking library entry in `gradle/libs.versions.toml`, and `extra["tomcat.version"]` in the backend build script.

## Related Issues

Closes #538
Cleanup follow-up tracked in #539

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Checklist

- [ ] Tests pass locally — ⚠️ not run: the authoring environment has no JDK, so Gradle (`dependencies`/`spotlessApply`/`build`) cannot execute here. CI is the verification (build, smoke-test, and the very "Backend SBOM vulnerability scan" gate this PR targets). Added lines are ≤ 80 chars (ktlint limit 120); build scripts are excluded from the Spotless license-header target; `*.toml` is not Spotless-targeted.
- [x] Documentation updated (if applicable) — N/A; interim override, not a new configuration property (no `application.yml`/`@ConfigurationProperties` change).
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A; no DB changes
- [x] CLA signed — authored under the project owner account (devtank42 / devtank42 GmbH, the copyright holder)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: **Claude Code — Claude Opus 4.7**)
- [ ] This PR was co-authored by human + AI agent
