### PR TITLE
docs: renumber duplicate ADR-0038 telemetry to ADR-0039 (DEV-51)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,7 +190,7 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # in-memory DB without the shedlock table.
 # PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED=true
 
-# --- Telemetry beacon (ADR-0038) ---
+# --- Telemetry beacon (ADR-0039) ---
 # Opt-out, zero-PII install beacon: {installId, version, installType, event} on
 # first start + once daily. See the "Telemetry & Privacy" section of README.md.
 # Set to false to fully disable (no install UUID, no schedule, no HTTP).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Plugwerk sends a small, **opt-out**, privacy-respecting telemetry beacon so the 
 | `installType` | `docker-compose` | How it is deployed: `docker-compose`, `jar`, `k8s`, or `unknown`. |
 | `event` | `server_start` | `server_start` or `heartbeat`. |
 
-**No** hostnames, IP addresses, namespaces, usernames, plugin names, or request data are ever collected. The payload is the four fields above and there is no code path that adds a fifth — see [ADR-0038](docs/adrs/0038-telemetry-beacon.md).
+**No** hostnames, IP addresses, namespaces, usernames, plugin names, or request data are ever collected. The payload is the four fields above and there is no code path that adds a fifth — see [ADR-0039](docs/adrs/0039-telemetry-beacon.md).
 
 It is **fail-open**: the beacon runs off the startup and request paths with short timeouts, and any failure (unreachable endpoint, timeout, error response) is silently ignored. Telemetry can never affect startup, health, or readiness.
 

