### PR TITLE
test(frontend): raise Vitest coverage to >=80% and enforce test:coverage gate (DEV-44)

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/.prettierignore
+++ b/plugwerk-server/plugwerk-server-frontend/.prettierignore
@@ -1,4 +1,5 @@
 build/
+coverage/
 dist/
 node_modules/
 package-lock.json

--- a/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
+++ b/plugwerk-server/plugwerk-server-frontend/build.gradle.kts
@@ -40,13 +40,16 @@ val npmLint by tasks.registering(Exec::class) {
     outputs.upToDateWhen { true }
 }
 
-// Vitest gate (DEV-29). The frontend suite was red on `main` and invisible to
-// CI — only `format:check` + `build` were wired in, so a broken test never
-// failed a build. `test:run` is non-watch and exits non-zero on any failure.
-val npmTest by tasks.registering(Exec::class) {
+// Vitest + coverage gate (DEV-29 → DEV-44). The frontend suite was red on
+// `main` and invisible to CI — only `format:check` + `build` were wired in, so
+// a broken test never failed a build. `test:coverage` runs the full non-watch
+// suite AND enforces the lines/branches/functions >= 80% thresholds declared in
+// `vitest.config.ts`, exiting non-zero on any test failure OR coverage
+// regression. It subsumes the earlier `test:run` gate.
+val npmCoverage by tasks.registering(Exec::class) {
     dependsOn(npmInstall)
     workingDir = projectDir
-    commandLine(npmCmd("run", "test:run"))
+    commandLine(npmCmd("run", "test:coverage"))
     inputs.dir("src")
     inputs.file("vitest.config.ts")
     outputs.upToDateWhen { true }
@@ -74,9 +77,10 @@ tasks.named("build") {
 }
 
 // `check` is wired into `build` by the `base` plugin, so attaching the Vitest
-// suite here makes `./gradlew build` (CI) enforce it without touching ci.yml.
+// coverage suite here makes `./gradlew build` (CI) enforce both the tests and
+// the coverage thresholds without touching ci.yml.
 tasks.named("check") {
-    dependsOn(npmTest)
+    dependsOn(npmCoverage)
 }
 
 // Make the static resources available as a runtime dependency

--- a/plugwerk-server/plugwerk-server-frontend/src/api/config.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/config.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AxiosError } from "axios";
+
+const getAccessToken = vi.fn<() => string | null>();
+const setAuth = vi.fn();
+const clearAuth = vi.fn();
+const refreshAccessToken = vi.fn();
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: getAccessToken(),
+      setAuth,
+      clearAuth,
+    }),
+  },
+}));
+
+vi.mock("./refresh", () => ({
+  refreshAccessToken: () => refreshAccessToken(),
+}));
+
+import { axiosInstance } from "./config";
+
+type RequestFulfilled = (config: {
+  headers: Record<string, string>;
+}) => Promise<{ headers: Record<string, string> }>;
+
+type ResponseRejected = (error: unknown) => Promise<unknown>;
+
+function requestInterceptor(): RequestFulfilled {
+  return (
+    axiosInstance.interceptors.request as unknown as {
+      handlers: { fulfilled: RequestFulfilled }[];
+    }
+  ).handlers[0].fulfilled;
+}
+
+function responseRejected(): ResponseRejected {
+  return (
+    axiosInstance.interceptors.response as unknown as {
+      handlers: { rejected: ResponseRejected }[];
+    }
+  ).handlers[0].rejected;
+}
+
+function axiosError(
+  status: number | undefined,
+  config: Record<string, unknown> | undefined,
+): AxiosError {
+  return {
+    isAxiosError: true,
+    name: "AxiosError",
+    message: "boom",
+    config,
+    response: status === undefined ? undefined : { status },
+  } as unknown as AxiosError;
+}
+
+describe("axiosInstance request interceptor", () => {
+  beforeEach(() => {
+    getAccessToken.mockReset();
+    setAuth.mockReset();
+    clearAuth.mockReset();
+    refreshAccessToken.mockReset();
+  });
+
+  it("attaches a Bearer header when a token is present", async () => {
+    getAccessToken.mockReturnValue("tok-123");
+    const out = await requestInterceptor()({ headers: {} });
+    expect(out.headers["Authorization"]).toBe("Bearer tok-123");
+  });
+
+  it("leaves headers untouched when no token is present", async () => {
+    getAccessToken.mockReturnValue(null);
+    const out = await requestInterceptor()({ headers: {} });
+    expect(out.headers["Authorization"]).toBeUndefined();
+  });
+});
+
+describe("axiosInstance response interceptor (401 refresh-retry)", () => {
+  const reject = () => responseRejected();
+
+  beforeEach(() => {
+    getAccessToken.mockReset();
+    setAuth.mockReset();
+    clearAuth.mockReset();
+    refreshAccessToken.mockReset();
+    // A plain, mutable stand-in: the redirect path assigns a *relative* href
+    // ("/login"), which a real `URL` instance would reject as invalid.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/catalog", href: "http://localhost:3000/catalog" },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects non-401 errors without refreshing", async () => {
+    const err = axiosError(500, { url: "/x" });
+    await expect(reject()(err)).rejects.toBe(err);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects when there is no original config", async () => {
+    const err = axiosError(401, undefined);
+    await expect(reject()(err)).rejects.toBe(err);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects when a retry was already attempted", async () => {
+    const err = axiosError(401, { url: "/x", _retryAttempted: true });
+    await expect(reject()(err)).rejects.toBe(err);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("does not retry the refresh endpoint itself", async () => {
+    const err = axiosError(401, { url: "/auth/refresh" });
+    await expect(reject()(err)).rejects.toBe(err);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("does not retry the login endpoint", async () => {
+    const err = axiosError(401, { url: "/auth/login" });
+    await expect(reject()(err)).rejects.toBe(err);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("refreshes then replays the original request on success", async () => {
+    refreshAccessToken.mockResolvedValue({
+      accessToken: "fresh",
+      userId: "u1",
+      displayName: "U",
+      email: "u@e.test",
+      source: "INTERNAL",
+      passwordChangeRequired: false,
+      isSuperadmin: false,
+    });
+    const replay = vi
+      .spyOn(axiosInstance, "request")
+      .mockResolvedValue({ data: "ok" });
+    const err = axiosError(401, { url: "/catalog/plugins", headers: {} });
+
+    const result = await reject()(err);
+
+    expect(setAuth).toHaveBeenCalledOnce();
+    expect(replay).toHaveBeenCalledOnce();
+    expect((result as { data: string }).data).toBe("ok");
+    const replayed = replay.mock.calls[0][0] as {
+      _retryAttempted?: boolean;
+      headers: Record<string, string>;
+    };
+    expect(replayed._retryAttempted).toBe(true);
+    expect(replayed.headers.Authorization).toBe("Bearer fresh");
+  });
+
+  it("clears auth and redirects to /login when refresh yields nothing", async () => {
+    refreshAccessToken.mockResolvedValue(null);
+    const err = axiosError(401, { url: "/catalog/plugins", headers: {} });
+
+    await expect(reject()(err)).rejects.toBe(err);
+
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(window.location.href).toBe("/login");
+    expect(setAuth).not.toHaveBeenCalled();
+  });
+
+  it("clears auth without redirect when already on /login", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/login", href: "http://localhost:3000/login" },
+    });
+    refreshAccessToken.mockResolvedValue(null);
+    const err = axiosError(401, { url: "/catalog/plugins", headers: {} });
+
+    await expect(reject()(err)).rejects.toBe(err);
+
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(window.location.pathname).toBe("/login");
+  });
+
+  it("clears auth and rejects when the refresh call throws", async () => {
+    const boom = new Error("refresh exploded");
+    refreshAccessToken.mockRejectedValue(boom);
+    const err = axiosError(401, { url: "/catalog/plugins", headers: {} });
+
+    await expect(reject()(err)).rejects.toBe(boom);
+    expect(clearAuth).toHaveBeenCalledOnce();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaces.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/api/hooks/useNamespaces.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "../../test/queryWrapper";
+import { useNamespace, useNamespaces } from "./useNamespaces";
+
+const { listNamespaces, authState } = vi.hoisted(() => ({
+  listNamespaces: vi.fn(),
+  authState: { isAuthenticated: true, isHydrating: false },
+}));
+
+vi.mock("../config", () => ({
+  namespacesApi: { listNamespaces: () => listNamespaces() },
+}));
+
+vi.mock("../../stores/authStore", () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) =>
+    selector(authState),
+}));
+
+const NAMESPACES = [
+  { slug: "default", displayName: "Default" },
+  { slug: "acme", displayName: "Acme" },
+];
+
+describe("useNamespaces", () => {
+  beforeEach(() => {
+    listNamespaces.mockReset();
+    authState.isAuthenticated = true;
+    authState.isHydrating = false;
+  });
+
+  it("fetches the namespace list when authenticated and hydrated", async () => {
+    listNamespaces.mockResolvedValue({ data: NAMESPACES });
+    const { result } = renderHook(() => useNamespaces(), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(NAMESPACES);
+    expect(listNamespaces).toHaveBeenCalledOnce();
+  });
+
+  it("does not fetch while the auth store is still hydrating", async () => {
+    authState.isHydrating = true;
+    const { result } = renderHook(() => useNamespaces(), {
+      wrapper: createQueryWrapper(),
+    });
+    // Disabled query stays idle — give React a tick, then assert no call.
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(listNamespaces).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the principal is unauthenticated", async () => {
+    authState.isAuthenticated = false;
+    renderHook(() => useNamespaces(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(listNamespaces).not.toHaveBeenCalled());
+  });
+});
+
+describe("useNamespace", () => {
+  beforeEach(() => {
+    listNamespaces.mockReset();
+    authState.isAuthenticated = true;
+    authState.isHydrating = false;
+    listNamespaces.mockResolvedValue({ data: NAMESPACES });
+  });
+
+  it("resolves a namespace by slug once the list has loaded", async () => {
+    const { result } = renderHook(() => useNamespace("acme"), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.namespace).toBeDefined());
+    expect(result.current.namespace?.slug).toBe("acme");
+  });
+
+  it("returns undefined for an unknown slug", async () => {
+    const { result } = renderHook(() => useNamespace("ghost"), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.namespace).toBeUndefined();
+  });
+
+  it("returns undefined when no slug is provided", async () => {
+    const { result } = renderHook(() => useNamespace(null), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.namespace).toBeUndefined();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/namespace-detail/MembersSection.test.tsx
@@ -19,10 +19,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AxiosError } from "axios";
 import { MembersSection } from "./MembersSection";
 import { renderWithTheme } from "../../../test/renderWithTheme";
+import { useUiStore } from "../../../stores/uiStore";
 import * as apiConfig from "../../../api/config";
-import type { UserDto } from "../../../api/generated/model";
+import type { NamespaceMemberDto, UserDto } from "../../../api/generated/model";
 
 vi.mock("../../../api/config", () => ({
   adminUsersApi: {
@@ -31,8 +33,33 @@ vi.mock("../../../api/config", () => ({
   namespaceMembersApi: {
     listNamespaceMembers: vi.fn(),
     addNamespaceMember: vi.fn(),
+    updateNamespaceMember: vi.fn(),
+    removeNamespaceMember: vi.fn(),
   },
 }));
+
+function memberDto(
+  overrides: Partial<NamespaceMemberDto> = {},
+): NamespaceMemberDto {
+  return {
+    userId: crypto.randomUUID(),
+    displayName: "Member One",
+    username: null,
+    source: "INTERNAL",
+    providerName: null,
+    role: "MEMBER",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as NamespaceMemberDto;
+}
+
+/** Builds an AxiosError carrying the given HTTP status for 409-path tests. */
+function axiosErrorWithStatus(status: number): AxiosError {
+  const err = new AxiosError("request failed");
+  // The component reads `error.response?.status`; only that field matters.
+  err.response = { status } as AxiosError["response"];
+  return err;
+}
 
 function userDto(overrides: Partial<UserDto>): UserDto {
   return {
@@ -383,5 +410,713 @@ describe("MembersSection — members table (issue #412)", () => {
 
     expect(await screen.findByText("Charlie Admin")).toBeInTheDocument();
     expect(await screen.findByText("charlie")).toBeInTheDocument();
+  });
+});
+
+describe("MembersSection — load states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ toasts: [] });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+  });
+
+  it("shows a loading spinner before the members list resolves", () => {
+    // Never-resolving promise keeps the component in the loading branch.
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockReturnValue(new Promise(() => {}) as never);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    // CircularProgress exposes role="progressbar".
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.queryByText("No members found.")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty-state message when there are no members", async () => {
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    expect(await screen.findByText("No members found.")).toBeInTheDocument();
+  });
+
+  it("falls back to an empty list when the members request fails", async () => {
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockRejectedValue(new Error("boom"));
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+
+    // The catch sets members to [] and clears loading → empty state.
+    expect(await screen.findByText("No members found.")).toBeInTheDocument();
+  });
+});
+
+describe("MembersSection — role change", () => {
+  const member = memberDto({ displayName: "Dora Member", role: "MEMBER" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ toasts: [] });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [member] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+  });
+
+  it("PATCHes the member role and updates the row on success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.namespaceMembersApi.updateNamespaceMember,
+    ).mockResolvedValue({
+      data: { ...member, role: "ADMIN" },
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.updateNamespaceMember>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    await screen.findByText("Dora Member");
+
+    // The row's role Select is the only "standard"-variant combobox; pick it
+    // by its current visible value "Member".
+    const roleSelect = screen.getByRole("combobox");
+    await user.click(roleSelect);
+    await user.click(await screen.findByRole("option", { name: "Admin" }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.namespaceMembersApi.updateNamespaceMember,
+      ).toHaveBeenCalledWith({
+        ns: "ns-1",
+        userId: member.userId,
+        namespaceMemberUpdateRequest: { role: "ADMIN" },
+      });
+    });
+  });
+
+  it("surfaces an error toast when the role update fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.namespaceMembersApi.updateNamespaceMember,
+    ).mockRejectedValue(new Error("nope"));
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    await screen.findByText("Dora Member");
+
+    const roleSelect = screen.getByRole("combobox");
+    await user.click(roleSelect);
+    await user.click(await screen.findByRole("option", { name: "Read Only" }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some(
+            (t) =>
+              t.message === 'Failed to update role for "Dora Member".' &&
+              t.type === "error",
+          ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("MembersSection — remove member", () => {
+  const member = memberDto({ displayName: "Evan Member" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ toasts: [] });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [member] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+  });
+
+  it("removes the member and emits a success toast", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.namespaceMembersApi.removeNamespaceMember,
+    ).mockResolvedValue({} as never);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    await screen.findByText("Evan Member");
+
+    await user.click(screen.getByRole("button", { name: /remove member/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.namespaceMembersApi.removeNamespaceMember,
+      ).toHaveBeenCalledWith({ ns: "ns-1", userId: member.userId });
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some(
+            (t) =>
+              t.message === 'Member "Evan Member" removed.' &&
+              t.type === "success",
+          ),
+      ).toBe(true);
+    });
+    // The row disappears once the optimistic filter runs.
+    await waitFor(() => {
+      expect(screen.queryByText("Evan Member")).not.toBeInTheDocument();
+    });
+  });
+
+  it("emits an error toast and keeps the row when removal fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.namespaceMembersApi.removeNamespaceMember,
+    ).mockRejectedValue(new Error("nope"));
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    await screen.findByText("Evan Member");
+
+    await user.click(screen.getByRole("button", { name: /remove member/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some(
+            (t) =>
+              t.message === 'Failed to remove member "Evan Member".' &&
+              t.type === "error",
+          ),
+      ).toBe(true);
+    });
+    // Failure path does not remove the row.
+    expect(screen.getByText("Evan Member")).toBeInTheDocument();
+  });
+});
+
+describe("MembersSection — add member outcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({ toasts: [] });
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+  });
+
+  it("adds a single user, emits a success toast, and closes the dialog", async () => {
+    const fiona = userDto({
+      displayName: "Fiona User",
+      username: "fiona",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([fiona]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockResolvedValue({
+      data: {
+        userId: fiona.id,
+        displayName: fiona.displayName,
+        username: "fiona",
+        role: "MEMBER",
+        createdAt: new Date().toISOString(),
+      },
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.addNamespaceMember>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Fiona User (fiona)"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /add member/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some(
+            (t) => t.message === 'Member "Fiona User (fiona)" added.',
+          ),
+      ).toBe(true);
+    });
+    // Full success closes the dialog.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the dialog open and shows a 409 'already a member' banner on failure", async () => {
+    const greg = userDto({
+      displayName: "Greg User",
+      username: "greg",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([greg]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockRejectedValue(axiosErrorWithStatus(409));
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Greg User (greg)"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /add member/i }),
+    );
+
+    // Single-user failure → "<label>: already a member of this namespace."
+    expect(
+      await screen.findByText(
+        /Greg User \(greg\): already a member of this namespace\./i,
+      ),
+    ).toBeInTheDocument();
+    // Dialog stays open so the operator sees the failure in context.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("aggregates a partial failure across multiple users (success toast + failure banner)", async () => {
+    const hank = userDto({
+      displayName: "Hank User",
+      username: "hank",
+      source: "INTERNAL",
+    });
+    const iris = userDto({
+      displayName: "Iris User",
+      username: "iris",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([hank, iris]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    // Hank succeeds; Iris fails with a non-409 (generic "failed to add").
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockImplementation((req) => {
+      const userId = (
+        req as { namespaceMemberCreateRequest: { userId: string } }
+      ).namespaceMemberCreateRequest.userId;
+      if (userId === hank.id) {
+        return Promise.resolve({
+          data: {
+            userId: hank.id,
+            displayName: hank.displayName,
+            username: "hank",
+            role: "MEMBER",
+            createdAt: new Date().toISOString(),
+          },
+        }) as unknown as ReturnType<
+          typeof apiConfig.namespaceMembersApi.addNamespaceMember
+        >;
+      }
+      return Promise.reject(
+        new Error("server exploded"),
+      ) as unknown as ReturnType<
+        typeof apiConfig.namespaceMembersApi.addNamespaceMember
+      >;
+    });
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Hank User (hank)"));
+    await user.click(await screen.findByText("Iris User (iris)"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /add 2 members/i }),
+    );
+
+    // One success toast (singular, since only Hank went through).
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => t.message === 'Member "Hank User (hank)" added.'),
+      ).toBe(true);
+    });
+    // Exactly one of the two adds failed, so the banner uses the singular
+    // "<label>: <reason>." form (the "N of M" aggregate form is reserved for
+    // two-or-more failures). Iris failed with a non-409 → generic reason.
+    expect(
+      await screen.findByText("Iris User (iris): failed to add."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("uses the aggregate 'N of M' banner when two or more users fail", async () => {
+    const paul = userDto({
+      displayName: "Paul User",
+      username: "paul",
+      source: "INTERNAL",
+    });
+    const quinn = userDto({
+      displayName: "Quinn User",
+      username: "quinn",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([paul, quinn]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    // Paul → 409 (already a member); Quinn → generic failure. Two failures
+    // trigger the aggregate banner branch.
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockImplementation((req) => {
+      const userId = (
+        req as { namespaceMemberCreateRequest: { userId: string } }
+      ).namespaceMemberCreateRequest.userId;
+      return Promise.reject(
+        userId === paul.id
+          ? axiosErrorWithStatus(409)
+          : new Error("server exploded"),
+      ) as unknown as ReturnType<
+        typeof apiConfig.namespaceMembersApi.addNamespaceMember
+      >;
+    });
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Paul User (paul)"));
+    await user.click(await screen.findByText("Quinn User (quinn)"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /add 2 members/i }),
+    );
+
+    expect(
+      await screen.findByText((content) => {
+        const normalized = content.replace(/\s+/g, " ");
+        return (
+          normalized.includes("2 of 2 users could not be added") &&
+          normalized.includes(
+            "Paul User (paul) (already a member of this namespace)",
+          ) &&
+          normalized.includes("Quinn User (quinn) (failed to add)")
+        );
+      }),
+    ).toBeInTheDocument();
+    // No success toast — every add failed.
+    expect(useUiStore.getState().toasts.some((t) => t.type === "success")).toBe(
+      false,
+    );
+  });
+
+  it("emits a plural success toast when several users are added at once", async () => {
+    const jane = userDto({
+      displayName: "Jane User",
+      username: "jane",
+      source: "INTERNAL",
+    });
+    const kyle = userDto({
+      displayName: "Kyle User",
+      username: "kyle",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([jane, kyle]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockImplementation((req) => {
+      const userId = (
+        req as { namespaceMemberCreateRequest: { userId: string } }
+      ).namespaceMemberCreateRequest.userId;
+      return Promise.resolve({
+        data: {
+          userId,
+          displayName: userId === jane.id ? "Jane User" : "Kyle User",
+          username: null,
+          role: "MEMBER",
+          createdAt: new Date().toISOString(),
+        },
+      }) as unknown as ReturnType<
+        typeof apiConfig.namespaceMembersApi.addNamespaceMember
+      >;
+    });
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Jane User (jane)"));
+    await user.click(await screen.findByText("Kyle User (kyle)"));
+    await user.click(
+      within(dialog).getByRole("button", { name: /add 2 members/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => t.message === "2 members added."),
+      ).toBe(true);
+    });
+  });
+
+  it("changes the role select before adding so the new member gets that role", async () => {
+    const liam = userDto({
+      displayName: "Liam User",
+      username: "liam",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([liam]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.addNamespaceMember,
+    ).mockResolvedValue({
+      data: {
+        userId: liam.id,
+        displayName: liam.displayName,
+        username: "liam",
+        role: "ADMIN",
+        createdAt: new Date().toISOString(),
+      },
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.addNamespaceMember>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Liam User (liam)"));
+
+    // Open the Role select in the dialog and pick Admin.
+    await user.click(within(dialog).getByRole("combobox", { name: /role/i }));
+    await user.click(await screen.findByRole("option", { name: "Admin" }));
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /add member/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        apiConfig.namespaceMembersApi.addNamespaceMember,
+      ).toHaveBeenCalledWith({
+        ns: "ns-1",
+        namespaceMemberCreateRequest: { userId: liam.id, role: "ADMIN" },
+      });
+    });
+  });
+
+  it("filters out users who are already members from the picker options", async () => {
+    // An existing member must not appear as an add candidate.
+    const existing = memberDto({ displayName: "Mona Member" });
+    const newUser = userDto({
+      id: existing.userId,
+      displayName: "Mona Member",
+      username: "mona",
+      source: "INTERNAL",
+    });
+    const other = userDto({
+      displayName: "Nina User",
+      username: "nina",
+      source: "INTERNAL",
+    });
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [existing] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([newUser, other]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    // Wait for the member row so `members` state is populated before opening.
+    await screen.findByText("Mona Member");
+    const { user, dialog } = await openAddMemberDialog();
+    await user.click(within(dialog).getByRole("combobox", { name: /user/i }));
+
+    // The non-member option is offered…
+    expect(await screen.findByText("Nina User (nina)")).toBeInTheDocument();
+    // …but the already-member option is not in the dropdown list.
+    expect(screen.queryByText("Mona Member (mona)")).not.toBeInTheDocument();
+  });
+
+  it("empties the picker options when the user search request fails (non-cancel)", async () => {
+    // A genuine failure (not an abort) must clear the option list per the
+    // catch branch's `if (!isCancel) setUserOptions([])`.
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockRejectedValue(
+      new Error("search backend down"),
+    );
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+    await user.click(within(dialog).getByRole("combobox", { name: /user/i }));
+
+    // MUI shows "No options" when the list is empty after a failed load.
+    expect(await screen.findByText(/no options/i)).toBeInTheDocument();
+  });
+
+  it("keeps the existing options when the search request is cancelled", async () => {
+    // A CanceledError must NOT clear the list — the in-flight request was
+    // superseded, not failed. We seed a successful first load, then reject the
+    // follow-up search with a CanceledError and assert the option survives.
+    const ruth = userDto({
+      displayName: "Ruth User",
+      username: "ruth",
+      source: "INTERNAL",
+    });
+    const cancel = Object.assign(new Error("canceled"), {
+      name: "CanceledError",
+      code: "ERR_CANCELED",
+    });
+    let call = 0;
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        return Promise.resolve({
+          data: pagedUsers([ruth]),
+        }) as unknown as ReturnType<typeof apiConfig.adminUsersApi.listUsers>;
+      }
+      return Promise.reject(cancel) as unknown as ReturnType<
+        typeof apiConfig.adminUsersApi.listUsers
+      >;
+    });
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    expect(await screen.findByText("Ruth User (ruth)")).toBeInTheDocument();
+
+    // Type to trigger a second (cancelled) search; the first option survives.
+    await user.type(input, "ru");
+    // Allow the debounced/cancelled effect to settle.
+    await waitFor(() => {
+      expect(apiConfig.adminUsersApi.listUsers).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText("Ruth User (ruth)")).toBeInTheDocument();
+  });
+
+  it("updates only the changed member's row when several members exist", async () => {
+    // Exercises the `m.userId === member.userId ? res.data : m` mapping's
+    // false branch — the untouched member must keep its original role.
+    const user = userEvent.setup();
+    const sam = memberDto({ displayName: "Sam Member", role: "MEMBER" });
+    const tina = memberDto({ displayName: "Tina Member", role: "READ_ONLY" });
+    vi.mocked(
+      apiConfig.namespaceMembersApi.listNamespaceMembers,
+    ).mockResolvedValue({ data: [sam, tina] } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.listNamespaceMembers>
+    >);
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+    vi.mocked(
+      apiConfig.namespaceMembersApi.updateNamespaceMember,
+    ).mockResolvedValue({
+      data: { ...sam, role: "ADMIN" },
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.namespaceMembersApi.updateNamespaceMember>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    await screen.findByText("Sam Member");
+
+    // Two role selects (one per member) — Sam's is the first.
+    const roleSelects = screen.getAllByRole("combobox");
+    await user.click(roleSelects[0]);
+    await user.click(await screen.findByRole("option", { name: "Admin" }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.namespaceMembersApi.updateNamespaceMember,
+      ).toHaveBeenCalledWith({
+        ns: "ns-1",
+        userId: sam.userId,
+        namespaceMemberUpdateRequest: { role: "ADMIN" },
+      });
+    });
+    // Tina's row is unchanged.
+    expect(screen.getByText("Tina Member")).toBeInTheDocument();
+  });
+
+  it("resets the picker state when the dialog is closed via the X button", async () => {
+    const opal = userDto({
+      displayName: "Opal User",
+      username: "opal",
+      source: "INTERNAL",
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: pagedUsers([opal]),
+    } as unknown as Awaited<
+      ReturnType<typeof apiConfig.adminUsersApi.listUsers>
+    >);
+
+    renderWithTheme(<MembersSection slug="ns-1" />);
+    const { user, dialog } = await openAddMemberDialog();
+    const input = within(dialog).getByRole("combobox", { name: /user/i });
+    await user.click(input);
+    await user.click(await screen.findByText("Opal User (opal)"));
+
+    // Close via the header X — exercises the onClose reset branch.
+    await user.click(
+      within(dialog).getByRole("button", { name: /close dialog/i }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    // Re-open: the previous selection is gone (fresh dialog).
+    await user.click(screen.getByRole("button", { name: /add member/i }));
+    const dialog2 = await screen.findByRole("dialog");
+    expect(
+      within(dialog2).getByRole("button", { name: /^add member$/i }),
+    ).toBeDisabled();
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/catalog/FilterBar.test.tsx
@@ -17,11 +17,37 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderWithRouter } from "../../test/renderWithTheme";
+import { buildTheme } from "../../theme/theme";
 import { FilterBar } from "./FilterBar";
 import { usePluginStore } from "../../stores/pluginStore";
+import { useUiStore } from "../../stores/uiStore";
+
+/**
+ * Renders FilterBar under the real dark theme so the search input's
+ * `isDark`-conditional styling (border/background/focus) is exercised. Reuses
+ * the same provider stack as `renderWithRouter` but swaps in `buildTheme("dark")`
+ * — the only way to reach the dark arm of those ternaries since the shared
+ * helper is pinned to the light theme.
+ */
+function renderDark(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={buildTheme("dark")}>
+        <CssBaseline />
+        <MemoryRouter>{ui}</MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
 
 vi.mock("../../api/config", () => ({
   catalogApi: {
@@ -29,7 +55,17 @@ vi.mock("../../api/config", () => ({
       data: { content: [], totalElements: 0, totalPages: 0 },
     }),
   },
-  axiosInstance: { get: vi.fn().mockResolvedValue({ data: [] }) },
+  // The tag autocomplete loads its options from `/namespaces/{ns}/tags`.
+  // Return a small fixed list so the picker has real selectable options.
+  axiosInstance: {
+    get: vi
+      .fn()
+      .mockImplementation((url: string) =>
+        url.endsWith("/tags")
+          ? Promise.resolve({ data: ["auth", "billing", "search"] })
+          : Promise.resolve({ data: [] }),
+      ),
+  },
   managementApi: {},
   reviewsApi: {},
 }));
@@ -47,6 +83,7 @@ const defaultFilters = {
 describe("FilterBar", () => {
   beforeEach(() => {
     usePluginStore.setState({ filters: { ...defaultFilters } });
+    useUiStore.setState({ searchQuery: "" });
   });
 
   it("renders tag, status, compatibility and sort selects", () => {
@@ -153,5 +190,154 @@ describe("FilterBar", () => {
     );
     // The selected value is rendered inside the combobox
     expect(screen.getByText("Most Downloads")).toBeInTheDocument();
+  });
+
+  it("updates the status filter and resets the page to 0 on change", async () => {
+    const user = userEvent.setup();
+    const setFiltersMock = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters, page: 3 },
+      setFilters: setFiltersMock,
+    });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    await user.click(
+      screen.getByRole("combobox", { name: /filter by status/i }),
+    );
+    await user.click(await screen.findByRole("option", { name: "Active" }));
+    expect(setFiltersMock).toHaveBeenCalledWith({ status: "active", page: 0 });
+  });
+
+  it("updates the compatibility filter on change", async () => {
+    const user = userEvent.setup();
+    const setFiltersMock = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters },
+      setFilters: setFiltersMock,
+    });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    await user.click(
+      screen.getByRole("combobox", { name: /filter by compatibility/i }),
+    );
+    await user.click(await screen.findByRole("option", { name: "≥ 2.0.0" }));
+    expect(setFiltersMock).toHaveBeenCalledWith({
+      version: ">=2.0.0",
+      page: 0,
+    });
+  });
+
+  it("updates the sort order on change", async () => {
+    const user = userEvent.setup();
+    const setFiltersMock = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters },
+      setFilters: setFiltersMock,
+    });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    await user.click(screen.getByRole("combobox", { name: /sort order/i }));
+    await user.click(await screen.findByRole("option", { name: "Newest" }));
+    expect(setFiltersMock).toHaveBeenCalledWith({
+      sort: "updatedAt,desc",
+      page: 0,
+    });
+  });
+
+  it("updates the tag filter via the autocomplete", async () => {
+    const user = userEvent.setup();
+    const setFiltersMock = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters },
+      setFilters: setFiltersMock,
+    });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    // The tag autocomplete is the only input rendered with the "All Tags"
+    // placeholder. Open it, then pick the "auth" option once the tags load.
+    const tagInput = screen.getByPlaceholderText(/all tags/i);
+    await user.click(tagInput);
+    await user.click(await screen.findByRole("option", { name: "auth" }));
+    await waitFor(() => {
+      expect(setFiltersMock).toHaveBeenCalledWith({ tag: "auth", page: 0 });
+    });
+  });
+
+  it("clears the tag filter when the autocomplete value is removed", async () => {
+    const user = userEvent.setup();
+    const setFiltersMock = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters, tag: "auth" },
+      setFilters: setFiltersMock,
+    });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    // MUI hides the clear indicator until the autocomplete is focused/hovered;
+    // focus the input first so the "Clear" button mounts. Clicking it fires
+    // onChange(null) → handleChange("tag", "").
+    const tagInput = screen.getByPlaceholderText(/all tags/i);
+    await user.click(tagInput);
+    const clearBtn = await screen.findByRole("button", { name: /clear/i });
+    await user.click(clearBtn);
+    expect(setFiltersMock).toHaveBeenCalledWith({ tag: "", page: 0 });
+  });
+
+  it("writes typed text into the UI store's search query", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    const search = screen.getByRole("textbox", { name: /search plugins/i });
+    await user.type(search, "auth");
+    expect(useUiStore.getState().searchQuery).toBe("auth");
+  });
+
+  it("shows a clear button only when the search query is non-empty and clears it", async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ searchQuery: "auth" });
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    const clear = screen.getByRole("button", { name: /clear search/i });
+    await user.click(clear);
+    expect(useUiStore.getState().searchQuery).toBe("");
+  });
+
+  it("does not show the search clear button when the query is empty", () => {
+    renderWithRouter(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /clear search/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reflects the controlled view prop on the toggle group", () => {
+    renderWithRouter(
+      <FilterBar view="list" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    const group = screen.getByRole("group", {
+      name: /filter and sort options/i,
+    });
+    expect(
+      within(group).getByRole("button", { name: /list view/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("renders the search input under the dark theme (isDark style branch)", () => {
+    // Exercises the `isDark ? … : …` ternaries on the search InputBase that
+    // are otherwise unreachable under the light-themed shared render helper.
+    renderDark(
+      <FilterBar view="card" onViewChange={vi.fn()} namespace="acme" />,
+    );
+    expect(
+      screen.getByRole("textbox", { name: /search plugins/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("search")).toBeInTheDocument();
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/TimezoneSelect.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/TimezoneSelect.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TimezoneSelect } from "./TimezoneSelect";
+import { renderWithTheme } from "../../test/renderWithTheme";
+
+describe("TimezoneSelect", () => {
+  it("renders the label for the currently selected zone", () => {
+    renderWithTheme(
+      <TimezoneSelect value="Europe/Berlin" onChange={() => {}} />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toMatch(/Europe\/Berlin/);
+  });
+
+  it("leaves the input empty for an unknown value", () => {
+    renderWithTheme(
+      <TimezoneSelect value="Not/AZone" onChange={() => {}} allowEmpty />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("emits the chosen zone id via onChange when an option is picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithTheme(<TimezoneSelect value="UTC" onChange={onChange} />);
+
+    const input = screen.getByRole("combobox");
+    await user.clear(input);
+    await user.type(input, "Europe/Berlin");
+    const option = await screen.findByRole("option", {
+      name: /Europe\/Berlin/,
+    });
+    await user.click(option);
+
+    expect(onChange).toHaveBeenCalledWith("Europe/Berlin");
+  });
+
+  it("offers the empty sentinel option when allowEmpty is set", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <TimezoneSelect
+        value="Europe/Berlin"
+        onChange={() => {}}
+        allowEmpty
+        emptyLabel="Use system default"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(
+      await screen.findByRole("option", { name: "Use system default" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the default Timezone label and is clearable-free without allowEmpty", () => {
+    renderWithTheme(<TimezoneSelect value="UTC" onChange={() => {}} />);
+    // disableClearable is true here, so no clear button is rendered.
+    expect(screen.queryByLabelText("Clear")).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Timezone/)).toBeInTheDocument();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/plugin-detail/VersionsTab.test.tsx
@@ -17,9 +17,10 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "../../test/renderWithTheme";
+import { useUiStore } from "../../stores/uiStore";
 import { VersionsTab } from "./VersionsTab";
 import type { PluginReleaseDto } from "../../api/generated/model";
 
@@ -31,7 +32,13 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 vi.mock("../../api/config", () => ({
   reviewsApi: { approveRelease: vi.fn() },
-  managementApi: { deleteRelease: vi.fn() },
+  managementApi: { deleteRelease: vi.fn(), updateReleaseStatus: vi.fn() },
+}));
+
+// downloadArtifact triggers a real fetch/blob flow; mock it so the action
+// callbacks (success + failure) can be exercised deterministically.
+vi.mock("../../utils/downloadArtifact", () => ({
+  downloadArtifact: vi.fn(),
 }));
 
 const publishedRelease: PluginReleaseDto = {
@@ -58,6 +65,18 @@ const draftRelease: PluginReleaseDto = {
   createdAt: "2026-02-01T00:00:00Z",
 };
 
+const deprecatedRelease: PluginReleaseDto = {
+  id: "00000000-0000-0000-0000-000000000003",
+  pluginId: "my-plugin",
+  version: "0.9.0",
+  status: "deprecated",
+  artifactSha256: "ghi",
+  artifactSize: 4096,
+  fileFormat: "jar",
+  downloadCount: 5,
+  createdAt: "2025-12-01T00:00:00Z",
+};
+
 const defaultProps = {
   releases: [publishedRelease, draftRelease],
   namespace: "acme",
@@ -68,6 +87,7 @@ describe("VersionsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockNavigate.mockReset();
+    useUiStore.setState({ toasts: [] });
   });
 
   it("shows delete buttons when canApprove is true (ADMIN)", () => {
@@ -236,5 +256,353 @@ describe("VersionsTab", () => {
     // Published release should show publishedAt formatted as dd.MM.yyyy HH:mm:ss
     const cells = screen.getAllByText(/\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}:\d{2}/);
     expect(cells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("marks the latest published version with a 'latest' label", () => {
+    renderWithRouter(<VersionsTab {...defaultProps} />);
+    expect(screen.getByText("latest")).toBeInTheDocument();
+  });
+
+  it("renders an em dash and no copy affordance when SHA-256 is missing", () => {
+    const noSha: PluginReleaseDto = {
+      ...publishedRelease,
+      artifactSha256: undefined,
+    };
+    renderWithRouter(
+      <VersionsTab releases={[noSha]} namespace="acme" pluginId="my-plugin" />,
+    );
+    expect(
+      screen.queryByText(/click to copy full sha-256/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("copies the full SHA-256 to the clipboard when the hash chip is clicked", async () => {
+    // userEvent installs its own clipboard stub, so define the spy and click
+    // via fireEvent to hit the component's handler with our own
+    // navigator.clipboard.writeText.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    renderWithRouter(<VersionsTab {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("abc…"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("abc"));
+  });
+
+  it("falls back to a draft badge for unknown statuses and shows the .jar default format", () => {
+    const weird: PluginReleaseDto = {
+      ...publishedRelease,
+      status: "weird" as PluginReleaseDto["status"],
+      fileFormat: undefined,
+      artifactSize: undefined,
+    };
+    renderWithRouter(
+      <VersionsTab releases={[weird]} namespace="acme" pluginId="my-plugin" />,
+    );
+    // Status badge title-cases the raw status string.
+    expect(screen.getByText("Weird")).toBeInTheDocument();
+    // fileFormat undefined → ".jar" default in the Format column.
+    expect(screen.getByText(".jar")).toBeInTheDocument();
+    // artifactSize undefined → em dash in the Size column.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  function findActionButton(version: string, name: RegExp): HTMLElement {
+    const versionBadge = screen.getByText(`v${version}`);
+    const row = versionBadge.closest("tr");
+    if (!row) throw new Error(`No row for v${version}`);
+    return within(row).getByRole("button", { name });
+  }
+
+  it("shows the Approve button only for draft releases when canApprove is true", () => {
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />);
+    expect(
+      screen.getByRole("button", { name: /approve/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("approves a draft release and shows a success toast", async () => {
+    const { reviewsApi } = await import("../../api/config");
+    const onReleasesChanged = vi.fn();
+    vi.mocked(reviewsApi.approveRelease).mockResolvedValue({} as never);
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        {...defaultProps}
+        canApprove={true}
+        onReleasesChanged={onReleasesChanged}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /approve/i }));
+
+    expect(reviewsApi.approveRelease).toHaveBeenCalledWith({
+      ns: "acme",
+      releaseId: draftRelease.id,
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /approved and published/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+    // updateReleaseLocally fires the onReleasesChanged callback with the
+    // optimistically-updated list.
+    expect(onReleasesChanged).toHaveBeenCalled();
+  });
+
+  it("shows an error toast when approval fails", async () => {
+    const { reviewsApi } = await import("../../api/config");
+    vi.mocked(reviewsApi.approveRelease).mockRejectedValue(new Error("nope"));
+    const user = userEvent.setup();
+
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />);
+    await user.click(screen.getByRole("button", { name: /approve/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /failed to approve v2\.0\.0/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("opens the status-transition menu and changes status on success", async () => {
+    const { managementApi } = await import("../../api/config");
+    vi.mocked(managementApi.updateReleaseStatus).mockResolvedValue({} as never);
+    const onReleasesChanged = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        canApprove={true}
+        onReleasesChanged={onReleasesChanged}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /change release status/i }),
+    );
+    // published → deprecated/yanked transitions exposed as menu items.
+    await user.click(screen.getByRole("menuitem", { name: /deprecated/i }));
+
+    expect(managementApi.updateReleaseStatus).toHaveBeenCalledWith({
+      ns: "acme",
+      pluginId: "my-plugin",
+      version: "1.0.0",
+      releaseStatusUpdateRequest: { status: "deprecated" },
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /status changed to deprecated/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+    expect(onReleasesChanged).toHaveBeenCalled();
+  });
+
+  it("shows an error toast when a status change fails", async () => {
+    const { managementApi } = await import("../../api/config");
+    vi.mocked(managementApi.updateReleaseStatus).mockRejectedValue(
+      new Error("boom"),
+    );
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[deprecatedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        canApprove={true}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /change release status/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /published/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /failed to change status of v0\.9\.0/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("closes the status menu without acting when dismissed", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        canApprove={true}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /change release status/i }),
+    );
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not render a status-change button for draft releases", () => {
+    renderWithRouter(
+      <VersionsTab
+        releases={[draftRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        canApprove={true}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /change release status/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("downloads the artifact when the download button is clicked", async () => {
+    const { downloadArtifact } = await import("../../utils/downloadArtifact");
+    vi.mocked(downloadArtifact).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    expect(downloadArtifact).toHaveBeenCalledWith(
+      "/api/v1/namespaces/acme/plugins/my-plugin/releases/1.0.0/download",
+      "my-plugin-1.0.0.jar",
+    );
+  });
+
+  it("shows an error toast when the download fails", async () => {
+    const { downloadArtifact } = await import("../../utils/downloadArtifact");
+    vi.mocked(downloadArtifact).mockRejectedValue(new Error("net"));
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /download failed/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("syncs local releases when the releases prop changes", () => {
+    const { rerender } = renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+      />,
+    );
+    expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+    expect(screen.queryByText("v2.0.0")).not.toBeInTheDocument();
+
+    rerender(
+      <VersionsTab
+        releases={[publishedRelease, draftRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+      />,
+    );
+    expect(screen.getByText("v2.0.0")).toBeInTheDocument();
+  });
+
+  it("shows a generic delete confirmation (not the plugin-removal warning) when more than one release exists", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />);
+
+    await user.click(findActionButton("1.0.0", /delete release/i));
+
+    expect(
+      screen.queryByText(/the entire plugin will also be removed/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/this action cannot be undone/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error toast when deleting a release fails", async () => {
+    const { managementApi } = await import("../../api/config");
+    vi.mocked(managementApi.deleteRelease).mockRejectedValue(new Error("x"));
+    const user = userEvent.setup();
+
+    renderWithRouter(
+      <VersionsTab
+        releases={[publishedRelease]}
+        namespace="acme"
+        pluginId="my-plugin"
+        canApprove={true}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete release/i }));
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /failed to delete v1\.0\.0/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("cancels the delete dialog without calling the API", async () => {
+    const { managementApi } = await import("../../api/config");
+    const user = userEvent.setup();
+    renderWithRouter(<VersionsTab {...defaultProps} canApprove={true} />);
+
+    await user.click(findActionButton("1.0.0", /delete release/i));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/this action cannot be undone/i),
+      ).not.toBeInTheDocument(),
+    );
+    expect(managementApi.deleteRelease).not.toHaveBeenCalled();
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/hooks/useMailTemplatePreview.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/hooks/useMailTemplatePreview.test.ts
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { AxiosError, AxiosHeaders } from "axios";
+import { createQueryWrapper } from "../test/queryWrapper";
+import {
+  useMailTemplatePreview,
+  type PreviewDraft,
+} from "./useMailTemplatePreview";
+import type { MailTemplatePreviewResponse } from "../api/generated/model/mail-template-preview-response";
+import * as apiConfig from "../api/config";
+
+vi.mock("../api/config", () => ({
+  adminEmailTemplatesApi: {
+    previewMailTemplate: vi.fn(),
+  },
+}));
+
+const KEY = "auth.password_reset";
+
+const DRAFT: PreviewDraft = {
+  subject: "Reset your password",
+  bodyPlain: "Hello {{username}}",
+  bodyHtml: "<p>Hello {{username}}</p>",
+};
+
+const RESULT: MailTemplatePreviewResponse = {
+  subject: "Reset your password",
+  bodyPlain: "Hello Alice",
+  bodyHtml: "<p>Hello Alice</p>",
+  sampleVars: { username: "Alice" },
+} as unknown as MailTemplatePreviewResponse;
+
+function mockPreviewResolved(data: MailTemplatePreviewResponse = RESULT) {
+  vi.mocked(
+    apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+  ).mockResolvedValue({ data } as Awaited<
+    ReturnType<typeof apiConfig.adminEmailTemplatesApi.previewMailTemplate>
+  >);
+}
+
+function mockPreviewRejected(error: unknown) {
+  vi.mocked(
+    apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+  ).mockRejectedValue(error);
+}
+
+function makeAxiosError(message: string, dataMessage?: string): AxiosError {
+  const err = new AxiosError(message);
+  if (dataMessage !== undefined) {
+    err.response = {
+      data: { message: dataMessage },
+      status: 400,
+      statusText: "Bad Request",
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    } as AxiosError["response"];
+  }
+  return err;
+}
+
+type SentPreviewRequest = {
+  subject?: string;
+  bodyPlain?: string;
+  bodyHtml?: string;
+  sampleVars?: Record<string, string>;
+};
+
+/** Pull the `mailTemplatePreviewRequest` out of the Nth generated-client call. */
+function previewRequestOf(index: number): SentPreviewRequest {
+  const call = vi.mocked(apiConfig.adminEmailTemplatesApi.previewMailTemplate)
+    .mock.calls[index][0] as { mailTemplatePreviewRequest: SentPreviewRequest };
+  return call.mailTemplatePreviewRequest;
+}
+
+function previewRequestOfLast(): SentPreviewRequest {
+  const lastCall = vi.mocked(
+    apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+  ).mock.lastCall as
+    | [{ mailTemplatePreviewRequest: SentPreviewRequest }]
+    | undefined;
+  return lastCall![0].mailTemplatePreviewRequest;
+}
+
+describe("useMailTemplatePreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts idle and fires no request when the draft is empty (enabled-gate)", async () => {
+    mockPreviewResolved();
+    const { result } = renderHook(
+      () =>
+        useMailTemplatePreview(
+          "",
+          { subject: "", bodyPlain: "", bodyHtml: null },
+          {},
+        ),
+      { wrapper: createQueryWrapper() },
+    );
+
+    // Empty draft → enabled is false → no API call, status stays idle.
+    expect(result.current.status).toBe("idle");
+    expect(result.current.result).toBeNull();
+    expect(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("skips the request when templateKey is empty even with a full draft", () => {
+    mockPreviewResolved();
+    renderHook(() => useMailTemplatePreview("", DRAFT, {}), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("skips the request when subject is blank but body is present", () => {
+    mockPreviewResolved();
+    renderHook(
+      () => useMailTemplatePreview(KEY, { ...DRAFT, subject: "" }, {}),
+      { wrapper: createQueryWrapper() },
+    );
+    expect(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("skips the request when bodyPlain is blank but subject is present", () => {
+    mockPreviewResolved();
+    renderHook(
+      () => useMailTemplatePreview(KEY, { ...DRAFT, bodyPlain: "" }, {}),
+      { wrapper: createQueryWrapper() },
+    );
+    expect(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("transitions syncing → live and exposes the result on a successful render", async () => {
+    mockPreviewResolved();
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    expect(result.current.result).toEqual(RESULT);
+    expect(result.current.error).toBeNull();
+    // The hook delegates to the store's preview(), which calls the generated
+    // client as `previewMailTemplate({ key, mailTemplatePreviewRequest })`.
+    expect(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).toHaveBeenCalledWith({
+      key: KEY,
+      mailTemplatePreviewRequest: expect.objectContaining({
+        subject: DRAFT.subject,
+        bodyPlain: DRAFT.bodyPlain,
+        bodyHtml: DRAFT.bodyHtml,
+      }),
+    });
+  });
+
+  it("omits bodyHtml from the request when the draft has no HTML body (null branch)", async () => {
+    mockPreviewResolved();
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, { ...DRAFT, bodyHtml: null }, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    const sentRequest = previewRequestOf(0);
+    // The store's preview() maps `bodyHtml ?? undefined`; with a null draft
+    // the field is omitted from the outgoing request.
+    expect(sentRequest).toEqual(
+      expect.objectContaining({ subject: DRAFT.subject }),
+    );
+    expect(sentRequest.bodyHtml ?? undefined).toBeUndefined();
+  });
+
+  it("forwards sample vars when present and omits them when empty", async () => {
+    mockPreviewResolved();
+    const { result, rerender } = renderHook(
+      ({ vars }: { vars: Record<string, string> }) =>
+        useMailTemplatePreview(KEY, DRAFT, vars, { debounceMs: 0 }),
+      {
+        wrapper: createQueryWrapper(),
+        initialProps: { vars: {} as Record<string, string> },
+      },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    expect(previewRequestOf(0).sampleVars).toBeUndefined();
+
+    rerender({ vars: { username: "Bob" } });
+    await waitFor(() => {
+      const lastReq = previewRequestOfLast();
+      expect(lastReq.sampleVars).toEqual({ username: "Bob" });
+    });
+  });
+
+  it("goes to error and surfaces the axios response.data.message", async () => {
+    mockPreviewRejected(
+      makeAxiosError("Request failed", "Malformed mustache token"),
+    );
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("Malformed mustache token");
+  });
+
+  it("falls back to axios error.message when response has no message", async () => {
+    mockPreviewRejected(makeAxiosError("Network Error"));
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("Network Error");
+  });
+
+  it("surfaces a plain Error's message", async () => {
+    mockPreviewRejected(new Error("boom"));
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("boom");
+  });
+
+  it("uses the generic fallback message for a non-Error rejection", async () => {
+    mockPreviewRejected("just a string");
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("Preview failed.");
+  });
+
+  it("refresh() triggers an immediate render bypassing the debounce", async () => {
+    mockPreviewResolved();
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}, { debounceMs: 500 }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    const callsAfterMount = vi.mocked(
+      apiConfig.adminEmailTemplatesApi.previewMailTemplate,
+    ).mock.calls.length;
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(apiConfig.adminEmailTemplatesApi.previewMailTemplate).mock
+          .calls.length,
+      ).toBeGreaterThan(callsAfterMount),
+    );
+  });
+
+  it("enters stale while the debounce timer is pending after an edit", async () => {
+    vi.useFakeTimers();
+    mockPreviewResolved();
+    const { result, rerender } = renderHook(
+      ({ draft }: { draft: PreviewDraft }) =>
+        useMailTemplatePreview(KEY, draft, {}, { debounceMs: 500 }),
+      { initialProps: { draft: DRAFT }, wrapper: createQueryWrapper() },
+    );
+
+    // The mount-time debounced key equals the initial draft, so the first
+    // request fires synchronously; flush its microtasks to settle "live".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.status).toBe("live");
+
+    // Edit the draft — debounce starts counting; status flips to "stale".
+    await act(async () => {
+      rerender({ draft: { ...DRAFT, subject: "Reset your password!" } });
+    });
+    expect(result.current.status).toBe("stale");
+
+    // Let the debounce elapse → a fresh request fires and settles "live".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(result.current.status).toBe("live");
+  });
+
+  it("discards an out-of-order (stale) response", async () => {
+    // First call resolves slowly, second resolves fast; the slow one must be
+    // dropped because the request-id counter has advanced past it.
+    let resolveSlow!: (v: { data: MailTemplatePreviewResponse }) => void;
+    const slow = new Promise<{ data: MailTemplatePreviewResponse }>((res) => {
+      resolveSlow = res;
+    });
+    const fastResult = {
+      ...RESULT,
+      subject: "FAST",
+    } as MailTemplatePreviewResponse;
+
+    vi.mocked(apiConfig.adminEmailTemplatesApi.previewMailTemplate)
+      .mockReturnValueOnce(
+        slow as ReturnType<
+          typeof apiConfig.adminEmailTemplatesApi.previewMailTemplate
+        >,
+      )
+      .mockResolvedValueOnce({ data: fastResult } as Awaited<
+        ReturnType<typeof apiConfig.adminEmailTemplatesApi.previewMailTemplate>
+      >);
+
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    // Mount fires request #1 (the slow one). Trigger request #2 via refresh.
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(result.current.result?.subject).toBe("FAST"));
+
+    // Now resolve the slow request #1 — it must NOT overwrite the fast result.
+    await act(async () => {
+      resolveSlow({ data: { ...RESULT, subject: "SLOW" } });
+      await Promise.resolve();
+    });
+    expect(result.current.result?.subject).toBe("FAST");
+  });
+
+  it("discards a stale error response from a superseded request", async () => {
+    let rejectSlow!: (e: unknown) => void;
+    const slow = new Promise<{ data: MailTemplatePreviewResponse }>(
+      (_res, rej) => {
+        rejectSlow = rej;
+      },
+    );
+    vi.mocked(apiConfig.adminEmailTemplatesApi.previewMailTemplate)
+      .mockReturnValueOnce(
+        slow as ReturnType<
+          typeof apiConfig.adminEmailTemplatesApi.previewMailTemplate
+        >,
+      )
+      .mockResolvedValueOnce({
+        data: { ...RESULT, subject: "FAST" } as MailTemplatePreviewResponse,
+      } as Awaited<
+        ReturnType<typeof apiConfig.adminEmailTemplatesApi.previewMailTemplate>
+      >);
+
+    const { result } = renderHook(
+      () => useMailTemplatePreview(KEY, DRAFT, {}),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(result.current.status).toBe("live"));
+
+    // The superseded slow request now rejects — the error branch must
+    // short-circuit on the request-id mismatch and leave status "live".
+    await act(async () => {
+      rejectSlow(new Error("late failure"));
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("live");
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/hooks/useUploadFiles.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/hooks/useUploadFiles.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createQueryWrapper } from "../test/queryWrapper";
+import { useUploadFiles } from "./useUploadFiles";
+import { useUploadStore } from "../stores/uploadStore";
+import { useUiStore } from "../stores/uiStore";
+import { useConfigStore } from "../stores/configStore";
+import { axiosInstance } from "../api/config";
+
+vi.mock("../api/config", () => ({
+  axiosInstance: { post: vi.fn(), get: vi.fn() },
+}));
+
+const post = vi.mocked(axiosInstance.post);
+
+function makeFile(name: string, size?: number): File {
+  const file = new File(["plugin-bytes"], name, {
+    type: "application/java-archive",
+  });
+  if (size !== undefined) {
+    Object.defineProperty(file, "size", { value: size });
+  }
+  return file;
+}
+
+function toasts() {
+  return useUiStore.getState().toasts;
+}
+
+function hasToast(predicate: (message: string) => boolean) {
+  return toasts().some((t) => predicate(t.message ?? ""));
+}
+
+async function upload(files: File[], namespace = "default") {
+  const { result } = renderHook(() => useUploadFiles(), {
+    wrapper: createQueryWrapper(),
+  });
+  await act(async () => {
+    await result.current.uploadFiles(files, namespace);
+  });
+}
+
+describe("useUploadFiles", () => {
+  beforeEach(() => {
+    post.mockReset();
+    useUploadStore.getState().reset();
+    useUiStore.setState({ toasts: [] });
+    // loaded=true short-circuits fetchConfig so the mocked GET is never needed.
+    useConfigStore.setState({ loaded: true, maxFileSizeMb: 100 });
+  });
+
+  it("warns about and skips files with unsupported extensions", async () => {
+    await upload([makeFile("notes.txt"), makeFile("image.png")]);
+    expect(hasToast((m) => /only \.jar and \.zip/i.test(m))).toBe(true);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("uploads a single valid file and reports success", async () => {
+    post.mockResolvedValue({ data: {} });
+    await upload([makeFile("plugin.jar")]);
+    expect(post).toHaveBeenCalledOnce();
+    expect(hasToast((m) => /release uploaded successfully/i.test(m))).toBe(
+      true,
+    );
+    expect(
+      useUploadStore.getState().entries.every((e) => e.status === "success"),
+    ).toBe(true);
+  });
+
+  it("pluralises the success toast for multiple files", async () => {
+    post.mockResolvedValue({ data: {} });
+    await upload([makeFile("a.jar"), makeFile("b.zip")]);
+    expect(hasToast((m) => /2 releases uploaded successfully/i.test(m))).toBe(
+      true,
+    );
+  });
+
+  it("forwards upload progress events to the store", async () => {
+    post.mockImplementation((_url, _data, config) => {
+      config?.onUploadProgress?.({
+        loaded: 5,
+        total: 10,
+        bytes: 5,
+        lengthComputable: true,
+      });
+      // total falsy -> progress branch skipped, must not throw
+      config?.onUploadProgress?.({
+        loaded: 5,
+        total: 0,
+        bytes: 5,
+        lengthComputable: true,
+      });
+      return Promise.resolve({ data: {} });
+    });
+    await upload([makeFile("plugin.jar")]);
+    const entry = useUploadStore.getState().entries.at(-1);
+    expect(entry?.status).toBe("success");
+    expect(entry?.progress).toBe(100);
+  });
+
+  it("marks a file that exceeds the size limit as failed without calling the API", async () => {
+    useConfigStore.setState({ loaded: true, maxFileSizeMb: 1 });
+    await upload([makeFile("huge.jar", 5 * 1024 * 1024)]);
+    expect(post).not.toHaveBeenCalled();
+    const entry = useUploadStore.getState().entries.at(-1);
+    expect(entry?.status).toBe("failed");
+    expect(entry?.errorMessage).toMatch(/file too large/i);
+    expect(hasToast((m) => /release upload failed/i.test(m))).toBe(true);
+  });
+
+  it("surfaces the server message on an axios upload error", async () => {
+    post.mockRejectedValue(
+      Object.assign(new Error("Network Error"), {
+        isAxiosError: true,
+        response: { data: { message: "Duplicate version rejected" } },
+      }),
+    );
+    await upload([makeFile("plugin.jar")]);
+    const entry = useUploadStore.getState().entries.at(-1);
+    expect(entry?.status).toBe("failed");
+    expect(entry?.errorMessage).toBe("Duplicate version rejected");
+  });
+
+  it("falls back to the axios error message when the body has none", async () => {
+    post.mockRejectedValue(
+      Object.assign(new Error("boom"), {
+        isAxiosError: true,
+        response: { data: {} },
+      }),
+    );
+    await upload([makeFile("plugin.jar")]);
+    expect(useUploadStore.getState().entries.at(-1)?.errorMessage).toBe("boom");
+  });
+
+  it("uses a generic message when the failure is not an Error", async () => {
+    post.mockRejectedValue("weird non-error");
+    await upload([makeFile("plugin.jar")]);
+    expect(useUploadStore.getState().entries.at(-1)?.errorMessage).toBe(
+      "Upload failed.",
+    );
+  });
+
+  it("reports a partial result when some uploads fail", async () => {
+    post
+      .mockResolvedValueOnce({ data: {} })
+      .mockRejectedValueOnce(new Error("nope"));
+    await upload([makeFile("ok.jar"), makeFile("bad.zip")]);
+    expect(hasToast((m) => /1 succeeded, 1 failed/i.test(m))).toBe(true);
+  });
+
+  it("reports an all-failed result with a pluralised message", async () => {
+    post.mockRejectedValue(new Error("nope"));
+    await upload([makeFile("a.jar"), makeFile("b.zip")]);
+    expect(hasToast((m) => /all 2 uploads failed/i.test(m))).toBe(true);
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/CatalogPage.test.tsx
@@ -17,7 +17,7 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { renderWithRouterAt } from "../test/renderWithTheme";
 import { CatalogPage } from "./CatalogPage";
 import { usePluginStore } from "../stores/pluginStore";
@@ -28,7 +28,10 @@ import type { PluginDto, PluginPagedResponse } from "../api/generated/model";
 
 vi.mock("../api/config", () => ({
   catalogApi: { listPlugins: vi.fn() },
-  axiosInstance: { get: vi.fn().mockResolvedValue({ data: [] }) },
+  axiosInstance: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
   namespacesApi: { listNamespaces: vi.fn().mockResolvedValue({ data: [] }) },
   namespaceMembersApi: {
     getMyMembership: vi.fn().mockRejectedValue(new Error("not a member")),
@@ -233,5 +236,135 @@ describe("CatalogPage", () => {
     );
     const { namespace } = useAuthStore.getState();
     expect(namespace).toBe("other-ns");
+  });
+
+  it("renders the list-view loading skeleton when list view is selected during the initial load", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    // The query never resolves → `isPending` stays true (no previous data to
+    // keep). Switching to list view while pending exercises the list-view
+    // skeleton branch (`loading && view === "list"`).
+    mockListPlugins.mockReturnValue(new Promise(() => {}));
+
+    renderCatalog();
+    // Card-view skeleton is up first.
+    expect(screen.getByLabelText("Loading plugins")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /list view/i }));
+    // Still loading, now in list view → the list-row skeletons render.
+    expect(screen.getByLabelText("Loading plugins")).toBeInTheDocument();
+    // The card grid skeleton must be gone (we switched views).
+    expect(
+      screen.queryByRole("list", { name: /plugin cards/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resets filters from the empty-state action", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const resetSpy = vi.fn();
+    usePluginStore.setState({
+      filters: { ...defaultFilters, tag: "missing" },
+      resetFilters: resetSpy,
+    });
+    renderCatalog();
+    await screen.findByText("No plugins found");
+    await user.click(screen.getByRole("button", { name: /show all plugins/i }));
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe("drag-and-drop upload affordance", () => {
+    function getMain() {
+      return document.getElementById("main-content") as HTMLElement;
+    }
+
+    function getOverlay() {
+      // The CatalogDropOverlay box carries the aria-hidden toggle.
+      return screen
+        .getByText("Drop .jar or .zip files to upload")
+        .closest("[aria-hidden]") as HTMLElement;
+    }
+
+    it("shows the drop overlay on drag-enter when the user can upload", () => {
+      useAuthStore.setState({
+        accessToken: "tok",
+        isAuthenticated: true,
+        namespace: "acme",
+      });
+      renderCatalog();
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "true");
+      fireEvent.dragEnter(getMain(), { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "false");
+    });
+
+    it("hides the overlay again after a matching drag-leave", () => {
+      useAuthStore.setState({
+        accessToken: "tok",
+        isAuthenticated: true,
+        namespace: "acme",
+      });
+      renderCatalog();
+      const main = getMain();
+      fireEvent.dragEnter(main, { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "false");
+      // dragOver keeps it visible; dragLeave decrements the counter to 0.
+      fireEvent.dragOver(main, { dataTransfer: { files: [] } });
+      fireEvent.dragLeave(main, { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("ignores drag events entirely when the user cannot upload", () => {
+      // Unauthenticated → canUpload false → handlers early-return, overlay
+      // stays hidden.
+      useAuthStore.setState({
+        accessToken: null,
+        isAuthenticated: false,
+        namespace: "acme",
+      });
+      renderCatalog();
+      fireEvent.dragEnter(getMain(), { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("clears the overlay on drop even when no files are present", () => {
+      useAuthStore.setState({
+        accessToken: "tok",
+        isAuthenticated: true,
+        namespace: "acme",
+      });
+      renderCatalog();
+      const main = getMain();
+      fireEvent.dragEnter(main, { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "false");
+      // Empty drop: resets the overlay, skips the uploadFiles branch.
+      fireEvent.drop(main, { dataTransfer: { files: [] } });
+      expect(getOverlay()).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("forwards dropped files to the upload pipeline", async () => {
+      const { axiosInstance } = await import("../api/config");
+      useAuthStore.setState({
+        accessToken: "tok",
+        isAuthenticated: true,
+        namespace: "acme",
+      });
+      renderCatalog();
+      const main = getMain();
+      const file = new File(["x"], "plugin.jar", {
+        type: "application/java-archive",
+      });
+      fireEvent.dragEnter(main, { dataTransfer: { files: [file] } });
+      fireEvent.drop(main, { dataTransfer: { files: [file] } });
+
+      // The upload hook posts the artifact to the namespace endpoint.
+      await waitFor(() => {
+        expect(axiosInstance.post).toHaveBeenCalledWith(
+          "/namespaces/acme/plugin-releases",
+          expect.any(FormData),
+          expect.objectContaining({
+            headers: { "Content-Type": "multipart/form-data" },
+          }),
+        );
+      });
+    });
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailServerPage.test.tsx
@@ -206,4 +206,246 @@ describe("EmailServerPage", () => {
     // not the raw enum value — STARTTLS-on-587 is what the operator reads.
     expect(screen.getByText(/STARTTLS \(port 587\)/)).toBeInTheDocument();
   });
+
+  it("shows a loading spinner before settings have loaded", () => {
+    useSettingsStore.setState({
+      settings: [],
+      loaded: false,
+      loading: true,
+      saving: false,
+      error: null,
+    });
+    renderWithTheme(<EmailServerPage />);
+    expect(screen.getByText(/loading smtp settings/i)).toBeInTheDocument();
+  });
+
+  it("keeps Save and Discard disabled until a field changes", () => {
+    renderWithTheme(<EmailServerPage />);
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^discard$/i })).toBeDisabled();
+  });
+
+  it("saves the dirty patch and toasts success", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    await user.clear(host);
+    await user.type(host, "mail.internal.test");
+
+    const save = screen.getByRole("button", { name: /save changes/i });
+    expect(save).toBeEnabled();
+    await user.click(save);
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminSettingsApi.updateApplicationSettings,
+      ).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => t.message === "SMTP settings saved."),
+      ).toBe(true);
+    });
+  });
+
+  it("blocks save and highlights the field when the port is out of range", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const port = screen.getByLabelText("Port") as HTMLInputElement;
+    await user.clear(port);
+    await user.type(port, "70000");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText(/must be <= 65535/i)).toBeInTheDocument();
+    expect(
+      useUiStore
+        .getState()
+        .toasts.some((t) =>
+          /fix the highlighted fields/i.test(t.message ?? ""),
+        ),
+    ).toBe(true);
+    expect(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a port below the minimum", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const port = screen.getByLabelText("Port") as HTMLInputElement;
+    await user.clear(port);
+    await user.type(port, "0");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText(/must be >= 1/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the server message when saving fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockRejectedValue(
+      Object.assign(new Error("Network Error"), {
+        isAxiosError: true,
+        response: { data: { message: "Validation failed on the server" } },
+      }),
+    );
+    renderWithTheme(<EmailServerPage />);
+
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    await user.clear(host);
+    await user.type(host, "mail.internal.test");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => t.message === "Validation failed on the server"),
+      ).toBe(true);
+    });
+  });
+
+  it("falls back to the Error message when a save error is not an axios error", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockRejectedValue(new Error("disk full"));
+    renderWithTheme(<EmailServerPage />);
+
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    await user.clear(host);
+    await user.type(host, "mail.internal.test");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore.getState().toasts.some((t) => t.message === "disk full"),
+      ).toBe(true);
+    });
+  });
+
+  it("discards pending edits and re-reads the stored value", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    await user.clear(host);
+    await user.type(host, "scratch.value");
+    expect(host.value).toBe("scratch.value");
+
+    await user.click(screen.getByRole("button", { name: /^discard$/i }));
+    expect(host.value).toBe("smtp.example.com");
+  });
+
+  it("refuses to send a test email with an empty recipient", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const recipient = screen.getByLabelText(
+      "Test recipient",
+    ) as HTMLInputElement;
+    await user.clear(recipient);
+    await user.click(screen.getByRole("button", { name: /send test email/i }));
+
+    expect(
+      await screen.findByText(/enter a recipient email address first/i),
+    ).toBeInTheDocument();
+  });
+
+  it("refuses to send a test email while there are unsaved changes", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<EmailServerPage />);
+
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    await user.clear(host);
+    await user.type(host, "dirty.value");
+
+    const recipient = screen.getByLabelText(
+      "Test recipient",
+    ) as HTMLInputElement;
+    await user.clear(recipient);
+    await user.type(recipient, "ada@example.test");
+    await user.click(screen.getByRole("button", { name: /send test email/i }));
+
+    expect(
+      await screen.findByText(/save your changes before sending/i),
+    ).toBeInTheDocument();
+  });
+
+  it("uses a generated fallback message when the test send omits one", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.adminEmailApi.sendTestEmail).mockResolvedValue({
+      data: {},
+    } as Awaited<ReturnType<typeof apiConfig.adminEmailApi.sendTestEmail>>);
+    renderWithTheme(<EmailServerPage />);
+
+    const recipient = screen.getByLabelText(
+      "Test recipient",
+    ) as HTMLInputElement;
+    await user.clear(recipient);
+    await user.type(recipient, "ada@example.test");
+    await user.click(screen.getByRole("button", { name: /send test email/i }));
+
+    expect(
+      await screen.findByText(/test email sent to ada@example\.test/i),
+    ).toBeInTheDocument();
+  });
+
+  it("reports a generic message when the test error is not an Error", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiConfig.adminEmailApi.sendTestEmail).mockRejectedValue(
+      "weird string failure",
+    );
+    renderWithTheme(<EmailServerPage />);
+
+    const recipient = screen.getByLabelText(
+      "Test recipient",
+    ) as HTMLInputElement;
+    await user.clear(recipient);
+    await user.type(recipient, "ada@example.test");
+    await user.click(screen.getByRole("button", { name: /send test email/i }));
+
+    expect(await screen.findByText(/unknown error/i)).toBeInTheDocument();
+  });
+
+  it("shows the enable-first hint when SMTP is disabled", () => {
+    useSettingsStore.setState({
+      settings: SMTP_SETTINGS.map((s) =>
+        s.key === "smtp.enabled" ? { ...s, value: "false" } : s,
+      ),
+      loaded: true,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    renderWithTheme(<EmailServerPage />);
+    expect(
+      screen.getByText(/enable smtp and save your changes/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to default encryption options when none are configured", () => {
+    useSettingsStore.setState({
+      settings: SMTP_SETTINGS.map((s) =>
+        s.key === "smtp.encryption"
+          ? { ...s, value: "none", allowedValues: undefined }
+          : s,
+      ),
+      loaded: true,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    renderWithTheme(<EmailServerPage />);
+    expect(screen.getByText(/none \(plain smtp\)/i)).toBeInTheDocument();
+  });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.test.tsx
@@ -17,8 +17,9 @@
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
 import { EmailTemplateEditPage } from "./EmailTemplateEditPage";
 import { renderWithRouterAt } from "../../test/renderWithTheme";
 import { useEmailTemplatesStore } from "../../stores/emailTemplatesStore";
@@ -61,6 +62,21 @@ function setStoreWithTemplate(template: MailTemplateResponse = TEMPLATE) {
     saving: false,
     error: null,
   });
+}
+
+/** Build an AxiosError, optionally carrying a `response.data.message`. */
+function makeAxiosError(message: string, dataMessage?: string): AxiosError {
+  const err = new AxiosError(message);
+  if (dataMessage !== undefined) {
+    err.response = {
+      data: { message: dataMessage },
+      status: 400,
+      statusText: "Bad Request",
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    } as AxiosError["response"];
+  }
+  return err;
 }
 
 describe("EmailTemplateEditPage", () => {
@@ -398,5 +414,417 @@ describe("EmailTemplateEditPage", () => {
     // its content as inline DOM text inside the labelled group wrapper.
     const htmlEditor = await screen.findByRole("group", { name: "HTML body" });
     expect(htmlEditor.textContent ?? "").toContain("default HTML body");
+  });
+
+  it("shows a loading spinner while templates are still loading", () => {
+    useEmailTemplatesStore.setState({
+      templates: [],
+      loaded: false,
+      loading: true,
+      saving: false,
+      error: null,
+    });
+    renderAt();
+    expect(screen.getByText("Loading template…")).toBeInTheDocument();
+  });
+
+  it("auto-loads templates on mount when the store is empty and surfaces an error toast on failure", async () => {
+    useEmailTemplatesStore.setState({
+      templates: [],
+      loaded: false,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.listMailTemplates,
+    ).mockRejectedValue(new Error("network down"));
+    renderAt();
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminEmailTemplatesApi.listMailTemplates,
+      ).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({
+          type: "error",
+          message: "Failed to load mail templates.",
+        }),
+      );
+    });
+  });
+
+  it("Back link on the 404 page navigates away (page content unmounts)", async () => {
+    const user = userEvent.setup();
+    useEmailTemplatesStore.setState({
+      templates: [],
+      loaded: true,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+    renderAt("never.registered");
+
+    await user.click(
+      screen.getByRole("button", { name: /Back to templates/i }),
+    );
+    // `/admin/email/templates` is not a registered route in this harness,
+    // so navigating there unmounts the page — the warning alert disappears.
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  it("'All templates' breadcrumb navigates away (page content unmounts)", async () => {
+    const user = userEvent.setup();
+    renderAt();
+    expect(screen.getByText("Auth · Password Reset")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /All templates/i }));
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Auth · Password Reset"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("inserts a placeholder into the subject field at the caret when the subject was last focused", async () => {
+    const user = userEvent.setup();
+    renderAt();
+
+    const subject = screen.getByLabelText("Subject") as HTMLInputElement;
+    // Focus the subject and place the caret at the start so the inserted
+    // token lands at position 0 (exercises the subject-target slice path).
+    await user.click(subject);
+    subject.setSelectionRange(0, 0);
+
+    // {{username}} appears in several places (chip + editor token + preview
+    // sample-vars label); the chip is the first match.
+    await user.click(screen.getAllByText("{{username}}")[0]);
+
+    await waitFor(() => {
+      expect(subject.value).toContain("{{username}}");
+    });
+    // Inserted at the caret (start), so it prefixes the original subject.
+    expect(subject.value.startsWith("{{username}}")).toBe(true);
+  });
+
+  it("blocks Save with an error toast when the subject is blank", async () => {
+    const user = userEvent.setup();
+    setStoreWithTemplate({ ...TEMPLATE, subject: " " });
+    renderAt();
+
+    // Type into plaintext-irrelevant subject then clear it to a blank string.
+    const subject = screen.getByLabelText("Subject") as HTMLInputElement;
+    await user.clear(subject);
+    await user.type(subject, "x");
+    await user.clear(subject);
+
+    // Save is dirty (subject changed from " " to "") so it is enabled.
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({
+          type: "error",
+          message: "Subject is required.",
+        }),
+      );
+    });
+    expect(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("blocks Save with an error toast when the plaintext body is blank", async () => {
+    const user = userEvent.setup();
+    // Seed a template whose plaintext body is already blank; editing the
+    // subject makes the form dirty without populating the body.
+    setStoreWithTemplate({ ...TEMPLATE, bodyPlain: "" });
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), "!");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({
+          type: "error",
+          message: "Plaintext body is required.",
+        }),
+      );
+    });
+    expect(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("Save failure surfaces the API error message from an axios response (extractApiError: axios w/ message)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockRejectedValue(makeAxiosError("Request failed", "Subject too long"));
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), " (edited)");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({ type: "error", message: "Subject too long" }),
+      );
+    });
+  });
+
+  it("Save failure falls back to axios error.message when the response carries no message (extractApiError: axios w/o message)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockRejectedValue(makeAxiosError("Network Error"));
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), " (edited)");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({ type: "error", message: "Network Error" }),
+      );
+    });
+  });
+
+  it("Save failure surfaces a plain Error message (extractApiError: Error)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockRejectedValue(new Error("boom"));
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), " (edited)");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({ type: "error", message: "boom" }),
+      );
+    });
+  });
+
+  it("Save failure shows the generic fallback for a non-Error rejection (extractApiError: unknown)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockRejectedValue("just a string");
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), " (edited)");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({ type: "error", message: "Unknown error" }),
+      );
+    });
+  });
+
+  it("Reset failure surfaces the API error message and shows no success toast", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.resetMailTemplate,
+    ).mockRejectedValue(makeAxiosError("Request failed", "Reset rejected"));
+    renderAt();
+
+    await user.click(screen.getByRole("button", { name: /Reset to default/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /Reset template/i }),
+    );
+
+    await waitFor(() => {
+      expect(useUiStore.getState().toasts).toContainEqual(
+        expect.objectContaining({ type: "error", message: "Reset rejected" }),
+      );
+    });
+    expect(useUiStore.getState().toasts).not.toContainEqual(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("Save persists the edited HTML body when the HTML alternative is enabled", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockResolvedValue({
+      data: TEMPLATE,
+    } as Awaited<
+      ReturnType<typeof apiConfig.adminEmailTemplatesApi.updateMailTemplate>
+    >);
+    // Template already has an HTML body, so the editor is visible on mount.
+    renderAt();
+
+    await user.type(screen.getByLabelText("Subject"), " (edited)");
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mailTemplateUpdateRequest: expect.objectContaining({
+            bodyHtml: TEMPLATE.bodyHtml,
+          }),
+        }),
+      );
+    });
+  });
+
+  it("toggling the HTML alternative off clears the HTML body so Save omits it", async () => {
+    const user = userEvent.setup();
+    vi.mocked(
+      apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+    ).mockResolvedValue({
+      data: { ...TEMPLATE, bodyHtml: undefined },
+    } as Awaited<
+      ReturnType<typeof apiConfig.adminEmailTemplatesApi.updateMailTemplate>
+    >);
+    renderAt();
+
+    // HTML editor is on (template has bodyHtml). Switching it off nulls the
+    // draft's bodyHtml; Save then omits the field entirely.
+    const toggle = screen.getByLabelText("HTML alternative enabled");
+    await user.click(toggle);
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(
+        apiConfig.adminEmailTemplatesApi.updateMailTemplate,
+      ).toHaveBeenCalled();
+    });
+    const call = vi.mocked(apiConfig.adminEmailTemplatesApi.updateMailTemplate)
+      .mock.calls[0][0] as {
+      mailTemplateUpdateRequest: { bodyHtml?: string };
+    };
+    expect(call.mailTemplateUpdateRequest.bodyHtml).toBeUndefined();
+  });
+
+  it("expands the 'Compare with default subject' panel to reveal the seeded default", async () => {
+    const user = userEvent.setup();
+    renderAt();
+
+    const compareToggle = screen.getByRole("button", {
+      name: /Show Default subject/i,
+    });
+    await user.click(compareToggle);
+
+    await waitFor(() => {
+      expect(screen.getByText(TEMPLATE.defaultSubject)).toBeInTheDocument();
+    });
+    // Toggling again collapses it (aria-label flips to "Hide …").
+    expect(
+      screen.getByRole("button", { name: /Hide Default subject/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the 'Factory default' attribution for an un-customised template", () => {
+    setStoreWithTemplate({
+      ...TEMPLATE,
+      source: MailTemplateResponseSourceEnum.Default,
+    });
+    renderAt();
+    expect(screen.getByText("Factory default")).toBeInTheDocument();
+  });
+
+  it("renders the edited-by attribution without a 'by' fragment when updatedBy is absent", () => {
+    setStoreWithTemplate({
+      ...TEMPLATE,
+      updatedBy: null,
+      updatedAt: "2026-05-03T10:00:00Z",
+    });
+    renderAt();
+    // The attribution caption starts with "Edited" and omits the "by …"
+    // fragment when no author is recorded.
+    const edited = screen.getByText(/^Edited/);
+    expect(edited.textContent ?? "").not.toContain("by ");
+  });
+
+  it("renders a bare 'Edited' attribution when both updatedAt and updatedBy are missing", () => {
+    setStoreWithTemplate({
+      ...TEMPLATE,
+      updatedAt: null,
+      updatedBy: null,
+    });
+    renderAt();
+    expect(screen.getByText("Edited")).toBeInTheDocument();
+  });
+
+  it("renders the 'takes no variables' note when the template has no placeholders", () => {
+    setStoreWithTemplate({ ...TEMPLATE, placeholders: [] });
+    renderAt();
+    expect(
+      screen.getByText("This template takes no variables."),
+    ).toBeInTheDocument();
+  });
+
+  it("routes placeholder insertion to the HTML editor when it was last focused", async () => {
+    const user = userEvent.setup();
+    renderAt();
+
+    // HTML editor is visible (template has an HTML body). Focus its
+    // contenteditable so lastFocusedRef flips to "bodyHtml", then click a
+    // chip — insertion is dispatched to the HTML editor handle.
+    const htmlGroup = screen.getByRole("group", { name: "HTML body" });
+    const htmlContent = htmlGroup.querySelector(".cm-content");
+    expect(htmlContent).not.toBeNull();
+    fireEvent.focus(htmlContent as Element);
+
+    await user.click(screen.getAllByText("{{username}}")[0]);
+
+    // The HTML editor now contains the inserted token. CodeMirror reflects
+    // its value as inline DOM text inside the labelled group wrapper.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("group", { name: "HTML body" }).textContent ?? "",
+      ).toContain("{{username}}");
+    });
+  });
+
+  it("omits the default-HTML diff panel when the template has no default HTML body", async () => {
+    const user = userEvent.setup();
+    // No default HTML body — the "Compare with default HTML body" panel must
+    // not render even once the HTML editor is shown.
+    setStoreWithTemplate({
+      ...TEMPLATE,
+      bodyHtml: undefined,
+      defaultBodyHtml: undefined,
+    });
+    renderAt();
+
+    await user.click(screen.getByLabelText("Plaintext only"));
+    await screen.findByRole("group", { name: "HTML body" });
+
+    expect(
+      screen.queryByRole("button", { name: /Default HTML body/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("seeds the HTML editor with an empty string when no default HTML body exists", async () => {
+    const user = userEvent.setup();
+    setStoreWithTemplate({
+      ...TEMPLATE,
+      bodyHtml: undefined,
+      defaultBodyHtml: undefined,
+    });
+    renderAt();
+
+    // Toggling on with no default seeds the editor with "" (the `?? ""`
+    // fallback branch), so it mounts but stays empty.
+    await user.click(screen.getByLabelText("Plaintext only"));
+    const htmlEditor = await screen.findByRole("group", { name: "HTML body" });
+    // Read the editable content element directly — the group wrapper also
+    // contains CodeMirror's line-number gutter, which is not document text.
+    const content = htmlEditor.querySelector(".cm-content");
+    expect((content?.textContent ?? "").trim()).toBe("");
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/GeneralSection.test.tsx
@@ -340,4 +340,308 @@ describe("GeneralSection", () => {
       expect(alert).toHaveTextContent(/restart/i);
     });
   });
+
+  it("shows a loading spinner while settings are being fetched", () => {
+    useSettingsStore.setState({ loaded: false, loading: true });
+    // load() guard requires !loaded && !loading to fire, so the mock isn't hit.
+    renderWithTheme(<GeneralSection />);
+    expect(screen.getByText("Loading settings…")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("shows an info alert when no settings are available", () => {
+    useSettingsStore.setState({ loaded: true, loading: false, settings: [] });
+    renderWithTheme(<GeneralSection />);
+    expect(
+      screen.getByText("No application settings are available."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error toast when loading settings fails", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockRejectedValue(new Error("network"));
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /Failed to load application settings/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("discards edits and re-disables the Save button", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+
+    const siteName = screen.getByLabelText("Site Name");
+    await user.clear(siteName);
+    await user.type(siteName, "Edited");
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: /discard/i }));
+
+    expect(screen.getByLabelText("Site Name")).toHaveValue("Plugwerk");
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
+    ).toBeDisabled();
+  });
+
+  it("validates a blank string field and blocks save", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+
+    const siteName = screen.getByLabelText("Site Name");
+    await user.clear(siteName);
+    await user.type(siteName, "   ");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.getByText("Must not be blank")).toBeInTheDocument();
+    expect(
+      vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("validates a non-integer value and shows the integer error", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Max File Size Mb")).toBeInTheDocument(),
+    );
+
+    const maxSize = screen.getByLabelText("Max File Size Mb");
+    await user.clear(maxSize);
+    // A number input keeps "1.5" as "1.5"; parseInt → 1, String(1) !== "1.5".
+    await user.type(maxSize, "1.5");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.getByText("Must be an integer")).toBeInTheDocument();
+  });
+
+  it("validates the integer minimum bound", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Password Reset Token Ttl Minutes"),
+      ).toBeInTheDocument(),
+    );
+
+    const ttl = screen.getByLabelText("Password Reset Token Ttl Minutes");
+    await user.clear(ttl);
+    await user.type(ttl, "1");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(screen.getByText("Must be >= 5")).toBeInTheDocument();
+  });
+
+  it("changes the default language select and sends the change", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockResolvedValue({
+      data: {
+        settings: SAMPLE_SETTINGS.map((s) =>
+          s.key === "general.default_language" ? { ...s, value: "de" } : s,
+        ),
+      },
+    } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Default Language")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByLabelText("Default Language"));
+    await user.click(screen.getByRole("option", { name: "de" }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings),
+      ).toHaveBeenCalledWith({
+        applicationSettingsUpdateRequest: {
+          settings: { "general.default_language": "de" },
+        },
+      });
+    });
+  });
+
+  it("renders the default timezone field when the setting is present", async () => {
+    // SAMPLE_SETTINGS has no timezone key (so renderField returns null for it);
+    // adding it exercises the general.default_timezone branch of renderField.
+    const withTz: ApplicationSettingDto[] = [
+      ...SAMPLE_SETTINGS,
+      dto({
+        key: "general.default_timezone",
+        value: "Europe/Berlin",
+        valueType: "STRING",
+        description: "Default display timezone.",
+      }),
+    ];
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: withTz } } as never);
+
+    renderWithTheme(<GeneralSection />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Default Timezone")).toBeInTheDocument(),
+    );
+    // The TimezoneSelect autocomplete is seeded from the setting value.
+    expect(screen.getByDisplayValue(/Europe\/Berlin/i)).toBeInTheDocument();
+  });
+
+  it("renders the default language fallback options when allowedValues is absent", async () => {
+    const noAllowed = SAMPLE_SETTINGS.map((s) =>
+      s.key === "general.default_language"
+        ? { ...s, allowedValues: undefined }
+        : s,
+    );
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: noAllowed } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Default Language")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByLabelText("Default Language"));
+    // Fallback ["en", "de"] — "de" has no LANGUAGE_LABELS entry so renders raw.
+    expect(screen.getByRole("option", { name: "de" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "English" })).toBeInTheDocument();
+  });
+
+  it("clears a field-level error when the field is edited again", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Max File Size Mb")).toBeInTheDocument(),
+    );
+
+    const maxSize = screen.getByLabelText("Max File Size Mb");
+    await user.clear(maxSize);
+    await user.type(maxSize, "9999");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    expect(screen.getByText("Must be <= 1024")).toBeInTheDocument();
+
+    // Editing the same field again must drop the existing error entry
+    // (handleFieldChange's key-in-prev branch).
+    await user.clear(maxSize);
+    await user.type(maxSize, "500");
+    expect(screen.queryByText("Must be <= 1024")).not.toBeInTheDocument();
+  });
+
+  it("saves valid edits across string, integer, boolean and enum fields", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+
+    // STRING (valid), INTEGER (in range), BOOLEAN, ENUM — walks every
+    // valid branch of validateLocally.
+    await user.clear(screen.getByLabelText("Site Name"));
+    await user.type(screen.getByLabelText("Site Name"), "Acme");
+    await user.clear(screen.getByLabelText("Max File Size Mb"));
+    await user.type(screen.getByLabelText("Max File Size Mb"), "200");
+    await user.click(screen.getByLabelText("Enabled"));
+    await user.click(screen.getByLabelText("Default Language"));
+    await user.click(screen.getByRole("option", { name: "de" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      const settings = (
+        vi.mocked(apiConfig.adminSettingsApi.updateApplicationSettings).mock
+          .calls[0]?.[0] as {
+          applicationSettingsUpdateRequest: {
+            settings: Record<string, string>;
+          };
+        }
+      ).applicationSettingsUpdateRequest.settings;
+      expect(settings["general.site_name"]).toBe("Acme");
+      expect(settings["upload.max_file_size_mb"]).toBe("200");
+      expect(settings["general.default_language"]).toBe("de");
+      expect(settings["tracking.enabled"]).toBe("false");
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /Settings saved/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("surfaces a save failure as an error toast", async () => {
+    vi.mocked(
+      apiConfig.adminSettingsApi.listApplicationSettings,
+    ).mockResolvedValue({ data: { settings: SAMPLE_SETTINGS } } as never);
+    vi.mocked(
+      apiConfig.adminSettingsApi.updateApplicationSettings,
+    ).mockRejectedValue(new Error("Conflict: stale value"));
+    const user = userEvent.setup();
+
+    renderWithTheme(<GeneralSection />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site Name")).toBeInTheDocument(),
+    );
+
+    const siteName = screen.getByLabelText("Site Name");
+    await user.clear(siteName);
+    await user.type(siteName, "Acme");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /Conflict: stale value/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/UsersSection.test.tsx
@@ -196,7 +196,9 @@ describe("UsersSection — admin reset password (#450)", () => {
     await waitFor(() => {
       const toasts = useUiStore.getState().toasts;
       expect(
-        toasts.some((t) => t.message && /Reset email sent/i.test(t.message)),
+        toasts.some(
+          (t) => t.message && /Reset email sent/i.test(t.message ?? ""),
+        ),
       ).toBe(true);
     });
     expect(apiConfig.adminUsersApi.adminResetUserPassword).toHaveBeenCalledWith(
@@ -254,9 +256,452 @@ describe("UsersSection — admin reset password (#450)", () => {
       const toasts = useUiStore.getState().toasts;
       expect(
         toasts.some(
-          (t) => t.message && /Failed to reset password/i.test(t.message),
+          (t) => t.message && /Failed to reset password/i.test(t.message ?? ""),
         ),
       ).toBe(true);
     });
+  });
+
+  it("on emailSent=false without a resetUrl shows the defensive error toast", async () => {
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockResolvedValue(
+      {
+        data: { tokenIssued: true, emailSent: false },
+      } as never,
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(findResetButtonForRow("Alice"));
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /no fallback link was returned/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("UsersSection — list / loading / empty states", () => {
+  beforeEach(() => {
+    useUiStore.setState({ toasts: [] });
+    useAuthStore.setState({
+      isAuthenticated: true,
+      userId: CALLER_ID,
+      username: "root",
+      isSuperadmin: true,
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockReset();
+  });
+
+  it("shows a spinner while users are loading", () => {
+    // Never-resolving promise keeps the component in its loading branch.
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockReturnValue(
+      new Promise(() => {}) as never,
+    );
+    renderWithTheme(<UsersSection />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no users", async () => {
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: { content: [], totalElements: 0, page: 0, size: 20, totalPages: 0 },
+    } as never);
+    renderWithTheme(<UsersSection />);
+    expect(await screen.findByText("No users found.")).toBeInTheDocument();
+  });
+
+  it("falls back to empty state when the list request rejects", async () => {
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockRejectedValue(
+      new Error("network"),
+    );
+    renderWithTheme(<UsersSection />);
+    expect(await screen.findByText("No users found.")).toBeInTheDocument();
+  });
+
+  it("renders superadmin and password-change-required badges", async () => {
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: {
+        content: [
+          callerSelf,
+          { ...aliceInternal, passwordChangeRequired: true },
+        ],
+        totalElements: 2,
+        page: 0,
+        size: 20,
+        totalPages: 1,
+      },
+    } as never);
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+    expect(screen.getByText("superadmin")).toBeInTheDocument();
+    expect(screen.getByText("pw change required")).toBeInTheDocument();
+  });
+});
+
+describe("UsersSection — toggle / delete / create", () => {
+  const allUsers = {
+    data: {
+      content: [aliceInternal, bobOidc, callerSelf, carolDisabled],
+      totalElements: 4,
+      page: 0,
+      size: 20,
+      totalPages: 1,
+    },
+  };
+
+  beforeEach(() => {
+    useUiStore.setState({ toasts: [] });
+    useAuthStore.setState({
+      isAuthenticated: true,
+      userId: CALLER_ID,
+      username: "root",
+      isSuperadmin: true,
+    });
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.updateUser).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.deleteUser).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.createUser).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockReset();
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue(
+      allUsers as never,
+    );
+  });
+
+  function toggleForRow(displayName: string): HTMLElement {
+    // The MUI Switch exposes its aria-label on the underlying input.
+    return screen.getByLabelText(`Toggle ${displayName}`);
+  }
+
+  it("toggles a user's enabled state and shows a success toast", async () => {
+    vi.mocked(apiConfig.adminUsersApi.updateUser).mockResolvedValue({
+      data: { ...aliceInternal, enabled: false },
+    } as never);
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(toggleForRow("Alice"));
+
+    expect(apiConfig.adminUsersApi.updateUser).toHaveBeenCalledWith({
+      userId: aliceInternal.id,
+      userUpdateRequest: { enabled: false },
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /"Alice" disabled/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("shows an error toast when the enabled toggle fails", async () => {
+    vi.mocked(apiConfig.adminUsersApi.updateUser).mockRejectedValue(
+      new Error("nope"),
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(toggleForRow("Alice"));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /Failed to update user Alice/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("disables the enabled toggle for superadmins", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() =>
+      expect(screen.getByText("Root Admin")).toBeInTheDocument(),
+    );
+    expect(toggleForRow("Root Admin")).toBeDisabled();
+  });
+
+  function deleteButtonForRow(displayName: string): HTMLElement {
+    const cell = screen.getByText(displayName);
+    const row = cell.closest("tr");
+    if (!row) throw new Error(`No row for ${displayName}`);
+    return within(row).getByRole("button", { name: /^delete$/i });
+  }
+
+  it("deletes a user with a membership warning and shows a success toast", async () => {
+    vi.mocked(apiConfig.adminUsersApi.deleteUser).mockResolvedValue(
+      {} as never,
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(deleteButtonForRow("Alice"));
+    // Alice has namespaceMembershipCount=1 → membership-aware warning.
+    expect(
+      await screen.findByText(/member of 1 namespace/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /delete user/i }));
+
+    expect(apiConfig.adminUsersApi.deleteUser).toHaveBeenCalledWith({
+      userId: aliceInternal.id,
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /"Alice" deleted/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("shows the no-membership delete copy and an error toast on failure", async () => {
+    vi.mocked(apiConfig.adminUsersApi.deleteUser).mockRejectedValue(
+      new Error("boom"),
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Carol")).toBeInTheDocument());
+
+    await user.click(deleteButtonForRow("Carol"));
+    // Carol has 0 memberships → permanent-deletion copy.
+    expect(
+      await screen.findByText(/will be permanently deleted/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /delete user/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) =>
+            /Failed to delete user Carol/i.test(t.message ?? ""),
+          ),
+      ).toBe(true);
+    });
+  });
+
+  it("cancels the delete dialog without calling the API", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Carol")).toBeInTheDocument());
+
+    await user.click(deleteButtonForRow("Carol"));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/will be permanently deleted/i),
+      ).not.toBeInTheDocument(),
+    );
+    expect(apiConfig.adminUsersApi.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("disables the delete button for superadmins", async () => {
+    renderWithTheme(<UsersSection />);
+    await waitFor(() =>
+      expect(screen.getByText("Root Admin")).toBeInTheDocument(),
+    );
+    expect(deleteButtonForRow("Root Admin")).toBeDisabled();
+  });
+
+  it("creates a user from the Add User dialog and shows a success toast", async () => {
+    vi.mocked(apiConfig.adminUsersApi.createUser).mockResolvedValue({
+      data: { ...aliceInternal, displayName: "Dave" },
+    } as never);
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /add user/i }));
+    await user.type(screen.getByLabelText(/username/i), "dave");
+    await user.type(screen.getByLabelText(/email/i), "dave@example.com");
+    await user.type(screen.getByLabelText(/initial password/i), "secret123");
+    await user.click(screen.getByRole("button", { name: /create user/i }));
+
+    expect(apiConfig.adminUsersApi.createUser).toHaveBeenCalledWith({
+      userCreateRequest: {
+        username: "dave",
+        email: "dave@example.com",
+        password: "secret123",
+      },
+    });
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /"Dave" created/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("shows an error toast when user creation fails", async () => {
+    vi.mocked(apiConfig.adminUsersApi.createUser).mockRejectedValue(
+      new Error("dup"),
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /add user/i }));
+    await user.type(screen.getByLabelText(/username/i), "dave");
+    await user.type(screen.getByLabelText(/email/i), "dave@example.com");
+    await user.type(screen.getByLabelText(/initial password/i), "secret123");
+    await user.click(screen.getByRole("button", { name: /create user/i }));
+
+    await waitFor(() => {
+      expect(
+        useUiStore
+          .getState()
+          .toasts.some((t) => /Failed to create user/i.test(t.message ?? "")),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps the Create button disabled until username and password are filled", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /add user/i }));
+    const createButton = screen.getByRole("button", { name: /create user/i });
+    expect(createButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/username/i), "dave");
+    // Still disabled — password is empty.
+    expect(createButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/initial password/i), "secret123");
+    expect(createButton).toBeEnabled();
+  });
+
+  it("changes the page size and refetches with the new size", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("combobox", { name: /users per page/i }));
+    await user.click(screen.getByRole("option", { name: "50" }));
+
+    await waitFor(() => {
+      expect(apiConfig.adminUsersApi.listUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ size: 50, page: 0 }),
+      );
+    });
+  });
+
+  it("advances to the next page and refetches with the new page index", async () => {
+    // totalElements (45) exceeds the page size (20) so the next-page arrow is
+    // enabled and onPageChange can fire.
+    vi.mocked(apiConfig.adminUsersApi.listUsers).mockResolvedValue({
+      data: {
+        content: [aliceInternal, bobOidc, callerSelf, carolDisabled],
+        totalElements: 45,
+        page: 0,
+        size: 20,
+        totalPages: 3,
+      },
+    } as never);
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /next page/i }));
+
+    await waitFor(() => {
+      expect(apiConfig.adminUsersApi.listUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  it("closes the Add User dialog when cancelled", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /add user/i }));
+    expect(
+      screen.getByText(/Create a new local user account/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Create a new local user account/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("dismisses the reset confirmation dialog without resetting", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    const cell = screen.getByText("Alice");
+    const row = cell.closest("tr")!;
+    await user.click(
+      within(row).getByRole("button", { name: /reset password/i }),
+    );
+    expect(
+      await screen.findByText(/Reset password for "Alice"\?/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Reset password for "Alice"\?/i),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      apiConfig.adminUsersApi.adminResetUserPassword,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("closes the manual reset-link dialog after an SMTP-unavailable reset", async () => {
+    vi.mocked(apiConfig.adminUsersApi.adminResetUserPassword).mockResolvedValue(
+      {
+        data: {
+          tokenIssued: true,
+          emailSent: false,
+          resetUrl: "https://plugwerk.example.com/reset-password?token=raw",
+        },
+      } as never,
+    );
+    const user = userEvent.setup();
+    renderWithTheme(<UsersSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    const row = screen.getByText("Alice").closest("tr")!;
+    await user.click(
+      within(row).getByRole("button", { name: /reset password/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    expect(
+      await screen.findByDisplayValue(
+        "https://plugwerk.example.com/reset-password?token=raw",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /close dialog/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByDisplayValue(
+          "https://plugwerk.example.com/reset-password?token=raw",
+        ),
+      ).not.toBeInTheDocument(),
+    );
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerJobsTable.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/scheduler/SchedulerJobsTable.test.tsx
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  screen,
+  within,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SchedulerJobsTable } from "./SchedulerJobsTable";
+import { renderWithTheme } from "../../../test/renderWithTheme";
+import type {
+  SchedulerJobDto,
+  SchedulerJobOutcome,
+} from "../../../api/generated/model";
+
+// SchedulerJobsTable is a pure presentational component — it never touches the
+// API singletons directly (its parent SchedulerSection does). We still mock the
+// module so the import graph stays inert and deterministic.
+vi.mock("../../../api/config", () => ({
+  adminSchedulerApi: {
+    listSchedulerJobs: vi.fn(),
+    updateSchedulerJob: vi.fn(),
+    runSchedulerJobNow: vi.fn(),
+  },
+}));
+
+function jobFixture(overrides: Partial<SchedulerJobDto> = {}): SchedulerJobDto {
+  return {
+    name: "refresh-token-cleanup",
+    description: "Hourly purge of expired refresh tokens.",
+    cronExpression: "0 0 * * * *",
+    supportsDryRun: false,
+    enabled: true,
+    runCountTotal: 0,
+    ...overrides,
+  };
+}
+
+function noopHandlers() {
+  return {
+    onToggleEnabled: vi.fn(),
+    onToggleDryRun: vi.fn(),
+    onRunNow: vi.fn(),
+  };
+}
+
+describe("SchedulerJobsTable — empty state", () => {
+  it("renders the placeholder when there are no jobs", () => {
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[]} busy={false} {...noopHandlers()} />,
+    );
+    expect(
+      screen.getByText("No scheduled jobs registered."),
+    ).toBeInTheDocument();
+    // The table itself must not render in the empty branch.
+    expect(
+      screen.queryByRole("table", { name: /scheduled jobs/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("SchedulerJobsTable — rows and columns", () => {
+  it("renders job name, description, cron chip and total runs", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[
+          jobFixture({
+            runCountTotal: 12345,
+          }),
+        ]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("refresh-token-cleanup")).toBeInTheDocument();
+    expect(
+      screen.getByText("Hourly purge of expired refresh tokens."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("0 0 * * * *")).toBeInTheDocument();
+    // toLocaleString() formats the count — separator is locale-dependent, so
+    // match the digits non-strictly.
+    expect(screen.getByText(/12.?345/)).toBeInTheDocument();
+  });
+
+  it("renders an em-dash for jobs that do not support dry-run", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ supportsDryRun: false })]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    // The dry-run cell shows "—" when supportsDryRun is false; the dry-run
+    // chip (which carries an aria-label) must be absent.
+    expect(
+      screen.queryByRole("button", { name: /toggle .* dry-run/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("SchedulerJobsTable — enabled switch", () => {
+  it("invokes onToggleEnabled with the inverse of the current state", async () => {
+    const user = userEvent.setup();
+    const handlers = noopHandlers();
+    const job = jobFixture({ enabled: true });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...handlers} />,
+    );
+    const toggle = screen.getByRole("switch", {
+      name: /toggle refresh-token-cleanup enabled/i,
+    });
+    await user.click(toggle);
+    expect(handlers.onToggleEnabled).toHaveBeenCalledWith(job, false);
+  });
+
+  it("disables the enabled switch while busy", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture()]}
+        busy={true}
+        {...noopHandlers()}
+      />,
+    );
+    expect(
+      screen.getByRole("switch", { name: /toggle .* enabled/i }),
+    ).toBeDisabled();
+  });
+});
+
+describe("SchedulerJobsTable — DryRunCycle three-state", () => {
+  // The cycle order is `null → true → false → null`. Each render asserts the
+  // visible label, and clicking advances to the next state via onToggleDryRun.
+
+  it("renders the 'default' state (dryRun null) and advances to true on click", async () => {
+    const user = userEvent.setup();
+    const handlers = noopHandlers();
+    const job = jobFixture({ supportsDryRun: true, dryRun: null });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...handlers} />,
+    );
+    expect(screen.getByText("default")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /toggle .* dry-run/i }),
+    );
+    expect(handlers.onToggleDryRun).toHaveBeenCalledWith(job, true);
+  });
+
+  it("renders the 'dry-run' state (dryRun true) and advances to false on click", async () => {
+    const user = userEvent.setup();
+    const handlers = noopHandlers();
+    const job = jobFixture({ supportsDryRun: true, dryRun: true });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...handlers} />,
+    );
+    expect(screen.getByText("dry-run")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /toggle .* dry-run/i }),
+    );
+    expect(handlers.onToggleDryRun).toHaveBeenCalledWith(job, false);
+  });
+
+  it("renders the 'live' state (dryRun false) and advances back to null on click", async () => {
+    const user = userEvent.setup();
+    const handlers = noopHandlers();
+    const job = jobFixture({ supportsDryRun: true, dryRun: false });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...handlers} />,
+    );
+    expect(screen.getByText("live")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /toggle .* dry-run/i }),
+    );
+    expect(handlers.onToggleDryRun).toHaveBeenCalledWith(job, null);
+  });
+
+  it("treats an undefined dryRun the same as null (default state)", () => {
+    const job = jobFixture({ supportsDryRun: true, dryRun: undefined });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...noopHandlers()} />,
+    );
+    expect(screen.getByText("default")).toBeInTheDocument();
+  });
+
+  it("disables the dry-run chip while busy", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ supportsDryRun: true, dryRun: true })]}
+        busy={true}
+        {...noopHandlers()}
+      />,
+    );
+    // A disabled MUI Chip drops the role="button"; assert via aria-label.
+    const chip = screen.getByLabelText(/toggle .* dry-run/i);
+    expect(chip).toHaveAttribute("aria-disabled", "true");
+  });
+});
+
+describe("SchedulerJobsTable — LastRunBadge", () => {
+  it("renders 'Never run' when the job has no recorded outcome", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ lastRunOutcome: null, lastRunAt: null })]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("Never run")).toBeInTheDocument();
+  });
+
+  it("renders 'Never run' when an outcome exists but no timestamp", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ lastRunOutcome: "SUCCESS", lastRunAt: null })]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("Never run")).toBeInTheDocument();
+  });
+
+  it("renders a SUCCESS badge with the duration suffix", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[
+          jobFixture({
+            lastRunOutcome: "SUCCESS",
+            lastRunAt: "2026-05-13T01:00:00Z",
+            lastRunDurationMs: 230,
+          }),
+        ]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("Success")).toBeInTheDocument();
+    expect(screen.getByText(/230 ms/)).toBeInTheDocument();
+  });
+
+  it("omits the duration suffix when durationMs is null", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[
+          jobFixture({
+            lastRunOutcome: "SUCCESS",
+            lastRunAt: "2026-05-13T01:00:00Z",
+            lastRunDurationMs: null,
+          }),
+        ]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("Success")).toBeInTheDocument();
+    expect(screen.queryByText(/\bms\b/)).not.toBeInTheDocument();
+  });
+
+  it("renders a FAILED badge", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[
+          jobFixture({
+            lastRunOutcome: "FAILED",
+            lastRunAt: "2026-05-13T01:00:00Z",
+          }),
+        ]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  // The remaining outcome labels share the "skipped/aborted" icon branch and
+  // exercise the outcomeLabel + paletteFor switch arms.
+  const otherOutcomes: Array<[SchedulerJobOutcome, string]> = [
+    ["SKIPPED_DISABLED", "Disabled"],
+    ["SKIPPED_LOCK", "Locked"],
+    ["ABORTED_LIMIT", "Aborted"],
+  ];
+
+  it.each(otherOutcomes)("renders the %s outcome as '%s'", (outcome, label) => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[
+          jobFixture({
+            lastRunOutcome: outcome,
+            lastRunAt: "2026-05-13T01:00:00Z",
+          }),
+        ]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});
+
+describe("SchedulerJobsTable — run-now confirmation flow", () => {
+  it("disables Run-now when the job is disabled", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ enabled: false })]}
+        busy={false}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+  });
+
+  it("disables Run-now while busy even when the job is enabled", () => {
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ enabled: true })]}
+        busy={true}
+        {...noopHandlers()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+  });
+
+  it("opens the confirm dialog and calls onRunNow on confirm", async () => {
+    // Run-now is wrapped in a Tooltip span with pointer-events: none; bypass
+    // user-event's pointer check, mirroring SchedulerSection.test.tsx.
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const handlers = noopHandlers();
+    const job = jobFixture({ enabled: true });
+    renderWithTheme(
+      <SchedulerJobsTable jobs={[job]} busy={false} {...handlers} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /run now/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/run refresh-token-cleanup now\?/i),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: /run job/i }));
+    expect(handlers.onRunNow).toHaveBeenCalledWith(job);
+  });
+
+  it("closes the confirm dialog without running when cancelled", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const handlers = noopHandlers();
+    renderWithTheme(
+      <SchedulerJobsTable
+        jobs={[jobFixture({ enabled: true })]}
+        busy={false}
+        {...handlers}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /run now/i }));
+    const dialog = await screen.findByRole("dialog");
+    // AppDialog's secondary action is the Cancel button.
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+    // MUI animates the close, so the dialog unmounts asynchronously.
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+    expect(handlers.onRunNow).not.toHaveBeenCalled();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/format.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/format.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, expect, it } from "vitest";
+import { ageBucket, formatBytes } from "./format";
+
+describe("formatBytes", () => {
+  it("renders raw bytes below 1 KiB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("renders kibibytes below 1 MiB", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("renders mebibytes below 1 GiB", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+
+  it("renders gibibytes at and above 1 GiB", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.00 GB");
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe("3.00 GB");
+  });
+});
+
+describe("ageBucket", () => {
+  it("classifies anything under a day as fresh", () => {
+    expect(ageBucket(0)).toBe("fresh");
+    expect(ageBucket(23.9)).toBe("fresh");
+  });
+
+  it("classifies one-day-to-one-week as day", () => {
+    expect(ageBucket(24)).toBe("day");
+    expect(ageBucket(24 * 6)).toBe("day");
+  });
+
+  it("classifies one-week-to-one-month as week", () => {
+    expect(ageBucket(24 * 7)).toBe("week");
+    expect(ageBucket(24 * 29)).toBe("week");
+  });
+
+  it("classifies a month or more as older", () => {
+    expect(ageBucket(24 * 30)).toBe("older");
+    expect(ageBucket(24 * 365)).toBe("older");
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/useTableState.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/storage-consistency/useTableState.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type SortDefinition, useTableState } from "./useTableState";
+
+interface Row {
+  name: string;
+  size: number;
+}
+
+const ROWS: Row[] = [
+  { name: "charlie", size: 30 },
+  { name: "alpha", size: 10 },
+  { name: "bravo", size: 20 },
+  { name: "delta", size: 40 },
+];
+
+const SORTS: SortDefinition<Row>[] = [
+  {
+    key: "name",
+    label: "Name",
+    compare: (a, b) => a.name.localeCompare(b.name),
+    defaultDirection: "asc",
+  },
+  {
+    key: "size",
+    label: "Size",
+    compare: (a, b) => a.size - b.size,
+    defaultDirection: "desc",
+  },
+];
+
+const searchFields = (row: Row) => [row.name];
+
+function setup(overrides?: {
+  sorts?: SortDefinition<Row>[];
+  initialSortKey?: string;
+  initialPageSize?: number;
+}) {
+  return renderHook(() =>
+    useTableState<Row, string>({
+      rows: ROWS,
+      searchFields,
+      sorts: overrides?.sorts ?? SORTS,
+      initialSortKey: overrides?.initialSortKey ?? "name",
+      initialPageSize: overrides?.initialPageSize,
+    }),
+  );
+}
+
+describe("useTableState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sorts ascending by the initial key by default", () => {
+    const { result } = setup();
+    expect(result.current.sortDirection).toBe("asc");
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+      "delta",
+    ]);
+    expect(result.current.filteredCount).toBe(4);
+  });
+
+  it("debounces the query, filters, and resets to the first page", () => {
+    const { result } = setup({ initialPageSize: 2 });
+    act(() => result.current.setPage(1));
+    expect(result.current.page).toBe(1);
+
+    act(() => result.current.setQuery("a"));
+    // Before the debounce fires nothing has changed yet.
+    expect(result.current.filteredCount).toBe(4);
+    act(() => vi.advanceTimersByTime(120));
+
+    expect(result.current.page).toBe(0);
+    expect(result.current.filtered.map((r) => r.name).sort()).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+      "delta",
+    ]);
+  });
+
+  it("narrows results to the matching rows", () => {
+    const { result } = setup();
+    act(() => result.current.setQuery("lph"));
+    act(() => vi.advanceTimersByTime(120));
+    expect(result.current.filtered.map((r) => r.name)).toEqual(["alpha"]);
+  });
+
+  it("toggles direction when the active sort key is toggled", () => {
+    const { result } = setup();
+    act(() => result.current.toggleSort("name"));
+    expect(result.current.sortDirection).toBe("desc");
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "delta",
+      "charlie",
+      "bravo",
+      "alpha",
+    ]);
+  });
+
+  it("switches to a new sort key with its default direction", () => {
+    const { result } = setup();
+    act(() => result.current.toggleSort("size"));
+    expect(result.current.sortKey).toBe("size");
+    expect(result.current.sortDirection).toBe("desc");
+    expect(result.current.pageRows.map((r) => r.size)).toEqual([
+      40, 30, 20, 10,
+    ]);
+  });
+
+  it("paginates and resets the page when the page size changes", () => {
+    const { result } = setup({ initialPageSize: 2 });
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "alpha",
+      "bravo",
+    ]);
+    act(() => result.current.setPage(1));
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "charlie",
+      "delta",
+    ]);
+    act(() => result.current.setPageSize(3));
+    expect(result.current.page).toBe(0);
+    expect(result.current.pageRows).toHaveLength(3);
+  });
+
+  it("honours setSortDirection and setSortKey setters (with page reset)", () => {
+    const { result } = setup({ initialPageSize: 2 });
+    act(() => result.current.setPage(1));
+    act(() => result.current.setSortDirection("desc"));
+    expect(result.current.page).toBe(0);
+    expect(result.current.sortDirection).toBe("desc");
+    act(() => result.current.setPage(1));
+    act(() => result.current.setSortKey("size"));
+    expect(result.current.page).toBe(0);
+    expect(result.current.sortKey).toBe("size");
+  });
+
+  it("falls back to the first sort when the active key is unknown", () => {
+    const { result } = setup({ initialSortKey: "ghost" });
+    // initialDir resolves to 'asc' (no matching sort), and sorted falls back
+    // to sorts[0] (name asc).
+    expect(result.current.sortDirection).toBe("asc");
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+      "delta",
+    ]);
+  });
+
+  it("returns rows unsorted when no sort definitions are supplied", () => {
+    const { result } = setup({ sorts: [], initialSortKey: "name" });
+    expect(result.current.pageRows.map((r) => r.name)).toEqual([
+      "charlie",
+      "alpha",
+      "bravo",
+      "delta",
+    ]);
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/configStore.test.ts
@@ -34,6 +34,7 @@ describe("configStore", () => {
       maxFileSizeMb: 100,
       defaultTimezone: "UTC",
       siteName: "Plugwerk",
+      oidcProviders: [],
       loaded: false,
     });
     vi.mocked(apiConfig.axiosInstance.get).mockReset();
@@ -150,5 +151,97 @@ describe("configStore", () => {
     await useConfigStore.getState().fetchConfig();
 
     expect(useConfigStore.getState().version).toBe("unknown");
+  });
+
+  it("re-fetches when force is passed even though already loaded", async () => {
+    vi.mocked(apiConfig.axiosInstance.get).mockResolvedValue({
+      data: { version: "1.0.0", upload: { maxFileSizeMb: 50 } },
+    });
+
+    await useConfigStore.getState().fetchConfig();
+    await useConfigStore.getState().fetchConfig({ force: true });
+
+    expect(vi.mocked(apiConfig.axiosInstance.get)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("configStore — OIDC provider parsing", () => {
+  beforeEach(() => {
+    useConfigStore.setState({ oidcProviders: [], loaded: false });
+    vi.mocked(apiConfig.axiosInstance.get).mockReset();
+  });
+
+  async function fetchWith(oidcProviders: unknown) {
+    vi.mocked(apiConfig.axiosInstance.get).mockResolvedValue({
+      data: {
+        version: "1.0.0",
+        upload: { maxFileSizeMb: 100 },
+        auth: { oidcProviders },
+      },
+    });
+    await useConfigStore.getState().fetchConfig({ force: true });
+    return useConfigStore.getState().oidcProviders;
+  }
+
+  it("returns an empty list when the payload is not an array", async () => {
+    expect(await fetchWith(undefined)).toEqual([]);
+    expect(await fetchWith({ not: "an array" })).toEqual([]);
+  });
+
+  it("parses a fully-populated provider entry", async () => {
+    const providers = await fetchWith([
+      {
+        id: "gh",
+        name: "GitHub",
+        loginUrl: "/oauth/github",
+        accountPickerLoginUrl: "/oauth/github?prompt=select_account",
+        accountSwitchHintUrl: "https://github.com/logout",
+        iconKind: "github",
+      },
+    ]);
+    expect(providers).toEqual([
+      {
+        id: "gh",
+        name: "GitHub",
+        loginUrl: "/oauth/github",
+        accountPickerLoginUrl: "/oauth/github?prompt=select_account",
+        accountSwitchHintUrl: "https://github.com/logout",
+        iconKind: "github",
+      },
+    ]);
+  });
+
+  it("nulls optional URLs and falls back to oidc icon on unknown/missing fields", async () => {
+    const providers = await fetchWith([
+      {
+        id: "corp",
+        name: "Corp SSO",
+        loginUrl: "/oauth/corp",
+        accountPickerLoginUrl: 42, // non-string -> null
+        // accountSwitchHintUrl missing -> null
+        iconKind: "totally-unknown", // not a known kind -> "oidc"
+      },
+    ]);
+    expect(providers[0].accountPickerLoginUrl).toBeNull();
+    expect(providers[0].accountSwitchHintUrl).toBeNull();
+    expect(providers[0].iconKind).toBe("oidc");
+  });
+
+  it("skips non-object entries and entries missing required string fields", async () => {
+    const providers = await fetchWith([
+      null,
+      "nope",
+      { id: "x", name: "X" }, // missing loginUrl
+      { id: 1, name: "Y", loginUrl: "/y" }, // id not a string
+      {
+        id: "ok",
+        name: "OK",
+        loginUrl: "/ok",
+        iconKind: "google",
+      },
+    ]);
+    expect(providers).toHaveLength(1);
+    expect(providers[0].id).toBe("ok");
+    expect(providers[0].iconKind).toBe("google");
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/timezones.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/timezones.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeOffset,
+  getTimezoneOptions,
+  timezoneAbbreviation,
+} from "./timezones";
+
+// A fixed instant so DST-dependent offsets stay deterministic across runs.
+const WINTER = new Date("2026-01-15T12:00:00Z");
+
+describe("computeOffset", () => {
+  it("returns +00:00 for UTC", () => {
+    expect(computeOffset("UTC", WINTER)).toBe("+00:00");
+  });
+
+  it("returns a positive padded offset for a positive zone", () => {
+    expect(computeOffset("Europe/Berlin", WINTER)).toBe("+01:00");
+  });
+
+  it("returns a negative offset for a western zone", () => {
+    expect(computeOffset("America/New_York", WINTER)).toBe("-05:00");
+  });
+
+  it("renders half-hour offsets with minutes", () => {
+    expect(computeOffset("Asia/Kolkata", WINTER)).toBe("+05:30");
+  });
+
+  it("falls back to +00:00 for an unknown identifier", () => {
+    expect(computeOffset("Not/AZone", WINTER)).toBe("+00:00");
+  });
+});
+
+describe("timezoneAbbreviation", () => {
+  it("returns the short name for a real zone", () => {
+    expect(timezoneAbbreviation("UTC", WINTER)).toBe("UTC");
+  });
+
+  it("echoes the identifier back when the zone is invalid", () => {
+    expect(timezoneAbbreviation("Bogus/Zone", WINTER)).toBe("Bogus/Zone");
+  });
+});
+
+describe("getTimezoneOptions", () => {
+  it("enriches each id with region, city, offset and a label", () => {
+    const options = getTimezoneOptions(WINTER);
+    const berlin = options.find((o) => o.id === "Europe/Berlin");
+    expect(berlin).toBeDefined();
+    expect(berlin!.region).toBe("Europe");
+    expect(berlin!.city).toBe("Berlin");
+    expect(berlin!.label).toBe("Europe/Berlin (UTC+01:00)");
+  });
+
+  it("treats slash-less ids (UTC) as region Etc with the id as the city", () => {
+    const options = getTimezoneOptions(WINTER);
+    const utc = options.find((o) => o.id === "UTC");
+    expect(utc).toBeDefined();
+    expect(utc!.region).toBe("Etc");
+    expect(utc!.city).toBe("UTC");
+  });
+
+  it("always surfaces the explicitly-included UTC / Etc zones", () => {
+    const ids = getTimezoneOptions(WINTER).map((o) => o.id);
+    expect(ids).toContain("UTC");
+    expect(ids).toContain("Etc/UTC");
+    expect(ids).toContain("Etc/GMT");
+  });
+
+  it("returns ids sorted alphabetically", () => {
+    const ids = getTimezoneOptions(WINTER).map((o) => o.id);
+    const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+    expect(ids).toEqual(sorted);
+  });
+
+  it("formats multi-segment cities by replacing underscores and slashes", () => {
+    const options = getTimezoneOptions(WINTER);
+    const ba = options.find((o) => o.id === "America/Argentina/Buenos_Aires");
+    // Only present in the fallback list, but most runtimes expose it too.
+    if (ba) {
+      expect(ba.city).toBe("Argentina / Buenos Aires");
+    }
+  });
+});
+
+describe("getTimezoneOptions — runtime capability fallbacks", () => {
+  // Cast to a shape where `supportedValuesOf` is optional so it can be deleted;
+  // the lib's `typeof Intl` declares it required, which blocks `delete`.
+  const intl = Intl as unknown as {
+    supportedValuesOf?: (key: "timeZone") => string[];
+  };
+  const original = intl.supportedValuesOf;
+
+  afterEach(() => {
+    if (original) {
+      intl.supportedValuesOf = original;
+    } else {
+      delete intl.supportedValuesOf;
+    }
+  });
+
+  it("uses the bundled fallback list when supportedValuesOf is absent", () => {
+    delete intl.supportedValuesOf;
+    const ids = getTimezoneOptions(WINTER).map((o) => o.id);
+    expect(ids).toContain("Europe/Berlin");
+    expect(ids).toContain("UTC");
+  });
+
+  it("uses the bundled fallback list when supportedValuesOf throws", () => {
+    intl.supportedValuesOf = vi.fn(() => {
+      throw new Error("not supported");
+    });
+    const ids = getTimezoneOptions(WINTER).map((o) => o.id);
+    expect(ids).toContain("Asia/Tokyo");
+    expect(intl.supportedValuesOf).toHaveBeenCalled();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/vitest.config.ts
+++ b/plugwerk-server/plugwerk-server-frontend/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
+    // The default 5s per-test timeout is too tight for the heavier
+    // `@testing-library/user-event` flows (multi-field dialogs, several
+    // `await user.type(...)` + `waitFor` round-trips) once they run on a
+    // slower, contended CI runner — they pass locally but time out in CI.
+    // 15s gives comfortable headroom without masking genuine hangs (DEV-44).
+    testTimeout: 15000,
     // `@mui/material` re-exports `react-transition-group@4`, which ships CJS
     // with an extensionless directory import (`.../TransitionGroupContext`)
     // and no `exports` map. Vitest externalises both by default, and Node's


### PR DESCRIPTION
## Summary

Closes **DEV-44** (split from DEV-29 ask 4). The frontend Vitest suite was green
again after #574, but coverage sat below the project's own 80% thresholds in
`vitest.config.ts`, so `npm run test:coverage` failed the threshold gate.
Branches (+12 pts needed) was the binding constraint.

This PR adds focused tests across the biggest gaps and wires the
threshold-enforced coverage run into the Gradle frontend `check` task so coverage
can no longer silently regress.

## Coverage (v8), before → after

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Lines | 73.67% | **88.27%** | 80% ✅ |
| Branches | 67.93% | **82.37%** | 80% ✅ |
| Functions | 72.74% | **86.19%** | 80% ✅ |
| Statements | 72.59% | **86.84%** | — |

Suite: **53 files / 438 tests → 62 files / 664 tests**, all green. No production
source changed — tests only (plus build wiring).

## Tests added / extended

- **api**: `config.ts` interceptors (401 refresh-retry, all branches), `hooks/useNamespaces`
- **stores**: `configStore` OIDC-provider parsing + `force` refetch
- **hooks**: `useUploadFiles`, `useMailTemplatePreview`
- **utils**: `timezones`, storage-consistency `format` + `useTableState`
- **components**: `TimezoneSelect`, `catalog/FilterBar`, `plugin-detail/VersionsTab`, `namespace-detail/MembersSection`
- **pages**: `EmailServerPage`, `EmailTemplateEditPage`, `GeneralSection`, `UsersSection`, `CatalogPage`, `scheduler/SchedulerJobsTable`

## Gradle gate (done-when #2)

- Replaced the `test:run` gate from #574 with `test:coverage` (task renamed
  `npmTest` → `npmCoverage`), still attached to `check`. `./gradlew build` (CI)
  now enforces both the suite **and** the ≥80% lines/branches/functions
  thresholds.
- Added `coverage/` to `.prettierignore` so the new coverage output dir can't
  trip `format:check`.

## Test plan

- [x] `npm run test:coverage` → exit 0, 664/664 passing, all thresholds met
- [x] `npm run lint` → exit 0 (0 errors)
- [x] `npm run format:check` → clean
- [x] Rebased onto current `main` (post-#574); diff is tests + build wiring only

🤖 Generated with [Claude Code](https://claude.com/claude-code)