### PR TITLE
test(oidc): add JaCoCo coverage gate; raise OIDC coverage ≥80% (DEV-30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,29 @@ jobs:
           PLUGWERK_AUTH_JWT_SECRET: ci-integration-test-secret-min-32-characters!!
           PLUGWERK_AUTH_ENCRYPTION_KEY: ci-encrypt-16chr
 
+      # Coverage report over the merged unit + integration exec data. The
+      # build step above produced build/jacoco/test.exec; the step above that
+      # produced build/jacoco/integrationTest.exec — jacocoTestReport reads
+      # both (see plugwerk-server-backend/build.gradle.kts, DEV-30).
+      - name: Coverage report (merged unit + integration)
+        run: ./gradlew :plugwerk-server:plugwerk-server-backend:jacocoTestReport
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: backend-coverage-report
+          path: |
+            plugwerk-server/plugwerk-server-backend/build/reports/jacoco/test/html/
+            plugwerk-server/plugwerk-server-backend/build/reports/jacoco/test/jacocoTestReport.xml
+          retention-days: 14
+
+      # Coverage gate. Fails the build when coverage drops below the ratchet
+      # floors defined in build.gradle.kts. Runs last so the report artifact
+      # above is always published, even on a gate failure.
+      - name: Coverage gate
+        run: ./gradlew :plugwerk-server:plugwerk-server-backend:jacocoTestCoverageVerification
+
       - name: Upload unit test reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/plugwerk-server/plugwerk-server-backend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-backend/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.cyclonedx.bom)
+    jacoco
     `maven-publish`
     signing
 }
