### PR TITLE
fix(test): add missing activationTelemetry arg to PluginReleaseService branch-coverage test (DEV-52)

### DIFF
--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceBranchCoverageTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/PluginReleaseServiceBranchCoverageTest.kt
@@ -30,6 +30,7 @@ import io.plugwerk.server.repository.PluginReleaseRepository
 import io.plugwerk.server.repository.PluginRepository
 import io.plugwerk.server.service.settings.ApplicationSettingsService
 import io.plugwerk.server.service.storage.ArtifactStorageService
+import io.plugwerk.server.service.telemetry.ActivationTelemetry
 import io.plugwerk.spi.model.ReleaseStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -75,6 +76,8 @@ class PluginReleaseServiceBranchCoverageTest {
 
     @Mock lateinit var downloadEventService: DownloadEventService
 
+    @Mock lateinit var activationTelemetry: ActivationTelemetry
+
     lateinit var releaseService: PluginReleaseService
 
     private val namespaceId = UUID.fromString("00000000-0000-0000-0000-000000000001")
@@ -96,6 +99,7 @@ class PluginReleaseServiceBranchCoverageTest {
             ObjectMapper(),
             settingsService,
             downloadEventService,
+            activationTelemetry,
         )
     }
 


### PR DESCRIPTION
## Summary

`origin/main` (HEAD `b1c1d95`) does **not compile its backend test sources** — every backend PR's `build` check is currently red:

```
e: PluginReleaseServiceBranchCoverageTest.kt:98:13 No value passed for parameter 'activationTelemetry'.
> Task :plugwerk-server:plugwerk-server-backend:compileTestKotlin FAILED
```

### Root cause — semantic merge conflict
- #577 (DEV-24, `978336c`) added a required `activationTelemetry: ActivationTelemetry` parameter to the `PluginReleaseService` constructor.
- #576 (DEV-42, `b1c1d95`, current HEAD) added `PluginReleaseServiceBranchCoverageTest`, which constructs the service with the **old 8-arg signature**.

Both PRs were green independently; #576 merged after #577 without a rebase, so `main` is broken when combined. Discovered while landing DEV-51 (ADR doc hygiene).

## Fix

Mirror the already-correct `PluginReleaseServiceTest`:
- add `import io.plugwerk.server.service.telemetry.ActivationTelemetry`
- add `@Mock lateinit var activationTelemetry: ActivationTelemetry`
- pass `activationTelemetry` as the 9th constructor argument

## Verification

- `./gradlew :plugwerk-server:plugwerk-server-backend:compileTestKotlin -x spotlessCheck` → **BUILD SUCCESSFUL**
- `spotlessApply` produces no further changes (formatting clean)
- Diff is 3 lines, test-only; no production code touched

Fixes the `main` build. Tracking issue: DEV-52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)