### PR TITLE
feat(telemetry): Cloudflare Worker reverse proxy + zero-PII allowlist (DEV-32)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,91 @@
+# Plugwerk Privacy Policy
+
+_Last updated: 2026-06-13_
+
+Plugwerk is self-hosted, open-source software. **You run your own instance**, so
+for everything that happens inside it — accounts, namespaces, plugins, uploads —
+**you are the data controller** and this policy does not govern that data. How you
+handle your end users' data is your responsibility.
+
+There is exactly **one** thing the Plugwerk software sends back to its maintainers,
+**devtank42 GmbH**: an opt-out **telemetry beacon**. This policy describes that
+beacon and nothing else.
+
+## What the telemetry beacon collects
+
+The beacon sends **exactly four fields, and there is no code path that adds a
+fifth** (enforced by construction — see
+[ADR-0039](docs/adrs/0039-telemetry-beacon.md)):
+
+| Field         | Example            | What it is                                                                                                   |
+| ------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `installId`   | `7c9e6f…` (UUID v4) | A random identifier generated **once** per installation and stored locally. Synthetic — not derived from anything and unlinkable to a person. |
+| `version`     | `1.1.0-SNAPSHOT`   | The Plugwerk version the instance is running.                                                                |
+| `installType` | `docker-compose`   | How it is deployed: `docker-compose`, `jar`, `k8s`, or `unknown`.                                            |
+| `event`       | `server_start`     | The lifecycle event: `server_start` or `heartbeat` (and, for later activation funnel events, `namespace_created` / `plugin_published`). |
+
+**No personal data is in the payload.** The beacon payload is exactly the four
+fields above — no hostnames, IP addresses, namespaces, usernames, plugin names,
+account data, or request contents. (As with any HTTPS request, the instance's IP
+address is visible as transient connection metadata to our reverse-proxy
+provider; it is never part of the telemetry payload, is not forwarded to PostHog,
+and is not used for analytics.) The events carry **no person profiles** — the
+analytics processor is configured event-only (`$process_person_profile: false`).
+
+## Why we collect it (purpose & legal basis)
+
+We use this pseudonymous signal solely to **size the install base, understand
+which versions and deployment types are in use, and prioritise engineering work**.
+It is product/activation analytics, not advertising or profiling.
+
+Insofar as the synthetic `installId` is treated as personal data at all, the legal
+basis is our **legitimate interest** (Art. 6(1)(f) GDPR) in understanding adoption
+of our own software, balanced against a strictly pseudonymous, PII-free payload and
+a one-line opt-out (below).
+
+## Who processes it (processor & data residency)
+
+- **Controller:** devtank42 GmbH (Plugwerk maintainers).
+- **Processor:** **PostHog**, used on **PostHog EU Cloud** — telemetry is stored and
+  processed **within the EU** (`eu.i.posthog.com`). A **Data Processing Agreement
+  (DPA)** is in place with PostHog before any production data is ingested (see the
+  DPA-acceptance runbook in
+  [`telemetry-proxy/README.md`](telemetry-proxy/README.md#dpa-acceptance-do-this-first)).
+- **Sub-processor (transport):** **Cloudflare**, which operates the
+  `telemetry.plugwerk.io` reverse proxy under its standard DPA. It processes the
+  connection (including source IP) transiently to route the request; the IP is not
+  forwarded to PostHog.
+- **Transport:** beacons go to a Plugwerk-owned HTTPS reverse proxy
+  (`telemetry.plugwerk.io`) that validates the payload against the four-field
+  allowlist and forwards it to PostHog. Request bodies are never logged.
+
+## Retention
+
+Telemetry is retained only as long as it is useful for the analytics purpose above
+and is subject to PostHog EU Cloud's storage. Because the payload contains no PII,
+there is no personal data to erase; resetting an instance's `installId` (Admin →
+Settings, or a fresh install) detaches all future beacons from any prior series.
+
+## How to turn it off
+
+Telemetry is **opt-out**. Disabling it stops everything — no install ID is
+generated, no heartbeat is scheduled, and no HTTP call is ever made:
+
+```bash
+PLUGWERK_TELEMETRY=false
+```
+
+See the [Telemetry & Privacy](README.md#telemetry--privacy) section of the README
+for the full list of related environment variables.
+
+## Your rights & contact
+
+For questions about this beacon, the DPA, or to exercise data-subject rights
+regarding any data we hold as controller, contact **devtank42 GmbH** at
+`privacy@plugwerk.io`.
+
+## Changes
+
+We will update this document if the telemetry payload, purpose, processor, or
+residency ever changes. Material changes are reflected in the "Last updated" date
+above and the project changelog.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Plugwerk sends a small, **opt-out**, privacy-respecting telemetry beacon so the 
 
 **No** hostnames, IP addresses, namespaces, usernames, plugin names, or request data are ever collected. The payload is the four fields above and there is no code path that adds a fifth — see [ADR-0039](docs/adrs/0039-telemetry-beacon.md).
 
+**Where it goes.** Beacons are sent over HTTPS to a Plugwerk-owned reverse proxy (`telemetry.plugwerk.io`) and forwarded to **PostHog EU Cloud**, where they are stored and processed **within the EU**. PostHog acts as a data processor under a **Data Processing Agreement (DPA)** that is signed before any telemetry is ingested (see the [runbook](telemetry-proxy/README.md#dpa-acceptance-do-this-first)), and events are configured person-profile-free (`$process_person_profile: false`). The controller is **devtank42 GmbH**. Full details: [`PRIVACY.md`](PRIVACY.md).
+
 It is **fail-open**: the beacon runs off the startup and request paths with short timeouts, and any failure (unreachable endpoint, timeout, error response) is silently ignored. Telemetry can never affect startup, health, or readiness.
 
 **Turn it off completely:**

--- a/telemetry-proxy/.dev.vars.example
+++ b/telemetry-proxy/.dev.vars.example
@@ -1,0 +1,9 @@
+# Copy this file to `.dev.vars` for local `wrangler dev`.
+# `.dev.vars` is gitignored — never commit a real key.
+#
+# This placeholder is NOT a real secret. For local runs use a throwaway PostHog
+# project key, or set POSTHOG_CAPTURE_URL to a local mock so nothing is forwarded.
+POSTHOG_PROJECT_KEY="phc_local_dev_placeholder"
+
+# Optional: override the capture endpoint locally (defaults to PostHog EU Cloud).
+# POSTHOG_CAPTURE_URL="https://eu.i.posthog.com/capture/"

--- a/telemetry-proxy/.gitignore
+++ b/telemetry-proxy/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.wrangler/
+dist/
+
+# Local Worker secrets for `wrangler dev` — never commit. Use .dev.vars.example.
+.dev.vars
+
+*.log

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -31,7 +31,7 @@ Accepted fields — **exactly these four, nothing else**:
 | `405`  | Non-POST method (includes `Allow: POST`)                                    |
 | `415`  | Wrong `Content-Type`                                                        |
 | `429`  | Per-IP rate limit exceeded (includes `Retry-After`); no PostHog forward     |
-| `502`  | PostHog forwarding failed (non-2xx, network error, or timeout)             |
+| `502`  | PostHog forwarding failed (non-2xx, network error, timeout, **or a misconfigured non-`phc_` key**) |
 
 Unknown fields are **rejected, not silently stripped**. Request bodies and field
 values are **never logged** (defense-in-depth, even though the payload is PII-free).
@@ -134,6 +134,13 @@ wrangler secret put POSTHOG_PROJECT_KEY
 # paste the PostHog project API key when prompted
 ```
 
+The key **must** be the write-only **`phc_…` project (ingestion) key** — never a
+personal (`phx_…`) or admin key — so a leak's blast radius stays capture-only
+(DEV-54, condition 2). This is **enforced in code** (`src/posthog.ts`): the Worker
+fails closed (`502`, no forward) on any key without the `phc_` prefix, so a
+misconfigured secret is caught at smoke-test time, not in production. The key value
+is still never logged — only the fact that the prefix check failed.
+
 > The same rule applies to a Paperclip-managed secret: store the key only in the
 > encrypted secret store, reference it by name, and never echo its value into a
 > comment, log, or document.
@@ -184,9 +191,52 @@ Rationale for the number: a single install emits only a handful of events/hour
 corporate egress) while clamping floods hard. Tighten later if observability shows
 headroom.
 
+Equivalent API call (Rulesets engine, `http_ratelimit` phase entrypoint) — for a
+reproducible, auditable apply instead of hand-clicking the dashboard:
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json" \
+  --data '{
+    "rules": [{
+      "description": "Plugwerk telemetry per-IP rate limit (DEV-47/DEV-54)",
+      "expression": "http.request.method eq \"POST\" and http.host eq \"telemetry.plugwerk.io\" and starts_with(http.request.uri.path, \"/v1/\")",
+      "action": "block",
+      "ratelimit": {
+        "characteristics": ["ip.src", "cf.colo.id"],
+        "period": 60,
+        "requests_per_period": 60,
+        "mitigation_timeout": 60
+      }
+    }]
+  }'
+```
+
+> `cf.colo.id` is required in `characteristics` on non-Enterprise plans (counting is
+> per data center); Enterprise Advanced Rate Limiting can drop it for true global
+> counting. Either way this zone rule blocks at the edge before the Worker runs.
+
 > The matching threshold/period is mirrored in the in-code binding so both layers
 > agree. If you change one, change the other (`simple` in `wrangler.toml` and
 > `RATE_LIMIT_PERIOD_SECONDS` in `src/constants.ts`).
+
+### Go-live security verification (DEV-54)
+
+Before opening the route to production traffic, run the read-only verifier to
+confirm all three go-live security conditions against the **live** config and
+capture the output as the DEV-54 sign-off evidence:
+
+```bash
+CF_API_TOKEN=<zone-scoped token> CF_ZONE_ID=<plugwerk.io zone id> \
+  ./go-live-check.sh https://telemetry.plugwerk.io
+```
+
+It asserts: (1) the zone rate-limit rule above is present (block, `ip.src`,
+60/60s, host + `/v1/`); (2) the `POSTHOG_PROJECT_KEY` secret is set (its `phc_`
+prefix is enforced in code, proven by the smoke `204`); (3) no Logpush job on the
+zone captures request bodies or headers. It then runs the live smoke test
+(`204`/`400`). It makes no changes.
 
 ### Rollback
 
@@ -224,3 +274,4 @@ allowlist until it is regenerated.
 | `test/*.test.ts`      | Validator + handler unit tests (incl. rate-limit regression) |
 | `wrangler.toml`       | Worker config + route + rate-limit binding (no secrets) |
 | `smoke-test.sh`       | curl smoke test (204 valid / 400 extra-field)          |
+| `go-live-check.sh`    | read-only go-live security verifier (DEV-54: zone rule, secret, Logpush) |

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -1,0 +1,169 @@
+# Plugwerk Telemetry Reverse Proxy
+
+A ~40-line Cloudflare Worker that backs `POST https://telemetry.plugwerk.io/v1/events`.
+It validates an opt-out telemetry beacon against a **strict zero-PII allowlist**, then
+forwards accepted events to PostHog EU Cloud. It is the receiving half of the beacon
+shipped in DEV-23; the architecture is recorded in DEV-27 / DEV-28.
+
+> **Scope:** this directory is **build only**. Live deploy, DNS, and the production
+> smoke test are handled by the deploy sibling (DEV-34) and depend on infra
+> provisioning (DEV-31). A security review (DEV-33) gates go-live.
+
+## Contract
+
+`POST /v1/events`, `Content-Type: application/json`, body ≤ 2 KB.
+
+Accepted fields — **exactly these four, nothing else**:
+
+| field         | rule                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| `installId`   | required, string, UUID v4                                           |
+| `version`     | required, string, semver-ish (e.g. `1.1.0-SNAPSHOT`), ≤ 32 chars    |
+| `installType` | required, enum: `docker-compose` \| `jar` \| `k8s` \| `unknown`     |
+| `event`       | enum: `server_start` \| `heartbeat` \| `namespace_created` \| `plugin_published` |
+
+### Status codes
+
+| Status | When                                                                        |
+| ------ | --------------------------------------------------------------------------- |
+| `204`  | Valid payload forwarded to PostHog (2xx upstream)                           |
+| `400`  | Missing/invalid field, wrong enum, malformed UUID, **unknown field**, or body > 2 KB |
+| `405`  | Non-POST method (includes `Allow: POST`)                                    |
+| `415`  | Wrong `Content-Type`                                                        |
+| `502`  | PostHog forwarding failed (non-2xx, network error, or timeout)             |
+
+Unknown fields are **rejected, not silently stripped**. Request bodies and field
+values are **never logged** (defense-in-depth, even though the payload is PII-free).
+
+The `502`/fail-open split is deliberate: the client beacon fails open on its side
+(DEV-23), so a `5xx` here never affects the Plugwerk server — it only makes our own
+delivery failures observable.
+
+### Forwarded shape (to `https://eu.i.posthog.com/capture/`)
+
+```json
+{
+  "api_key": "<POSTHOG_PROJECT_KEY>",
+  "event": "<event>",
+  "distinct_id": "<installId>",
+  "properties": {
+    "version": "<version>",
+    "installType": "<installType>",
+    "$process_person_profile": false
+  }
+}
+```
+
+`distinct_id = installId` groups Growth funnels by install; `$process_person_profile: false`
+keeps events person-profile-free.
+
+## Local development
+
+```bash
+npm install
+npm run typecheck        # tsc --noEmit
+npm test                 # vitest (validator + handler unit tests)
+
+cp .dev.vars.example .dev.vars   # add a throwaway PostHog key (gitignored)
+npm run dev              # wrangler dev on http://127.0.0.1:8787
+./smoke-test.sh          # 204 for a valid sample, 400 for an extra-field sample
+```
+
+`.dev.vars` holds local secrets and is gitignored. For a fully offline check, point
+`POSTHOG_CAPTURE_URL` (in `.dev.vars`) at a local mock so nothing is forwarded; the
+`400` extra-field path needs no upstream at all.
+
+## Deploy runbook (deploy sibling — DEV-34)
+
+Prerequisite: the `plugwerk.io` zone is on Cloudflare and `telemetry.plugwerk.io`
+resolves (see **DNS** below). PostHog project + key provisioned in DEV-31.
+
+### DPA acceptance (do this first)
+
+GDPR requires a signed Data Processing Agreement with PostHog **before** any
+production telemetry is ingested. PostHog offers self-serve DPA acceptance — no
+legal back-and-forth — so do this the moment the PostHog account exists, ahead of
+secret setup:
+
+1. Sign in to **PostHog EU Cloud** (`https://eu.posthog.com`) with the project owner
+   account.
+2. Open **Organization settings → Legal & compliance** (Settings → _Legal &
+   compliance_; on some plans it appears under _Billing → Legal documents_).
+3. Under **Data Processing Agreement**, fill in the company legal entity
+   (**devtank42 GmbH**) and **Accept / Sign** the self-serve DPA.
+4. **Download the countersigned PDF** and file it with the company's legal records
+   (Paperclip document / drive). Note the acceptance date in the DEV-34 deploy issue
+   so go-live has an auditable record.
+5. Confirm the project's **data region is EU** (Organization settings → the region
+   badge reads _EU_, host `eu.i.posthog.com`). If a US project was created by
+   mistake, recreate it in the EU region — region cannot be migrated in place.
+
+Only after the DPA is accepted and the EU region is confirmed should the project API
+key be captured and injected as a secret (below). The key is captured from
+**Project settings → Project API key** (`phc_…`) and is **read once into the secret
+prompt — never pasted into a file, commit, chat, or ticket**.
+
+### Secret setup
+
+```bash
+# One-time per environment. Value is encrypted at rest; never committed or echoed.
+wrangler secret put POSTHOG_PROJECT_KEY
+# paste the PostHog project API key when prompted
+```
+
+> The same rule applies to a Paperclip-managed secret: store the key only in the
+> encrypted secret store, reference it by name, and never echo its value into a
+> comment, log, or document.
+
+### Deploy
+
+```bash
+npm run deploy           # wrangler deploy
+```
+
+`wrangler.toml` binds the route `telemetry.plugwerk.io/v1/*` on `zone_name = "plugwerk.io"`.
+
+### DNS pointing
+
+Add a proxied DNS record for `telemetry` on the `plugwerk.io` zone (orange-cloud
+ON so the Worker route intercepts):
+
+- `telemetry` → `AAAA 100::` (or any placeholder) **proxied**, **or** a `CNAME`
+  to a proxied hostname. The record only needs to exist and be proxied; the Worker
+  route handles `/v1/*`. TLS is automatic via Cloudflare's edge cert for the zone.
+
+Verify after deploy:
+
+```bash
+./smoke-test.sh https://telemetry.plugwerk.io   # expect 204 then 400
+```
+
+### Rollback
+
+Instant — remove the route (no redeploy of the Plugwerk server needed):
+
+```bash
+# Option A: delete the route in the Cloudflare dashboard (Workers Routes), or
+# Option B: remove the `routes` entry from wrangler.toml and redeploy, or
+wrangler delete           # tears down the Worker entirely
+```
+
+Because the beacon fails open, removing the route is harmless to clients — events
+simply stop being collected.
+
+## Rotation
+
+To rotate the PostHog key, re-run `wrangler secret put POSTHOG_PROJECT_KEY` with the
+new value and `npm run deploy`. No code change required.
+
+## Files
+
+| Path                  | Purpose                                                |
+| --------------------- | ------------------------------------------------------ |
+| `src/index.ts`        | Worker entry: routing, method/content-type/size guards |
+| `src/validate.ts`     | Pure zero-PII allowlist validator                      |
+| `src/posthog.ts`      | PostHog forwarding (secret read from env, never logged) |
+| `src/constants.ts`    | Allowlist, enums, limits, endpoints                    |
+| `test/*.test.ts`      | Validator + handler unit tests                         |
+| `wrangler.toml`       | Worker config + route (no secrets)                     |
+| `smoke-test.sh`       | curl smoke test (204 valid / 400 extra-field)          |

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -98,6 +98,12 @@ secret setup:
    badge reads _EU_, host `eu.i.posthog.com`). If a US project was created by
    mistake, recreate it in the EU region — region cannot be migrated in place.
 
+> **Production residency:** the capture host **must** remain an EU PostHog host
+> (`eu.i.posthog.com`). The `POSTHOG_CAPTURE_URL` binding (`src/posthog.ts`) is a
+> non-secret override intended for **local/mock use only** — never point it at a
+> non-EU host in production, or telemetry would leave the EU and break the DPA
+> residency guarantee above.
+
 Only after the DPA is accepted and the EU region is confirmed should the project API
 key be captured and injected as a secret (below). The key is captured from
 **Project settings → Project API key** (`phc_…`) and is **read once into the secret
@@ -155,6 +161,12 @@ simply stop being collected.
 
 To rotate the PostHog key, re-run `wrangler secret put POSTHOG_PROJECT_KEY` with the
 new value and `npm run deploy`. No code change required.
+
+After deploying the new secret, **regenerate/rotate the project API key in PostHog
+→ Project settings** so the previous value is invalidated. Re-running
+`wrangler secret put` alone leaves the old key valid: a leaked previous `phc_…`
+ingestion key would still let anyone POST events to PostHog past the proxy
+allowlist until it is regenerated.
 
 ## Files
 

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -30,10 +30,27 @@ Accepted fields — **exactly these four, nothing else**:
 | `400`  | Missing/invalid field, wrong enum, malformed UUID, **unknown field**, or body > 2 KB |
 | `405`  | Non-POST method (includes `Allow: POST`)                                    |
 | `415`  | Wrong `Content-Type`                                                        |
+| `429`  | Per-IP rate limit exceeded (includes `Retry-After`); no PostHog forward     |
 | `502`  | PostHog forwarding failed (non-2xx, network error, or timeout)             |
 
 Unknown fields are **rejected, not silently stripped**. Request bodies and field
 values are **never logged** (defense-in-depth, even though the payload is PII-free).
+
+### Rate limiting (two-layer defense)
+
+The endpoint is public and unauthenticated, so it must not become an amplifier into
+per-event-billed PostHog (OWASP API4:2023, DEV-33 HIGH gate). Two layers throttle it,
+both keyed by client IP at **60 requests / 60 s**:
+
+1. **In-code Worker binding** (`wrangler.toml` → `[[ratelimits]]` `RATE_LIMITER`):
+   `src/index.ts` meters every real ingestion attempt _after_ the path/method/
+   content-type guards and returns `429` before reading the body or forwarding.
+   **Caveat:** the Workers rate-limit binding counts **per Cloudflare colo**, not
+   globally — it is best-effort, not an authoritative global cap.
+2. **Cloudflare zone rate-limiting rule** (authoritative, global; provisioned in the
+   DEV-34 deploy runbook below). It blocks at the edge before the Worker spins up.
+
+Both are required: layer 1 travels with the code, layer 2 is the global enforcement.
 
 The `502`/fail-open split is deliberate: the client beacon fails open on its side
 (DEV-23), so a `5xx` here never affects the Plugwerk server — it only makes our own
@@ -144,6 +161,33 @@ Verify after deploy:
 ./smoke-test.sh https://telemetry.plugwerk.io   # expect 204 then 400
 ```
 
+### Zone rate-limiting rule (REQUIRED — authoritative edge control)
+
+The in-code Worker binding (`[[ratelimits]]` in `wrangler.toml`) only throttles
+**per Cloudflare colo**, not globally. Go-live therefore also requires an
+authoritative **zone rate-limiting rule** that blocks at the edge before the Worker
+runs. This is the DEV-33 HIGH gate (DEV-47); it must exist before opening the route
+to production traffic.
+
+Configure on the `plugwerk.io` zone (Security → WAF → Rate limiting rules), or via
+API on the `http_ratelimit` phase ruleset:
+
+- **Match expression:**
+  `http.request.method eq "POST" and http.host eq "telemetry.plugwerk.io" and starts_with(http.request.uri.path, "/v1/")`
+- **Counting characteristic:** client IP (`ip.src`).
+- **Threshold:** **60 requests / 60 s** per IP.
+- **Action:** **block** for 60 s. **Do NOT use a managed challenge** — the client is
+  a JVM beacon (DEV-23), not a browser, and cannot solve challenges.
+
+Rationale for the number: a single install emits only a handful of events/hour
+(DEV-23 cadence), so 60/min/IP is very generous for legit traffic (including NAT'd
+corporate egress) while clamping floods hard. Tighten later if observability shows
+headroom.
+
+> The matching threshold/period is mirrored in the in-code binding so both layers
+> agree. If you change one, change the other (`simple` in `wrangler.toml` and
+> `RATE_LIMIT_PERIOD_SECONDS` in `src/constants.ts`).
+
 ### Rollback
 
 Instant — remove the route (no redeploy of the Plugwerk server needed):
@@ -172,10 +216,11 @@ allowlist until it is regenerated.
 
 | Path                  | Purpose                                                |
 | --------------------- | ------------------------------------------------------ |
-| `src/index.ts`        | Worker entry: routing, method/content-type/size guards |
+| `src/index.ts`        | Worker entry: routing, method/content-type/size guards, per-IP rate limit |
 | `src/validate.ts`     | Pure zero-PII allowlist validator                      |
 | `src/posthog.ts`      | PostHog forwarding (secret read from env, never logged) |
+| `src/ratelimit.ts`    | Per-IP rate-limit binding type + metering helper       |
 | `src/constants.ts`    | Allowlist, enums, limits, endpoints                    |
-| `test/*.test.ts`      | Validator + handler unit tests                         |
-| `wrangler.toml`       | Worker config + route (no secrets)                     |
+| `test/*.test.ts`      | Validator + handler unit tests (incl. rate-limit regression) |
+| `wrangler.toml`       | Worker config + route + rate-limit binding (no secrets) |
 | `smoke-test.sh`       | curl smoke test (204 valid / 400 extra-field)          |

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -32,6 +32,7 @@ Accepted fields — **exactly these four, nothing else**:
 | `415`  | Wrong `Content-Type`                                                        |
 | `429`  | Per-IP rate limit exceeded (includes `Retry-After`); no PostHog forward     |
 | `502`  | PostHog forwarding failed (non-2xx, network error, timeout, **or a misconfigured non-`phc_` key**) |
+| `503`  | Kill switch active (`PROXY_DISABLED = "true"`); nothing metered, read, or forwarded |
 
 Unknown fields are **rejected, not silently stripped**. Request bodies and field
 values are **never logged** (defense-in-depth, even though the payload is PII-free).
@@ -237,6 +238,17 @@ It asserts: (1) the zone rate-limit rule above is present (block, `ip.src`,
 prefix is enforced in code, proven by the smoke `204`); (3) no Logpush job on the
 zone captures request bodies or headers. It then runs the live smoke test
 (`204`/`400`). It makes no changes.
+
+### Emergency stop (kill switch)
+
+Fastest way to stop ingestion without touching code or routes: set the
+`PROXY_DISABLED` variable to `"true"` — either in the Cloudflare dashboard
+(Workers → plugwerk-telemetry-proxy → Settings → Variables, takes effect in
+seconds, no deploy) or via `wrangler.toml` `[vars]` plus `wrangler deploy`.
+While active, every request to `/v1/events` is refused with `503` before any
+rate-limiter metering, body read, or PostHog forward. The client beacon fails
+open (DEV-23), so no Plugwerk installation is affected. Unset (or set to
+anything other than `"true"`) to resume.
 
 ### Rollback
 

--- a/telemetry-proxy/go-live-check.sh
+++ b/telemetry-proxy/go-live-check.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Go-live security verifier for the Plugwerk telemetry endpoint (DEV-54).
+#
+# Read-only. It inspects the LIVE Cloudflare configuration and the deployed Worker
+# and asserts the three security go-live conditions that gate opening
+# telemetry.plugwerk.io/v1/* to production traffic:
+#
+#   1. Zone rate-limiting rule applied  (authoritative edge layer; the in-code
+#      [[ratelimits]] binding is only best-effort per-colo).
+#   2. PostHog secret is set            (the phc_ project-key prefix is enforced
+#                                        in code — src/posthog.ts — and proven by
+#                                        the smoke 204; this script confirms the
+#                                        secret EXISTS, since its value is not
+#                                        readable by design).
+#   3. No Logpush request-body/header capture on the zone.
+#
+# It makes no changes. Run it at deploy time (DEV-34) and paste the output into the
+# DEV-54 thread as the go-live confirmation evidence.
+#
+# Usage:
+#   CF_API_TOKEN=<zone-scoped token> CF_ZONE_ID=<plugwerk.io zone id> \
+#     ./go-live-check.sh [BASE_URL]
+#
+#   BASE_URL (optional) defaults to https://telemetry.plugwerk.io and, when set,
+#   triggers the live smoke test (204 valid / 400 extra-field) via smoke-test.sh.
+#
+# Requirements: curl, python3. Optional: wrangler (for the secret-existence check).
+
+set -euo pipefail
+
+HOST="telemetry.plugwerk.io"
+CF_API="https://api.cloudflare.com/client/v4"
+EXPECTED_PERIOD=60
+EXPECTED_REQUESTS=60
+BASE_URL="${1:-https://${HOST}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass=0
+fail=0
+
+ok() { echo "PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL: $1"; fail=$((fail + 1)); }
+info() { echo "      $1"; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required but not installed." >&2; exit 2; }
+}
+
+require curl
+require python3
+
+: "${CF_API_TOKEN:?Set CF_API_TOKEN to a zone-scoped Cloudflare API token}"
+: "${CF_ZONE_ID:?Set CF_ZONE_ID to the plugwerk.io Cloudflare zone id}"
+
+cf_get() {
+  curl -sS --fail-with-body \
+    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${CF_API}/zones/${CF_ZONE_ID}/$1"
+}
+
+echo "Go-live security check for ${HOST} (DEV-54)"
+echo "================================================================"
+
+# --- Condition 1: zone rate-limiting rule -----------------------------------
+echo
+echo "[1/3] Zone rate-limiting rule (http_ratelimit phase)"
+if rl_json="$(cf_get "rulesets/phases/http_ratelimit/entrypoint" 2>/dev/null)"; then
+  result="$(
+    HOST="$HOST" EXPECTED_PERIOD="$EXPECTED_PERIOD" EXPECTED_REQUESTS="$EXPECTED_REQUESTS" \
+    python3 - "$rl_json" <<'PY'
+import json, os, sys
+
+host = os.environ["HOST"]
+exp_period = int(os.environ["EXPECTED_PERIOD"])
+exp_requests = int(os.environ["EXPECTED_REQUESTS"])
+data = json.loads(sys.argv[1])
+rules = (data.get("result") or {}).get("rules") or []
+
+def matches(rule):
+    expr = (rule.get("expression") or "")
+    rl = rule.get("ratelimit") or {}
+    chars = rl.get("characteristics") or []
+    return (
+        host in expr
+        and "/v1/" in expr
+        and rule.get("action") == "block"
+        and "ip.src" in chars
+        and rl.get("period") == exp_period
+        and rl.get("requests_per_period") == exp_requests
+    )
+
+hit = next((r for r in rules if matches(r)), None)
+if hit:
+    rl = hit.get("ratelimit") or {}
+    print("OK|block, ip.src, %s req / %s s (mitigation_timeout=%ss)" % (
+        rl.get("requests_per_period"), rl.get("period"), rl.get("mitigation_timeout")))
+    print("EXPR|%s" % (hit.get("expression") or ""))
+else:
+    summary = "; ".join(
+        "action=%s period=%s rpp=%s expr=%r" % (
+            r.get("action"), (r.get("ratelimit") or {}).get("period"),
+            (r.get("ratelimit") or {}).get("requests_per_period"), (r.get("expression") or "")[:80])
+        for r in rules) or "(no rate-limiting rules on this zone)"
+    print("MISS|%s" % summary)
+PY
+  )"
+  verdict="${result%%|*}"
+  detail="${result#*|}"
+  detail="${detail%%$'\n'*}"
+  if [[ "$verdict" == "OK" ]]; then
+    ok "rate-limit rule present — ${detail}"
+    info "$(printf '%s\n' "$result" | sed -n 's/^EXPR|/expr: /p')"
+  else
+    bad "no matching rate-limit rule (need: block, ip.src, ${EXPECTED_REQUESTS}/${EXPECTED_PERIOD}s, host+/v1/)"
+    info "found: ${detail}"
+    info "fix: apply the rule from README.md -> 'Zone rate-limiting rule (REQUIRED)'"
+  fi
+else
+  bad "could not read the http_ratelimit ruleset (check CF_API_TOKEN scope / CF_ZONE_ID)"
+fi
+
+# --- Condition 2: PostHog project key secret --------------------------------
+echo
+echo "[2/3] PostHog project key secret (phc_ prefix enforced in code)"
+if command -v wrangler >/dev/null 2>&1; then
+  if secrets_json="$(cd "$SCRIPT_DIR" && wrangler secret list --format json 2>/dev/null)"; then
+    if printf '%s' "$secrets_json" | python3 -c \
+      'import json,sys; sys.exit(0 if any(s.get("name")=="POSTHOG_PROJECT_KEY" for s in json.load(sys.stdin)) else 1)'; then
+      ok "POSTHOG_PROJECT_KEY secret is set on the deployed Worker"
+      info "value is write-only; the phc_ prefix is enforced at runtime (src/posthog.ts)"
+      info "a non-phc_ key fails closed (502) — proven green by the smoke 204 below"
+    else
+      bad "POSTHOG_PROJECT_KEY secret is NOT set — run: wrangler secret put POSTHOG_PROJECT_KEY"
+    fi
+  else
+    info "SKIP: 'wrangler secret list' failed (not authenticated?). The smoke 204 still"
+    info "      proves a working phc_ key, and the code guard rejects any non-phc_ key."
+  fi
+else
+  info "SKIP: wrangler not installed. The phc_ prefix is enforced in code (src/posthog.ts);"
+  info "      a passing smoke 204 below confirms a valid phc_ key is configured."
+fi
+
+# --- Condition 3: no Logpush body/header capture ----------------------------
+echo
+echo "[3/3] Logpush — no request-body / header capture"
+if lp_json="$(cf_get "logpush/jobs" 2>/dev/null)"; then
+  result="$(python3 - "$lp_json" <<'PY'
+import json, sys
+
+data = json.loads(sys.argv[1])
+jobs = data.get("result") or []
+
+# Fields that would capture request bodies or headers (PII risk for this gate).
+SENSITIVE = {
+    "ClientRequestBody", "RequestHeaders", "ResponseHeaders",
+    "ClientRequestHeaders", "OriginResponseHeaders", "RequestBody", "ResponseBody",
+}
+
+def fields_of(job):
+    oo = job.get("output_options") or {}
+    names = set(oo.get("field_names") or [])
+    legacy = job.get("logpull_options") or ""  # e.g. "fields=ClientIP,RequestHeaders&timestamps=rfc3339"
+    for part in legacy.split("&"):
+        if part.startswith("fields="):
+            names.update(f for f in part[len("fields="):].split(",") if f)
+    return names
+
+offenders = []
+warnings = []
+for job in jobs:
+    if not job.get("enabled", True):
+        continue
+    f = fields_of(job)
+    hits = sorted(SENSITIVE & f)
+    label = "%s (dataset=%s, id=%s)" % (job.get("name") or "?", job.get("dataset"), job.get("id"))
+    if hits:
+        offenders.append("%s -> %s" % (label, ", ".join(hits)))
+    elif job.get("dataset") == "workers_trace_events":
+        warnings.append("%s -> captures Worker console logs (we log nothing, but confirm)" % label)
+
+if offenders:
+    print("FAIL|" + " ; ".join(offenders))
+elif not jobs:
+    print("OK|no Logpush jobs configured on this zone")
+else:
+    msg = "%d Logpush job(s), none capture request body/headers" % len(jobs)
+    if warnings:
+        msg += " | WARN: " + " ; ".join(warnings)
+    print("OK|" + msg)
+PY
+  )"
+  verdict="${result%%|*}"
+  detail="${result#*|}"
+  if [[ "$verdict" == "OK" ]]; then
+    ok "no request-body/header Logpush capture — ${detail}"
+  else
+    bad "Logpush job(s) capture request body/headers: ${detail}"
+    info "fix: remove those fields from the job, or delete the job, for this zone"
+  fi
+else
+  bad "could not read Logpush jobs (check CF_API_TOKEN scope / CF_ZONE_ID)"
+fi
+
+# --- Live smoke test (204 / 400) --------------------------------------------
+echo
+echo "[+] Live smoke test against ${BASE_URL}"
+if [[ -x "${SCRIPT_DIR}/smoke-test.sh" ]]; then
+  if "${SCRIPT_DIR}/smoke-test.sh" "$BASE_URL"; then
+    ok "smoke test passed (204 valid / 400 extra-field)"
+  else
+    bad "smoke test failed — endpoint not healthy"
+  fi
+else
+  info "SKIP: smoke-test.sh not found/executable next to this script"
+fi
+
+echo
+echo "================================================================"
+echo "${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]

--- a/telemetry-proxy/package-lock.json
+++ b/telemetry-proxy/package-lock.json
@@ -1,0 +1,2799 @@
+{
+  "name": "@plugwerk/telemetry-proxy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@plugwerk/telemetry-proxy",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260613.1",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.8",
+        "wrangler": "^4.100.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260611.1.tgz",
+      "integrity": "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260611.1.tgz",
+      "integrity": "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260611.1.tgz",
+      "integrity": "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260611.1.tgz",
+      "integrity": "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260611.1.tgz",
+      "integrity": "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260613.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260613.1.tgz",
+      "integrity": "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260611.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260611.0.tgz",
+      "integrity": "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260611.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260611.1.tgz",
+      "integrity": "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260611.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260611.1",
+        "@cloudflare/workerd-linux-64": "1.20260611.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260611.1",
+        "@cloudflare/workerd-windows-64": "1.20260611.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.100.0.tgz",
+      "integrity": "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260611.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260611.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260611.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/telemetry-proxy/package.json
+++ b/telemetry-proxy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@plugwerk/telemetry-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker reverse proxy for Plugwerk zero-PII telemetry ingestion (telemetry.plugwerk.io/v1/events).",
+  "license": "AGPL-3.0-or-later",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "smoke": "bash smoke-test.sh"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260613.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8",
+    "wrangler": "^4.100.0"
+  }
+}

--- a/telemetry-proxy/smoke-test.sh
+++ b/telemetry-proxy/smoke-test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Smoke test for the Plugwerk telemetry reverse proxy.
+#
+# Usage:
+#   ./smoke-test.sh [BASE_URL]
+#
+#   BASE_URL defaults to http://127.0.0.1:8787 (the `wrangler dev` default).
+#   Examples:
+#     ./smoke-test.sh                                  # local wrangler dev
+#     ./smoke-test.sh https://telemetry.plugwerk.io    # deployed endpoint
+#
+# Checks:
+#   1. A valid zero-PII payload  -> 204 No Content
+#   2. A payload with an extra field -> 400 Bad Request (unknown field rejected)
+#
+# Note: the 204 check requires the proxy to reach PostHog (a reachable capture
+# endpoint + a configured key). The 400 check is validator-only and offline.
+
+set -euo pipefail
+
+BASE_URL="${1:-http://127.0.0.1:8787}"
+ENDPOINT="${BASE_URL%/}/v1/events"
+
+UUID="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+VALID="{\"installId\":\"${UUID}\",\"version\":\"1.1.0-SNAPSHOT\",\"installType\":\"docker-compose\",\"event\":\"server_start\"}"
+EXTRA="{\"installId\":\"${UUID}\",\"version\":\"1.1.0-SNAPSHOT\",\"installType\":\"docker-compose\",\"event\":\"server_start\",\"hostname\":\"leaky\"}"
+
+pass=0
+fail=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: ${name} (HTTP ${actual})"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${name} (expected ${expected}, got ${actual})"
+    fail=$((fail + 1))
+  fi
+}
+
+post_status() {
+  curl -s -o /dev/null -w "%{http_code}" -X POST "$ENDPOINT" \
+    -H "Content-Type: application/json" --data "$1"
+}
+
+echo "Smoke-testing ${ENDPOINT}"
+echo "----"
+
+check "valid payload -> 204" "204" "$(post_status "$VALID")"
+check "extra field -> 400" "400" "$(post_status "$EXTRA")"
+
+echo "----"
+echo "${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]

--- a/telemetry-proxy/smoke-test.sh
+++ b/telemetry-proxy/smoke-test.sh
@@ -22,6 +22,10 @@ set -euo pipefail
 BASE_URL="${1:-http://127.0.0.1:8787}"
 ENDPOINT="${BASE_URL%/}/v1/events"
 
+# Fixed, well-known SYNTHETIC install id. When this smoke test runs against the
+# live endpoint it forwards a real event to PostHog, so keep this id constant and
+# exclude it from analytics (e.g. filter out distinct_id = this UUID) to keep the
+# install-base metric clean. It is not a real installation.
 UUID="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
 VALID="{\"installId\":\"${UUID}\",\"version\":\"1.1.0-SNAPSHOT\",\"installType\":\"docker-compose\",\"event\":\"server_start\"}"
 EXTRA="{\"installId\":\"${UUID}\",\"version\":\"1.1.0-SNAPSHOT\",\"installType\":\"docker-compose\",\"event\":\"server_start\",\"hostname\":\"leaky\"}"

--- a/telemetry-proxy/src/constants.ts
+++ b/telemetry-proxy/src/constants.ts
@@ -31,6 +31,17 @@ export const MAX_VERSION_LENGTH = 32;
 /** PostHog EU Cloud capture endpoint (events are forwarded here). */
 export const DEFAULT_POSTHOG_CAPTURE_URL = "https://eu.i.posthog.com/capture/";
 
+/**
+ * Required prefix of a PostHog **project** (ingestion / capture) API key.
+ *
+ * The go-live security gate (DEV-54, condition 2) requires the configured secret to
+ * be the write-only `phc_…` project key — never a personal (`phx_…`) or admin key —
+ * so a leak's blast radius stays capture-only, not data-read/admin. We enforce this
+ * in code (fail-closed) so a misconfigured key is never used to forward events,
+ * rather than relying on the operator getting `wrangler secret put` right.
+ */
+export const POSTHOG_PROJECT_KEY_PREFIX = "phc_";
+
 /** Upstream forward timeout in milliseconds; a slower PostHog is treated as a delivery failure (502). */
 export const POSTHOG_TIMEOUT_MS = 5000;
 

--- a/telemetry-proxy/src/constants.ts
+++ b/telemetry-proxy/src/constants.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/** Shared constants and types for the telemetry reverse proxy. */
+
+/** The single public ingestion path. Anything else 404s. */
+export const TELEMETRY_PATH = "/v1/events";
+
+/** Maximum accepted request body size in bytes (2 KB). Larger bodies are rejected with 400. */
+export const MAX_BODY_BYTES = 2048;
+
+/** Maximum accepted length of the `version` string. */
+export const MAX_VERSION_LENGTH = 32;
+
+/** PostHog EU Cloud capture endpoint (events are forwarded here). */
+export const DEFAULT_POSTHOG_CAPTURE_URL = "https://eu.i.posthog.com/capture/";
+
+/** Upstream forward timeout in milliseconds; a slower PostHog is treated as a delivery failure (502). */
+export const POSTHOG_TIMEOUT_MS = 5000;
+
+/** Allowed `installType` values (mirrors the beacon contract in DEV-23). */
+export const INSTALL_TYPES = ["docker-compose", "jar", "k8s", "unknown"] as const;
+export type InstallType = (typeof INSTALL_TYPES)[number];
+
+/** Allowed `event` values. Superset of the current beacon (DEV-23) to cover funnel events from DEV-22. */
+export const EVENTS = ["server_start", "heartbeat", "namespace_created", "plugin_published"] as const;
+export type TelemetryEvent = (typeof EVENTS)[number];
+
+/**
+ * The ONLY fields accepted on the wire. The validator rejects (does not strip)
+ * any payload carrying a key outside this allowlist — strict zero-PII contract.
+ */
+export const ALLOWED_FIELDS = ["installId", "version", "installType", "event"] as const;
+
+/** RFC 4122 UUID v4: version nibble = 4, variant nibble in [8,9,a,b]. */
+export const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * "semver-ish": must start with a digit, then dotted alphanumeric / build metadata.
+ * Intentionally lenient — the beacon ships values like `1.1.0-SNAPSHOT` (see VERSION).
+ */
+export const VERSION_RE = /^[0-9][0-9A-Za-z.+-]*$/;

--- a/telemetry-proxy/src/constants.ts
+++ b/telemetry-proxy/src/constants.ts
@@ -34,6 +34,12 @@ export const DEFAULT_POSTHOG_CAPTURE_URL = "https://eu.i.posthog.com/capture/";
 /** Upstream forward timeout in milliseconds; a slower PostHog is treated as a delivery failure (502). */
 export const POSTHOG_TIMEOUT_MS = 5000;
 
+/**
+ * Per-IP rate-limit window in seconds, surfaced in the `Retry-After` header on a 429.
+ * MUST match `simple.period` of the `[[ratelimits]]` binding in wrangler.toml.
+ */
+export const RATE_LIMIT_PERIOD_SECONDS = 60;
+
 /** Allowed `installType` values (mirrors the beacon contract in DEV-23). */
 export const INSTALL_TYPES = ["docker-compose", "jar", "k8s", "unknown"] as const;
 export type InstallType = (typeof INSTALL_TYPES)[number];

--- a/telemetry-proxy/src/index.ts
+++ b/telemetry-proxy/src/index.ts
@@ -22,9 +22,23 @@ import { forwardToPostHog, type PostHogEnv } from "./posthog";
 import { isWithinRateLimit, type RateLimitEnv } from "./ratelimit";
 import { validatePayload } from "./validate";
 
-export type Env = PostHogEnv & RateLimitEnv;
+/** Optional non-secret vars controlling the proxy itself (wrangler.toml `[vars]` or dashboard). */
+export interface ProxyToggleEnv {
+  /**
+   * Operational kill switch. When set to `"true"` every request to the telemetry
+   * path is refused with 503 before metering, body read, or PostHog forward.
+   * Editable in the Cloudflare dashboard without a code deploy.
+   */
+  PROXY_DISABLED?: string;
+}
+
+export type Env = PostHogEnv & RateLimitEnv & ProxyToggleEnv;
 
 const JSON_CONTENT_TYPE = "application/json";
+
+function isProxyDisabled(env: Env): boolean {
+  return (env.PROXY_DISABLED ?? "").trim().toLowerCase() === "true";
+}
 
 function emptyResponse(status: number, headers?: HeadersInit): Response {
   return new Response(null, { status, headers });
@@ -35,8 +49,9 @@ function emptyResponse(status: number, headers?: HeadersInit): Response {
  *
  * Accepts `POST /v1/events` with a strict zero-PII JSON body, then forwards the
  * validated event to PostHog. Status contract:
- *   404 wrong path · 405 non-POST · 415 wrong content-type · 429 rate-limited ·
- *   400 invalid/oversized/unknown-field body · 204 forwarded · 502 forward failed.
+ *   404 wrong path · 503 proxy disabled · 405 non-POST · 415 wrong content-type ·
+ *   429 rate-limited · 400 invalid/oversized/unknown-field body · 204 forwarded ·
+ *   502 forward failed.
  *
  * Request bodies and field values are never logged (defense-in-depth).
  */
@@ -45,6 +60,13 @@ const handler: ExportedHandler<Env> = {
     const { pathname } = new URL(request.url);
     if (pathname !== TELEMETRY_PATH) {
       return emptyResponse(404);
+    }
+
+    // Operational kill switch: a deliberate 503 (not a silent 204) keeps the stop
+    // observable in delivery metrics, while the fail-open client beacon (DEV-23)
+    // guarantees no Plugwerk installation is ever affected by flipping it.
+    if (isProxyDisabled(env)) {
+      return emptyResponse(503);
     }
 
     if (request.method !== "POST") {

--- a/telemetry-proxy/src/index.ts
+++ b/telemetry-proxy/src/index.ts
@@ -17,11 +17,12 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { MAX_BODY_BYTES, TELEMETRY_PATH } from "./constants";
+import { MAX_BODY_BYTES, RATE_LIMIT_PERIOD_SECONDS, TELEMETRY_PATH } from "./constants";
 import { forwardToPostHog, type PostHogEnv } from "./posthog";
+import { isWithinRateLimit, type RateLimitEnv } from "./ratelimit";
 import { validatePayload } from "./validate";
 
-export type Env = PostHogEnv;
+export type Env = PostHogEnv & RateLimitEnv;
 
 const JSON_CONTENT_TYPE = "application/json";
 
@@ -34,7 +35,7 @@ function emptyResponse(status: number, headers?: HeadersInit): Response {
  *
  * Accepts `POST /v1/events` with a strict zero-PII JSON body, then forwards the
  * validated event to PostHog. Status contract:
- *   404 wrong path · 405 non-POST · 415 wrong content-type ·
+ *   404 wrong path · 405 non-POST · 415 wrong content-type · 429 rate-limited ·
  *   400 invalid/oversized/unknown-field body · 204 forwarded · 502 forward failed.
  *
  * Request bodies and field values are never logged (defense-in-depth).
@@ -53,6 +54,15 @@ const handler: ExportedHandler<Env> = {
     const contentType = request.headers.get("content-type") ?? "";
     if (!contentType.toLowerCase().trimStart().startsWith(JSON_CONTENT_TYPE)) {
       return emptyResponse(415);
+    }
+
+    // Per-IP rate limit AFTER the cheap path/method/content-type guards, so only real
+    // ingestion attempts are metered. Throttled requests get a 429 and we skip the body
+    // read and the outbound PostHog forward entirely — this endpoint is public and
+    // unauthenticated, so it must not become an amplifier (OWASP API4:2023). Best-effort
+    // per-colo throttle; the authoritative global cap is the zone rule (see DEV-34).
+    if (!(await isWithinRateLimit(request, env))) {
+      return emptyResponse(429, { "retry-after": String(RATE_LIMIT_PERIOD_SECONDS) });
     }
 
     // Cheap guard: reject an oversized declared length before buffering the body.

--- a/telemetry-proxy/src/index.ts
+++ b/telemetry-proxy/src/index.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { MAX_BODY_BYTES, TELEMETRY_PATH } from "./constants";
+import { forwardToPostHog, type PostHogEnv } from "./posthog";
+import { validatePayload } from "./validate";
+
+export type Env = PostHogEnv;
+
+const JSON_CONTENT_TYPE = "application/json";
+
+function emptyResponse(status: number, headers?: HeadersInit): Response {
+  return new Response(null, { status, headers });
+}
+
+/**
+ * Telemetry reverse proxy.
+ *
+ * Accepts `POST /v1/events` with a strict zero-PII JSON body, then forwards the
+ * validated event to PostHog. Status contract:
+ *   404 wrong path · 405 non-POST · 415 wrong content-type ·
+ *   400 invalid/oversized/unknown-field body · 204 forwarded · 502 forward failed.
+ *
+ * Request bodies and field values are never logged (defense-in-depth).
+ */
+const handler: ExportedHandler<Env> = {
+  async fetch(request, env): Promise<Response> {
+    const { pathname } = new URL(request.url);
+    if (pathname !== TELEMETRY_PATH) {
+      return emptyResponse(404);
+    }
+
+    if (request.method !== "POST") {
+      return emptyResponse(405, { allow: "POST" });
+    }
+
+    const contentType = request.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().trimStart().startsWith(JSON_CONTENT_TYPE)) {
+      return emptyResponse(415);
+    }
+
+    // Cheap guard: reject an oversized declared length before buffering the body.
+    const declaredLength = Number(request.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+      return emptyResponse(400);
+    }
+
+    const rawBody = await request.text();
+    const byteLength = new TextEncoder().encode(rawBody).length;
+
+    const result = validatePayload(rawBody, byteLength);
+    if (!result.ok) {
+      return emptyResponse(400);
+    }
+
+    const delivered = await forwardToPostHog(result.payload, env);
+    return emptyResponse(delivered ? 204 : 502);
+  },
+};
+
+export default handler;

--- a/telemetry-proxy/src/index.ts
+++ b/telemetry-proxy/src/index.ts
@@ -45,6 +45,60 @@ function emptyResponse(status: number, headers?: HeadersInit): Response {
 }
 
 /**
+ * True when the media type is exactly `application/json` (parameters like
+ * `; charset=utf-8` are allowed). Matches the media-type token on a `;` boundary
+ * so near-misses such as `application/json-patch+json` are rejected (415) rather
+ * than slipping through a loose prefix check.
+ */
+function isJsonContentType(contentType: string): boolean {
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return mediaType === JSON_CONTENT_TYPE;
+}
+
+/**
+ * Read the request body while enforcing the byte cap as bytes arrive, so an
+ * oversized (or `Content-Length`-less chunked) body is abandoned mid-stream
+ * instead of being fully buffered before the size check. Returns the decoded
+ * body, or `null` once the cap is exceeded (the caller maps that to 400).
+ */
+async function readBodyWithinLimit(request: Request, maxBytes: number): Promise<string | null> {
+  const stream = request.body;
+  if (stream === null) {
+    return "";
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel();
+          return null;
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+/**
  * Telemetry reverse proxy.
  *
  * Accepts `POST /v1/events` with a strict zero-PII JSON body, then forwards the
@@ -74,7 +128,7 @@ const handler: ExportedHandler<Env> = {
     }
 
     const contentType = request.headers.get("content-type") ?? "";
-    if (!contentType.toLowerCase().trimStart().startsWith(JSON_CONTENT_TYPE)) {
+    if (!isJsonContentType(contentType)) {
       return emptyResponse(415);
     }
 
@@ -87,13 +141,19 @@ const handler: ExportedHandler<Env> = {
       return emptyResponse(429, { "retry-after": String(RATE_LIMIT_PERIOD_SECONDS) });
     }
 
-    // Cheap guard: reject an oversized declared length before buffering the body.
+    // Cheap guard: reject an oversized declared length before even reading the body.
     const declaredLength = Number(request.headers.get("content-length"));
     if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
       return emptyResponse(400);
     }
 
-    const rawBody = await request.text();
+    // Authoritative guard: enforce the byte cap as the body streams in, so a
+    // chunked body that omits (or lies about) Content-Length is abandoned rather
+    // than fully buffered.
+    const rawBody = await readBodyWithinLimit(request, MAX_BODY_BYTES);
+    if (rawBody === null) {
+      return emptyResponse(400);
+    }
     const byteLength = new TextEncoder().encode(rawBody).length;
 
     const result = validatePayload(rawBody, byteLength);

--- a/telemetry-proxy/src/posthog.ts
+++ b/telemetry-proxy/src/posthog.ts
@@ -17,7 +17,11 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DEFAULT_POSTHOG_CAPTURE_URL, POSTHOG_TIMEOUT_MS } from "./constants";
+import {
+  DEFAULT_POSTHOG_CAPTURE_URL,
+  POSTHOG_PROJECT_KEY_PREFIX,
+  POSTHOG_TIMEOUT_MS,
+} from "./constants";
 import type { ValidPayload } from "./validate";
 
 /** Worker environment bindings. `POSTHOG_PROJECT_KEY` is an encrypted secret. */
@@ -38,10 +42,24 @@ export interface PostHogEnv {
  * or timeout returns `false`, which the caller maps to HTTP 502 so delivery
  * failures stay observable (the client beacon already fails open per DEV-23).
  *
+ * Fails closed if the configured key is not a `phc_…` PostHog project key
+ * (DEV-54, condition 2): a personal/admin key is never used to forward, the
+ * request gets a 502, and a secret-free error is logged so the misconfiguration
+ * is distinguishable from a real upstream outage.
+ *
  * The secret project key is read from the environment and is never logged or
  * echoed in errors.
  */
 export async function forwardToPostHog(payload: ValidPayload, env: PostHogEnv): Promise<boolean> {
+  // Defense-in-depth go-live gate: only a write-only project key may forward events.
+  // The key VALUE is never logged — only the fact that the prefix check failed.
+  if (!env.POSTHOG_PROJECT_KEY.startsWith(POSTHOG_PROJECT_KEY_PREFIX)) {
+    console.error(
+      `POSTHOG_PROJECT_KEY is not a '${POSTHOG_PROJECT_KEY_PREFIX}' project key; refusing to forward (502).`,
+    );
+    return false;
+  }
+
   const captureUrl = env.POSTHOG_CAPTURE_URL ?? DEFAULT_POSTHOG_CAPTURE_URL;
 
   const body = JSON.stringify({

--- a/telemetry-proxy/src/posthog.ts
+++ b/telemetry-proxy/src/posthog.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { DEFAULT_POSTHOG_CAPTURE_URL, POSTHOG_TIMEOUT_MS } from "./constants";
+import type { ValidPayload } from "./validate";
+
+/** Worker environment bindings. `POSTHOG_PROJECT_KEY` is an encrypted secret. */
+export interface PostHogEnv {
+  /** Encrypted Worker secret — set via `wrangler secret put POSTHOG_PROJECT_KEY`. Never logged. */
+  POSTHOG_PROJECT_KEY: string;
+  /** Optional non-secret override of the capture endpoint (defaults to PostHog EU Cloud). */
+  POSTHOG_CAPTURE_URL?: string;
+}
+
+/**
+ * Forward a validated event to PostHog's capture API.
+ *
+ * `distinct_id = installId` so Growth funnels group by install, and
+ * `$process_person_profile: false` keeps it event-only (no person profiles).
+ *
+ * Returns `true` only on a 2xx upstream response. Any non-2xx, network error,
+ * or timeout returns `false`, which the caller maps to HTTP 502 so delivery
+ * failures stay observable (the client beacon already fails open per DEV-23).
+ *
+ * The secret project key is read from the environment and is never logged or
+ * echoed in errors.
+ */
+export async function forwardToPostHog(payload: ValidPayload, env: PostHogEnv): Promise<boolean> {
+  const captureUrl = env.POSTHOG_CAPTURE_URL ?? DEFAULT_POSTHOG_CAPTURE_URL;
+
+  const body = JSON.stringify({
+    api_key: env.POSTHOG_PROJECT_KEY,
+    event: payload.event,
+    distinct_id: payload.installId,
+    properties: {
+      version: payload.version,
+      installType: payload.installType,
+      $process_person_profile: false,
+    },
+  });
+
+  try {
+    const response = await fetch(captureUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      signal: AbortSignal.timeout(POSTHOG_TIMEOUT_MS),
+    });
+    return response.ok;
+  } catch {
+    // Network error or timeout. Do not log the body/key; the 502 is the signal.
+    return false;
+  }
+}

--- a/telemetry-proxy/src/ratelimit.ts
+++ b/telemetry-proxy/src/ratelimit.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/** Header Cloudflare's edge sets to the original client IP. */
+const CLIENT_IP_HEADER = "cf-connecting-ip";
+
+/**
+ * Fallback rate-limit key when the client IP header is absent (e.g. `wrangler dev`
+ * locally). The production edge always sets `cf-connecting-ip`, so this bucket is
+ * only ever hit off the edge; sharing one bucket there is acceptable.
+ */
+const UNKNOWN_KEY = "unknown";
+
+/** Worker environment binding for the per-IP rate limiter. */
+export interface RateLimitEnv {
+  /**
+   * Workers Rate Limiting binding, keyed by client IP (configured in wrangler.toml
+   * as the `[[ratelimits]]` binding `RATE_LIMITER`).
+   *
+   * CAVEAT: this binding counts per Cloudflare colo (data center), NOT globally, so
+   * it is best-effort throttling — not an authoritative global cap. The authoritative
+   * edge control is a Cloudflare zone rate-limiting rule on the route, which blocks
+   * before the Worker even spins up and is global (provisioned in the DEV-34 deploy
+   * runbook). Both layers are required; this one travels with the code.
+   */
+  RATE_LIMITER: RateLimit;
+}
+
+/**
+ * Returns `true` when the request is within the per-IP rate limit (allow), `false`
+ * when the limit is exceeded and the caller should reject with HTTP 429.
+ *
+ * Keyed by `cf-connecting-ip` (the original client IP, set by Cloudflare's edge).
+ * Pure metering: no logging, no mutation of the request.
+ */
+export async function isWithinRateLimit(request: Request, env: RateLimitEnv): Promise<boolean> {
+  const key = request.headers.get(CLIENT_IP_HEADER) ?? UNKNOWN_KEY;
+  const { success } = await env.RATE_LIMITER.limit({ key });
+  return success;
+}

--- a/telemetry-proxy/src/validate.ts
+++ b/telemetry-proxy/src/validate.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+  ALLOWED_FIELDS,
+  EVENTS,
+  INSTALL_TYPES,
+  MAX_BODY_BYTES,
+  MAX_VERSION_LENGTH,
+  UUID_V4,
+  VERSION_RE,
+  type InstallType,
+  type TelemetryEvent,
+} from "./constants";
+
+/** A payload that passed every allowlist and field-shape check. */
+export interface ValidPayload {
+  installId: string;
+  version: string;
+  installType: InstallType;
+  event: TelemetryEvent;
+}
+
+export type ValidationResult =
+  | { ok: true; payload: ValidPayload }
+  | { ok: false; reason: string };
+
+function reject(reason: string): ValidationResult {
+  return { ok: false, reason };
+}
+
+function isAllowedField(key: string): key is (typeof ALLOWED_FIELDS)[number] {
+  return (ALLOWED_FIELDS as readonly string[]).includes(key);
+}
+
+/**
+ * Validate a raw telemetry request body against the strict zero-PII allowlist.
+ *
+ * Pure and side-effect free: no logging, no network, no mutation. The caller
+ * maps any rejection to HTTP 400. `reason` names the offending field only —
+ * never the submitted value — so it is safe to surface without leaking payload
+ * data (defense-in-depth, even though the contract is already PII-free).
+ *
+ * @param rawBody    the request body, exactly as received
+ * @param byteLength UTF-8 byte length of `rawBody` (the size cap is on bytes)
+ */
+export function validatePayload(rawBody: string, byteLength: number): ValidationResult {
+  if (byteLength > MAX_BODY_BYTES) {
+    return reject("body exceeds size limit");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return reject("malformed JSON");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return reject("body must be a JSON object");
+  }
+
+  const body = parsed as Record<string, unknown>;
+
+  // Reject (never strip) any field outside the allowlist.
+  for (const key of Object.keys(body)) {
+    if (!isAllowedField(key)) {
+      return reject("unknown field present");
+    }
+  }
+
+  const { installId, version, installType, event } = body;
+
+  if (typeof installId !== "string" || !UUID_V4.test(installId)) {
+    return reject("installId must be a UUID v4");
+  }
+  if (
+    typeof version !== "string" ||
+    version.length === 0 ||
+    version.length > MAX_VERSION_LENGTH ||
+    !VERSION_RE.test(version)
+  ) {
+    return reject("version is missing or malformed");
+  }
+  if (typeof installType !== "string" || !INSTALL_TYPES.includes(installType as InstallType)) {
+    return reject("installType is not in the allowed set");
+  }
+  if (typeof event !== "string" || !EVENTS.includes(event as TelemetryEvent)) {
+    return reject("event is not in the allowed set");
+  }
+
+  return {
+    ok: true,
+    payload: {
+      installId,
+      version,
+      installType: installType as InstallType,
+      event: event as TelemetryEvent,
+    },
+  };
+}

--- a/telemetry-proxy/test/config.test.ts
+++ b/telemetry-proxy/test/config.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from "vitest";
+import { RATE_LIMIT_PERIOD_SECONDS } from "../src/constants";
+// Vite `?raw` import: the file's contents as a string. Typed inline to avoid
+// pulling @types/node into a config that intentionally scopes types to the
+// Cloudflare Workers runtime only.
+// @ts-expect-error virtual raw module resolved by Vite/Vitest at test time
+import wranglerToml from "../wrangler.toml?raw";
+
+/**
+ * Guards the coupling documented in both files: the `Retry-After` seconds the
+ * Worker emits (RATE_LIMIT_PERIOD_SECONDS) must equal the `[[ratelimits]]`
+ * `simple.period` in wrangler.toml. Editing one without the other would silently
+ * desync the advertised retry window from the actual throttle window.
+ */
+describe("rate-limit period stays in sync with wrangler.toml", () => {
+  const toml: string = wranglerToml;
+
+  it("matches simple.period in the [[ratelimits]] binding", () => {
+    const match = toml.match(/simple\s*=\s*\{[^}]*\bperiod\s*=\s*(\d+)/);
+    expect(match, "could not find simple.period in wrangler.toml").not.toBeNull();
+    const tomlPeriod = Number(match?.[1]);
+    expect(tomlPeriod).toBe(RATE_LIMIT_PERIOD_SECONDS);
+  });
+
+  it("uses a Cloudflare-permitted period (10 or 60)", () => {
+    expect([10, 60]).toContain(RATE_LIMIT_PERIOD_SECONDS);
+  });
+});

--- a/telemetry-proxy/test/validate.test.ts
+++ b/telemetry-proxy/test/validate.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from "vitest";
+import { MAX_BODY_BYTES, MAX_VERSION_LENGTH } from "../src/constants";
+import { validatePayload, type ValidationResult } from "../src/validate";
+
+/** Build a payload object and the (rawBody, byteLength) pair the validator expects. */
+function encode(payload: unknown): [string, number] {
+  const raw = JSON.stringify(payload);
+  return [raw, new TextEncoder().encode(raw).length];
+}
+
+function validate(payload: unknown): ValidationResult {
+  return validatePayload(...encode(payload));
+}
+
+const VALID = {
+  installId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+  version: "1.1.0-SNAPSHOT",
+  installType: "docker-compose",
+  event: "server_start",
+} as const;
+
+describe("validatePayload — happy path", () => {
+  it("accepts a fully valid payload", () => {
+    const result = validate(VALID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload).toEqual(VALID);
+    }
+  });
+
+  it("accepts the snapshot version from the VERSION file (lenient semver)", () => {
+    const result = validate({ ...VALID, version: "1.1.0-SNAPSHOT" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts every allowed installType", () => {
+    for (const installType of ["docker-compose", "jar", "k8s", "unknown"]) {
+      expect(validate({ ...VALID, installType }).ok).toBe(true);
+    }
+  });
+
+  it("accepts every allowed event", () => {
+    for (const event of ["server_start", "heartbeat", "namespace_created", "plugin_published"]) {
+      expect(validate({ ...VALID, event }).ok).toBe(true);
+    }
+  });
+
+  it("accepts a version at exactly the max length", () => {
+    const version = "1" + "0".repeat(MAX_VERSION_LENGTH - 1); // length === MAX_VERSION_LENGTH
+    expect(version.length).toBe(MAX_VERSION_LENGTH);
+    expect(validate({ ...VALID, version }).ok).toBe(true);
+  });
+});
+
+describe("validatePayload — unknown field rejection", () => {
+  it("rejects a payload with one extra field (does not strip it)", () => {
+    const result = validate({ ...VALID, hostname: "leaky.internal" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("unknown field present");
+  });
+
+  it("rejects PII-shaped extras even alongside a valid allowlist", () => {
+    for (const extra of [{ ip: "1.2.3.4" }, { email: "a@b.c" }, { namespace: "acme" }, { $ip: "x" }]) {
+      expect(validate({ ...VALID, ...extra }).ok).toBe(false);
+    }
+  });
+});
+
+describe("validatePayload — missing fields", () => {
+  it("rejects when each required field is absent", () => {
+    for (const field of ["installId", "version", "installType", "event"] as const) {
+      const partial = { ...VALID };
+      delete (partial as Record<string, unknown>)[field];
+      expect(validate(partial).ok).toBe(false);
+    }
+  });
+});
+
+describe("validatePayload — installId", () => {
+  it("rejects a non-UUID string", () => {
+    expect(validate({ ...VALID, installId: "not-a-uuid" }).ok).toBe(false);
+  });
+
+  it("rejects a UUID v1 (wrong version nibble)", () => {
+    expect(validate({ ...VALID, installId: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" }).ok).toBe(false);
+  });
+
+  it("rejects a non-string installId", () => {
+    expect(validate({ ...VALID, installId: 12345 }).ok).toBe(false);
+  });
+});
+
+describe("validatePayload — version", () => {
+  it("rejects an empty version", () => {
+    expect(validate({ ...VALID, version: "" }).ok).toBe(false);
+  });
+
+  it("rejects a version over the length cap", () => {
+    expect(validate({ ...VALID, version: "1." + "9".repeat(MAX_VERSION_LENGTH) }).ok).toBe(false);
+  });
+
+  it("rejects a version not starting with a digit", () => {
+    expect(validate({ ...VALID, version: "v1.0.0" }).ok).toBe(false);
+  });
+
+  it("rejects a version with whitespace/control characters", () => {
+    expect(validate({ ...VALID, version: "1.0 .0" }).ok).toBe(false);
+  });
+});
+
+describe("validatePayload — enums", () => {
+  it("rejects an installType outside the allowed set", () => {
+    expect(validate({ ...VALID, installType: "windows" }).ok).toBe(false);
+  });
+
+  it("rejects an event outside the allowed set", () => {
+    expect(validate({ ...VALID, event: "user_login" }).ok).toBe(false);
+  });
+});
+
+describe("validatePayload — body shape and size", () => {
+  it("rejects malformed JSON", () => {
+    const raw = "{ not json";
+    const result = validatePayload(raw, raw.length);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed JSON");
+  });
+
+  it("rejects a JSON array", () => {
+    expect(validate([VALID]).ok).toBe(false);
+  });
+
+  it("rejects a JSON primitive", () => {
+    const raw = "42";
+    expect(validatePayload(raw, raw.length).ok).toBe(false);
+  });
+
+  it("accepts a body at exactly the byte limit", () => {
+    const [raw] = encode(VALID);
+    const result = validatePayload(raw, MAX_BODY_BYTES);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a body one byte over the limit before parsing", () => {
+    const [raw] = encode(VALID);
+    const result = validatePayload(raw, MAX_BODY_BYTES + 1);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("body exceeds size limit");
+  });
+
+  it("rejects an oversized body even when its JSON would otherwise be valid", () => {
+    // A padded-but-syntactically-valid blob: size check fires first, no parse needed.
+    const raw = " ".repeat(MAX_BODY_BYTES + 10) + JSON.stringify(VALID);
+    const byteLength = new TextEncoder().encode(raw).length;
+    expect(validatePayload(raw, byteLength).ok).toBe(false);
+  });
+});

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -21,7 +21,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 
 const ENDPOINT = "https://telemetry.plugwerk.io/v1/events";
-const ENV = { POSTHOG_PROJECT_KEY: "phc_test_key", POSTHOG_CAPTURE_URL: "https://capture.test/capture/" };
+
+// Mock for the Workers Rate Limiting binding. Reset in beforeEach to allow-all so
+// the non-rate-limit suites exercise the forwarding path; the rate limiting suite
+// overrides it to simulate the over-limit case.
+const limitMock = vi.fn();
+
+const ENV = {
+  POSTHOG_PROJECT_KEY: "phc_test_key",
+  POSTHOG_CAPTURE_URL: "https://capture.test/capture/",
+  RATE_LIMITER: { limit: limitMock } as unknown as RateLimit,
+};
 
 const VALID_BODY = JSON.stringify({
   installId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
@@ -47,6 +57,8 @@ let fetchMock: ReturnType<typeof vi.fn>;
 beforeEach(() => {
   fetchMock = vi.fn();
   vi.stubGlobal("fetch", fetchMock);
+  limitMock.mockReset();
+  limitMock.mockResolvedValue({ success: true });
 });
 
 afterEach(() => {
@@ -135,5 +147,63 @@ describe("forwarding to PostHog", () => {
     fetchMock.mockRejectedValue(new Error("connection reset"));
     const res = await call(post(VALID_BODY));
     expect(res.status).toBe(502);
+  });
+});
+
+describe("rate limiting", () => {
+  // Regression test for DEV-47 (DEV-33 HIGH gate): the public, unauthenticated
+  // endpoint must not amplify floods into per-event-billed PostHog forwards.
+  it("429s the over-limit request and does NOT forward to PostHog", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 1 }), { status: 200 }));
+    // First two calls allowed, the third is over the limit.
+    limitMock
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false });
+
+    expect((await call(post(VALID_BODY))).status).toBe(204);
+    expect((await call(post(VALID_BODY))).status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const throttled = await call(post(VALID_BODY));
+    expect(throttled.status).toBe(429);
+    // No PostHog forward on throttle — the forward count stays at 2.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 429 with an empty body and a Retry-After header", async () => {
+    limitMock.mockResolvedValue({ success: false });
+    const res = await call(post(VALID_BODY));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("60");
+    expect(await res.text()).toBe("");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("meters before reading the body (throttles even an oversized/invalid request)", async () => {
+    limitMock.mockResolvedValue({ success: false });
+    // Oversized declared length would otherwise 400; rate limiting runs first.
+    const res = await call(post(VALID_BODY, { "content-type": "application/json", "content-length": "9999" }));
+    expect(res.status).toBe(429);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keys the limiter by the cf-connecting-ip header", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    await call(post(VALID_BODY, { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" }));
+    expect(limitMock).toHaveBeenCalledWith({ key: "203.0.113.7" });
+  });
+
+  it("falls back to an 'unknown' key when cf-connecting-ip is absent", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    await call(post(VALID_BODY));
+    expect(limitMock).toHaveBeenCalledWith({ key: "unknown" });
+  });
+
+  it("does not meter requests rejected by the path/method/content-type guards", async () => {
+    await call(new Request(ENDPOINT, { method: "GET" }));
+    await call(post(VALID_BODY, { "content-type": "text/plain" }));
+    await call(new Request("https://telemetry.plugwerk.io/", { method: "POST" }));
+    expect(limitMock).not.toHaveBeenCalled();
   });
 });

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index";
+
+const ENDPOINT = "https://telemetry.plugwerk.io/v1/events";
+const ENV = { POSTHOG_PROJECT_KEY: "phc_test_key", POSTHOG_CAPTURE_URL: "https://capture.test/capture/" };
+
+const VALID_BODY = JSON.stringify({
+  installId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+  version: "1.1.0-SNAPSHOT",
+  installType: "k8s",
+  event: "heartbeat",
+});
+
+// Minimal ExecutionContext stub; the handler does not use it.
+const ctx = { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext;
+
+function post(body: string, headers: Record<string, string> = { "content-type": "application/json" }): Request {
+  return new Request(ENDPOINT, { method: "POST", headers, body });
+}
+
+function call(request: Request): Promise<Response> {
+  // The handler ignores ctx but the runtime signature includes it.
+  return (worker.fetch as (r: Request, e: typeof ENV, c: ExecutionContext) => Promise<Response>)(request, ENV, ctx);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("routing and method guards", () => {
+  it("404s an unknown path", async () => {
+    const res = await call(new Request("https://telemetry.plugwerk.io/", { method: "POST" }));
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("405s a non-POST with an Allow header", async () => {
+    const res = await call(new Request(ENDPOINT, { method: "GET" }));
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("POST");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("415s a wrong content-type", async () => {
+    const res = await call(post(VALID_BODY, { "content-type": "text/plain" }));
+    expect(res.status).toBe(415);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts application/json with a charset parameter", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const res = await call(post(VALID_BODY, { "content-type": "application/json; charset=utf-8" }));
+    expect(res.status).toBe(204);
+  });
+});
+
+describe("validation guards", () => {
+  it("400s an extra-field payload and never forwards", async () => {
+    const body = JSON.stringify({
+      installId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+      version: "1.0.0",
+      installType: "jar",
+      event: "server_start",
+      hostname: "leaky",
+    });
+    const res = await call(post(body));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400s an oversized body via the content-length pre-read guard", async () => {
+    const res = await call(post(VALID_BODY, { "content-type": "application/json", "content-length": "9999" }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("forwarding to PostHog", () => {
+  it("204s and forwards a correctly mapped event on PostHog 2xx", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 1 }), { status: 200 }));
+    const res = await call(post(VALID_BODY));
+    expect(res.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(ENV.POSTHOG_CAPTURE_URL);
+    expect(init.method).toBe("POST");
+
+    const forwarded = JSON.parse(init.body as string);
+    expect(forwarded).toEqual({
+      api_key: "phc_test_key",
+      event: "heartbeat",
+      distinct_id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+      properties: {
+        version: "1.1.0-SNAPSHOT",
+        installType: "k8s",
+        $process_person_profile: false,
+      },
+    });
+  });
+
+  it("502s when PostHog returns a non-2xx", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 500 }));
+    const res = await call(post(VALID_BODY));
+    expect(res.status).toBe(502);
+  });
+
+  it("502s when the upstream fetch rejects (network error / timeout)", async () => {
+    fetchMock.mockRejectedValue(new Error("connection reset"));
+    const res = await call(post(VALID_BODY));
+    expect(res.status).toBe(502);
+  });
+});

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -191,6 +191,53 @@ describe("PostHog project key guard (DEV-54 condition 2)", () => {
   });
 });
 
+describe("kill switch (PROXY_DISABLED)", () => {
+  function callWithEnv(request: Request, extra: Record<string, string>): Promise<Response> {
+    const env = { ...ENV, ...extra };
+    return (worker.fetch as (r: Request, e: typeof env, c: ExecutionContext) => Promise<Response>)(request, env, ctx);
+  }
+
+  it("503s a valid POST and neither meters nor forwards when disabled", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const res = await callWithEnv(post(VALID_BODY), { PROXY_DISABLED: "true" });
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(limitMock).not.toHaveBeenCalled();
+  });
+
+  it("parses the flag case-insensitively and ignoring whitespace", async () => {
+    const res = await callWithEnv(post(VALID_BODY), { PROXY_DISABLED: " True " });
+    expect(res.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("wins over the method guard — a GET on the telemetry path also 503s", async () => {
+    const res = await callWithEnv(new Request(ENDPOINT, { method: "GET" }), { PROXY_DISABLED: "true" });
+    expect(res.status).toBe(503);
+  });
+
+  it("still 404s unknown paths while disabled", async () => {
+    const res = await callWithEnv(new Request("https://telemetry.plugwerk.io/", { method: "POST" }), {
+      PROXY_DISABLED: "true",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it.each(["false", "", "1", "yes"])("stays enabled when the flag is %o", async (value) => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const res = await callWithEnv(post(VALID_BODY), { PROXY_DISABLED: value });
+    expect(res.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays enabled when the var is absent (default)", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const res = await call(post(VALID_BODY));
+    expect(res.status).toBe(204);
+  });
+});
+
 describe("rate limiting", () => {
   // Regression test for DEV-47 (DEV-33 HIGH gate): the public, unauthenticated
   // endpoint must not amplify floods into per-event-billed PostHog forwards.

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -150,6 +150,47 @@ describe("forwarding to PostHog", () => {
   });
 });
 
+describe("PostHog project key guard (DEV-54 condition 2)", () => {
+  // The go-live security gate requires the write-only `phc_` project key. A personal
+  // (`phx_`) or admin key must never be used to forward — it widens a leak's blast
+  // radius from capture-only to data-read/admin. The Worker fails closed (502).
+  const BAD_KEYS = ["phx_personal_key", "admin_secret", "phc", ""];
+
+  function callWithKey(request: Request, key: string): Promise<Response> {
+    const env = { ...ENV, POSTHOG_PROJECT_KEY: key };
+    return (worker.fetch as (r: Request, e: typeof env, c: ExecutionContext) => Promise<Response>)(request, env, ctx);
+  }
+
+  it.each(BAD_KEYS)("502s and never forwards when the key is %o (not a phc_ key)", async (key) => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await callWithKey(post(VALID_BODY), key);
+
+    expect(res.status).toBe(502);
+    expect(fetchMock).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("logs a secret-free misconfiguration error (never echoes the key value)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await callWithKey(post(VALID_BODY), "phx_super_secret_value");
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = String(errorSpy.mock.calls[0]?.[0] ?? "");
+    expect(logged).not.toContain("phx_super_secret_value");
+    errorSpy.mockRestore();
+  });
+
+  it("still 204s with a valid phc_ key", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const res = await callWithKey(post(VALID_BODY), "phc_valid_project_key");
+    expect(res.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("rate limiting", () => {
   // Regression test for DEV-47 (DEV-33 HIGH gate): the public, unauthenticated
   // endpoint must not amplify floods into per-event-billed PostHog forwards.

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -90,6 +90,12 @@ describe("routing and method guards", () => {
     const res = await call(post(VALID_BODY, { "content-type": "application/json; charset=utf-8" }));
     expect(res.status).toBe(204);
   });
+
+  it("415s a near-miss media type (application/json-patch+json)", async () => {
+    const res = await call(post(VALID_BODY, { "content-type": "application/json-patch+json" }));
+    expect(res.status).toBe(415);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("validation guards", () => {
@@ -108,6 +114,28 @@ describe("validation guards", () => {
 
   it("400s an oversized body via the content-length pre-read guard", async () => {
     const res = await call(post(VALID_BODY, { "content-type": "application/json", "content-length": "9999" }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400s an oversized body that omits Content-Length (streamed byte cap)", async () => {
+    // A chunked stream body carries no Content-Length, so the cheap pre-read guard
+    // cannot fire — the streaming byte cap must reject it before it is fully buffered.
+    const chunk = new TextEncoder().encode("x".repeat(1024));
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 4; i++) controller.enqueue(chunk); // 4 KB > 2 KB cap
+        controller.close();
+      },
+    });
+    const request = new Request(ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      // Node/undici require duplex when the body is a stream.
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    const res = await call(request);
     expect(res.status).toBe(400);
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/telemetry-proxy/tsconfig.json
+++ b/telemetry-proxy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "test", "vitest.config.ts"]
+}

--- a/telemetry-proxy/vitest.config.ts
+++ b/telemetry-proxy/vitest.config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/telemetry-proxy/wrangler.toml
+++ b/telemetry-proxy/wrangler.toml
@@ -16,6 +16,25 @@ routes = [
 [observability]
 enabled = true
 
+# --- Rate limiting (per client IP) -------------------------------------------
+# Workers Rate Limiting binding: 60 requests / 60 s per client IP. This is the
+# in-code defense that travels with the Worker (DEV-47); src/index.ts meters every
+# real ingestion attempt and returns 429 before forwarding to PostHog.
+#
+# CAVEAT: this binding counts per Cloudflare colo (data center), NOT globally — it
+# is best-effort throttling, not an authoritative global cap. The authoritative
+# edge control is a Cloudflare ZONE rate-limiting rule on telemetry.plugwerk.io/v1/*
+# (blocks before the Worker even spins up, and is global), provisioned in the
+# DEV-34 deploy runbook. Both layers are required.
+#
+# `period` must be 10 or 60. `namespace_id` is an account-unique integer; reusing
+# it across bindings/Workers shares the same counters (intentional here: one limiter).
+# Keep `period` in sync with RATE_LIMIT_PERIOD_SECONDS in src/constants.ts.
+[[ratelimits]]
+name = "RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 60, period = 60 }
+
 # --- Secrets (NOT set here) ---------------------------------------------------
 # POSTHOG_PROJECT_KEY  -> wrangler secret put POSTHOG_PROJECT_KEY
 #

--- a/telemetry-proxy/wrangler.toml
+++ b/telemetry-proxy/wrangler.toml
@@ -1,0 +1,25 @@
+# Cloudflare Worker config for the Plugwerk telemetry reverse proxy.
+# No secret values live in this file. The PostHog project key is an encrypted
+# Worker secret (see README.md → "Secret setup").
+
+name = "plugwerk-telemetry-proxy"
+main = "src/index.ts"
+compatibility_date = "2025-06-01"
+
+# Public ingestion route. The zone telemetry.plugwerk.io must already exist on
+# the plugwerk.io Cloudflare zone before this route resolves (DEV-31 / DEV-34).
+routes = [
+  { pattern = "telemetry.plugwerk.io/v1/*", zone_name = "plugwerk.io" },
+]
+
+# Observability helps monitor 4xx/5xx delivery rates without logging payloads.
+[observability]
+enabled = true
+
+# --- Secrets (NOT set here) ---------------------------------------------------
+# POSTHOG_PROJECT_KEY  -> wrangler secret put POSTHOG_PROJECT_KEY
+#
+# --- Optional non-secret override ---------------------------------------------
+# Defaults to https://eu.i.posthog.com/capture/ when unset.
+# [vars]
+# POSTHOG_CAPTURE_URL = "https://eu.i.posthog.com/capture/"

--- a/telemetry-proxy/wrangler.toml
+++ b/telemetry-proxy/wrangler.toml
@@ -38,7 +38,13 @@ simple = { limit = 60, period = 60 }
 # --- Secrets (NOT set here) ---------------------------------------------------
 # POSTHOG_PROJECT_KEY  -> wrangler secret put POSTHOG_PROJECT_KEY
 #
-# --- Optional non-secret override ---------------------------------------------
-# Defaults to https://eu.i.posthog.com/capture/ when unset.
+# --- Optional non-secret overrides ---------------------------------------------
+# POSTHOG_CAPTURE_URL: defaults to https://eu.i.posthog.com/capture/ when unset.
+# PROXY_DISABLED: operational kill switch. Set to "true" (here, or live in the
+# Cloudflare dashboard without a code deploy) to refuse all ingestion with 503 —
+# nothing is metered, read, or forwarded to PostHog until it is unset. The client
+# beacon fails open (DEV-23), so flipping this never affects Plugwerk servers.
+# Any value other than "true" (case-insensitive) means enabled.
 # [vars]
 # POSTHOG_CAPTURE_URL = "https://eu.i.posthog.com/capture/"
+# PROXY_DISABLED = "false"


### PR DESCRIPTION
## Summary

Adds the **telemetry reverse proxy** that backs `POST https://telemetry.plugwerk.io/v1/events` — a small Cloudflare Worker (TypeScript) that validates the opt-out telemetry beacon against a strict **zero-PII allowlist** and forwards accepted events to PostHog EU Cloud. **Build only**; live deploy/DNS/prod smoke (DEV-34) and PostHog key provisioning (DEV-31) are separate siblings. Go-live is gated on the security review (DEV-33).

New package: `telemetry-proxy/` (isolated; no changes to the Gradle backend or frontend).

### Contract enforced
- Accepts **only** four fields: `installId` (UUID v4), `version` (semver-ish, ≤32 chars — accepts `1.1.0-SNAPSHOT`), `installType` (`docker-compose|jar|k8s|unknown`), `event` (`server_start|heartbeat|namespace_created|plugin_published`). Mirrors the DEV-23 beacon payload.
- Unknown fields are **rejected (400), not silently stripped**. Body capped at 2 KB.
- Status codes: `204` forwarded · `400` invalid/oversized/unknown-field · `405` non-POST (`Allow: POST`) · `415` wrong content-type · `502` PostHog forward failure.
- Forwards `{ api_key, event, distinct_id: installId, properties: { version, installType, $process_person_profile: false } }`.
- Request bodies and field values are **never logged** (defense-in-depth).

### Why 502 on forward failure
The client beacon fails open on its side (DEV-23), so a `5xx` here never affects the Plugwerk server — it only makes our own delivery failures observable.

### Verification
- `tsc --noEmit` clean.
- 32 vitest unit tests green (validator: valid, each invalid case, extra-field rejection, oversized body, enum/UUID/version edges; handler: routing, 405/415, content-length guard, 204/502, PostHog payload mapping incl. no-leak assertion).
- `wrangler dev` smoke verified against a local capture mock (no external calls): `204` valid, `400` extra-field, plus 404/405/415/400-enum/400-uuid matrix.
- No secrets committed: `POSTHOG_PROJECT_KEY` is a `wrangler secret`; `.dev.vars` is gitignored; only `.dev.vars.example` (placeholder) is tracked.

## Related Issues

Refs DEV-32. Unblocks DEV-33 (security review) and DEV-34 (deploy). Parent DEV-28. Beacon contract DEV-23.
(Does not auto-close a GitHub issue — tracked in Paperclip.)

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable) — `telemetry-proxy/README.md` runbook (deploy, DPA, secret setup, rollback, DNS)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A (no DB changes)
- [x] CLA signed (already signed)

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (specify: WebEngineer — Claude Opus, via Paperclip)


---

## Update (2026-07-20, corrected): what actually landed here

- **`PROXY_DISABLED` kill switch** (operator emergency stop, `503` before metering/read/forward) — **included in this merge**.
- **workers.dev variant** (no zone route, `plugwerk.io` DNS untouched) — **NOT in this merge**: that commit was pushed to the branch after this PR had already been merged and is re-applied in follow-up PR #601. Until #601 merges, `main` still configures the `telemetry.plugwerk.io` zone route, which requires DNS this project does not currently have on Cloudflare.
