### PR TITLE
feat(telemetry): opt-out server-start + daily heartbeat beacon (DEV-23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,18 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # in-memory DB without the shedlock table.
 # PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED=true
 
+# --- Telemetry beacon (ADR-0038) ---
+# Opt-out, zero-PII install beacon: {installId, version, installType, event} on
+# first start + once daily. See the "Telemetry & Privacy" section of README.md.
+# Set to false to fully disable (no install UUID, no schedule, no HTTP).
+# PLUGWERK_TELEMETRY=true
+# HTTPS-only analytics endpoint. Empty (default) = build but never send.
+# PLUGWERK_TELEMETRY_ENDPOINT=
+# Override the auto-detected install type: docker-compose | jar | k8s.
+# PLUGWERK_INSTALL_TYPE=
+# Spring cron for the daily heartbeat. Default 03:30, staggered from the reaper.
+# PLUGWERK_TELEMETRY_CRON=0 30 3 * * *
+
 # --- Database ---
 
 # PLUGWERK_DB_URL=jdbc:postgresql://localhost:5432/plugwerk

--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ Interactive API reference (Scalar) is served by every running instance:
 
 Hosted reference: [plugwerk.io/api-docs](https://www.plugwerk.io/api-docs/).
 
+## Telemetry & Privacy
+
+Plugwerk sends a small, **opt-out**, privacy-respecting telemetry beacon so the team can size the install base and prioritise work. It fires once on first server start and once per day thereafter.
+
+**Exactly what is sent — and nothing else:**
+
+| Field | Example | What it is |
+|-------|---------|------------|
+| `installId` | `7c9e6f...` (UUID v4) | A random identifier generated once per installation and stored locally. Synthetic — it is **not** derived from anything and is unlinkable to you. |
+| `version` | `1.1.0-SNAPSHOT` | The Plugwerk version you are running. |
+| `installType` | `docker-compose` | How it is deployed: `docker-compose`, `jar`, `k8s`, or `unknown`. |
+| `event` | `server_start` | `server_start` or `heartbeat`. |
+
+**No** hostnames, IP addresses, namespaces, usernames, plugin names, or request data are ever collected. The payload is the four fields above and there is no code path that adds a fifth — see [ADR-0038](docs/adrs/0038-telemetry-beacon.md).
+
+It is **fail-open**: the beacon runs off the startup and request paths with short timeouts, and any failure (unreachable endpoint, timeout, error response) is silently ignored. Telemetry can never affect startup, health, or readiness.
+
+**Turn it off completely:**
+
+```bash
+# No install ID is generated, no heartbeat is scheduled, no HTTP call is made.
+PLUGWERK_TELEMETRY=false
+```
+
+Related environment variables: `PLUGWERK_TELEMETRY_ENDPOINT` (HTTPS-only analytics endpoint), `PLUGWERK_INSTALL_TYPE` (override the auto-detected install type). See [`.env.example`](.env.example).
+
 ## Repository Layout
 
 ```

--- a/docs/adrs/0038-telemetry-beacon.md
+++ b/docs/adrs/0038-telemetry-beacon.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Proposed
+Accepted
 
-(Security/privacy review — [DEV-25](/DEV/issues/DEV-25) — flips this to Accepted.)
+(Security/privacy review — [DEV-25](/DEV/issues/DEV-25) — passed with no CRITICAL/HIGH
+findings: zero-PII payload allowlist, random-UUID install id, complete opt-out, HTTPS-only
+configurable endpoint, and fail-open all verified. Flipped Proposed → Accepted on sign-off.)
 
 ## Context
 

--- a/docs/adrs/0038-telemetry-beacon.md
+++ b/docs/adrs/0038-telemetry-beacon.md
@@ -1,0 +1,107 @@
+# ADR-0038: Opt-out telemetry beacon
+
+## Status
+
+Proposed
+
+(Security/privacy review — [DEV-25](/DEV/issues/DEV-25) — flips this to Accepted.)
+
+## Context
+
+Plugwerk is a self-hosted, open-source plugin marketplace. To size the activation
+funnel and prioritise work, the team needs a basic, privacy-respecting signal of
+how many installations exist, what versions are deployed, and how they are run
+(Docker Compose / JAR / Kubernetes). There is currently no signal at all once a
+build leaves our hands.
+
+The Growth spec ([DEV-15](/DEV/issues/DEV-15)) and the GTM-readiness note
+([DEV-12](/DEV/issues/DEV-12) §G) mandate **opt-out** (not opt-in) telemetry,
+because opt-in collection on self-hosted infrastructure yields a participation
+rate too low to be useful. Opt-out shifts the burden onto us to make the
+collection unimpeachable: it must be impossible for a beacon to leak anything
+identifying, trivial to turn off, well-documented, and incapable of affecting the
+running server.
+
+This is the P0 child ([DEV-23](/DEV/issues/DEV-23)) of the telemetry epic
+([DEV-22](/DEV/issues/DEV-22)).
+
+## Decision
+
+Ship an **opt-out** telemetry beacon in the server with four guardrails that make
+opt-out defensible:
+
+1. **Strict zero-PII payload (allowlist by construction).** The beacon sends
+   exactly four fields and there is nowhere in the code to attach a fifth:
+
+   ```json
+   { "installId": "<uuid-v4>", "version": "1.1.0-SNAPSHOT", "installType": "docker-compose", "event": "server_start" }
+   ```
+
+   - `installId` — a random UUID v4 generated once per installation and persisted
+     locally via the existing DB-backed `ApplicationSettingsService`
+     (`telemetry.install_id`). It is synthetic and unlinkable to any real-world
+     identity.
+   - `version` — the running Plugwerk version (from build info / `VERSION`).
+   - `installType` — `docker-compose` | `jar` | `k8s` | `unknown`. Tells us *how*
+     the software is deployed, never *where*.
+   - `event` — `server_start` | `heartbeat`.
+
+   No hostnames, IPs, namespaces, usernames, plugin names, or request data are
+   collected. The payload is a Kotlin `data class` with exactly these fields, and
+   a unit test asserts the serialized JSON has exactly these keys, so a future
+   change cannot silently widen it.
+
+2. **One clean opt-out.** `PLUGWERK_TELEMETRY=false` (relaxed-bound to
+   `plugwerk.telemetry.enabled`) fully disables the feature: no install UUID is
+   generated, no heartbeat is scheduled (the scheduler bean is
+   `@ConditionalOnProperty`-gated), and no HTTP call is ever made. Default is
+   enabled.
+
+3. **Loud documentation.** The root `README.md` carries a "Telemetry & Privacy"
+   section stating precisely what is sent, why, and how to disable it.
+
+4. **Fail-open, silent.** Telemetry never runs on the request path; the first-start
+   beacon is dispatched off the startup thread. Every send is wrapped so any
+   exception (timeout, DNS, 5xx, serialization) is swallowed and logged at debug,
+   with short (2s) connect/read timeouts. Telemetry can never affect startup,
+   health, or readiness.
+
+**Endpoint ownership.** The beacon POSTs to a single, configurable,
+**Plugwerk-owned, HTTPS-only** endpoint (`PLUGWERK_TELEMETRY_ENDPOINT`). Until
+Growth provisions the live URL (sibling endpoint-coordination child), the
+endpoint defaults to empty; a blank or non-HTTPS endpoint means the payload is
+built but never sent — a harmless no-op under the fail-open design. HTTPS-only is
+enforced at **send time** (skip + debug-log), deliberately **not** as startup
+bean validation, so a misconfigured endpoint can never crash the server.
+
+**Build vs. reuse.** No new persistence or scheduling primitives were introduced:
+- install UUID persistence reuses `ApplicationSettingsService` /
+  `ApplicationSettingKey` (ADR-0016);
+- the daily heartbeat reuses the `@Scheduled` + ShedLock + scheduler-control-plane
+  pattern (ADR-0036), so operators can pause it from the admin dashboard and only
+  one instance emits per tick in a cluster;
+- the HTTP call reuses Spring's `RestClient` already on the classpath.
+
+## Consequences
+
+- **Easier:** the team gets a minimal, honest install/version/deployment signal
+  without compromising the project's privacy posture; operators who object turn it
+  off with a single environment variable and can verify the payload from the
+  README.
+- **Easier:** because nothing new was built for persistence or scheduling, the
+  surface area to review is small and the failure modes are already understood.
+- **Harder / accepted trade-offs:**
+  - Opt-out means some operators will send a beacon before reading the docs. The
+    zero-PII guarantee is what makes this acceptable; the payload is reviewed by
+    Security ([DEV-25](/DEV/issues/DEV-25)) before this ADR is Accepted.
+  - The `telemetry.install_id` setting is surfaced in the Admin → Settings list
+    (a side effect of reusing `ApplicationSettingsService`). Changing it only
+    resets the anonymous install identity; it carries no PII and no security
+    impact.
+  - A brand-new multi-instance cluster could briefly generate two install IDs on
+    first start (a benign race); analytics reconciles to one quickly and the
+    fail-open caller never surfaces the race.
+- **Follow-ups:** the live endpoint URL is provisioned by Growth out of band; P1
+  activation events (namespace-created, first-plugin-publish —
+  [DEV-24](/DEV/issues/DEV-24)) build on this beacon's transport and payload
+  conventions. QA ([DEV-26](/DEV/issues/DEV-26)) verifies opt-out + fail-open.

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -51,7 +51,58 @@ data class PlugwerkProperties(
     val storage: StorageProperties = StorageProperties(),
     @field:Valid val server: ServerProperties = ServerProperties(),
     @field:Valid val auth: AuthProperties = AuthProperties(),
+    val telemetry: TelemetryProperties = TelemetryProperties(),
 ) {
+    /**
+     * Opt-out telemetry-beacon configuration (`plugwerk.telemetry.*`) — DEV-23 / ADR-0038.
+     *
+     * The beacon sends a strictly zero-PII install heartbeat (install UUID, version,
+     * install type, event) on first server start and once per day. It is **opt-out**:
+     * enabled by default, fully disabled by `PLUGWERK_TELEMETRY=false`.
+     *
+     * Fail-open is the governing constraint — a blank, non-HTTPS, or unreachable
+     * [endpoint] never affects startup, health, or readiness. Endpoint correctness is
+     * therefore enforced at send time in
+     * [io.plugwerk.server.service.telemetry.HttpTelemetrySender] (skip + debug-log),
+     * **not** as startup bean validation, so a misconfiguration can never crash the
+     * server. See `README.md` → "Telemetry & Privacy".
+     *
+     * @property enabled Master opt-out switch. When `false`, no install UUID is
+     *   generated, no heartbeat is scheduled, and no HTTP call is ever made.
+     *   The heartbeat scheduler bean is `@ConditionalOnProperty`-gated on this value;
+     *   the first-start beacon is gated by an in-code guard reached on every startup.
+     *   Default `true`.
+     *
+     *   Environment variable: `PLUGWERK_TELEMETRY` (Spring relaxed binding maps it to
+     *   `plugwerk.telemetry.enabled` via the `application.yml` placeholder).
+     *
+     * @property endpoint HTTPS-only analytics endpoint the beacon POSTs to. Empty by
+     *   default until the Plugwerk-owned endpoint is provisioned; an empty or
+     *   non-HTTPS value means the payload is built but never sent (a harmless no-op
+     *   under the fail-open design). **Do not block on this being live.**
+     *
+     *   Environment variable: `PLUGWERK_TELEMETRY_ENDPOINT`
+     *
+     * @property installType Optional override for the auto-detected install type
+     *   (`docker-compose` | `jar` | `k8s`). Blank (default) means auto-detect; an
+     *   unrecognized value resolves to `unknown`. See
+     *   [io.plugwerk.server.service.telemetry.TelemetryInstallTypeDetector].
+     *
+     *   Environment variable: `PLUGWERK_INSTALL_TYPE`
+     *
+     * @property cron Spring cron expression for the daily heartbeat. Default `0 30 3 * * *`
+     *   (03:30 server-local), staggered against the storage reaper (03:15) and the
+     *   on-the-hour token-cleanup jobs.
+     *
+     *   Environment variable: `PLUGWERK_TELEMETRY_CRON`
+     */
+    data class TelemetryProperties(
+        val enabled: Boolean = true,
+        val endpoint: String = "",
+        val installType: String? = null,
+        val cron: String = "0 30 3 * * *",
+    )
+
     /**
      * Artifact storage configuration (`plugwerk.storage.*`).
      *

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
@@ -225,6 +225,21 @@ enum class ApplicationSettingKey(
         minInt = 5,
         maxInt = 1440,
     ),
+
+    // ---- Telemetry (DEV-23 / ADR-0038) -------------------------------------
+    // Anonymous random UUID v4 identifying this installation in the opt-out
+    // telemetry beacon. Generated once on the first beacon send and persisted
+    // here; blank (the default) until then. Carries **no** personal data — it
+    // is a synthetic, per-install random value. Persisted via ApplicationSetting
+    // purely to reuse the existing DB-backed settings store (no new
+    // persistence layer). `allowBlank` because the unset state IS the default.
+
+    TELEMETRY_INSTALL_ID(
+        key = "telemetry.install_id",
+        valueType = SettingValueType.STRING,
+        defaultValue = "",
+        allowBlank = true,
+    ),
     ;
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySender.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySender.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+/**
+ * Sends the telemetry payload over HTTPS to the configured, Plugwerk-owned
+ * endpoint (DEV-23 / ADR-0038).
+ *
+ * Two guards keep this fail-open and safe:
+ *  - **Short timeouts** ([CONNECT_TIMEOUT] / [READ_TIMEOUT]) cap the worst-case
+ *    blocking time so a hung endpoint cannot stall the scheduler thread (the
+ *    first-start beacon is additionally dispatched off the startup thread by
+ *    [TelemetryBeacon]).
+ *  - **HTTPS-only** — a blank or non-`https://` endpoint is treated as "not
+ *    configured" and the send is skipped with a debug log. This is enforced here
+ *    rather than as startup bean validation precisely so a misconfigured
+ *    endpoint can never crash the server (fail-open beats fail-fast for
+ *    telemetry).
+ *
+ * A reachable-but-erroring endpoint (4xx/5xx) makes `retrieve()` throw; that
+ * exception propagates to [TelemetryBeacon], which swallows it. This class never
+ * has to catch anything itself.
+ */
+@Component
+class HttpTelemetrySender(private val properties: PlugwerkProperties) : TelemetrySender {
+
+    private val log = LoggerFactory.getLogger(HttpTelemetrySender::class.java)
+
+    // Spring Boot does not autoconfigure a RestClient.Builder bean in our
+    // dependency set (see GitHubEmailFetcher for the same note), so the client
+    // is built directly here with an explicitly-bounded request factory.
+    private val restClient: RestClient = RestClient.builder()
+        .requestFactory(
+            SimpleClientHttpRequestFactory().apply {
+                setConnectTimeout(CONNECT_TIMEOUT)
+                setReadTimeout(READ_TIMEOUT)
+            },
+        )
+        .build()
+
+    override fun send(payload: TelemetryPayload) {
+        val endpoint = properties.telemetry.endpoint.trim()
+        if (endpoint.isEmpty()) {
+            log.debug("telemetry endpoint not configured; skipping {} beacon", payload.event)
+            return
+        }
+        if (!endpoint.startsWith("https://", ignoreCase = true)) {
+            log.debug("telemetry endpoint is not HTTPS; refusing to send {} beacon", payload.event)
+            return
+        }
+        restClient.post()
+            .uri(endpoint)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(payload)
+            .retrieve()
+            .toBodilessEntity()
+        log.debug("telemetry {} beacon sent", payload.event)
+    }
+
+    companion object {
+        private val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(2)
+        private val READ_TIMEOUT: Duration = Duration.ofSeconds(2)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallIdProvider.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallIdProvider.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Supplies the stable, anonymous install identifier used by the telemetry
+ * beacon (DEV-23 / ADR-0038).
+ *
+ * Extracted as an interface so the orchestrating [TelemetryBeacon] can be
+ * unit-tested with a recording fake — the opt-out test asserts that a disabled
+ * beacon never calls [getOrCreate] (i.e. no UUID is generated when telemetry is
+ * off).
+ */
+interface InstallIdProvider {
+    /**
+     * Returns the persisted install UUID, generating and storing one on first
+     * call. Resolving this is the *only* place a UUID is ever created — callers
+     * (the beacon) invoke it strictly after the opt-out gate, so an opted-out
+     * installation never generates one.
+     */
+    fun getOrCreate(): String
+}
+
+/**
+ * DB-backed [InstallIdProvider] that persists the install UUID via the existing
+ * [ApplicationSettingsService] (no new persistence layer — DEV-23 reuse
+ * mandate).
+ *
+ * Generation is **lazy**: the UUID is created and stored the first time a beacon
+ * actually needs it, so toggling telemetry off before the first send means no
+ * identifier is ever written. [getOrCreate] is `@Synchronized` so two concurrent
+ * beacons on the same instance cannot both generate; the rare cross-instance
+ * race on a brand-new cluster is harmless (analytics briefly sees two installs)
+ * and is left to fail-open at the caller.
+ */
+@Component
+class TelemetryInstallIdProvider(private val settings: ApplicationSettingsService) : InstallIdProvider {
+
+    @Synchronized
+    override fun getOrCreate(): String {
+        val existing = settings.getRaw(ApplicationSettingKey.TELEMETRY_INSTALL_ID).trim()
+        if (existing.isNotBlank()) return existing
+        val generated = UUID.randomUUID().toString()
+        settings.update(ApplicationSettingKey.TELEMETRY_INSTALL_ID, generated, updatedBy = UPDATED_BY)
+        return generated
+    }
+
+    companion object {
+        /** Audit `updated_by` marker so an operator can see the row was machine-written. */
+        const val UPDATED_BY = "telemetry"
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallType.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallType.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+/**
+ * How this Plugwerk installation is being run, as reported by the opt-out
+ * telemetry beacon (DEV-23 / ADR-0038).
+ *
+ * The [wireValue] is the only form that ever leaves the process — the payload
+ * carries the lowercase, hyphenated string, never the enum constant name. The
+ * closed set is part of the zero-PII allowlist: it tells Plugwerk *how* the
+ * software is deployed, never *where* or *by whom*.
+ */
+enum class InstallType(val wireValue: String) {
+    DOCKER_COMPOSE("docker-compose"),
+    JAR("jar"),
+    K8S("k8s"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        /**
+         * Resolves a [wireValue] (case-insensitive, trimmed) back to its enum
+         * constant, or `null` if it is not one of the known install types. Used
+         * to validate the `PLUGWERK_INSTALL_TYPE` operator override.
+         */
+        fun fromWireValue(value: String): InstallType? {
+            val needle = value.trim()
+            return entries.firstOrNull { it.wireValue.equals(needle, ignoreCase = true) }
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.VersionProvider
+import jakarta.annotation.PreDestroy
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Orchestrates the opt-out telemetry beacon (DEV-23 / ADR-0038): builds the
+ * zero-PII payload and hands it to the [TelemetrySender], gated by the global
+ * opt-out and wrapped fail-open.
+ *
+ * Two design points carry the issue's hard constraints:
+ *
+ *  - **Opt-out gate.** [emit] returns immediately when `plugwerk.telemetry.enabled`
+ *    is false — *before* resolving the install id or touching the sender. This is
+ *    the single, unit-tested source of truth for "telemetry is off": a disabled
+ *    beacon generates no UUID and makes no HTTP call. The guard is reached on
+ *    every startup via [onApplicationReady], so it is live code, not a dead
+ *    branch. (The daily heartbeat is additionally suppressed at the bean level —
+ *    [TelemetryHeartbeatScheduler] is `@ConditionalOnProperty`-gated — so a
+ *    disabled install also registers no schedule.)
+ *
+ *  - **Fail-open.** Every emit wraps payload-build + send in [runCatching]; any
+ *    exception (timeout, DNS, 5xx, serialization, a settings-write blip while
+ *    generating the install id) is swallowed and logged at debug. Telemetry can
+ *    never affect startup, health, or readiness.
+ *
+ * The first-start beacon is dispatched on a dedicated single-thread executor so a
+ * slow or hung endpoint cannot delay `ApplicationReadyEvent` propagation. The
+ * heartbeat path runs on the scheduler thread (already off the request/startup
+ * path) and calls [emit] directly.
+ */
+@Component
+class TelemetryBeacon(
+    private val properties: PlugwerkProperties,
+    private val installIdProvider: InstallIdProvider,
+    private val versionProvider: VersionProvider,
+    private val installTypeDetector: TelemetryInstallTypeDetector,
+    private val sender: TelemetrySender,
+) {
+    private val log = LoggerFactory.getLogger(TelemetryBeacon::class.java)
+
+    /** Off-startup-thread dispatcher for the first-start beacon. Daemon so it never blocks JVM exit. */
+    private val startupExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "telemetry-startup").apply { isDaemon = true }
+    }
+
+    /**
+     * Sends a single beacon for [event]. No-op when telemetry is disabled.
+     * Synchronous and fail-open: returns normally whether the send succeeded,
+     * was skipped (no/insecure endpoint), or threw.
+     */
+    fun emit(event: TelemetryEvent) {
+        if (!properties.telemetry.enabled) return
+        runCatching {
+            val payload = TelemetryPayloadBuilder.build(
+                installId = installIdProvider.getOrCreate(),
+                version = versionProvider.getVersion(),
+                installType = installTypeDetector.detect(),
+                event = event,
+            )
+            sender.send(payload)
+        }.onFailure { ex ->
+            log.debug("telemetry {} beacon failed (ignored, fail-open): {}", event.wireValue, ex.message)
+        }
+    }
+
+    /**
+     * First-start beacon. Fired once when the application is ready; dispatched off
+     * the event thread so the send (or its timeout) never delays startup.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationReady() {
+        startupExecutor.execute { emit(TelemetryEvent.SERVER_START) }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        startupExecutor.shutdown()
+        runCatching { startupExecutor.awaitTermination(2, TimeUnit.SECONDS) }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryHeartbeatScheduler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryHeartbeatScheduler.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.scheduler.SchedulerJobAuditor
+import io.plugwerk.server.service.scheduler.SchedulerJobDescriptor
+import io.plugwerk.server.service.scheduler.SchedulerJobRegistry
+import jakarta.annotation.PostConstruct
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Lazy
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Daily telemetry heartbeat (DEV-23 / ADR-0038).
+ *
+ * `@ConditionalOnProperty`-gated on `plugwerk.telemetry.enabled` so that an
+ * opted-out installation registers **no** schedule at all (the strongest reading
+ * of "no scheduling when disabled") — mirroring
+ * [io.plugwerk.server.service.storage.consistency.OrphanReaperScheduler]. When
+ * enabled, the job is registered with the scheduler control plane (ADR-0036), so
+ * an operator can pause it from the admin dashboard and it is bootstrapped into
+ * the `scheduler_job` table on startup.
+ *
+ * The tick runs through [SchedulerJobAuditor.gateAndRun] (control-plane
+ * enable/disable + run accounting) and delegates to [TelemetryBeacon.emit], which
+ * is itself fail-open — so a failing send is swallowed inside the beacon and the
+ * job records `SUCCESS` for "dispatched the heartbeat". ShedLock scopes the tick
+ * cluster-wide so only one instance emits per day. Dry-run is not meaningful for
+ * a fire-and-forget beacon, hence `supportsDryRun = false`.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "plugwerk.telemetry",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class TelemetryHeartbeatScheduler(
+    private val beacon: TelemetryBeacon,
+    private val properties: PlugwerkProperties,
+    private val schedulerJobRegistry: SchedulerJobRegistry,
+    private val schedulerJobAuditor: SchedulerJobAuditor,
+) {
+
+    /** See [io.plugwerk.server.service.storage.consistency.OrphanReaperScheduler.self] — same Spring-proxy reason. */
+    @Autowired
+    @Lazy
+    private lateinit var self: TelemetryHeartbeatScheduler
+
+    @PostConstruct
+    fun registerScheduledJob() {
+        schedulerJobRegistry.register(
+            SchedulerJobDescriptor(
+                name = JOB_NAME,
+                description = "Sends the daily Plugwerk opt-out telemetry heartbeat " +
+                    "(anonymous install id, version, install type — zero PII). " +
+                    "Disable globally with PLUGWERK_TELEMETRY=false.",
+                cronExpression = properties.telemetry.cron,
+                supportsDryRun = false,
+                runNowExecutor = { self.heartbeat() },
+            ),
+        )
+    }
+
+    /**
+     * Heartbeat tick. Cron from `plugwerk.telemetry.cron` (default `0 30 3 * * *`).
+     * Lock windows are tight because the body is a single bounded HTTP call:
+     * `lockAtMostFor=PT2M` comfortably covers the short connect/read timeouts even
+     * under retry-free worst case, and `lockAtLeastFor=PT10S` avoids a second
+     * instance double-emitting on a fast tick.
+     */
+    @Scheduled(cron = "\${plugwerk.telemetry.cron:0 30 3 * * *}")
+    @SchedulerLock(
+        name = JOB_NAME,
+        lockAtMostFor = "PT2M",
+        lockAtLeastFor = "PT10S",
+    )
+    fun heartbeat() {
+        schedulerJobAuditor.gateAndRun(JOB_NAME) { beacon.emit(TelemetryEvent.HEARTBEAT) }
+    }
+
+    companion object {
+        private const val JOB_NAME = "telemetry-heartbeat"
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetector.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetector.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves how this installation is being run, for the telemetry payload's
+ * `installType` field (DEV-23 / ADR-0038).
+ *
+ * Resolution order:
+ *  1. **Operator override** — `PLUGWERK_INSTALL_TYPE` (bound to
+ *     `plugwerk.telemetry.install-type`). A recognized value wins outright; an
+ *     unrecognized non-blank value resolves to [InstallType.UNKNOWN] rather than
+ *     guessing.
+ *  2. **Kubernetes** — the `KUBERNETES_SERVICE_HOST` env var is injected into
+ *     every pod by the kubelet, so its presence is a reliable k8s signal.
+ *  3. **Docker Compose** — the `/.dockerenv` marker file is present in every
+ *     Docker container. We report `docker-compose` because that is Plugwerk's
+ *     supported container-deployment shape; a bare `docker run` is
+ *     indistinguishable and lumped in here intentionally.
+ *  4. **Plain JAR** — the fallback for a process started directly on a host.
+ *
+ * The env-var and marker-file lookups are injectable so the resolution logic can
+ * be unit-tested without touching the real environment or filesystem.
+ */
+@Component
+class TelemetryInstallTypeDetector(private val properties: PlugwerkProperties) {
+
+    /** Env-var accessor. Overridable in tests; production reads the real environment. */
+    internal var envLookup: (String) -> String? = { System.getenv(it) }
+
+    /** Docker marker-file probe. Overridable in tests; production checks the real path. */
+    internal var dockerEnvMarkerPresent: () -> Boolean = { Files.exists(Path.of(DOCKER_ENV_MARKER)) }
+
+    fun detect(): InstallType {
+        val override = properties.telemetry.installType?.trim()?.takeIf { it.isNotBlank() }
+        if (override != null) {
+            return InstallType.fromWireValue(override) ?: InstallType.UNKNOWN
+        }
+        if (!envLookup(KUBERNETES_SERVICE_HOST_ENV).isNullOrBlank()) return InstallType.K8S
+        if (dockerEnvMarkerPresent()) return InstallType.DOCKER_COMPOSE
+        return InstallType.JAR
+    }
+
+    companion object {
+        const val KUBERNETES_SERVICE_HOST_ENV = "KUBERNETES_SERVICE_HOST"
+        const val DOCKER_ENV_MARKER = "/.dockerenv"
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+/**
+ * The lifecycle event a [TelemetryPayload] reports (DEV-23 / ADR-0038).
+ *
+ * Only the [wireValue] is serialized; the enum constant name never leaves the
+ * process.
+ */
+enum class TelemetryEvent(val wireValue: String) {
+    /** Emitted once per process on `ApplicationReadyEvent`. */
+    SERVER_START("server_start"),
+
+    /** Emitted ~once per 24h by the scheduled heartbeat job. */
+    HEARTBEAT("heartbeat"),
+}
+
+/**
+ * The complete, zero-PII telemetry payload (DEV-23 / ADR-0038).
+ *
+ * This data class **is** the allowlist: Jackson serializes exactly these four
+ * camelCase fields and nothing else. There is deliberately no place to attach a
+ * hostname, IP, namespace, user, or any other identifying data — privacy is
+ * enforced by construction, not by a runtime filter. The only test that has to
+ * stay green forever is "the serialized payload has exactly these keys".
+ *
+ * @property installId Random UUID v4 generated once per installation and
+ *   persisted locally (see
+ *   [io.plugwerk.server.service.telemetry.TelemetryInstallIdProvider]). Synthetic
+ *   and unlinkable to any real-world identity.
+ * @property version The running Plugwerk version (build info / `VERSION`).
+ * @property installType One of the [InstallType.wireValue]s.
+ * @property event One of the [TelemetryEvent.wireValue]s.
+ */
+data class TelemetryPayload(val installId: String, val version: String, val installType: String, val event: String)
+
+/**
+ * Pure builder for [TelemetryPayload]. Kept as a free function with no Spring
+ * wiring so the allowlist contract can be unit-tested in isolation, and so the
+ * orchestrating [io.plugwerk.server.service.telemetry.TelemetryBeacon] stays the
+ * single place that resolves the (potentially side-effecting) install id.
+ */
+object TelemetryPayloadBuilder {
+    fun build(installId: String, version: String, installType: InstallType, event: TelemetryEvent): TelemetryPayload =
+        TelemetryPayload(
+            installId = installId,
+            version = version,
+            installType = installType.wireValue,
+            event = event.wireValue,
+        )
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetrySender.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetrySender.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+/**
+ * Transport seam for the telemetry beacon (DEV-23 / ADR-0038).
+ *
+ * Pulled out as an interface for one reason above all: the fail-open acceptance
+ * criterion requires a test that injects a *failing* sender and proves the
+ * exception never reaches startup/health. Production wires [HttpTelemetrySender];
+ * tests wire a throwing or recording fake.
+ *
+ * Implementations may throw freely — the caller ([TelemetryBeacon]) wraps every
+ * call so any failure is swallowed and logged at debug.
+ */
+fun interface TelemetrySender {
+    fun send(payload: TelemetryPayload)
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -149,6 +149,35 @@ plugwerk:
     shedlock:
       # Env: PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED
       enabled: ${PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED:true}
+
+  # Opt-out telemetry beacon (ADR-0038). Sends a strictly zero-PII install
+  # heartbeat — {installId, version, installType, event} and nothing else — on
+  # first server start and once per day, so the Plugwerk team can size the
+  # activation funnel. No hostnames, IPs, namespaces, or user data are ever
+  # collected. See the "Telemetry & Privacy" section of the root README for the
+  # full payload and rationale. Fail-open by design: a blank, non-HTTPS, or
+  # unreachable endpoint is harmless and never affects startup, health, or
+  # readiness.
+  telemetry:
+    # Master opt-out. Set PLUGWERK_TELEMETRY=false to fully disable: no install
+    # UUID is generated, no heartbeat is scheduled, and no HTTP call is made.
+    # Env: PLUGWERK_TELEMETRY
+    enabled: ${PLUGWERK_TELEMETRY:true}
+    # HTTPS-only, Plugwerk-owned analytics endpoint the beacon POSTs to. Empty by
+    # default until the live endpoint is provisioned; an empty or non-HTTPS value
+    # means the payload is built but never sent (a harmless no-op). Do NOT treat
+    # an unset endpoint as a reason to delay a deployment.
+    # Env: PLUGWERK_TELEMETRY_ENDPOINT
+    endpoint: ${PLUGWERK_TELEMETRY_ENDPOINT:}
+    # Override the auto-detected install type (docker-compose | jar | k8s). Empty
+    # (default) = auto-detect (KUBERNETES_SERVICE_HOST ⇒ k8s; /.dockerenv ⇒
+    # docker-compose; else jar). An unrecognized value reports as 'unknown'.
+    # Env: PLUGWERK_INSTALL_TYPE
+    install-type: ${PLUGWERK_INSTALL_TYPE:}
+    # Daily heartbeat cron (sec min hour day-of-month month day-of-week). Default
+    # 03:30 server-local, staggered against the storage reaper (03:15).
+    # Env: PLUGWERK_TELEMETRY_CRON
+    cron: ${PLUGWERK_TELEMETRY_CRON:0 30 3 * * *}
   server:
     base-url: ${PLUGWERK_BASE_URL:http://localhost:8080}
     # Frontend base URL for browser-facing links emitted by the server (e.g. the

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -69,3 +69,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0034_scheduler_job.yaml
   - include:
       file: db/changelog/migrations/0035_application_asset.yaml
+  - include:
+      file: db/changelog/migrations/0036_seed_telemetry_install_id.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0036_seed_telemetry_install_id.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0036_seed_telemetry_install_id.yaml
@@ -1,0 +1,34 @@
+# Seed the telemetry install-id setting registered in ApplicationSettingKey
+# (DEV-23 / ADR-0038). The value is intentionally empty: the install UUID is
+# generated lazily on the first telemetry beacon send and written back to this
+# row. Seeding the row (rather than relying on the enum default fallback) keeps
+# the Admin → Settings list source-consistent (DATABASE, not DEFAULT) with every
+# other application setting. The value carries no personal data — it is a
+# synthetic per-install random UUID v4.
+databaseChangeLog:
+  - changeSet:
+      id: 0036-seed-telemetry-install-id
+      author: plugwerk
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: id
+                  valueComputed: gen_random_uuid()
+              - column:
+                  name: setting_key
+                  value: telemetry.install_id
+              - column:
+                  name: setting_value
+                  value: ""
+              - column:
+                  name: setting_desc
+                  value: "Anonymous random UUID v4 identifying this installation in the opt-out telemetry beacon (ADR-0038). Generated on the first beacon send; blank until then. Contains no personal data. Disable telemetry entirely with PLUGWERK_TELEMETRY=false."
+              - column:
+                  name: value_type
+                  value: STRING
+      rollback:
+        - delete:
+            tableName: application_setting
+            where: "setting_key = 'telemetry.install_id'"

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconIT.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+/**
+ * Fail-open integration check (DEV-23 / ADR-0038, acceptance criterion 3).
+ *
+ * Telemetry is **enabled** and pointed at a deliberately broken HTTPS endpoint
+ * (a closed local port). The first-start beacon fires on `ApplicationReadyEvent`
+ * and the heartbeat job is scheduled — but because every send is wrapped
+ * fail-open with short timeouts, the unreachable endpoint must not affect
+ * startup or `/actuator/health`. If telemetry could break the app, this context
+ * would fail to start or health would be non-200.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:telemetry-failopen;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "plugwerk.telemetry.enabled=true",
+        // Port 1 is never listening — connect fails fast and is swallowed.
+        "plugwerk.telemetry.endpoint=https://127.0.0.1:1/telemetry",
+    ],
+)
+class TelemetryBeaconIT {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `health stays green with telemetry enabled against a broken endpoint`() {
+        mockMvc.get("/actuator/health")
+            .andExpect { status { isOk() } }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import io.plugwerk.server.service.VersionProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the two hard constraints the beacon owns (DEV-23 / ADR-0038):
+ * the **opt-out gate** (disabled ⇒ no UUID, no send) and **fail-open** (a
+ * throwing sender never propagates). Hand-written fakes keep the seams explicit.
+ */
+class TelemetryBeaconTest {
+
+    /** Records how often the install id was resolved — i.e. whether a UUID was generated. */
+    private class RecordingInstallIdProvider(private val id: String = "fixed-install-id") : InstallIdProvider {
+        var calls: Int = 0
+            private set
+
+        override fun getOrCreate(): String {
+            calls++
+            return id
+        }
+    }
+
+    private class RecordingSender : TelemetrySender {
+        val sent: MutableList<TelemetryPayload> = mutableListOf()
+
+        override fun send(payload: TelemetryPayload) {
+            sent += payload
+        }
+    }
+
+    private class ThrowingSender : TelemetrySender {
+        override fun send(payload: TelemetryPayload): Nothing =
+            throw RuntimeException("simulated telemetry endpoint failure")
+    }
+
+    private fun detector(): TelemetryInstallTypeDetector = TelemetryInstallTypeDetector(PlugwerkProperties()).apply {
+        envLookup = { null }
+        dockerEnvMarkerPresent = { false }
+    }
+
+    private fun beacon(
+        enabled: Boolean,
+        installIdProvider: InstallIdProvider,
+        sender: TelemetrySender,
+    ): TelemetryBeacon = TelemetryBeacon(
+        properties = PlugwerkProperties(
+            telemetry = PlugwerkProperties.TelemetryProperties(enabled = enabled),
+        ),
+        installIdProvider = installIdProvider,
+        versionProvider = VersionProvider(null),
+        installTypeDetector = detector(),
+        sender = sender,
+    )
+
+    @Test
+    fun `opt-out disables everything — no UUID generated, no send`() {
+        val provider = RecordingInstallIdProvider()
+        val sender = RecordingSender()
+        val beacon = beacon(enabled = false, installIdProvider = provider, sender = sender)
+
+        beacon.emit(TelemetryEvent.SERVER_START)
+        beacon.emit(TelemetryEvent.HEARTBEAT)
+
+        assertThat(provider.calls).describedAs("no install UUID resolved when disabled").isZero()
+        assertThat(sender.sent).describedAs("no HTTP send when disabled").isEmpty()
+    }
+
+    @Test
+    fun `enabled beacon sends the payload built from the resolved inputs`() {
+        val provider = RecordingInstallIdProvider(id = "the-install-id")
+        val sender = RecordingSender()
+        val beacon = beacon(enabled = true, installIdProvider = provider, sender = sender)
+
+        beacon.emit(TelemetryEvent.HEARTBEAT)
+
+        assertThat(provider.calls).isEqualTo(1)
+        assertThat(sender.sent).hasSize(1)
+        val payload = sender.sent.single()
+        assertThat(payload.installId).isEqualTo("the-install-id")
+        assertThat(payload.installType).isEqualTo("jar")
+        assertThat(payload.event).isEqualTo("heartbeat")
+    }
+
+    @Test
+    fun `fail-open — a throwing sender never propagates`() {
+        val provider = RecordingInstallIdProvider()
+        val beacon = beacon(enabled = true, installIdProvider = provider, sender = ThrowingSender())
+
+        assertThatCode { beacon.emit(TelemetryEvent.SERVER_START) }
+            .describedAs("telemetry failure must be swallowed")
+            .doesNotThrowAnyException()
+        // The id was resolved (the failure was downstream, at the send), proving
+        // the swallow happens around the whole emit, not by skipping the build.
+        assertThat(provider.calls).isEqualTo(1)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryDisabledIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryDisabledIT.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Opt-out integration check (DEV-23 / ADR-0038, acceptance criterion 1).
+ *
+ * With `PLUGWERK_TELEMETRY=false` (here as `plugwerk.telemetry.enabled=false`):
+ *  - **No schedule** — the `@ConditionalOnProperty`-gated heartbeat scheduler
+ *    bean is absent from the context entirely.
+ *  - **No UUID** — the first-start beacon's in-code gate short-circuits before
+ *    resolving the install id, so the `telemetry.install_id` setting stays blank.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:telemetry-disabled;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "plugwerk.telemetry.enabled=false",
+    ],
+)
+class TelemetryDisabledIT {
+
+    @Autowired private lateinit var applicationContext: ApplicationContext
+
+    @Autowired private lateinit var applicationSettingsService: ApplicationSettingsService
+
+    @Test
+    fun `no heartbeat schedule is registered when telemetry is disabled`() {
+        assertThat(applicationContext.getBeanNamesForType(TelemetryHeartbeatScheduler::class.java))
+            .describedAs("disabled telemetry must register no scheduled heartbeat bean")
+            .isEmpty()
+    }
+
+    @Test
+    fun `no install UUID is generated when telemetry is disabled`() {
+        assertThat(applicationSettingsService.getRaw(ApplicationSettingKey.TELEMETRY_INSTALL_ID))
+            .describedAs("disabled telemetry must not generate or persist an install id")
+            .isBlank()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallIdProviderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallIdProviderTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.service.settings.ApplicationSettingKey
+import io.plugwerk.server.service.settings.ApplicationSettingsService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+/**
+ * Unit tests for the lazy, DB-backed install-id provider (DEV-23 / ADR-0038).
+ */
+class TelemetryInstallIdProviderTest {
+
+    @Test
+    fun `generates and persists a UUID v4 when none is stored yet`() {
+        val settings = mock<ApplicationSettingsService>()
+        whenever(settings.getRaw(ApplicationSettingKey.TELEMETRY_INSTALL_ID)).thenReturn("")
+        val provider = TelemetryInstallIdProvider(settings)
+
+        val id = provider.getOrCreate()
+
+        // Returned value is a syntactically valid UUID (v4 from UUID.randomUUID()).
+        assertThat(UUID.fromString(id).version()).isEqualTo(4)
+        // ...and it was persisted back through the settings store, marked machine-written.
+        verify(settings).update(
+            eq(ApplicationSettingKey.TELEMETRY_INSTALL_ID),
+            eq(id),
+            eq(TelemetryInstallIdProvider.UPDATED_BY),
+        )
+    }
+
+    @Test
+    fun `returns the stored id without regenerating when one already exists`() {
+        val stored = "stored-install-id"
+        val settings = mock<ApplicationSettingsService>()
+        whenever(settings.getRaw(ApplicationSettingKey.TELEMETRY_INSTALL_ID)).thenReturn(stored)
+        val provider = TelemetryInstallIdProvider(settings)
+
+        val id = provider.getOrCreate()
+
+        assertThat(id).isEqualTo(stored)
+        verify(settings, never()).update(any(), any(), any())
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetectorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetectorTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for install-type resolution (DEV-23 / ADR-0038). The env-var and
+ * docker-marker probes are stubbed so the four-step resolution order can be
+ * exercised deterministically without touching the real environment.
+ */
+class TelemetryInstallTypeDetectorTest {
+
+    private fun detector(
+        installTypeOverride: String? = null,
+        env: Map<String, String> = emptyMap(),
+        dockerMarker: Boolean = false,
+    ): TelemetryInstallTypeDetector {
+        val properties = PlugwerkProperties(
+            telemetry = PlugwerkProperties.TelemetryProperties(installType = installTypeOverride),
+        )
+        return TelemetryInstallTypeDetector(properties).apply {
+            envLookup = { env[it] }
+            dockerEnvMarkerPresent = { dockerMarker }
+        }
+    }
+
+    @Test
+    fun `operator override wins over auto-detection`() {
+        val detector = detector(
+            installTypeOverride = "jar",
+            env = mapOf(TelemetryInstallTypeDetector.KUBERNETES_SERVICE_HOST_ENV to "10.0.0.1"),
+            dockerMarker = true,
+        )
+        assertThat(detector.detect()).isEqualTo(InstallType.JAR)
+    }
+
+    @Test
+    fun `override is case-insensitive and trimmed`() {
+        assertThat(detector(installTypeOverride = "  K8S ").detect()).isEqualTo(InstallType.K8S)
+    }
+
+    @Test
+    fun `unrecognized override resolves to unknown rather than guessing`() {
+        assertThat(detector(installTypeOverride = "heroku").detect()).isEqualTo(InstallType.UNKNOWN)
+    }
+
+    @Test
+    fun `detects kubernetes from the service-host env var`() {
+        val detector = detector(
+            env = mapOf(TelemetryInstallTypeDetector.KUBERNETES_SERVICE_HOST_ENV to "10.0.0.1"),
+            dockerMarker = true,
+        )
+        assertThat(detector.detect()).isEqualTo(InstallType.K8S)
+    }
+
+    @Test
+    fun `detects docker-compose from the dockerenv marker when not on kubernetes`() {
+        assertThat(detector(dockerMarker = true).detect()).isEqualTo(InstallType.DOCKER_COMPOSE)
+    }
+
+    @Test
+    fun `falls back to jar with no signals`() {
+        assertThat(detector().detect()).isEqualTo(InstallType.JAR)
+    }
+
+    @Test
+    fun `blank kubernetes env var is not treated as a kubernetes signal`() {
+        val detector = detector(
+            env = mapOf(TelemetryInstallTypeDetector.KUBERNETES_SERVICE_HOST_ENV to "  "),
+        )
+        assertThat(detector.detect()).isEqualTo(InstallType.JAR)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Contract tests for the telemetry payload allowlist (DEV-23 / ADR-0038).
+ *
+ * The single invariant that must never regress: a serialized payload carries
+ * **exactly** `installId`, `version`, `installType`, `event` — no PII field can
+ * sneak in because the [TelemetryPayload] data class has nowhere to put one.
+ */
+class TelemetryPayloadBuilderTest {
+
+    private val objectMapper = ObjectMapper()
+
+    @Test
+    fun `builds payload with exactly the allowlisted fields`() {
+        val payload = TelemetryPayloadBuilder.build(
+            installId = "11111111-2222-4333-8444-555555555555",
+            version = "1.1.0-SNAPSHOT",
+            installType = InstallType.DOCKER_COMPOSE,
+            event = TelemetryEvent.SERVER_START,
+        )
+
+        assertThat(payload.installId).isEqualTo("11111111-2222-4333-8444-555555555555")
+        assertThat(payload.version).isEqualTo("1.1.0-SNAPSHOT")
+        assertThat(payload.installType).isEqualTo("docker-compose")
+        assertThat(payload.event).isEqualTo("server_start")
+    }
+
+    @Test
+    fun `serialized JSON contains only the four allowlisted keys`() {
+        val payload = TelemetryPayloadBuilder.build(
+            installId = "id",
+            version = "v",
+            installType = InstallType.K8S,
+            event = TelemetryEvent.HEARTBEAT,
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val asMap = objectMapper.readValue(objectMapper.writeValueAsString(payload), Map::class.java)
+            as Map<String, Any?>
+
+        assertThat(asMap.keys).containsExactlyInAnyOrder("installId", "version", "installType", "event")
+        assertThat(asMap["installType"]).isEqualTo("k8s")
+        assertThat(asMap["event"]).isEqualTo("heartbeat")
+    }
+
+    @Test
+    fun `event and install type serialize to their wire values, never enum names`() {
+        assertThat(TelemetryEvent.SERVER_START.wireValue).isEqualTo("server_start")
+        assertThat(TelemetryEvent.HEARTBEAT.wireValue).isEqualTo("heartbeat")
+        assertThat(InstallType.DOCKER_COMPOSE.wireValue).isEqualTo("docker-compose")
+        assertThat(InstallType.JAR.wireValue).isEqualTo("jar")
+        assertThat(InstallType.K8S.wireValue).isEqualTo("k8s")
+        assertThat(InstallType.UNKNOWN.wireValue).isEqualTo("unknown")
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **P0 opt-out telemetry beacon** (DEV-23, parent DEV-22): a strictly zero-PII install heartbeat sent once on first server start and once per day to a configurable, Plugwerk-owned, HTTPS-only endpoint. Records the opt-out decision and its guardrails as **ADR-0038** (Proposed — Security review flips it to Accepted).

Payload is exactly `{installId, version, installType, event}` and nothing else — enforced by construction (a `data class` with no room for a fifth field, plus a test asserting the serialized key set).

## What's included

- **`service/telemetry/`** — new package:
  - `TelemetryBeacon` — opt-out gate + fail-open `emit()`, first-start beacon on `ApplicationReadyEvent` (dispatched off the startup thread).
  - `TelemetryHeartbeatScheduler` — `@ConditionalOnProperty`-gated daily `@Scheduled` job on the scheduler control plane (ADR-0036) + ShedLock.
  - `TelemetryInstallIdProvider` — lazy UUID v4 persisted via the existing `ApplicationSettingsService` (new `ApplicationSettingKey.TELEMETRY_INSTALL_ID` + Liquibase seed `0036`).
  - `TelemetryInstallTypeDetector` — `PLUGWERK_INSTALL_TYPE` override → k8s → docker-compose → jar.
  - `HttpTelemetrySender` — `RestClient`, 2s connect/read timeouts, HTTPS-only enforced at send time (skip + debug log, never fail startup).
- **Config:** `plugwerk.telemetry.*` in `PlugwerkProperties` + `application.yml` (`PLUGWERK_TELEMETRY`, `PLUGWERK_TELEMETRY_ENDPOINT`, `PLUGWERK_INSTALL_TYPE`, `PLUGWERK_TELEMETRY_CRON`).
- **Docs:** README "Telemetry & Privacy" section, `docs/adrs/0038-telemetry-beacon.md`, `.env.example`.

## Acceptance criteria

1. ✅ Start beacon + daily heartbeat emit exactly `{installId, version, installType, event}`; `PLUGWERK_TELEMETRY=false` disables it entirely (no UUID, no schedule, no HTTP).
2. ✅ README privacy section documents the beacon and the opt-out.
3. ✅ Zero PII; telemetry failure (timeout/DNS/5xx/serialization) cannot affect startup, health, or readiness — proven by an integration test that boots against a broken endpoint, and a unit test that injects a throwing sender.
4. ✅ `docs/adrs/0038-telemetry-beacon.md` added.

## Test plan

- **Unit:** payload allowlist (exact key set), opt-out gating (disabled ⇒ no UUID/no send), fail-open (throwing sender swallowed), install-type detection.
- **Integration (H2):** enabled + deliberately broken HTTPS endpoint ⇒ `/actuator/health` stays `200`; disabled ⇒ no heartbeat scheduler bean and `telemetry.install_id` stays blank.
- Verified locally: backend `test` suite green, `spotlessCheck` green, and `LiquibaseRollbackIT` green against PostgreSQL 18 (migration `0036` applies + rolls back cleanly).

## Reviews / gates (sibling children)

- 🔒 Security/privacy review — DEV-25 (merge gate, auto-wakes when this is done).
- ✅ QA verification of opt-out + fail-open — DEV-26 (auto-wakes when this is done).

> Note: developed in a shared multi-agent worktree alongside DEV-32 (telemetry reverse proxy). This branch is based on clean `main` and contains **only** the DEV-23 backend beacon — no DEV-32 proxy/PRIVACY.md files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)