### PR TITLE
chore(deps): upgrade Spring Boot to 4.1.0, isolate Spotless in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,15 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
 
+      # Spotless runs isolated, before the main build: its formatter classloader
+      # is flaky under concurrent task load (diffplug/spotless#2850 — backing JAR
+      # closed mid-build → NoClassDefFoundError). Standalone invocation is
+      # reliable; see plugwerk#563 for the investigation.
+      - name: Spotless check (isolated)
+        run: ./gradlew spotlessCheck
+
       - name: Build and run unit tests
-        run: ./gradlew build
+        run: ./gradlew build -x spotlessCheck
 
       - name: Pre-pull Docker images (with retry)
         run: |

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -48,9 +48,11 @@ jobs:
         if: steps.check.outputs.is_snapshot == 'true'
         uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
 
+      # -x spotlessCheck: lint enforcement happens in ci.yml (isolated step);
+      # running Spotless under full build load is flaky (diffplug/spotless#2850).
       - name: Build all modules
         if: steps.check.outputs.is_snapshot == 'true'
-        run: ./gradlew build -x integrationTest
+        run: ./gradlew build -x integrationTest -x spotlessCheck
 
       - name: Publish SNAPSHOTs to GitHub Packages
         if: steps.check.outputs.is_snapshot == 'true'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.4.0"
-spring-boot = "4.0.7"
+spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
 openapi-generator = "7.23.0"
 pf4j = "3.15.0"

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcJwtValidators.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/OidcJwtValidators.kt
@@ -132,7 +132,7 @@ object OidcJwtValidators {
      * `contains` check covers both shapes uniformly.
      */
     private fun audienceValidator(expected: String): OAuth2TokenValidator<Jwt> =
-        JwtClaimValidator<List<String>?>(JwtClaimNames.AUD) { aud ->
+        JwtClaimValidator<List<String>>(JwtClaimNames.AUD) { aud ->
             !aud.isNullOrEmpty() && aud.contains(expected)
         }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolver.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/security/PromptAwareOAuth2AuthorizationRequestResolver.kt
@@ -96,7 +96,7 @@ class PromptAwareOAuth2AuthorizationRequestResolver(
         return maybeAddPrompt(request, resolved)
     }
 
-    override fun resolve(request: HttpServletRequest, clientRegistrationId: String?): OAuth2AuthorizationRequest? {
+    override fun resolve(request: HttpServletRequest, clientRegistrationId: String): OAuth2AuthorizationRequest? {
         val resolved = delegate.resolve(request, clientRegistrationId) ?: return null
         return maybeAddPrompt(request, resolved)
     }


### PR DESCRIPTION
## Summary

Closes #563. Two independent changes that belong together because the second unblocks reliable CI for the first:

### Spring Boot 4.0.7 → 4.1.0

Spring Security 7.1 (shipped with Boot 4.1) adopts JSpecify nullness annotations, which changes Kotlin signatures in two places:

- `PromptAwareOAuth2AuthorizationRequestResolver.resolve(request, clientRegistrationId)` — the registration id parameter is now non-null `String`
- `JwtClaimValidator<T>` is now bounded `T : Any` — the audience validator passes `List<String>` as the type argument; the predicate still receives a nullable claim value, the null/empty guard is unchanged

The 4.1.0 BOM manages Tomcat 11.0.22 (same as 4.0.7), so no security regression.

### CI mitigation for the Spotless classloader race

As investigated in #563, Spotless ≥ 8.x has a formatter-classloader race under concurrent task load (upstream: diffplug/spotless#2850 — backing JAR closed mid-build → cascading `NoClassDefFoundError`), previously masked by the Gradle build cache and falsely attributed to this upgrade. Standalone invocation is 100% reliable (verified locally and reported upstream), so:

- `ci.yml`: new isolated `./gradlew spotlessCheck` step before the main build; `build` runs with `-x spotlessCheck`
- `snapshot-publish.yml`: `-x spotlessCheck` (lint enforcement happens in ci.yml)

## Verification

- [x] `./gradlew spotlessCheck` green (isolated)
- [x] 3× `./gradlew clean build -x spotlessCheck --no-build-cache` green (847 unit tests)
- [x] `:plugwerk-server:plugwerk-server-backend:integrationTest` green (Testcontainers/PostgreSQL)
- [ ] CI green including the new isolated Spotless step

🤖 Generated with [Claude Code](https://claude.com/claude-code)