### PR TITLE
docs: fix AGENTS.md inaccuracies (namespace schema, client-plugin JVM, eslint-CI claim)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Before **every commit**, run the formatter and linter for the language(s) you ch
 | TypeScript / TSX | `npm run lint` | `plugwerk-server/plugwerk-server-frontend/` |
 | TypeScript / TSX formatting | `npm run format` | `plugwerk-server/plugwerk-server-frontend/` |
 
-CI enforces all three (`spotlessKotlinCheck`, `eslint`, and `prettier --check` via the Gradle `npmFormatCheck` task that runs as part of `./gradlew build`) and will fail if violations are committed.
+CI enforces Kotlin formatting (`spotlessCheck`, run as an isolated job) and frontend formatting (`prettier --check` via the Gradle `npmFormatCheck` task that runs as part of `./gradlew build`), and will fail if violations are committed. CI does **not** yet run ESLint — `npm run lint` is a local-only check for now; wiring ESLint into the pipeline is tracked separately (DEV-21).
 Never skip these checks — even for "small" renames or refactors (longer class names can exceed line limits).
 
 - **Never commit directly to `main`** – always use a feature branch
@@ -216,7 +216,7 @@ plugwerk/
 ├── plugwerk-server/
 │   ├── plugwerk-server-backend/   # Spring Boot 4.x + Kotlin REST API (JVM 21)
 │   └── plugwerk-server-frontend/  # React + TypeScript + MUI + Zustand (embedded in server JAR)
-└── plugwerk-client-plugin/        # PF4J plugin, OkHttp, Jackson (JVM 17)
+└── plugwerk-client-plugin/        # PF4J plugin, OkHttp, Jackson (JVM 11)
 ```
 
 ### Key Design Constraints
@@ -234,7 +234,7 @@ plugwerk/
 ### Core Data Model
 
 ```
-Namespace (slug, name, description, settings JSON)
+Namespace (slug, name, description, public_catalog, auto_approve_releases)
   └── Plugin (plugin_id unique per ns, tags[], status)
         └── PluginRelease (SemVer version, artifact_sha256, requires_system_version,
         │                   plugin_dependencies JSON, status: draft/published/deprecated/yanked)


### PR DESCRIPTION
## Summary

Doc-only fixes to `AGENTS.md` for three inaccuracies found during DEV-11 onboarding, each confirmed against the code. Sibling to #567 (encryption-docs reconciliation).

## Corrections

1. **Core Data Model — Namespace has no "settings JSON".** The sketch showed `Namespace (slug, name, description, settings JSON)`. The real schema (`NamespaceEntity.kt` + migration `0001_initial_schema.yaml`) uses discrete boolean columns `public_catalog` + `auto_approve_releases` — there is no JSON blob. Updated the diagram to list those columns.
2. **`plugwerk-client-plugin` is JVM 11, not JVM 17.** The module-structure block said `(JVM 17)`; `plugwerk-client-plugin/build.gradle.kts` sets `jvmTarget = JVM_11` (same for `plugwerk-api-model`), and the tech-stack table already says "JVM 11+". Fixed the internal contradiction.
3. **CI does not enforce ESLint.** The Git Workflow section claimed CI "enforces all three (`spotlessKotlinCheck`, `eslint`, `prettier`)". CI actually runs Spotless (isolated job) + Prettier (`npmFormatCheck` via `./gradlew build`) + the build — there is **no** eslint step. Reworded to match reality; ESLint stays a local-only check (tracked as DEV-21).

> Note: the AES-256-CBC→GCM line is handled in #567 and is intentionally **not** touched here.

## Verification

- `NamespaceEntity.kt` → `publicCatalog` / `autoApproveReleases` boolean properties; migration `0001` → `auto_approve_releases boolean`. No JSON column.
- `plugwerk-client-plugin/build.gradle.kts:14` & `plugwerk-api/plugwerk-api-model/build.gradle.kts:15` → `jvmTarget = JVM_11`.
- `.github/workflows/ci.yml` → `spotlessCheck` (isolated) + `build -x spotlessCheck`; no eslint invocation.
- Residual grep over `AGENTS.md` for `settings JSON`, `JVM 17`, `enforces all three` → all clean.

Doc-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)