### PR TITLE
docs: resolve duplicate ADR-0006 numbering (renumber phase2 → ADR-0038)

### DIFF
--- a/docs/adrs/0006-auth-strategy.md
+++ b/docs/adrs/0006-auth-strategy.md
@@ -41,7 +41,7 @@ Both token types are handled by separate Spring Security filters that run in ord
 - Token validity: 8 hours (configurable)
 
 > **Phase 1 is superseded.** The `dev-users` list and `DevUserCredentialValidator` have been removed.
-> See [ADR-0006 Phase 2](./0006-phase2-auth-and-rbac.md) for the current implementation.
+> See [ADR-0038](./0038-phase2-auth-and-rbac.md) for the current implementation.
 
 ### Phase 2+ (see issue #77) — implemented
 

--- a/docs/adrs/0038-phase2-auth-and-rbac.md
+++ b/docs/adrs/0038-phase2-auth-and-rbac.md
@@ -1,4 +1,6 @@
-# ADR-0006: Phase 2 — Database-Backed Authentication, OIDC Support, and Namespace RBAC
+# ADR-0038: Phase 2 — Database-Backed Authentication, OIDC Support, and Namespace RBAC
+
+> **Renumbered from ADR-0006.** This ADR originally shared the number `0006` with [ADR-0006: Authentication Strategy](./0006-auth-strategy.md). The duplicate was resolved per the DEV-11 onboarding readiness review: `0006-auth-strategy.md` keeps the canonical `ADR-0006` anchor and this Phase 2 ADR moved to the next free number, `ADR-0038`.
 
 ## Status
 
@@ -72,6 +74,8 @@ Three new tables added via Liquibase migration `0002_user_and_rbac.yaml`:
 - Throws `ForbiddenException` (→ 403) on insufficient role
 
 ### Client Secret Encryption
+
+> **Superseded by [ADR-0022](./0022-encryption-key-size.md) and [ADR-0033](./0033-aes-gcm-text-encryptor.md).** The PBKDF2/AES-128 `TextEncryptor` details described below are historical: ADR-0022 clarified that `plugwerk.auth.encryption-key` is a PBKDF2 password (not a literal AES-128 key), and ADR-0033 migrated `TextEncryptor` to AES-GCM (AEAD) via `Encryptors.delux()`. The wording below is retained as an immutable historical record.
 
 OIDC provider client secrets are encrypted at rest using Spring's `TextEncryptor` (AES/PBKDF2):
 - Key: `plugwerk.auth.encryption-key` (16 characters, AES-128)


### PR DESCRIPTION
## Summary

Resolves the duplicate **ADR-0006** numbering. Two ADRs shared `0006`; this PR keeps the older, broader auth-strategy ADR as the canonical **ADR-0006** anchor and renumbers the Phase 2 ADR to the next free number, **ADR-0038** (`0037` was the prior max). Decision is per the DEV-11 onboarding readiness review (open question #3).

## Changes

- `git mv docs/adrs/0006-phase2-auth-and-rbac.md → docs/adrs/0038-phase2-auth-and-rbac.md` (rename preserved in history) and updated its heading `# ADR-0006:` → `# ADR-0038:`.
- Added a "renumbered from ADR-0006" provenance note to the moved ADR so the history stays traceable.
- Updated the single inbound cross-reference in `docs/adrs/0006-auth-strategy.md` (`./0006-phase2-auth-and-rbac.md` → `./0038-phase2-auth-and-rbac.md`).
- Marked the historical **Client Secret Encryption** section in the renumbered ADR as **Superseded by ADR-0022 / ADR-0033** (PBKDF2/AES-128 `TextEncryptor` → AES-GCM AEAD via `Encryptors.delux()`), with the original immutable wording retained as a historical record. Scoped during the DEV-19 sign-off.

## Verification

- All ADR file-number prefixes are now unique (`ls docs/adrs | grep -oE '^[0-9]{4}' | sort | uniq -d` → empty).
- All cross-reference targets resolve: `0006-auth-strategy.md`, `0022-encryption-key-size.md`, `0033-aes-gcm-text-encryptor.md`, `0038-phase2-auth-and-rbac.md`.
- No leftover references to the old `0006-phase2-auth-and-rbac` filename or the old `# ADR-0006: Phase 2` heading remain in `docs/`.

## Notes

- Docs-only change; no code paths touched. Rides alongside #567 (DEV-19 crypto doc hygiene).
- Follow-up (out of scope here): the untracked `docs/onboarding-primer-draft.md` has a textual `ADR-0006` reference to the OIDC hot-reload behavior, which now lives in ADR-0038. That draft belongs to the DEV-11 onboarding work and should point to ADR-0038 when finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)