### PR TITLE
feat(telemetry): P1 activation events — namespace_created + first_plugin_publish (DEV-24)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceEntity.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/domain/NamespaceEntity.kt
@@ -49,6 +49,11 @@ import java.util.UUID
  * @property name Human-readable display name of the namespace.
  * @property description Optional longer description of the namespace.
  * @property autoApproveReleases Whether new plugin releases are auto-approved without manual review.
+ * @property firstPublishedAt Timestamp of the first plugin release ever published in this namespace,
+ *   or `null` if none yet. Set once (and only once) via
+ *   [io.plugwerk.server.repository.NamespaceRepository.markFirstPublishedIfAbsent]; it is the gate
+ *   that makes the `first_plugin_publish` activation telemetry event (DEV-24) fire exactly once per
+ *   namespace. Carries no personal data — a coarse activation timestamp only.
  * @property createdAt Creation timestamp (set automatically, immutable).
  * @property updatedAt Timestamp of the last modification (updated automatically).
  */
@@ -74,6 +79,9 @@ class NamespaceEntity(
 
     @Column(name = "auto_approve_releases", nullable = false)
     var autoApproveReleases: Boolean = false,
+
+    @Column(name = "first_published_at")
+    var firstPublishedAt: OffsetDateTime? = null,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceRepository.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/repository/NamespaceRepository.kt
@@ -20,6 +20,10 @@ package io.plugwerk.server.repository
 
 import io.plugwerk.server.domain.NamespaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.OffsetDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -28,4 +32,26 @@ interface NamespaceRepository : JpaRepository<NamespaceEntity, UUID> {
     fun findBySlug(slug: String): Optional<NamespaceEntity>
 
     fun existsBySlug(slug: String): Boolean
+
+    /**
+     * Atomically stamps the first-publish timestamp on a namespace, but **only**
+     * if it has never been published before (`first_published_at IS NULL`).
+     *
+     * This is the race-safe gate behind the `first_plugin_publish` activation
+     * telemetry event (DEV-24): two concurrent first publishes both run this
+     * `UPDATE ... WHERE first_published_at IS NULL`, but the database row lock
+     * serialises them and the `IS NULL` predicate guarantees exactly one returns
+     * `1` (the winner) while the other returns `0`. The caller emits the event
+     * iff this returns `1`, so it fires at most once per namespace lifetime
+     * regardless of concurrency or which publish path (auto-approve upload vs.
+     * review approval) reached it first.
+     *
+     * @return the number of rows updated — `1` on the first publish, `0` thereafter.
+     */
+    @Modifying
+    @Query(
+        "UPDATE NamespaceEntity n SET n.firstPublishedAt = :now " +
+            "WHERE n.id = :id AND n.firstPublishedAt IS NULL",
+    )
+    fun markFirstPublishedIfAbsent(@Param("id") id: UUID, @Param("now") now: OffsetDateTime): Int
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/NamespaceService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/NamespaceService.kt
@@ -24,6 +24,7 @@ import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.settings.UserSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -38,6 +39,7 @@ class NamespaceService(
     private val storageService: ArtifactStorageService,
     private val userSettingsService: UserSettingsService,
     private val namespaceDeletionTransaction: NamespaceDeletionTransaction,
+    private val activationTelemetry: ActivationTelemetry,
 ) {
 
     private val log = LoggerFactory.getLogger(NamespaceService::class.java)
@@ -56,7 +58,7 @@ class NamespaceService(
         autoApproveReleases: Boolean = false,
     ): NamespaceEntity {
         if (namespaceRepository.existsBySlug(slug)) throw NamespaceAlreadyExistsException(slug)
-        return namespaceRepository.save(
+        val saved = namespaceRepository.save(
             NamespaceEntity(
                 slug = slug,
                 name = name,
@@ -65,6 +67,11 @@ class NamespaceService(
                 autoApproveReleases = autoApproveReleases,
             ),
         )
+        // DEV-24: activation telemetry. Deferred to after commit and dispatched
+        // off-thread (fail-open) so it cannot affect this create. Zero PII —
+        // only the event name leaves the process, never the namespace itself.
+        activationTelemetry.namespaceCreated()
+        return saved
     }
 
     @Transactional

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/PluginReleaseService.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -38,6 +39,7 @@ import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.security.MessageDigest
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
@@ -51,6 +53,7 @@ class PluginReleaseService(
     private val objectMapper: ObjectMapper,
     private val settingsService: ApplicationSettingsService,
     private val downloadEventService: DownloadEventService,
+    private val activationTelemetry: ActivationTelemetry,
 ) {
 
     fun findAllByPlugin(namespaceSlug: String, pluginId: String): List<PluginReleaseEntity> {
@@ -96,7 +99,9 @@ class PluginReleaseService(
             throw ReleaseNotFoundException("id=$id", "")
         }
         release.status = status
-        return releaseRepository.save(release)
+        val saved = releaseRepository.save(release)
+        recordFirstPublishActivation(status, release.plugin.namespace)
+        return saved
     }
 
     @Transactional
@@ -161,7 +166,7 @@ class PluginReleaseService(
             ReleaseStatus.DRAFT
         }
 
-        return releaseRepository.save(
+        val saved = releaseRepository.save(
             PluginReleaseEntity(
                 plugin = plugin,
                 version = descriptor.version,
@@ -174,6 +179,8 @@ class PluginReleaseService(
                 status = initialStatus,
             ),
         )
+        recordFirstPublishActivation(initialStatus, plugin.namespace)
+        return saved
     }
 
     @Transactional
@@ -185,7 +192,33 @@ class PluginReleaseService(
     ): PluginReleaseEntity {
         val release = findByVersion(namespaceSlug, pluginId, version)
         release.status = status
-        return releaseRepository.save(release)
+        val saved = releaseRepository.save(release)
+        recordFirstPublishActivation(status, release.plugin.namespace)
+        return saved
+    }
+
+    /**
+     * Emits the `first_plugin_publish` activation event (DEV-24) the first time a
+     * release reaches [ReleaseStatus.PUBLISHED] in [namespace], and never again.
+     *
+     * All three publish paths (auto-approve [upload], [updateStatus], and review
+     * approval via [updateStatusByIdInNamespace]) funnel through here. The "first
+     * only" guarantee does **not** rely on this method being called once — it
+     * relies on [NamespaceRepository.markFirstPublishedIfAbsent], an atomic
+     * conditional `UPDATE` that flips `first_published_at` for exactly one caller.
+     * We emit the event iff that update reported a row changed, so the event is
+     * tied to the same transaction that durably set the flag and fires at most
+     * once per namespace regardless of path or concurrency.
+     *
+     * No-op for any non-published transition (DRAFT/DEPRECATED/YANKED).
+     */
+    private fun recordFirstPublishActivation(status: ReleaseStatus, namespace: NamespaceEntity) {
+        if (status != ReleaseStatus.PUBLISHED) return
+        val namespaceId = requireNotNull(namespace.id) { "Namespace has no persisted id" }
+        val firstPublish = namespaceRepository.markFirstPublishedIfAbsent(namespaceId, OffsetDateTime.now()) == 1
+        if (firstPublish) {
+            activationTelemetry.firstPluginPublished()
+        }
     }
 
     /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/ActivationTelemetry.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/ActivationTelemetry.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * Emits the P1 server-side activation events (DEV-24): `namespace_created` and
+ * `first_plugin_publish`. A thin seam over [TelemetryBeacon] that owns one extra
+ * concern the beacon deliberately does not: **transaction awareness**.
+ *
+ * The activation events are raised from inside a business transaction (namespace
+ * create, plugin publish). Two rules follow:
+ *
+ *  - **Fire only on commit.** The send is deferred to `afterCommit` so a
+ *    rolled-back create/publish never produces a telemetry event for work that
+ *    did not actually happen. This also keeps the `first_plugin_publish` gate
+ *    honest: the `namespace.first_published_at` flag and the emitted event share
+ *    the same commit, so the event fires exactly when the flag is durably set.
+ *    (The gate itself — flipping the flag atomically only on the first publish —
+ *    lives in the calling service via
+ *    [io.plugwerk.server.repository.NamespaceRepository.markFirstPublishedIfAbsent];
+ *    this class only carries the "if the gate opened, announce it" half.)
+ *
+ *  - **Never block the caller.** The actual send goes through
+ *    [TelemetryBeacon.emitAsync], off the request thread, so neither the
+ *    `afterCommit` callback nor a no-transaction direct call stalls on the
+ *    telemetry HTTP timeout.
+ *
+ * The opt-out gate and fail-open guarantee are inherited unchanged from
+ * [TelemetryBeacon.emit]; this class adds no new way for telemetry to affect the
+ * request it rides on.
+ */
+@Service
+class ActivationTelemetry(private val beacon: TelemetryBeacon) {
+
+    /** Records a namespace creation. Call from within the create transaction. */
+    fun namespaceCreated() = emitAfterCommit(TelemetryEvent.NAMESPACE_CREATED)
+
+    /**
+     * Records the first plugin publish in a namespace. Call only when the
+     * first-publish gate actually opened (see
+     * [io.plugwerk.server.repository.NamespaceRepository.markFirstPublishedIfAbsent]),
+     * from within the publish transaction.
+     */
+    fun firstPluginPublished() = emitAfterCommit(TelemetryEvent.FIRST_PLUGIN_PUBLISH)
+
+    /**
+     * Defers [TelemetryBeacon.emitAsync] to after the current transaction
+     * commits. When no transaction is active (defensive — the production callers
+     * are always transactional) the event is dispatched immediately so the
+     * behaviour degrades to "fire now" rather than "drop silently".
+     */
+    private fun emitAfterCommit(event: TelemetryEvent) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() = beacon.emitAsync(event)
+                },
+            )
+        } else {
+            beacon.emitAsync(event)
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
@@ -52,7 +52,9 @@ import java.util.concurrent.TimeUnit
  * The first-start beacon is dispatched on a dedicated single-thread executor so a
  * slow or hung endpoint cannot delay `ApplicationReadyEvent` propagation. The
  * heartbeat path runs on the scheduler thread (already off the request/startup
- * path) and calls [emit] directly.
+ * path) and calls [emit] directly. The activation events (DEV-24) reuse the same
+ * executor via [emitAsync] so a request thread (namespace create / plugin
+ * publish) is never blocked on the telemetry HTTP send or its timeout.
  */
 @Component
 class TelemetryBeacon(
@@ -64,9 +66,13 @@ class TelemetryBeacon(
 ) {
     private val log = LoggerFactory.getLogger(TelemetryBeacon::class.java)
 
-    /** Off-startup-thread dispatcher for the first-start beacon. Daemon so it never blocks JVM exit. */
-    private val startupExecutor = Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "telemetry-startup").apply { isDaemon = true }
+    /**
+     * Off-request/startup-thread dispatcher for the first-start beacon and the
+     * activation events. Single-threaded (telemetry volume is tiny and ordering
+     * is irrelevant) and daemon so it never blocks JVM exit.
+     */
+    private val dispatchExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "telemetry-dispatch").apply { isDaemon = true }
     }
 
     /**
@@ -90,17 +96,31 @@ class TelemetryBeacon(
     }
 
     /**
+     * Fire-and-forget variant of [emit] for callers on a latency-sensitive thread
+     * (request handlers emitting activation events, DEV-24). Submits the [emit]
+     * to the off-thread [dispatchExecutor] and returns immediately. Fail-open: a
+     * rejected submission (executor shut down during app teardown) is swallowed
+     * and logged at debug, exactly like a failed send.
+     */
+    fun emitAsync(event: TelemetryEvent) {
+        runCatching { dispatchExecutor.execute { emit(event) } }
+            .onFailure { ex ->
+                log.debug("telemetry {} async dispatch rejected (ignored, fail-open): {}", event.wireValue, ex.message)
+            }
+    }
+
+    /**
      * First-start beacon. Fired once when the application is ready; dispatched off
      * the event thread so the send (or its timeout) never delays startup.
      */
     @EventListener(ApplicationReadyEvent::class)
     fun onApplicationReady() {
-        startupExecutor.execute { emit(TelemetryEvent.SERVER_START) }
+        dispatchExecutor.execute { emit(TelemetryEvent.SERVER_START) }
     }
 
     @PreDestroy
     fun shutdown() {
-        startupExecutor.shutdown()
-        runCatching { startupExecutor.awaitTermination(2, TimeUnit.SECONDS) }
+        dispatchExecutor.shutdown()
+        runCatching { dispatchExecutor.awaitTermination(2, TimeUnit.SECONDS) }
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
@@ -30,6 +30,20 @@ enum class TelemetryEvent(val wireValue: String) {
 
     /** Emitted ~once per 24h by the scheduled heartbeat job. */
     HEARTBEAT("heartbeat"),
+
+    /**
+     * Activation event (DEV-24): a namespace was created. Fired once per
+     * namespace creation, after the owning transaction commits.
+     */
+    NAMESPACE_CREATED("namespace_created"),
+
+    /**
+     * Activation event (DEV-24): the **first** plugin release was published in a
+     * namespace. Fired at most once per namespace lifetime — gated by the
+     * `namespace.first_published_at` timestamp, not emitted on subsequent
+     * publishes.
+     */
+    FIRST_PLUGIN_PUBLISH("first_plugin_publish"),
 }
 
 /**

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -71,3 +71,5 @@ databaseChangeLog:
       file: db/changelog/migrations/0035_application_asset.yaml
   - include:
       file: db/changelog/migrations/0036_seed_telemetry_install_id.yaml
+  - include:
+      file: db/changelog/migrations/0037_add_namespace_first_published.yaml

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0037_add_namespace_first_published.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0037_add_namespace_first_published.yaml
@@ -1,0 +1,37 @@
+# Add nullable namespace.first_published_at for the P1 activation telemetry
+# (DEV-24 / ADR-0038). It is the gate behind the `first_plugin_publish` event:
+# the column is stamped exactly once per namespace, by the atomic conditional
+# UPDATE in NamespaceRepository.markFirstPublishedIfAbsent
+# (`... WHERE first_published_at IS NULL`), and the event is emitted only when
+# that UPDATE reports a row changed. Subsequent publishes leave it untouched.
+#
+# Why nullable, no default, no backfill:
+#   NULL is the meaningful "never published yet" state the gate keys off. A
+#   default of now() would lie about historic state and, worse, would mark every
+#   pre-existing namespace as already-published — silently suppressing the very
+#   first real publish event we want to measure. Existing namespaces therefore
+#   start NULL and emit `first_plugin_publish` on their next publish, which is
+#   the correct activation signal for an in-flight install.
+#
+# Privacy: the column holds a coarse activation timestamp only — no namespace
+# name, plugin name, or user identifier. It is never serialized into the
+# telemetry payload (which stays {installId, version, installType, event}); it
+# lives server-side purely to gate the event. See ADR-0038.
+
+databaseChangeLog:
+  - changeSet:
+      id: 0037-add-namespace-first-published-at
+      author: plugwerk
+      changes:
+        - addColumn:
+            tableName: namespace
+            columns:
+              - column:
+                  name: first_published_at
+                  type: timestamptz
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: namespace
+            columnName: first_published_at

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/DownloadEventServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import io.plugwerk.descriptor.PlugwerkDescriptor
 import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.repository.DownloadEventRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -77,6 +78,11 @@ class DownloadEventServiceIntegrationTest {
 
         @Bean
         fun objectMapper(): ObjectMapper = ObjectMapper()
+
+        // DEV-24: NamespaceService/PluginReleaseService now collaborate with the
+        // activation telemetry seam — mocked here, this slice covers downloads only.
+        @Bean
+        fun activationTelemetry(): ActivationTelemetry = mock(ActivationTelemetry::class.java)
     }
 
     companion object {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceIntegrationTest.kt
@@ -30,6 +30,7 @@ import io.plugwerk.server.repository.NamespaceRepository
 import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
@@ -66,6 +67,11 @@ class NamespaceServiceIntegrationTest {
     class MockConfig {
         @Bean
         fun artifactStorageService(): ArtifactStorageService = mock(ArtifactStorageService::class.java)
+
+        // DEV-24: the activation telemetry seam is mocked — this slice exercises
+        // persistence, not the telemetry transport (covered by ActivationTelemetryTest).
+        @Bean
+        fun activationTelemetry(): ActivationTelemetry = mock(ActivationTelemetry::class.java)
     }
 
     companion object {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/NamespaceServiceTest.kt
@@ -26,6 +26,7 @@ import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.settings.UserSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -63,6 +64,9 @@ class NamespaceServiceTest {
     @Mock
     lateinit var namespaceDeletionTransaction: NamespaceDeletionTransaction
 
+    @Mock
+    lateinit var activationTelemetry: ActivationTelemetry
+
     @InjectMocks
     lateinit var namespaceService: NamespaceService
 
@@ -96,6 +100,8 @@ class NamespaceServiceTest {
 
         assertThat(result.slug).isEqualTo("new-ns")
         verify(namespaceRepository).save(any<NamespaceEntity>())
+        // DEV-24: the namespace_created activation event fires on a successful create.
+        verify(activationTelemetry).namespaceCreated()
     }
 
     @Test
@@ -107,6 +113,8 @@ class NamespaceServiceTest {
         }
 
         verify(namespaceRepository, never()).save(any<NamespaceEntity>())
+        // No persistence, no activation event.
+        verify(activationTelemetry, never()).namespaceCreated()
     }
 
     @Test

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceIntegrationTest.kt
@@ -22,6 +22,7 @@ import io.plugwerk.descriptor.DescriptorResolver
 import io.plugwerk.descriptor.PlugwerkDescriptor
 import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -29,6 +30,10 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
@@ -72,6 +77,11 @@ class PluginReleaseServiceIntegrationTest {
 
         @Bean
         fun objectMapper(): ObjectMapper = ObjectMapper()
+
+        // DEV-24: telemetry transport is mocked; this slice verifies the real
+        // first-publish gate (the conditional UPDATE) against Postgres, not the send.
+        @Bean
+        fun activationTelemetry(): ActivationTelemetry = mock(ActivationTelemetry::class.java)
     }
 
     companion object {
@@ -95,11 +105,17 @@ class PluginReleaseServiceIntegrationTest {
     @Autowired
     lateinit var descriptorResolver: DescriptorResolver
 
+    @Autowired
+    lateinit var activationTelemetry: ActivationTelemetry
+
     lateinit var testNamespace: io.plugwerk.server.domain.NamespaceEntity
 
     @BeforeEach
     fun setUp() {
         testNamespace = namespaceService.create("rel-int-ns", "Integration Org")
+        // The bean is a context-cached singleton; reset interactions recorded by
+        // the setUp create() (and any prior test) so per-test verify() counts are honest.
+        clearInvocations(activationTelemetry)
     }
 
     @Test
@@ -161,5 +177,35 @@ class PluginReleaseServiceIntegrationTest {
         val result = releaseService.upload("auto-approve-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
 
         assertThat(result.status).isEqualTo(ReleaseStatus.PUBLISHED)
+    }
+
+    @Test
+    fun `first_plugin_publish fires once per namespace — gated by the real conditional UPDATE (DEV-24)`() {
+        namespaceService.create("first-pub-ns", "First Pub Org", autoApproveReleases = true)
+        val first = PlugwerkDescriptor(id = "alpha-plugin", version = "1.0.0", name = "Alpha")
+        val second = PlugwerkDescriptor(id = "beta-plugin", version = "1.0.0", name = "Beta")
+        whenever(descriptorResolver.resolve(any())).thenReturn(first).thenReturn(second)
+
+        // Two distinct auto-approved (=PUBLISHED) publishes in the same namespace.
+        // The first opens the gate; the second hits markFirstPublishedIfAbsent's
+        // `WHERE first_published_at IS NULL` after the column is already stamped
+        // (same transaction) and updates 0 rows — so no second event fires.
+        releaseService.upload("first-pub-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
+        releaseService.upload("first-pub-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
+
+        verify(activationTelemetry, times(1)).firstPluginPublished()
+    }
+
+    @Test
+    fun `first_plugin_publish does not fire while releases stay in DRAFT (DEV-24)`() {
+        // rel-int-ns (from setUp) has autoApproveReleases = false → uploads land
+        // as DRAFT, which must not touch the first-publish gate.
+        val descriptor = PlugwerkDescriptor(id = "draft-plugin", version = "1.0.0", name = "Draft")
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+
+        val result = releaseService.upload("rel-int-ns", ByteArrayInputStream(FAKE_JAR), FAKE_JAR.size.toLong())
+
+        assertThat(result.status).isEqualTo(ReleaseStatus.DRAFT)
+        verify(activationTelemetry, never()).firstPluginPublished()
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceTest.kt
@@ -29,6 +29,7 @@ import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -44,6 +45,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayInputStream
+import java.time.OffsetDateTime
 import java.util.Optional
 import java.util.UUID
 import kotlin.test.assertFailsWith
@@ -62,6 +64,8 @@ class PluginReleaseServiceTest {
     @Mock lateinit var descriptorResolver: DescriptorResolver
 
     @Mock lateinit var downloadEventService: DownloadEventService
+
+    @Mock lateinit var activationTelemetry: ActivationTelemetry
 
     lateinit var releaseService: PluginReleaseService
 
@@ -93,6 +97,7 @@ class PluginReleaseServiceTest {
             ObjectMapper(),
             settingsService,
             downloadEventService,
+            activationTelemetry,
         )
     }
 
@@ -480,5 +485,126 @@ class PluginReleaseServiceTest {
         val result = releaseService.upload("auto-ns", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
 
         assertThat(result.status).isEqualTo(ReleaseStatus.PUBLISHED)
+    }
+
+    // --- DEV-24: first_plugin_publish activation gating ---
+
+    @Test
+    fun `upload fires first_plugin_publish on the first auto-approved publish in a namespace`() {
+        val jarBytes = fakeJarBytes()
+        val descriptor = PlugwerkDescriptor(id = "auto-plugin", version = "1.0.0", name = "Auto Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("auto-ns")).thenReturn(Optional.of(autoApproveNamespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(autoApproveNamespace, "auto-plugin"))
+            .thenReturn(Optional.of(autoApprovePlugin))
+        whenever(releaseRepository.existsByPluginAndVersion(autoApprovePlugin, "1.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+        // Gate opens: this is the first publish in the namespace.
+        whenever(namespaceRepository.markFirstPublishedIfAbsent(eq(autoApproveNamespaceId), any<OffsetDateTime>()))
+            .thenReturn(1)
+
+        releaseService.upload("auto-ns", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        verify(namespaceRepository).markFirstPublishedIfAbsent(eq(autoApproveNamespaceId), any<OffsetDateTime>())
+        verify(activationTelemetry).firstPluginPublished()
+    }
+
+    @Test
+    fun `upload does not fire first_plugin_publish when the namespace already published before`() {
+        val jarBytes = fakeJarBytes()
+        val descriptor = PlugwerkDescriptor(id = "auto-plugin", version = "2.0.0", name = "Auto Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("auto-ns")).thenReturn(Optional.of(autoApproveNamespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(autoApproveNamespace, "auto-plugin"))
+            .thenReturn(Optional.of(autoApprovePlugin))
+        whenever(releaseRepository.existsByPluginAndVersion(autoApprovePlugin, "2.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+        // Gate stays shut: a prior publish already stamped first_published_at.
+        whenever(namespaceRepository.markFirstPublishedIfAbsent(eq(autoApproveNamespaceId), any<OffsetDateTime>()))
+            .thenReturn(0)
+
+        releaseService.upload("auto-ns", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        verify(namespaceRepository).markFirstPublishedIfAbsent(eq(autoApproveNamespaceId), any<OffsetDateTime>())
+        verify(activationTelemetry, never()).firstPluginPublished()
+    }
+
+    @Test
+    fun `upload does not touch the first-publish gate when the release stays DRAFT`() {
+        val jarBytes = fakeJarBytes()
+        val descriptor = PlugwerkDescriptor(id = "my-plugin", version = "4.0.0", name = "My Plugin")
+
+        whenever(descriptorResolver.resolve(any())).thenReturn(descriptor)
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.existsByPluginAndVersion(plugin, "4.0.0")).thenReturn(false)
+        whenever(storageService.store(any(), any(), any())).thenReturn("key")
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenAnswer { it.getArgument(0) }
+
+        releaseService.upload("acme", ByteArrayInputStream(jarBytes), jarBytes.size.toLong())
+
+        verify(namespaceRepository, never()).markFirstPublishedIfAbsent(any<UUID>(), any<OffsetDateTime>())
+        verify(activationTelemetry, never()).firstPluginPublished()
+    }
+
+    @Test
+    fun `updateStatus to PUBLISHED fires first_plugin_publish only on the first publish`() {
+        val release = PluginReleaseEntity(
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "acme:my-plugin:1.0.0:jar",
+        )
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findByPluginAndVersion(plugin, "1.0.0")).thenReturn(Optional.of(release))
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(release)
+        whenever(namespaceRepository.markFirstPublishedIfAbsent(eq(namespaceId), any<OffsetDateTime>())).thenReturn(1)
+
+        releaseService.updateStatus("acme", "my-plugin", "1.0.0", ReleaseStatus.PUBLISHED)
+
+        verify(activationTelemetry).firstPluginPublished()
+    }
+
+    @Test
+    fun `updateStatus to a non-published status never touches the first-publish gate`() {
+        val release = PluginReleaseEntity(
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "acme:my-plugin:1.0.0:jar",
+        )
+        whenever(namespaceRepository.findBySlug("acme")).thenReturn(Optional.of(namespace))
+        whenever(pluginRepository.findByNamespaceAndPluginId(namespace, "my-plugin")).thenReturn(Optional.of(plugin))
+        whenever(releaseRepository.findByPluginAndVersion(plugin, "1.0.0")).thenReturn(Optional.of(release))
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(release)
+
+        releaseService.updateStatus("acme", "my-plugin", "1.0.0", ReleaseStatus.DEPRECATED)
+
+        verify(namespaceRepository, never()).markFirstPublishedIfAbsent(any<UUID>(), any<OffsetDateTime>())
+        verify(activationTelemetry, never()).firstPluginPublished()
+    }
+
+    @Test
+    fun `updateStatusByIdInNamespace to PUBLISHED fires first_plugin_publish on the first publish`() {
+        val releaseId = UUID.randomUUID()
+        val release = PluginReleaseEntity(
+            id = releaseId,
+            plugin = plugin,
+            version = "1.0.0",
+            artifactSha256 = "sha",
+            artifactKey = "acme:my-plugin:1.0.0:jar",
+        )
+        whenever(releaseRepository.findByIdWithPlugin(releaseId)).thenReturn(Optional.of(release))
+        whenever(releaseRepository.save(any<PluginReleaseEntity>())).thenReturn(release)
+        whenever(namespaceRepository.markFirstPublishedIfAbsent(eq(namespaceId), any<OffsetDateTime>())).thenReturn(1)
+
+        releaseService.updateStatusByIdInNamespace(releaseId, "acme", ReleaseStatus.PUBLISHED)
+
+        verify(activationTelemetry).firstPluginPublished()
     }
 }

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceIntegrationTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginServiceIntegrationTest.kt
@@ -21,6 +21,7 @@ package io.plugwerk.server.service
 import io.plugwerk.server.SharedPostgresContainer
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.PluginStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -61,6 +62,10 @@ class PluginServiceIntegrationTest {
 
     @MockitoBean
     lateinit var artifactStorageService: ArtifactStorageService
+
+    // DEV-24: NamespaceService now collaborates with the activation telemetry seam.
+    @MockitoBean
+    lateinit var activationTelemetry: ActivationTelemetry
 
     @Autowired
     lateinit var pluginService: PluginService

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/ActivationTelemetryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/ActivationTelemetryTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * Unit tests for the transaction-awareness [ActivationTelemetry] adds on top of
+ * [TelemetryBeacon] (DEV-24): activation events must fire **only after the
+ * owning transaction commits**, and must never fire on the calling thread.
+ *
+ * The opt-out gate and fail-open behaviour are owned and tested by
+ * [TelemetryBeaconTest]; here we only assert the deferral/dispatch wiring.
+ */
+class ActivationTelemetryTest {
+
+    private val beacon: TelemetryBeacon = mock()
+    private val activationTelemetry = ActivationTelemetry(beacon)
+
+    @AfterEach
+    fun tearDown() {
+        // Never leak the thread-local synchronization state between tests.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
+    }
+
+    @Test
+    fun `namespaceCreated dispatches NAMESPACE_CREATED immediately when no transaction is active`() {
+        activationTelemetry.namespaceCreated()
+
+        verify(beacon).emitAsync(TelemetryEvent.NAMESPACE_CREATED)
+    }
+
+    @Test
+    fun `firstPluginPublished dispatches FIRST_PLUGIN_PUBLISH immediately when no transaction is active`() {
+        activationTelemetry.firstPluginPublished()
+
+        verify(beacon).emitAsync(TelemetryEvent.FIRST_PLUGIN_PUBLISH)
+    }
+
+    @Test
+    fun `event is deferred until the transaction commits when a transaction is active`() {
+        TransactionSynchronizationManager.initSynchronization()
+
+        activationTelemetry.namespaceCreated()
+
+        // Nothing sent yet — the work is still in-flight.
+        verify(beacon, never()).emitAsync(TelemetryEvent.NAMESPACE_CREATED)
+
+        // Simulate the commit: drive the registered afterCommit callbacks.
+        TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+
+        verify(beacon).emitAsync(TelemetryEvent.NAMESPACE_CREATED)
+    }
+
+    @Test
+    fun `event is not sent when the transaction rolls back (afterCommit never runs)`() {
+        TransactionSynchronizationManager.initSynchronization()
+
+        activationTelemetry.firstPluginPublished()
+
+        // A rollback means afterCommit is never invoked; the synchronization is
+        // simply discarded. No telemetry must escape.
+        TransactionSynchronizationManager.clearSynchronization()
+
+        verify(beacon, never()).emitAsync(TelemetryEvent.FIRST_PLUGIN_PUBLISH)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
@@ -75,4 +75,33 @@ class TelemetryPayloadBuilderTest {
         assertThat(InstallType.K8S.wireValue).isEqualTo("k8s")
         assertThat(InstallType.UNKNOWN.wireValue).isEqualTo("unknown")
     }
+
+    // --- DEV-24: activation events reuse the same allowlisted payload ---
+
+    @Test
+    fun `activation events serialize to their wire values`() {
+        assertThat(TelemetryEvent.NAMESPACE_CREATED.wireValue).isEqualTo("namespace_created")
+        assertThat(TelemetryEvent.FIRST_PLUGIN_PUBLISH.wireValue).isEqualTo("first_plugin_publish")
+    }
+
+    @Test
+    fun `activation event payloads carry exactly the four allowlisted keys and no PII`() {
+        for (event in listOf(TelemetryEvent.NAMESPACE_CREATED, TelemetryEvent.FIRST_PLUGIN_PUBLISH)) {
+            val payload = TelemetryPayloadBuilder.build(
+                installId = "11111111-2222-4333-8444-555555555555",
+                version = "1.1.0",
+                installType = InstallType.DOCKER_COMPOSE,
+                event = event,
+            )
+
+            @Suppress("UNCHECKED_CAST")
+            val asMap = objectMapper.readValue(objectMapper.writeValueAsString(payload), Map::class.java)
+                as Map<String, Any?>
+
+            // Same hard allowlist as the P0 beacon: no place for a namespace name,
+            // plugin name, user id, count, or free text to ride along.
+            assertThat(asMap.keys).containsExactlyInAnyOrder("installId", "version", "installType", "event")
+            assertThat(asMap["event"]).isEqualTo(event.wireValue)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

P1 follow-on to the P0 telemetry beacon (DEV-23, merged in #572). Emits two **server-side activation events** so the team can size the activation funnel and time-to-first-publish, reusing the P0 transport with the **same zero-PII discipline**.

- `namespace_created` — fires once when a namespace is created.
- `first_plugin_publish` — fires **only on the first publish per namespace**, across all three publish paths (auto-approve upload, status update, review approval).

> Supersedes #575 (auto-closed when its stacked base branch `feat/dev23-telemetry-beacon` was deleted on #572 merge). This PR is the same commit, rebased onto `main`.

## Design

- **Payload unchanged.** Two new `TelemetryEvent` values only — the wire payload stays exactly `{installId, version, installType, event}`. The DEV-23 allowlist contract ("exactly these four keys") still holds; no field for a namespace/plugin/user identifier or free text.
- **First-publish gating** via a new nullable column `namespace.first_published_at` (Liquibase `0037`), flipped by an **atomic conditional UPDATE** `NamespaceRepository.markFirstPublishedIfAbsent` (`... WHERE first_published_at IS NULL`). Exactly one caller gets `1`; the event fires iff that update changed a row — at-most-once per namespace under concurrency and regardless of path.
- **`ActivationTelemetry`** defers the send to `afterCommit` (no event on rollback; flag and event share one commit) and dispatches off the request thread via `TelemetryBeacon.emitAsync` (fail-open, never blocks namespace-create / publish).

## Acceptance criteria

1. ✅ `namespace_created` on create; `first_plugin_publish` only on first publish per namespace.
2. ✅ Zero PII; fail-open silent (inherited from `TelemetryBeacon.emit`).
3. ✅ Unit tests for the "first publish only" gating and payload contents.
4. ✅ **Security sign-off on the exact non-PII payload** — approved in DEV-50 (zero-PII confirmed; payload identical to ADR-0038, accepted via DEV-25).

## Test plan

- [x] `:plugwerk-server-backend:test` — full unit suite green (incl. `ActivationTelemetryTest`, payload allowlist, `NamespaceServiceTest` + `PluginReleaseServiceTest` gating).
- [x] `:plugwerk-server-backend:integrationTest` — namespace/release/plugin/download ITs green; new ITs verify the real conditional UPDATE against Postgres and that DRAFT never opens the gate.
- [x] `SmokeTest` (full app boot, Liquibase + `ddl-auto: validate`) confirms `0037` matches the entity; `LiquibaseRollbackIT` confirms rollback.
- [x] `spotlessCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)