### PR TITLE
fix(frontend): unblock Vitest suite, repair BrandingSection tests, enforce in CI (DEV-29)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
@@ -40,6 +40,18 @@ val npmLint by tasks.registering(Exec::class) {
     outputs.upToDateWhen { true }
 }
 
+// Vitest gate (DEV-29). The frontend suite was red on `main` and invisible to
+// CI — only `format:check` + `build` were wired in, so a broken test never
+// failed a build. `test:run` is non-watch and exits non-zero on any failure.
+val npmTest by tasks.registering(Exec::class) {
+    dependsOn(npmInstall)
+    workingDir = projectDir
+    commandLine(npmCmd("run", "test:run"))
+    inputs.dir("src")
+    inputs.file("vitest.config.ts")
+    outputs.upToDateWhen { true }
+}
+
 val npmBuild by tasks.registering(Exec::class) {
     dependsOn(npmInstall, npmFormatCheck, npmLint)
     workingDir = projectDir
@@ -59,6 +71,12 @@ val copyFrontend by tasks.registering(Copy::class) {
 
 tasks.named("build") {
     dependsOn(copyFrontend)
+}
+
+// `check` is wired into `build` by the `base` plugin, so attaching the Vitest
+// suite here makes `./gradlew build` (CI) enforce it without touching ci.yml.
+tasks.named("check") {
+    dependsOn(npmTest)
 }
 
 // Make the static resources available as a runtime dependency

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/branding/BrandingSection.test.tsx
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as apiConfig from "../../../api/config";
 import { renderWithTheme } from "../../../test/renderWithTheme";
 import { BrandingSection } from "./BrandingSection";
@@ -29,9 +29,43 @@ vi.mock("../../../api/config", () => ({
   },
 }));
 
+// Each card decides Custom-vs-Default (and whether to show "Reset to default")
+// by probing its public endpoint with an off-DOM `new Image()` inside an effect
+// — deliberately *not* the rendered <img>'s onLoad/onError, to avoid the
+// fallback-swap race documented in BrandingSection.tsx ("#530 follow-up").
+// jsdom never fires load/error on a real Image, so drive the probe with a
+// controllable stub whose outcome each test selects via `probeOutcome`.
+let probeOutcome: "load" | "error" = "error";
+
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private _src = "";
+
+  set src(value: string) {
+    this._src = value;
+    // Defer so the effect has finished assigning onload/onerror before we
+    // fire, mirroring a real asynchronous image fetch.
+    setTimeout(() => {
+      if (probeOutcome === "load") this.onload?.();
+      else this.onerror?.();
+    }, 0);
+  }
+
+  get src(): string {
+    return this._src;
+  }
+}
+
 describe("BrandingSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    probeOutcome = "error";
+    vi.stubGlobal("Image", FakeImage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders three tiles for the slot model", () => {
@@ -43,13 +77,8 @@ describe("BrandingSection", () => {
   });
 
   it("falls back to Default when the public asset 404s", async () => {
+    probeOutcome = "error";
     renderWithTheme(<BrandingSection />);
-
-    // Each tile renders an <img> pointing at /api/v1/branding/{slot}.
-    // Simulate the 404 the server returns when the slot is at its
-    // default by firing the image's onError on every preview.
-    const previews = await screen.findAllByRole("img");
-    previews.forEach((img) => fireEvent.error(img));
 
     await waitFor(() => {
       expect(screen.getAllByText("Default").length).toBeGreaterThanOrEqual(3);
@@ -60,10 +89,8 @@ describe("BrandingSection", () => {
   });
 
   it("flips to Custom + offers Reset when the asset loads", async () => {
+    probeOutcome = "load";
     renderWithTheme(<BrandingSection />);
-
-    const previews = await screen.findAllByRole("img");
-    previews.forEach((img) => fireEvent.load(img));
 
     await waitFor(() => {
       expect(

--- a/plugwerk-server/plugwerk-server-frontend/vitest.config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/vitest.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
+    // `@mui/material` re-exports `react-transition-group@4`, which ships CJS
+    // with an extensionless directory import (`.../TransitionGroupContext`)
+    // and no `exports` map. Vitest externalises both by default, and Node's
+    // ESM resolver then rejects the directory import, breaking any test file
+    // that mounts a MUI transition component. Inlining forces Vite to bundle
+    // and resolve them through its own pipeline. See DEV-29.
+    server: {
+      deps: {
+        inline: [/@mui\//, /react-transition-group/],
+      },
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
## Summary

The frontend Vitest suite was **red on `main` and unenforced by CI** (DEV-29, found by QA during the DEV-20 onboarding sign-off). Neither `vitest` nor the Gradle frontend build ran the tests, so regressions were invisible. This PR fixes the suite and wires it into the build.

### Changes
- **`vitest.config.ts`** — Vitest externalised `@mui/material` + `react-transition-group@4`; Node's ESM resolver then rejected react-transition-group's extensionless directory import (`.../TransitionGroupContext`), failing **37/53** test files. Inline both via `test.server.deps.inline` so Vite resolves them through its own pipeline.
- **`BrandingSection.test.tsx`** — the slot card was migrated to an off-DOM `Image()` probe (#530 follow-up), but the tests still fired `load`/`error` on the rendered `<img>`, which jsdom never resolves — so `hasCustom` stayed `null` and the Custom/Default chip + "Reset to default" button never appeared. The 2 tests now drive the **actual** probe via a controllable `Image` stub.
- **`build.gradle.kts`** — add an `npmTest` task wired into the `check` lifecycle (itself wired into `build` by the `base` plugin), so `./gradlew build` — and therefore CI — runs `npm run test:run`. A failing test now blocks the PR, without touching `ci.yml`.

### Result
`npm run test:run`: **53 files, 438/438 tests pass.** Gradle `:plugwerk-server-frontend:check` now depends on `npmTest` (verified via `--dry-run`).

## Scope / coordination
- **ESLint** (DEV-29 ask 3) is delivered separately on the DEV-21 branch (`make eslint green and enforce it in the Gradle build`), which also adds an `npmLint` gate — the two build.gradle.kts gates (`npmLint`, `npmTest`) will merge together.
- **Coverage to ≥80%** (DEV-29 ask 4) is tracked as a follow-up; current baseline is lines 73.67 / branches 67.93 / functions 72.74.

## Test plan
- [x] `npm run test:run` → 53 files / 438 tests green
- [x] `BrandingSection.test.tsx` 3/3 (probe load → Custom+Reset; probe error → Default)
- [x] `./gradlew :plugwerk-server-frontend:check --dry-run` shows `check → npmTest → npmInstall`
- [ ] CI green on this PR

Refs DEV-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)