--- a/docs/adrs/0039-telemetry-beacon.md
+++ b/docs/adrs/0039-telemetry-beacon.md
@@ -1,4 +1,4 @@
-# ADR-0038: Opt-out telemetry beacon
+# ADR-0039: Opt-out telemetry beacon
 
 ## Status
 

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -54,7 +54,7 @@ data class PlugwerkProperties(
     val telemetry: TelemetryProperties = TelemetryProperties(),
 ) {
     /**
-     * Opt-out telemetry-beacon configuration (`plugwerk.telemetry.*`) — DEV-23 / ADR-0038.
+     * Opt-out telemetry-beacon configuration (`plugwerk.telemetry.*`) — DEV-23 / ADR-0039.
      *
      * The beacon sends a strictly zero-PII install heartbeat (install UUID, version,
      * install type, event) on first server start and once per day. It is **opt-out**:

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/settings/ApplicationSettingKey.kt
@@ -226,7 +226,7 @@ enum class ApplicationSettingKey(
         maxInt = 1440,
     ),
 
-    // ---- Telemetry (DEV-23 / ADR-0038) -------------------------------------
+    // ---- Telemetry (DEV-23 / ADR-0039) -------------------------------------
     // Anonymous random UUID v4 identifying this installation in the opt-out
     // telemetry beacon. Generated once on the first beacon send and persisted
     // here; blank (the default) until then. Carries **no** personal data — it

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySender.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySender.kt
@@ -28,7 +28,7 @@ import java.time.Duration
 
 /**
  * Sends the telemetry payload over HTTPS to the configured, Plugwerk-owned
- * endpoint (DEV-23 / ADR-0038).
+ * endpoint (DEV-23 / ADR-0039).
  *
  * Two guards keep this fail-open and safe:
  *  - **Short timeouts** ([CONNECT_TIMEOUT] / [READ_TIMEOUT]) cap the worst-case

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallIdProvider.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallIdProvider.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 
 /**
  * Supplies the stable, anonymous install identifier used by the telemetry
- * beacon (DEV-23 / ADR-0038).
+ * beacon (DEV-23 / ADR-0039).
  *
  * Extracted as an interface so the orchestrating [TelemetryBeacon] can be
  * unit-tested with a recording fake — the opt-out test asserts that a disabled

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallType.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/InstallType.kt
@@ -20,7 +20,7 @@ package io.plugwerk.server.service.telemetry
 
 /**
  * How this Plugwerk installation is being run, as reported by the opt-out
- * telemetry beacon (DEV-23 / ADR-0038).
+ * telemetry beacon (DEV-23 / ADR-0039).
  *
  * The [wireValue] is the only form that ever leaves the process — the payload
  * carries the lowercase, hyphenated string, never the enum constant name. The

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeacon.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 /**
- * Orchestrates the opt-out telemetry beacon (DEV-23 / ADR-0038): builds the
+ * Orchestrates the opt-out telemetry beacon (DEV-23 / ADR-0039): builds the
  * zero-PII payload and hands it to the [TelemetrySender], gated by the global
  * opt-out and wrapped fail-open.
  *

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryHeartbeatScheduler.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryHeartbeatScheduler.kt
@@ -31,7 +31,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 /**
- * Daily telemetry heartbeat (DEV-23 / ADR-0038).
+ * Daily telemetry heartbeat (DEV-23 / ADR-0039).
  *
  * `@ConditionalOnProperty`-gated on `plugwerk.telemetry.enabled` so that an
  * opted-out installation registers **no** schedule at all (the strongest reading

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetector.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetector.kt
@@ -25,7 +25,7 @@ import java.nio.file.Path
 
 /**
  * Resolves how this installation is being run, for the telemetry payload's
- * `installType` field (DEV-23 / ADR-0038).
+ * `installType` field (DEV-23 / ADR-0039).
  *
  * Resolution order:
  *  1. **Operator override** — `PLUGWERK_INSTALL_TYPE` (bound to

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayload.kt
@@ -19,7 +19,7 @@
 package io.plugwerk.server.service.telemetry
 
 /**
- * The lifecycle event a [TelemetryPayload] reports (DEV-23 / ADR-0038).
+ * The lifecycle event a [TelemetryPayload] reports (DEV-23 / ADR-0039).
  *
  * Only the [wireValue] is serialized; the enum constant name never leaves the
  * process.
@@ -47,7 +47,7 @@ enum class TelemetryEvent(val wireValue: String) {
 }
 
 /**
- * The complete, zero-PII telemetry payload (DEV-23 / ADR-0038).
+ * The complete, zero-PII telemetry payload (DEV-23 / ADR-0039).
  *
  * This data class **is** the allowlist: Jackson serializes exactly these four
  * camelCase fields and nothing else. There is deliberately no place to attach a

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetrySender.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/service/telemetry/TelemetrySender.kt
@@ -19,7 +19,7 @@
 package io.plugwerk.server.service.telemetry
 
 /**
- * Transport seam for the telemetry beacon (DEV-23 / ADR-0038).
+ * Transport seam for the telemetry beacon (DEV-23 / ADR-0039).
  *
  * Pulled out as an interface for one reason above all: the fail-open acceptance
  * criterion requires a test that injects a *failing* sender and proves the

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -150,7 +150,7 @@ plugwerk:
       # Env: PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED
       enabled: ${PLUGWERK_SCHEDULER_SHEDLOCK_ENABLED:true}
 
-  # Opt-out telemetry beacon (ADR-0038). Sends a strictly zero-PII install
+  # Opt-out telemetry beacon (ADR-0039). Sends a strictly zero-PII install
   # heartbeat — {installId, version, installType, event} and nothing else — on
   # first server start and once per day, so the Plugwerk team can size the
   # activation funnel. No hostnames, IPs, namespaces, or user data are ever

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0036_seed_telemetry_install_id.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0036_seed_telemetry_install_id.yaml
@@ -1,5 +1,5 @@
 # Seed the telemetry install-id setting registered in ApplicationSettingKey
-# (DEV-23 / ADR-0038). The value is intentionally empty: the install UUID is
+# (DEV-23 / ADR-0039). The value is intentionally empty: the install UUID is
 # generated lazily on the first telemetry beacon send and written back to this
 # row. Seeding the row (rather than relying on the enum default fallback) keeps
 # the Admin → Settings list source-consistent (DATABASE, not DEFAULT) with every
@@ -24,7 +24,7 @@ databaseChangeLog:
                   value: ""
               - column:
                   name: setting_desc
-                  value: "Anonymous random UUID v4 identifying this installation in the opt-out telemetry beacon (ADR-0038). Generated on the first beacon send; blank until then. Contains no personal data. Disable telemetry entirely with PLUGWERK_TELEMETRY=false."
+                  value: "Anonymous random UUID v4 identifying this installation in the opt-out telemetry beacon (ADR-0039). Generated on the first beacon send; blank until then. Contains no personal data. Disable telemetry entirely with PLUGWERK_TELEMETRY=false."
               - column:
                   name: value_type
                   value: STRING

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0037_add_namespace_first_published.yaml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/db/changelog/migrations/0037_add_namespace_first_published.yaml
@@ -1,5 +1,5 @@
 # Add nullable namespace.first_published_at for the P1 activation telemetry
-# (DEV-24 / ADR-0038). It is the gate behind the `first_plugin_publish` event:
+# (DEV-24 / ADR-0039). It is the gate behind the `first_plugin_publish` event:
 # the column is stamped exactly once per namespace, by the atomic conditional
 # UPDATE in NamespaceRepository.markFirstPublishedIfAbsent
 # (`... WHERE first_published_at IS NULL`), and the event is emitted only when
@@ -16,7 +16,7 @@
 # Privacy: the column holds a coarse activation timestamp only — no namespace
 # name, plugin name, or user identifier. It is never serialized into the
 # telemetry payload (which stays {installId, version, installType, event}); it
-# lives server-side purely to gate the event. See ADR-0038.
+# lives server-side purely to gate the event. See ADR-0039.
 
 databaseChangeLog:
   - changeSet:

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconIT.kt
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 /**
- * Fail-open integration check (DEV-23 / ADR-0038, acceptance criterion 3).
+ * Fail-open integration check (DEV-23 / ADR-0039, acceptance criterion 3).
  *
  * Telemetry is **enabled** and pointed at a deliberately broken HTTPS endpoint
  * (a closed local port). The first-start beacon fires on `ApplicationReadyEvent`

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryBeaconTest.kt
@@ -25,7 +25,7 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 
 /**
- * Unit tests for the two hard constraints the beacon owns (DEV-23 / ADR-0038):
+ * Unit tests for the two hard constraints the beacon owns (DEV-23 / ADR-0039):
  * the **opt-out gate** (disabled ⇒ no UUID, no send) and **fail-open** (a
  * throwing sender never propagates). Hand-written fakes keep the seams explicit.
  */

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryDisabledIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryDisabledIT.kt
@@ -29,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 
 /**
- * Opt-out integration check (DEV-23 / ADR-0038, acceptance criterion 1).
+ * Opt-out integration check (DEV-23 / ADR-0039, acceptance criterion 1).
  *
  * With `PLUGWERK_TELEMETRY=false` (here as `plugwerk.telemetry.enabled=false`):
  *  - **No schedule** — the `@ConditionalOnProperty`-gated heartbeat scheduler

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallIdProviderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallIdProviderTest.kt
@@ -31,7 +31,7 @@ import org.mockito.kotlin.whenever
 import java.util.UUID
 
 /**
- * Unit tests for the lazy, DB-backed install-id provider (DEV-23 / ADR-0038).
+ * Unit tests for the lazy, DB-backed install-id provider (DEV-23 / ADR-0039).
  */
 class TelemetryInstallIdProviderTest {
 

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetectorTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryInstallTypeDetectorTest.kt
@@ -23,7 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 /**
- * Unit tests for install-type resolution (DEV-23 / ADR-0038). The env-var and
+ * Unit tests for install-type resolution (DEV-23 / ADR-0039). The env-var and
  * docker-marker probes are stubbed so the four-step resolution order can be
  * exercised deterministically without touching the real environment.
  */

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/TelemetryPayloadBuilderTest.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Contract tests for the telemetry payload allowlist (DEV-23 / ADR-0038).
+ * Contract tests for the telemetry payload allowlist (DEV-23 / ADR-0039).
  *
  * The single invariant that must never regress: a serialized payload carries
  * **exactly** `installId`, `version`, `installType`, `event` — no PII field can


### PR DESCRIPTION
## Summary

Two ADRs on `main` shared the index number **0038**, breaking the monotonic ADR sequence:

- `docs/adrs/0038-phase2-auth-and-rbac.md` — renumbered from ADR-0006 in #569
- `docs/adrs/0038-telemetry-beacon.md` — added later in DEV-23 / #572

The phase2-auth ADR keeps the canonical **0038** anchor (it claimed the number first and is already cross-referenced from `0006-auth-strategy.md`). The telemetry beacon ADR (added later, per the issue's recommendation) moves to the next free number, **0039**. ADR status (`Accepted`) is preserved.

## Changes

- `git mv docs/adrs/0038-telemetry-beacon.md → 0039-telemetry-beacon.md` and updated its title heading.
- Updated every cross-reference to the telemetry ADR:
  - README "Telemetry & Privacy" link (label **and** path)
  - `.env.example`, `application.yml`
  - 2 Liquibase migration comment headers
  - KDoc headers across the telemetry service + test sources
- **Intentionally left untouched:** the `ADR-0036` (scheduler-control-plane) cross-reference inside the telemetry ADR, and the `ADR-0038` / `ADR-0006` anchors for phase2-auth.

Doc/comment-only change — no logic affected.

## Verification

- `git grep "ADR-0038"` (excluding the auth ADR + `0006`) → empty ✅
- `git grep "0038-telemetry-beacon"` → empty ✅
- Auth `ADR-0038` anchors + `0006` cross-ref preserved ✅
- `ADR-0036` cross-ref in the telemetry ADR preserved ✅
- Diff is 22 files, 25/25 lines, all single-token `ADR-0038`→`ADR-0039` swaps; no non-ADR line changed.

Closes DEV-51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)