@@ -205,6 +206,10 @@ tasks.named<Test>("test") {
     useJUnitPlatform {
         excludeTags("integration")
     }
+    // A plain `./gradlew build` always leaves a fresh coverage number behind
+    // (unit-only — no Docker required). CI re-runs the report after the
+    // integration suite to produce the merged number (see below + ci.yml).
+    finalizedBy(tasks.named("jacocoTestReport"))
 }
 
 tasks.register<Test>("integrationTest") {
@@ -216,4 +221,69 @@ tasks.register<Test>("integrationTest") {
     classpath = sourceSets["test"].runtimeClasspath
     testClassesDirs = sourceSets["test"].output.classesDirs
     shouldRunAfter(tasks.named("test"))
+}
+
+// ---------------------------------------------------------------------------
+// Code coverage (JaCoCo) — DEV-30
+//
+// The `test` (unit) and `integrationTest` tasks each emit their own `.exec`
+// file via the JacocoTaskExtension the plugin attaches to every Test task.
+// The report and verification tasks below read *whichever* `.exec` files are
+// present under build/jacoco, so the wiring works in both contexts:
+//   - `./gradlew build`             → unit-only number, no Docker needed
+//   - CI: build + integrationTest   → merged number matching the QA baseline
+//
+// CI publishes the XML/HTML report as an artifact and runs
+// `jacocoCoverageVerification` as the gate (see .github/workflows/ci.yml).
+// ---------------------------------------------------------------------------
+
+jacoco {
+    // Pinned for reproducibility; 0.8.13 fully supports Java 21 bytecode.
+    toolVersion = "0.8.13"
+}
+
+// Lazily collects every coverage exec file that exists at execution time, so
+// the merged report transparently picks up integrationTest.exec when present.
+val coverageExecData = fileTree(layout.buildDirectory.dir("jacoco")) {
+    include("*.exec")
+}
+
+tasks.jacocoTestReport {
+    executionData.setFrom(coverageExecData)
+    // Order-only: when both suites are requested in one invocation the report
+    // runs last. In CI they run in separate invocations, so this is a no-op
+    // there and the report simply reads the persisted .exec files.
+    mustRunAfter(tasks.named("integrationTest"))
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    executionData.setFrom(coverageExecData)
+    mustRunAfter(tasks.named("integrationTest"))
+    violationRules {
+        // Repo-wide ratchet floors, seeded at the DEV-30 baseline (test +
+        // integrationTest merged) so the gate catches regressions today.
+        // BRANCH ramps to 0.80 as the DEV-30 follow-up tests land — raise
+        // these numbers as coverage improves, never lower them.
+        rule {
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.85".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.65".toBigDecimal()
+            }
+        }
+    }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/OidcProviderServiceTest.kt
@@ -18,8 +18,10 @@
  */
 package io.plugwerk.server.service
 
+import io.plugwerk.server.domain.OidcIdentityEntity
 import io.plugwerk.server.domain.OidcProviderEntity
 import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.domain.UserEntity
 import io.plugwerk.server.repository.OidcIdentityRepository
 import io.plugwerk.server.repository.OidcProviderRepository
 import io.plugwerk.server.repository.UserRepository
@@ -31,6 +33,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -331,6 +335,227 @@ class OidcProviderServiceTest {
 
         assertThat(outcome.success).isFalse()
         assertThat(outcome.error).startsWith("OIDC discovery failed")
+    }
+
+    // -----------------------------------------------------------------------
+    // findAll / findById — previously-untested read paths (DEV-30).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `findAll delegates straight to the repository`() {
+        val providers = listOf(newProvider())
+        whenever(oidcProviderRepository.findAll()).thenReturn(providers)
+
+        assertThat(service.findAll()).isEqualTo(providers)
+    }
+
+    @Test
+    fun `findById returns the provider when it exists`() {
+        val provider = newProvider()
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.of(provider))
+
+        assertThat(service.findById(providerId)).isSameAs(provider)
+    }
+
+    @Test
+    fun `findById throws EntityNotFoundException when the id is unknown`() {
+        whenever(oidcProviderRepository.findById(providerId)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.findById(providerId) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+            .hasMessageContaining(providerId.toString())
+    }
+
+    // -----------------------------------------------------------------------
+    // create — OIDC + OAUTH2 paths, SSRF gating, secret encryption (DEV-30).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `create persists an OIDC provider with an encrypted secret, disabled by default`() {
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        val created = service.create(
+            name = "Company Keycloak",
+            providerType = OidcProviderType.OIDC,
+            clientId = "kc-client",
+            clientSecret = "super-secret-value",
+            issuerUri = "https://idp.example.com",
+            scope = "openid email profile",
+        )
+
+        assertThat(created.name).isEqualTo("Company Keycloak")
+        assertThat(created.providerType).isEqualTo(OidcProviderType.OIDC)
+        assertThat(created.clientId).isEqualTo("kc-client")
+        assertThat(created.clientSecretEncrypted).isEqualTo("ENCRYPTED-super-secret-value")
+        assertThat(created.issuerUri).isEqualTo("https://idp.example.com")
+        // A freshly created provider is disabled until an admin activates it,
+        // so it stays invisible to both registries — create() must not refresh.
+        assertThat(created.enabled).isFalse()
+        verify(oidcProviderRegistry, never()).refresh()
+        verify(dbClientRegistrationRepository, never()).refresh()
+    }
+
+    @Test
+    fun `create rejects an OIDC provider whose issuerUri is missing`() {
+        assertThatThrownBy {
+            service.create(
+                name = "Broken OIDC",
+                providerType = OidcProviderType.OIDC,
+                clientId = "c",
+                clientSecret = "secret-1234",
+                issuerUri = null,
+                scope = "openid",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("issuerUri")
+
+        verify(oidcProviderRepository, never()).save(any())
+    }
+
+    @Test
+    fun `create rejects an OIDC issuerUri pointing at a private host (SSRF guard)`() {
+        assertThatThrownBy {
+            service.create(
+                name = "SSRF OIDC",
+                providerType = OidcProviderType.OIDC,
+                clientId = "c",
+                clientSecret = "secret-1234",
+                issuerUri = "http://10.0.0.1/realms/internal",
+                scope = "openid",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        verify(oidcProviderRepository, never()).save(any())
+    }
+
+    @Test
+    fun `create rejects an OAUTH2 provider missing the required endpoint URIs`() {
+        assertThatThrownBy {
+            service.create(
+                name = "Half OAuth2",
+                providerType = OidcProviderType.OAUTH2,
+                clientId = "c",
+                clientSecret = "secret-1234",
+                issuerUri = null,
+                scope = "read_user",
+                authorizationUri = null,
+                tokenUri = "https://idp.example.com/token",
+                userInfoUri = "https://idp.example.com/userinfo",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("authorizationUri")
+
+        verify(oidcProviderRepository, never()).save(any())
+    }
+
+    @Test
+    fun `create persists an OAUTH2 provider with the supplied endpoint URIs`() {
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        val created = service.create(
+            name = "Self-hosted GitLab",
+            providerType = OidcProviderType.OAUTH2,
+            clientId = "gl-client",
+            clientSecret = "secret-1234",
+            issuerUri = null,
+            scope = "read_user",
+            authorizationUri = "https://gitlab.example.com/oauth/authorize",
+            tokenUri = "https://gitlab.example.com/oauth/token",
+            userInfoUri = "https://gitlab.example.com/api/v4/user",
+            jwkSetUri = null,
+            subjectAttribute = "id",
+            emailAttribute = "email",
+            displayNameAttribute = "name",
+        )
+
+        assertThat(created.providerType).isEqualTo(OidcProviderType.OAUTH2)
+        assertThat(created.authorizationUri).isEqualTo("https://gitlab.example.com/oauth/authorize")
+        assertThat(created.tokenUri).isEqualTo("https://gitlab.example.com/oauth/token")
+        assertThat(created.userInfoUri).isEqualTo("https://gitlab.example.com/api/v4/user")
+        assertThat(created.subjectAttribute).isEqualTo("id")
+    }
+
+    @Test
+    fun `create normalises blank optional fields down to null`() {
+        whenever(oidcProviderRepository.save(any<OidcProviderEntity>())).thenAnswer {
+            it.arguments[0] as OidcProviderEntity
+        }
+
+        val created = service.create(
+            name = "OIDC with blanks",
+            providerType = OidcProviderType.OIDC,
+            clientId = "c",
+            clientSecret = "secret-1234",
+            issuerUri = "https://idp.example.com",
+            scope = "openid",
+            // Optional + ignored for OIDC; blank input must normalise to null
+            // rather than persisting an empty string.
+            authorizationUri = "   ",
+            subjectAttribute = "   ",
+        )
+
+        assertThat(created.authorizationUri).isNull()
+        assertThat(created.subjectAttribute).isNull()
+    }
+
+    // -----------------------------------------------------------------------
+    // delete — Politik C: orphaned users disabled before the cascade (DEV-30).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `delete throws EntityNotFoundException for an unknown id and touches nothing`() {
+        whenever(oidcProviderRepository.existsById(providerId)).thenReturn(false)
+
+        assertThatThrownBy { service.delete(providerId) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+
+        verify(oidcProviderRepository, never()).deleteById(any())
+        verify(userRepository, never()).disableAll(any())
+        verify(oidcProviderRegistry, never()).refresh()
+    }
+
+    @Test
+    fun `delete disables orphaned users before removing the provider (Politik C)`() {
+        val userId1 = UUID.randomUUID()
+        val userId2 = UUID.randomUUID()
+        // Build the identity mocks before the outer stubbing — creating mocks
+        // (which stub their own getters) mid-`whenever(...)` would trip
+        // Mockito's UnfinishedStubbingException.
+        val identities = listOf(identityForUser(userId1), identityForUser(userId2))
+        whenever(oidcProviderRepository.existsById(providerId)).thenReturn(true)
+        whenever(oidcIdentityRepository.findAllByOidcProviderId(providerId)).thenReturn(identities)
+        whenever(userRepository.disableAll(any())).thenReturn(2)
+
+        service.delete(providerId)
+
+        val captor = argumentCaptor<Collection<UUID>>()
+        verify(userRepository).disableAll(captor.capture())
+        assertThat(captor.firstValue).containsExactlyInAnyOrder(userId1, userId2)
+        verify(oidcProviderRepository).deleteById(providerId)
+        verify(oidcProviderRegistry, times(1)).refresh()
+        verify(dbClientRegistrationRepository, times(1)).refresh()
+    }
+
+    @Test
+    fun `delete with no linked identities skips user disabling but still refreshes`() {
+        whenever(oidcProviderRepository.existsById(providerId)).thenReturn(true)
+        whenever(oidcIdentityRepository.findAllByOidcProviderId(providerId)).thenReturn(emptyList())
+
+        service.delete(providerId)
+
+        verify(userRepository, never()).disableAll(any())
+        verify(oidcProviderRepository).deleteById(providerId)
+        verify(oidcProviderRegistry, times(1)).refresh()
+        verify(dbClientRegistrationRepository, times(1)).refresh()
+    }
+
+    private fun identityForUser(userId: UUID): OidcIdentityEntity {
+        val userMock = mock<UserEntity> { on { id } doReturn userId }
+        return mock { on { user } doReturn userMock }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the DEV-30 backend coverage gaps. The backend had **no coverage instrumentation**, so `./gradlew build` and CI produced no number. This adds a JaCoCo report + gate and raises the OIDC surface above the 80% bar.

### 1. Coverage plugin + gate (DEV-30 ask #1) ✅
- Apply the `jacoco` plugin (toolVersion `0.8.13`, Java 21 safe) to `plugwerk-server-backend`.
- `jacocoTestReport` reads whichever `*.exec` files exist under `build/jacoco`, so:
  - `./gradlew build` → unit-only number (no Docker needed)
  - CI (`build` + `integrationTest`) → **merged** number matching the QA baseline
  - XML + HTML reports enabled.
- `test` is `finalizedBy jacocoTestReport` so every build leaves a fresh number.
- `jacocoTestCoverageVerification` gate seeded at the DEV-30 baseline floors (**instruction 0.80 / line 0.85 / branch 0.65**) to catch regressions today; ramps to 0.80 branch as follow-up tests land.
- CI: after integration tests, generate the merged report, upload it as the `backend-coverage-report` artifact (always), then run the gate.

### 2. OIDC line coverage ≥80% (DEV-30 ask #3) ✅
New `OidcProviderService` unit tests covering the previously-untested methods (the worst offender at 43.9%):
- `create`: OIDC + OAUTH2 happy paths, SSRF rejection of a private issuer, missing required URIs, blank-optional normalisation, secret encryption.
- `findAll`, `findById` (found + not-found), `delete` (unknown id, Politik C orphaned-user disabling, no-identities path).

### Verification (merged `test` + `integrationTest`, run locally with Docker)
| Metric | Before | After |
|---|---|---|
| `OidcProviderService` line | 43.9% | **73.9%** |
| OIDC surface line | 75.9% | **83.2%** (≥80% ✅) |
| Overall instruction | 80.9% | 82.0% |
| Overall line | 86.6% | 87.4% |
| Overall branch | 65.4% | 67.1% |

- Coverage gate **passes** against merged data; `spotlessCheck` clean; full unit + integration suites green.

### Remaining (tracked separately)
- **Ask #2 — overall branch coverage ≥80%** (currently 67.1%) is a broad, codebase-wide test effort (~300 branches) tracked as a follow-up issue; the gate's branch floor ratchets to 0.80 when that lands.
- A few residual OIDC classes remain <80% individually (`OidcProviderRegistry` 61%, `PromptAware…$Companion`, `OidcRegistrationIds`) — candidates for the follow-up.

> **Security coordination:** OIDC is a security-sensitive auth surface (readiness risk #2). Requesting review from the Security Engineer on the new OIDC tests per the DEV-30 ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)