### PR TITLE
chore(deps): remove interim Tomcat override, bump Spring Boot to 4.0.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,7 @@
 [versions]
 kotlin = "2.4.0"
-spring-boot = "4.0.6"
+spring-boot = "4.0.7"
 spring-dependency-management = "1.1.7"
-# Security override: Spring Boot 4.0.6 manages tomcat-embed-* 11.0.21, which has
-# 5 CVEs (CVE-2026-41293/43512 CRITICAL, -41284/42498/43513 HIGH). Pinned to the
-# patched 11.0.22 via the `tomcat.version` BOM property in the backend build.
-# Remove once Spring Boot >= 4.0.7 carries the fix (#538 / follow-up #539).
-tomcat = "11.0.22"
 openapi-generator = "7.23.0"
 pf4j = "3.15.0"
 okhttp = "5.4.0"
@@ -41,10 +36,6 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 
 # Spring Boot
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
-# Not declared as a dependency — only present so Renovate's gradle version-catalog
-# manager tracks the `tomcat` version key and proposes the next patch. The actual
-# override is applied via the `tomcat.version` BOM property in the backend build.
-tomcat-embed-core = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -9,17 +9,6 @@ plugins {
     signing
 }
 
-// Security: override the Spring Boot-managed Apache Tomcat version. Spring Boot
-// 4.0.6 manages tomcat-embed-* 11.0.21, which carries 5 fixed CVEs
-// (CVE-2026-41293 / CVE-2026-43512 CRITICAL; CVE-2026-41284 / CVE-2026-42498 /
-// CVE-2026-43513 HIGH) and fails the required backend SBOM scan. No stable
-// Spring Boot 4.0.x ships the patched Tomcat yet, so the `tomcat.version` BOM
-// property is overridden here — it propagates to every tomcat-embed-* artifact
-// via the io.spring.dependency-management plugin. Remove this override and the
-// libs.versions.toml `tomcat` key once Spring Boot >= 4.0.7 carries the fix
-// (tracked in #538; cleanup follow-up #539).
-extra["tomcat.version"] = libs.versions.tomcat.get()
-
 // CycloneDX SBOM generation for CI vulnerability scanning (issue #297, ADR-0030).
 // Restricted to runtimeClasspath: only deps that ship in the production artefact
 // are security-relevant. Test/compile-only deps would add false-positive noise.


### PR DESCRIPTION
## Summary

Follow-up to #538, closes #539. Spring Boot 4.0.7 is published and its `spring-boot-dependencies` BOM manages `tomcat.version = 11.0.22` — exactly the version we pinned manually to close 5 CVEs (2 CRITICAL, 3 HIGH). The interim override is therefore removed:

- Bump `spring-boot` 4.0.6 → 4.0.7 in `gradle/libs.versions.toml`
- Remove the `tomcat` version key and its security-override comment
- Remove the `tomcat-embed-core` catalog entry (existed only so Renovate tracked the pin)
- Remove the `extra["tomcat.version"]` BOM property override in the backend build

## Acceptance criteria (#539)

- [x] Spring Boot 4.0.7 BOM manages `tomcat.version` ≥ 11.0.22 (verified in `spring-boot-dependencies-4.0.7.pom`)
- [x] Spring Boot bumped to 4.0.7
- [x] Override + catalog entries removed
- [x] `:plugwerk-server:plugwerk-server-backend:dependencies` resolves all `tomcat-embed-*` artifacts at 11.0.22 purely via BOM constraints, no override
- [x] `./gradlew clean build` green locally (847 tests)
- [ ] Backend SBOM vulnerability scan green in CI

## Note on Spring Boot 4.1.0

4.1.0 is also published and manages the same Tomcat 11.0.22, but bumping to it breaks `spotlessKotlinGradleCheck` (`NoClassDefFoundError: com/pinterest/ktlint/rule/engine/api/EditorConfigDefaults`) even on the latest Spotless 8.6.0 / ktlint 1.8.0. Deterministic A/B-verified: 4.0.7 green, 4.1.0 red. The 4.1 upgrade should be tackled separately (Renovate will propose it) once the Spotless/ktlint interaction is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)