### PR TITLE
test: expand unit, integration and smoke coverage across the stack

### DIFF
--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkExceptionTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/PlugwerkExceptionTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.client
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the message formatting and field exposure of the SDK exception
+ * hierarchy. These messages and fields are part of the contract SDK consumers
+ * see when handling failures, so their shape must not drift silently.
+ */
+class PlugwerkExceptionTest {
+
+    @Test
+    fun `base exception carries message and optional cause`() {
+        val cause = IllegalStateException("boom")
+        val ex = PlugwerkException("something failed", cause)
+
+        assertEquals("something failed", ex.message)
+        assertSame(cause, ex.cause)
+    }
+
+    @Test
+    fun `base exception cause defaults to null`() {
+        assertNull(PlugwerkException("no cause").cause)
+    }
+
+    @Test
+    fun `api exception formats status code into message and exposes it`() {
+        val ex = PlugwerkApiException(500, "Internal Server Error")
+
+        assertEquals(500, ex.statusCode)
+        assertEquals("HTTP 500: Internal Server Error", ex.message)
+    }
+
+    @Test
+    fun `auth exception formats status code into message and exposes it`() {
+        val ex = PlugwerkAuthException(401, "invalid api key")
+
+        assertEquals(401, ex.statusCode)
+        assertEquals("Auth error HTTP 401: invalid api key", ex.message)
+    }
+
+    @Test
+    fun `not-found exception formats the url into the message and exposes it`() {
+        val ex = PlugwerkNotFoundException("plugins/io.example.plugin")
+
+        assertEquals("plugins/io.example.plugin", ex.url)
+        assertEquals("Resource not found: plugins/io.example.plugin", ex.message)
+    }
+}

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/internal/DtoMappersTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/internal/DtoMappersTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.client.internal
+
+import io.plugwerk.api.model.PluginReleaseDto
+import io.plugwerk.spi.model.ReleaseStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import java.util.UUID
+
+/**
+ * Unit tests for the internal DTO → SPI mappers in `DtoMappers.kt`.
+ *
+ * The higher-level catalog/updater tests exercise these mappers only through the
+ * `published` JSON path; this test locks the full field-mapping contract and
+ * every branch of the status mapping directly.
+ */
+class DtoMappersTest {
+
+    private fun dto(
+        status: PluginReleaseDto.Status = PluginReleaseDto.Status.PUBLISHED,
+        artifactSha256: String? = "a".repeat(64),
+        requiresSystemVersion: String? = ">=2.0.0",
+    ) = PluginReleaseDto(
+        id = UUID.randomUUID(),
+        pluginId = "io.example.my-plugin",
+        version = "1.2.3",
+        status = status,
+        artifactSha256 = artifactSha256,
+        requiresSystemVersion = requiresSystemVersion,
+    )
+
+    @Test
+    fun `toReleaseInfo copies all mapped fields`() {
+        val info = dto().toReleaseInfo()
+
+        assertEquals("io.example.my-plugin", info.pluginId)
+        assertEquals("1.2.3", info.version)
+        assertEquals("a".repeat(64), info.artifactSha256)
+        assertEquals(">=2.0.0", info.requiresSystemVersion)
+        assertEquals(ReleaseStatus.PUBLISHED, info.status)
+    }
+
+    @Test
+    fun `toReleaseInfo leaves downloadUrl null - it is not part of the release DTO`() {
+        // The download URL is resolved separately via PlugwerkCatalog.getPluginRelease;
+        // the mapper must never fabricate one, otherwise consumers could try to
+        // download from a null/blank URL.
+        assertNull(dto().toReleaseInfo().downloadUrl)
+    }
+
+    @Test
+    fun `toReleaseInfo preserves null artifactSha256 as unverified`() {
+        val info = dto(artifactSha256 = null).toReleaseInfo()
+        assertNull(info.artifactSha256)
+    }
+
+    @Test
+    fun `toReleaseInfo preserves null requiresSystemVersion as no constraint`() {
+        val info = dto(requiresSystemVersion = null).toReleaseInfo()
+        assertNull(info.requiresSystemVersion)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "DRAFT, DRAFT",
+        "PUBLISHED, PUBLISHED",
+        "DEPRECATED, DEPRECATED",
+        "YANKED, YANKED",
+    )
+    fun `toReleaseStatus maps every DTO status to its SPI counterpart`(
+        dtoStatus: PluginReleaseDto.Status,
+        expected: ReleaseStatus,
+    ) {
+        assertEquals(expected, dtoStatus.toReleaseStatus())
+        assertEquals(expected, dto(status = dtoStatus).toReleaseInfo().status)
+    }
+}

--- a/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/EntryNameValidationTest.kt
+++ b/plugwerk-descriptor/src/test/kotlin/io/plugwerk/descriptor/EntryNameValidationTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.descriptor
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Security tests for [validateEntryName], the Zip-Slip / path-traversal
+ * guard applied to every JAR entry inside an uploaded ZIP bundle.
+ *
+ * The function is the last line of defence before entry bytes are read, so
+ * its accept/reject contract is verified directly here rather than only
+ * through the higher-level [DescriptorResolver] paths. It rejects two shapes:
+ *  - `..` path-traversal segments (escape the extraction root)
+ *  - embedded NUL bytes (can truncate paths in native / filesystem calls)
+ * Everything else — including spaces — is a legitimate archive entry name.
+ */
+class EntryNameValidationTest {
+
+    /** A single NUL byte, spelled out to keep it visible in source. */
+    private val nul = '\u0000'
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "plugin.jar",
+            "META-INF/MANIFEST.MF",
+            "nested/dir/plugin.properties",
+            "io.example.my-plugin-1.0.0.jar",
+            "a.jar",
+            // Spaces are legitimate in archive entry names and must be accepted;
+            // only `..` traversal and NUL bytes are rejected.
+            "My Plugin.jar",
+        ],
+    )
+    fun `accepts safe entry names`(name: String) {
+        assertDoesNotThrow { validateEntryName(name) }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "../evil.jar",
+            "../../etc/passwd",
+            "nested/../../escape.jar",
+            "foo/..",
+            "..",
+        ],
+    )
+    fun `rejects path-traversal entry names`(name: String) {
+        val ex = assertThrows<IllegalArgumentException> { validateEntryName(name) }
+        assertEquals("Suspicious JAR entry name: $name", ex.message)
+    }
+
+    @Test
+    fun `rejects an entry name with an embedded NUL byte`() {
+        // A NUL byte can truncate a path in native / filesystem calls, sneaking
+        // bytes past extension checks — the guard rejects it outright.
+        val name = "plugin$nul.jar"
+        val ex = assertThrows<IllegalArgumentException> { validateEntryName(name) }
+        assertEquals("Suspicious JAR entry name: $name", ex.message)
+    }
+
+    @Test
+    fun `rejects a NUL byte at the end of an otherwise safe name`() {
+        val name = "META-INF/MANIFEST.MF$nul"
+        assertThrows<IllegalArgumentException> { validateEntryName(name) }
+    }
+
+    @Test
+    fun `rejection message names the offending entry`() {
+        val ex = assertThrows<IllegalArgumentException> { validateEntryName("../../secret") }
+        assertEquals("Suspicious JAR entry name: ../../secret", ex.message)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/domain/FileFormatTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/domain/FileFormatTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class FileFormatTest {
+
+    @Test
+    fun `zip extension resolves to ZIP`() {
+        assertThat(FileFormat.fromExtension("zip")).isEqualTo(FileFormat.ZIP)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ZIP", "Zip", "zIp"])
+    fun `extension matching is case-insensitive`(extension: String) {
+        assertThat(FileFormat.fromExtension(extension)).isEqualTo(FileFormat.ZIP)
+    }
+
+    @Test
+    fun `jar extension resolves to JAR`() {
+        assertThat(FileFormat.fromExtension("jar")).isEqualTo(FileFormat.JAR)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["jar", "war", "tar", "", "unknown"])
+    fun `unrecognized extensions default to JAR`(extension: String) {
+        assertThat(FileFormat.fromExtension(extension)).isEqualTo(FileFormat.JAR)
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -151,9 +151,104 @@ class SmokeTest {
         kotlin.test.assertEquals(expectedSha256, actualSha256, "SHA-256 of downloaded artifact must match uploaded JAR")
     }
 
+    @Test
+    fun `review approval and rejection flow`() {
+        val authHeader = "Bearer $token"
+        val reviewNs = "smoke-review"
+
+        // ------------------------------------------------------------------ //
+        // 1. Create a namespace that requires manual review                    //
+        // ------------------------------------------------------------------ //
+        mockMvc.post("/api/v1/namespaces") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("slug" to reviewNs, "name" to "Smoke Review", "autoApproveReleases" to false),
+            )
+        }.andExpect {
+            status { isCreated() }
+        }
+
+        // ------------------------------------------------------------------ //
+        // 2. Upload a release — with auto-approve off it lands in `draft`      //
+        //    and must surface in the pending review queue                      //
+        // ------------------------------------------------------------------ //
+        val approveId = "review-approve-plugin"
+        val approveReleaseId = uploadRelease(reviewNs, approveId, "1.0.0", authHeader)
+
+        mockMvc.get("/api/v1/namespaces/$reviewNs/reviews/pending") {
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.releaseId == '$approveReleaseId')]").exists()
+            jsonPath("$[?(@.pluginId == '$approveId')]").exists()
+        }
+
+        // ------------------------------------------------------------------ //
+        // 3. Approve — the release transitions to `published`                  //
+        // ------------------------------------------------------------------ //
+        mockMvc.post("/api/v1/namespaces/$reviewNs/reviews/$approveReleaseId/approve") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(mapOf("comment" to "Reviewed and approved."))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.status") { value("published") }
+        }
+
+        // …and it is no longer pending
+        mockMvc.get("/api/v1/namespaces/$reviewNs/reviews/pending") {
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.releaseId == '$approveReleaseId')]").doesNotExist()
+        }
+
+        // ------------------------------------------------------------------ //
+        // 4. Reject path — a second release is yanked out of the queue         //
+        // ------------------------------------------------------------------ //
+        val rejectId = "review-reject-plugin"
+        val rejectReleaseId = uploadRelease(reviewNs, rejectId, "1.0.0", authHeader)
+
+        mockMvc.post("/api/v1/namespaces/$reviewNs/reviews/$rejectReleaseId/reject") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(mapOf("comment" to "Rejected during smoke test."))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.status") { value("yanked") }
+        }
+
+        mockMvc.get("/api/v1/namespaces/$reviewNs/reviews/pending") {
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$[?(@.releaseId == '$rejectReleaseId')]").doesNotExist()
+        }
+    }
+
     // ----------------------------------------------------------------------- //
     // Helpers                                                                   //
     // ----------------------------------------------------------------------- //
+
+    /** Uploads a minimal plugin JAR to [ns] and returns the created release id. */
+    private fun uploadRelease(ns: String, pluginId: String, version: String, authHeader: String): String {
+        val artifact = MockMultipartFile(
+            "artifact",
+            "$pluginId-$version.jar",
+            "application/java-archive",
+            buildMinimalJar(pluginId, version),
+        )
+        val result = mockMvc.multipart("/api/v1/namespaces/$ns/plugin-releases") {
+            file(artifact)
+            header("Authorization", authHeader)
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id").exists()
+        }.andReturn()
+        val body = objectMapper.readValue(result.response.contentAsString, Map::class.java)
+        return body["id"] as String
+    }
 
     private fun buildMinimalJar(id: String, version: String): ByteArray {
         val manifest = java.util.jar.Manifest().apply {

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/SmokeTest.kt
@@ -227,6 +227,53 @@ class SmokeTest {
         }
     }
 
+    @Test
+    fun `update-check reports a newer published version`() {
+        val authHeader = "Bearer $token"
+        val updateNs = "smoke-updates"
+        val updatePlugin = "update-plugin"
+
+        // Auto-approve on → both uploads are immediately `published`, which is
+        // the only status the update checker considers.
+        mockMvc.post("/api/v1/namespaces") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("slug" to updateNs, "name" to "Smoke Updates", "autoApproveReleases" to true),
+            )
+        }.andExpect {
+            status { isCreated() }
+        }
+
+        uploadRelease(updateNs, updatePlugin, "1.0.0", authHeader)
+        uploadRelease(updateNs, updatePlugin, "2.0.0", authHeader)
+
+        // A client on 1.0.0 must be told 2.0.0 is available…
+        mockMvc.post("/api/v1/namespaces/$updateNs/updates/check") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("plugins" to listOf(mapOf("pluginId" to updatePlugin, "currentVersion" to "1.0.0"))),
+            )
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.updates[?(@.pluginId == '$updatePlugin')].latestVersion") { value("2.0.0") }
+            jsonPath("$.updates[?(@.pluginId == '$updatePlugin')].currentVersion") { value("1.0.0") }
+        }
+
+        // …and a client already on 2.0.0 must be told nothing is pending.
+        mockMvc.post("/api/v1/namespaces/$updateNs/updates/check") {
+            header("Authorization", authHeader)
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(
+                mapOf("plugins" to listOf(mapOf("pluginId" to updatePlugin, "currentVersion" to "2.0.0"))),
+            )
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.updates[?(@.pluginId == '$updatePlugin')]").doesNotExist()
+        }
+    }
+
     // ----------------------------------------------------------------------- //
     // Helpers                                                                   //
     // ----------------------------------------------------------------------- //

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcKeycloakLoginIT.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/e2e/auth/OidcKeycloakLoginIT.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.e2e.auth
+
+import io.plugwerk.server.SharedPostgresContainer
+import io.plugwerk.server.domain.OidcProviderEntity
+import io.plugwerk.server.domain.OidcProviderType
+import io.plugwerk.server.domain.UserSource
+import io.plugwerk.server.repository.OidcIdentityRepository
+import io.plugwerk.server.repository.OidcProviderRepository
+import io.plugwerk.server.repository.RefreshTokenRepository
+import io.plugwerk.server.repository.UserRepository
+import io.plugwerk.server.security.DbClientRegistrationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.security.crypto.encrypt.TextEncryptor
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Full-roundtrip OIDC web-login integration test against a **real Keycloak**
+ * (issue #79) running in a Testcontainers container, complementing the
+ * mock-oauth2-server flow in [OidcWebLoginIT].
+ *
+ * Where the mock server shortcircuits user consent, Keycloak serves a real HTML
+ * login form — so this test additionally submits `alice` / `password` against
+ * Keycloak's `login-actions/authenticate` endpoint, proving Plugwerk's OIDC
+ * integration works against a genuine, spec-compliant IdP (discovery metadata,
+ * PKCE S256, ID-token signature + issuer validation, code exchange).
+ *
+ * The container imports [/keycloak/plugwerk-test-realm.json]: the same
+ * `plugwerk-local` confidential client as the dev realm, but with a wildcard
+ * redirect URI because the Spring Boot test binds a RANDOM_PORT the realm cannot
+ * know in advance.
+ */
+@Tag("integration")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OidcKeycloakLoginIT {
+
+    companion object {
+        private const val REALM = "plugwerk"
+        private const val CLIENT_ID = "plugwerk-local"
+        private const val CLIENT_SECRET = "local-dev-secret-do-not-use-in-prod"
+        private const val KEYCLOAK_INTERNAL_PORT = 8080
+
+        /** Matches Keycloak's login `<form id="kc-form-login" … action="…">` to recover the POST target. */
+        private val LOGIN_FORM_ACTION =
+            Regex("<form[^>]*id=\"kc-form-login\"[^>]*action=\"([^\"]+)\"", RegexOption.DOT_MATCHES_ALL)
+
+        @JvmStatic
+        private val keycloak: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("quay.io/keycloak/keycloak:26.1"))
+                .withExposedPorts(KEYCLOAK_INTERNAL_PORT)
+                .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
+                .withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
+                .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("keycloak/plugwerk-test-realm.json"),
+                    "/opt/keycloak/data/import/plugwerk-test-realm.json",
+                )
+                .withCommand("start-dev", "--import-realm")
+                .waitingFor(
+                    Wait.forHttp("/realms/$REALM/.well-known/openid-configuration")
+                        .forPort(KEYCLOAK_INTERNAL_PORT)
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)),
+                )
+
+        @BeforeAll
+        @JvmStatic
+        fun startKeycloak() {
+            keycloak.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stopKeycloak() {
+            keycloak.stop()
+        }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun overrideDataSource(registry: DynamicPropertyRegistry) {
+            val postgres = SharedPostgresContainer.instance
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+
+    @LocalServerPort private var port: Int = 0
+
+    @Autowired private lateinit var oidcProviderRepository: OidcProviderRepository
+
+    @Autowired private lateinit var oidcIdentityRepository: OidcIdentityRepository
+
+    @Autowired private lateinit var userRepository: UserRepository
+
+    @Autowired private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @Autowired private lateinit var dbClientRegistrationRepository: DbClientRegistrationRepository
+
+    @Autowired private lateinit var textEncryptor: TextEncryptor
+
+    private val keycloakBaseUrl: String
+        get() = "http://${keycloak.host}:${keycloak.getMappedPort(KEYCLOAK_INTERNAL_PORT)}"
+
+    @BeforeEach
+    fun seedProvider() {
+        refreshTokenRepository.deleteAll()
+        oidcIdentityRepository.deleteAll()
+        userRepository.findAll()
+            .filter { it.enabled && it.source == UserSource.EXTERNAL }
+            .forEach { userRepository.delete(it) }
+        oidcProviderRepository.deleteAll()
+
+        oidcProviderRepository.saveAndFlush(
+            OidcProviderEntity(
+                name = "Keycloak",
+                providerType = OidcProviderType.OIDC,
+                enabled = true,
+                clientId = CLIENT_ID,
+                clientSecretEncrypted = textEncryptor.encrypt(CLIENT_SECRET),
+                issuerUri = "$keycloakBaseUrl/realms/$REALM",
+                scope = "openid email profile",
+            ),
+        )
+        // Load the freshly-registered provider into the in-memory registry so the
+        // first /oauth2/authorization/{id} request resolves it.
+        dbClientRegistrationRepository.refresh()
+    }
+
+    @Test
+    fun `alice logs in through Keycloak - user is provisioned and a refresh cookie is set`() {
+        val providerId = oidcProviderRepository.findAll().single().id.toString()
+
+        val callback = loginThroughKeycloak(providerId, "alice", "password")
+
+        // Plugwerk's OidcLoginSuccessHandler redirects the SPA to root after a
+        // successful login and drops the httpOnly refresh cookie.
+        assertThat(callback.statusCode()).isEqualTo(302)
+        assertThat(URI.create(callback.headers().firstValue("Location").orElse("")).path).isEqualTo("/")
+        val cookies = callback.headers().allValues("Set-Cookie")
+        assertThat(cookies).anyMatch { it.startsWith("plugwerk_refresh=") && it.contains("HttpOnly") }
+
+        // A plugwerk_user row was provisioned from the Keycloak identity.
+        val user = userRepository.findAll().single { it.email == "alice@plugwerk.test" }
+        assertThat(user.source).isEqualTo(UserSource.EXTERNAL)
+        assertThat(user.username).isNull()
+        assertThat(user.passwordHash).isNull()
+        assertThat(user.displayName).isEqualTo("Alice Tester")
+        assertThat(user.enabled).isTrue()
+
+        val refreshTokens = refreshTokenRepository.findAll().filter { it.userId == user.id }
+        assertThat(refreshTokens).hasSize(1)
+    }
+
+    @Test
+    fun `wrong Keycloak password never provisions a Plugwerk user`() {
+        val providerId = oidcProviderRepository.findAll().single().id.toString()
+
+        // Keycloak re-renders the login form (200) instead of redirecting back,
+        // so the flow never reaches Plugwerk's callback.
+        val loginForm = submitKeycloakLogin(providerId, "alice", "wrong-password")
+        assertThat(loginForm.statusCode()).isEqualTo(200)
+        assertThat(userRepository.findAll().none { it.email == "alice@plugwerk.test" }).isTrue()
+    }
+
+    /**
+     * Drives authorize → Keycloak login form → callback and returns Plugwerk's
+     * final callback response.
+     */
+    private fun loginThroughKeycloak(providerId: String, username: String, password: String): HttpResponse<String> {
+        val flow = HttpFlow()
+        val callbackUrl = submitKeycloakLoginWith(flow, providerId, username, password)
+            .headers().firstValue("Location")
+            .orElseThrow { IllegalStateException("Keycloak did not redirect back to Plugwerk — login likely failed") }
+        return flow.get(callbackUrl)
+    }
+
+    /** Runs authorize + login-form POST and returns Keycloak's raw response to the POST. */
+    private fun submitKeycloakLogin(providerId: String, username: String, password: String): HttpResponse<String> =
+        submitKeycloakLoginWith(HttpFlow(), providerId, username, password)
+
+    private fun submitKeycloakLoginWith(
+        flow: HttpFlow,
+        providerId: String,
+        username: String,
+        password: String,
+    ): HttpResponse<String> {
+        // 1. authorize-start: Plugwerk redirects to Keycloak's authorize endpoint.
+        val authorizeStart = flow.get("http://localhost:$port/oauth2/authorization/$providerId")
+        check(authorizeStart.statusCode() == 302) {
+            "authorize-start returned ${authorizeStart.statusCode()}, expected 302"
+        }
+        val keycloakAuthorizeUrl = authorizeStart.headers().firstValue("Location")
+            .orElseThrow { IllegalStateException("authorize-start missing Location header") }
+
+        // 2. Keycloak serves the HTML login form.
+        val loginPage = flow.get(keycloakAuthorizeUrl)
+        check(loginPage.statusCode() == 200) {
+            "expected Keycloak login page (200), got ${loginPage.statusCode()}"
+        }
+        val formAction = LOGIN_FORM_ACTION.find(loginPage.body())?.groupValues?.get(1)?.replace("&amp;", "&")
+            ?: error("could not locate the Keycloak login form action in the response body")
+
+        // 3. Submit credentials.
+        return flow.postForm(formAction, "username=${enc(username)}&password=${enc(password)}&credentialId=")
+    }
+
+    private fun enc(value: String): String = URLEncoder.encode(value, Charsets.UTF_8)
+
+    /**
+     * Minimal manual cookie jar over the JDK [HttpClient]. Needed because
+     * Keycloak marks its session cookies `Secure` even on the plain-HTTP test
+     * connection, and the JDK's built-in [CookieManager] refuses to replay
+     * `Secure` cookies over HTTP — which breaks the login-form POST. We instead
+     * capture every `Set-Cookie` name/value and echo it back on the next request
+     * (ignoring attributes), mirroring how a browser treats cookies as
+     * host-scoped rather than port-scoped on localhost.
+     */
+    private inner class HttpFlow {
+        private val jar = LinkedHashMap<String, String>()
+        private val client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build()
+
+        fun get(url: String): HttpResponse<String> = send(HttpRequest.newBuilder(URI.create(url)).GET())
+
+        fun postForm(url: String, body: String): HttpResponse<String> = send(
+            HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body)),
+        )
+
+        private fun send(builder: HttpRequest.Builder): HttpResponse<String> {
+            if (jar.isNotEmpty()) {
+                builder.header("Cookie", jar.entries.joinToString("; ") { "${it.key}=${it.value}" })
+            }
+            val response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+            response.headers().allValues("set-cookie").forEach { setCookie ->
+                val pair = setCookie.substringBefore(";")
+                val name = pair.substringBefore("=").trim()
+                val value = pair.substringAfter("=", "").trim()
+                if (name.isNotEmpty()) {
+                    if (value.isEmpty()) jar.remove(name) else jar[name] = value
+                }
+            }
+            return response
+        }
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactoryTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/security/RefreshTokenCookieFactoryTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.security
+
+import io.plugwerk.server.PlugwerkProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/**
+ * Locks the security-relevant attribute invariants of the refresh-token cookie
+ * (ADR-0027 / #294). These attributes are the entire reason the session moved
+ * off `localStorage`, so a silent regression on any of them must fail the build.
+ */
+class RefreshTokenCookieFactoryTest {
+
+    private val jwtSecret = "test-secret-key-that-is-long-enough-32chars"
+
+    private fun factory(cookieSecure: Boolean = true, baseUrl: String = "https://plugwerk.example.com") =
+        RefreshTokenCookieFactory(
+            PlugwerkProperties(
+                server = PlugwerkProperties.ServerProperties(baseUrl = baseUrl),
+                auth = PlugwerkProperties.AuthProperties(jwtSecret = jwtSecret, cookieSecure = cookieSecure),
+            ),
+        )
+
+    @Test
+    fun `build sets the hardened attribute set for an issued token`() {
+        val cookie = factory().build("opaque-token", Duration.ofHours(168))
+
+        assertThat(cookie.name).isEqualTo(RefreshTokenCookieFactory.COOKIE_NAME)
+        assertThat(cookie.value).isEqualTo("opaque-token")
+        assertThat(cookie.isHttpOnly).isTrue()
+        assertThat(cookie.isSecure).isTrue()
+        assertThat(cookie.sameSite).isEqualTo(RefreshTokenCookieFactory.SAME_SITE)
+        assertThat(cookie.sameSite).isEqualTo("Strict")
+        assertThat(cookie.path).isEqualTo(RefreshTokenCookieFactory.COOKIE_PATH)
+        assertThat(cookie.path).isEqualTo("/api/v1/auth")
+        assertThat(cookie.maxAge).isEqualTo(Duration.ofHours(168))
+    }
+
+    @Test
+    fun `build honours cookieSecure=false for local HTTP dev`() {
+        val cookie = factory(cookieSecure = false, baseUrl = "http://localhost:8080")
+            .build("opaque-token", Duration.ofHours(1))
+
+        assertThat(cookie.isSecure).isFalse()
+        // Everything else stays hardened even when Secure is off.
+        assertThat(cookie.isHttpOnly).isTrue()
+        assertThat(cookie.sameSite).isEqualTo("Strict")
+    }
+
+    @Test
+    fun `clear produces an expired empty cookie with the same scope and hardening`() {
+        val cookie = factory().clear()
+
+        assertThat(cookie.name).isEqualTo(RefreshTokenCookieFactory.COOKIE_NAME)
+        assertThat(cookie.value).isEmpty()
+        assertThat(cookie.maxAge).isEqualTo(Duration.ZERO)
+        assertThat(cookie.isHttpOnly).isTrue()
+        assertThat(cookie.sameSite).isEqualTo("Strict")
+        assertThat(cookie.path).isEqualTo("/api/v1/auth")
+    }
+
+    @Test
+    fun `startup validation warns without throwing for the http-plus-secure misconfiguration`() {
+        // http:// base URL + Secure=true is the classic "silent logout" trap; the
+        // validator logs a WARN but must never fail startup.
+        assertThatCode {
+            factory(cookieSecure = true, baseUrl = "http://localhost:8080")
+                .validateCookieSecureAgainstBaseUrl()
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `startup validation is a no-op for a correct HTTPS-plus-secure deployment`() {
+        assertThatCode {
+            factory(cookieSecure = true, baseUrl = "https://plugwerk.example.com")
+                .validateCookieSecureAgainstBaseUrl()
+        }.doesNotThrowAnyException()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySenderTest.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/test/kotlin/io/plugwerk/server/service/telemetry/HttpTelemetrySenderTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.plugwerk.server.service.telemetry
+
+import io.plugwerk.server.PlugwerkProperties
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the fail-open guards of [HttpTelemetrySender] — the branches that keep a
+ * misconfigured telemetry endpoint from ever affecting the server (ADR-0039).
+ *
+ * The endpoint is pointed at a live MockWebServer so we can assert that a skip
+ * decision produces **zero** network traffic, not merely that `send()` returns.
+ * The HTTPS happy-path POST is covered by the Spring integration test
+ * (`TelemetryBeaconIT`); it needs a TLS endpoint and is out of scope here.
+ */
+class HttpTelemetrySenderTest {
+
+    private lateinit var server: MockWebServer
+
+    private val payload = TelemetryPayload(
+        installId = "00000000-0000-0000-0000-000000000000",
+        version = "1.0.0",
+        installType = "docker",
+        event = TelemetryEvent.HEARTBEAT.wireValue,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun sender(endpoint: String): HttpTelemetrySender = HttpTelemetrySender(
+        PlugwerkProperties(
+            telemetry = PlugwerkProperties.TelemetryProperties(endpoint = endpoint),
+        ),
+    )
+
+    @Test
+    fun `skips sending when the endpoint is empty`() {
+        assertThatCode { sender("").send(payload) }.doesNotThrowAnyException()
+        assertThat(server.requestCount).isZero()
+    }
+
+    @Test
+    fun `skips sending when the endpoint is blank whitespace`() {
+        assertThatCode { sender("   ").send(payload) }.doesNotThrowAnyException()
+        assertThat(server.requestCount).isZero()
+    }
+
+    @Test
+    fun `refuses to send over plain HTTP - no request reaches the server`() {
+        val httpEndpoint = server.url("/telemetry").toString()
+
+        assertThatCode { sender(httpEndpoint).send(payload) }.doesNotThrowAnyException()
+
+        assertThat(httpEndpoint).startsWith("http://")
+        assertThat(server.requestCount).isZero()
+    }
+
+    @Test
+    fun `HTTPS scheme check is case-insensitive - an uppercase HTTP URL is still refused`() {
+        val upperHttp = server.url("/telemetry").toString().replaceFirst("http://", "HTTP://")
+
+        assertThatCode { sender(upperHttp).send(payload) }.doesNotThrowAnyException()
+
+        assertThat(server.requestCount).isZero()
+    }
+}

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/keycloak/plugwerk-test-realm.json
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/keycloak/plugwerk-test-realm.json
@@ -1,0 +1,57 @@
+{
+  "realm": "plugwerk",
+  "displayName": "Plugwerk (integration test)",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+
+  "clients": [
+    {
+      "clientId": "plugwerk-local",
+      "name": "Plugwerk (integration test backend)",
+      "description": "Throwaway OAuth2 client for the Testcontainers Keycloak integration test. Redirect URIs are wildcarded because the Spring Boot test binds a RANDOM_PORT — never reuse this realm outside tests.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-dev-secret-do-not-use-in-prod",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access"]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "alice",
+      "email": "alice@plugwerk.test",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Tester",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/plugwerk-server/plugwerk-server-frontend/src/components/common/CopyablePluginId.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/common/CopyablePluginId.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { CopyablePluginId } from "./CopyablePluginId";
+import { renderWithTheme } from "../../test/renderWithTheme";
+
+/**
+ * `userEvent` installs its own `navigator.clipboard` stub on setup, so — like
+ * VersionsTab.test.tsx — we install our own spy and drive the click through
+ * `fireEvent` to hit the component's real handler.
+ */
+let writeText: ReturnType<typeof vi.fn>;
+
+function mockClipboard(impl?: () => Promise<void>) {
+  writeText = vi.fn(impl ?? (() => Promise.resolve()));
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+}
+
+const copyButton = () => screen.getByRole("button", { name: "Copy plugin ID" });
+
+describe("CopyablePluginId", () => {
+  beforeEach(() => {
+    mockClipboard();
+  });
+
+  it("renders the plugin id", () => {
+    renderWithTheme(<CopyablePluginId pluginId="io.example.my-plugin" />);
+    expect(screen.getByText("io.example.my-plugin")).toBeInTheDocument();
+  });
+
+  it("copies the plugin id to the clipboard and shows the copied icon", async () => {
+    const { container } = renderWithTheme(
+      <CopyablePluginId pluginId="io.example.my-plugin" />,
+    );
+
+    expect(container.querySelector(".lucide-copy")).not.toBeNull();
+    expect(container.querySelector(".lucide-check")).toBeNull();
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("io.example.my-plugin"),
+    );
+    await waitFor(() =>
+      expect(container.querySelector(".lucide-check")).not.toBeNull(),
+    );
+  });
+
+  it("reverts to the copy icon after the 2s timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = renderWithTheme(
+        <CopyablePluginId pluginId="io.example.my-plugin" />,
+      );
+
+      fireEvent.click(copyButton());
+      // Flush the awaited clipboard promise so setCopied(true) is applied.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(container.querySelector(".lucide-check")).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(container.querySelector(".lucide-check")).toBeNull();
+      expect(container.querySelector(".lucide-copy")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the click from propagating to a surrounding clickable row", async () => {
+    const onRowClick = vi.fn();
+    renderWithTheme(
+      <div onClick={onRowClick}>
+        <CopyablePluginId pluginId="io.example.my-plugin" />
+      </div>,
+    );
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("swallows clipboard failures without crashing or entering the copied state", async () => {
+    mockClipboard(() => Promise.reject(new Error("clipboard blocked")));
+    const { container } = renderWithTheme(
+      <CopyablePluginId pluginId="io.example.my-plugin" />,
+    );
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    // The catch branch means the icon never flips to the check state.
+    expect(container.querySelector(".lucide-check")).toBeNull();
+    expect(container.querySelector(".lucide-copy")).not.toBeNull();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/stores/userSettingsStore.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/stores/userSettingsStore.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AxiosError } from "axios";
+import { useUserSettingsStore } from "./userSettingsStore";
+import * as apiConfig from "../api/config";
+
+vi.mock("../api/config", () => ({
+  userSettingsApi: {
+    getUserSettings: vi.fn(),
+    updateUserSettings: vi.fn(),
+  },
+}));
+
+const getUserSettings = () =>
+  vi.mocked(apiConfig.userSettingsApi.getUserSettings);
+const updateUserSettings = () =>
+  vi.mocked(apiConfig.userSettingsApi.updateUserSettings);
+
+describe("userSettingsStore", () => {
+  beforeEach(() => {
+    useUserSettingsStore.getState().reset();
+    getUserSettings().mockReset();
+    updateUserSettings().mockReset();
+  });
+
+  it("has the expected initial state", () => {
+    const s = useUserSettingsStore.getState();
+    expect(s.settings).toEqual({});
+    expect(s.loaded).toBe(false);
+    expect(s.loading).toBe(false);
+    expect(s.saving).toBe(false);
+    expect(s.error).toBeNull();
+  });
+
+  describe("load", () => {
+    it("stores settings and marks loaded on success", async () => {
+      getUserSettings().mockResolvedValue({
+        data: { settings: { theme: "dark", locale: "de" } },
+      } as never);
+
+      await useUserSettingsStore.getState().load();
+
+      const s = useUserSettingsStore.getState();
+      expect(s.settings).toEqual({ theme: "dark", locale: "de" });
+      expect(s.loaded).toBe(true);
+      expect(s.loading).toBe(false);
+      expect(s.error).toBeNull();
+    });
+
+    it("records the server error message and rethrows on failure", async () => {
+      const err = new AxiosError("Request failed");
+      err.response = {
+        data: { message: "settings unavailable" },
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: {},
+        config: {} as never,
+      };
+      getUserSettings().mockRejectedValue(err);
+
+      await expect(useUserSettingsStore.getState().load()).rejects.toBe(err);
+
+      const s = useUserSettingsStore.getState();
+      expect(s.error).toBe("settings unavailable");
+      expect(s.loaded).toBe(true);
+      expect(s.loading).toBe(false);
+    });
+
+    it("falls back to the axios error message when the body has no message", async () => {
+      const err = new AxiosError("network down");
+      getUserSettings().mockRejectedValue(err);
+
+      await expect(useUserSettingsStore.getState().load()).rejects.toBe(err);
+      expect(useUserSettingsStore.getState().error).toBe("network down");
+    });
+
+    it("uses a plain Error message for non-axios failures", async () => {
+      getUserSettings().mockRejectedValue(new Error("boom"));
+
+      await expect(useUserSettingsStore.getState().load()).rejects.toThrow(
+        "boom",
+      );
+      expect(useUserSettingsStore.getState().error).toBe("boom");
+    });
+
+    it("reports Unknown error for a non-Error rejection", async () => {
+      getUserSettings().mockRejectedValue("just a string");
+
+      await expect(useUserSettingsStore.getState().load()).rejects.toBe(
+        "just a string",
+      );
+      expect(useUserSettingsStore.getState().error).toBe("Unknown error");
+    });
+  });
+
+  describe("update", () => {
+    it("stores the returned settings and clears saving on success", async () => {
+      updateUserSettings().mockResolvedValue({
+        data: { settings: { theme: "light" } },
+      } as never);
+
+      await useUserSettingsStore.getState().update({ theme: "light" });
+
+      const s = useUserSettingsStore.getState();
+      expect(s.settings).toEqual({ theme: "light" });
+      expect(s.saving).toBe(false);
+      expect(s.error).toBeNull();
+      expect(updateUserSettings()).toHaveBeenCalledWith({
+        userSettingsUpdateRequest: { settings: { theme: "light" } },
+      });
+    });
+
+    it("records the error and rethrows on failure", async () => {
+      updateUserSettings().mockRejectedValue(new Error("save failed"));
+
+      await expect(
+        useUserSettingsStore.getState().update({ theme: "x" }),
+      ).rejects.toThrow("save failed");
+
+      const s = useUserSettingsStore.getState();
+      expect(s.error).toBe("save failed");
+      expect(s.saving).toBe(false);
+    });
+  });
+
+  it("reset returns the store to its initial state", async () => {
+    getUserSettings().mockResolvedValue({
+      data: { settings: { a: "b" } },
+    } as never);
+    await useUserSettingsStore.getState().load();
+
+    useUserSettingsStore.getState().reset();
+
+    const s = useUserSettingsStore.getState();
+    expect(s.settings).toEqual({});
+    expect(s.loaded).toBe(false);
+    expect(s.error).toBeNull();
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/utils/downloadArtifact.test.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/utils/downloadArtifact.test.ts
@@ -16,8 +16,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { decideDownload, setDownloadAllowedHosts } from "./downloadArtifact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  decideDownload,
+  downloadArtifact,
+  setDownloadAllowedHosts,
+} from "./downloadArtifact";
+import { useAuthStore } from "../stores/authStore";
 
 /**
  * Tests for the origin / allow-list decision (ADR-0027 / #294 — TS-003). We test
@@ -80,5 +85,126 @@ describe("decideDownload", () => {
     setDownloadAllowedHosts(["cdn.example.com"]);
     const d = decideDownload("https://evil.example.com/plugins/x.jar");
     expect(d.attachBearer).toBe(false);
+  });
+});
+
+/**
+ * Tests for `downloadArtifact` itself: the fetch, bearer-header wiring, error
+ * translation, and the blob-URL download side effects. These are the security-
+ * and UX-critical paths that `decideDownload` alone does not exercise.
+ */
+describe("downloadArtifact", () => {
+  const testOrigin = "http://localhost:3000";
+  const fetchMock = vi.fn();
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setDownloadAllowedHosts([]);
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: new URL(testOrigin),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    // jsdom does not implement blob-URL object creation.
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    // Neutralise the anchor click so jsdom does not warn about navigation.
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    useAuthStore.setState({ accessToken: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    setDownloadAllowedHosts([]);
+  });
+
+  function okResponse(): Response {
+    return {
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(new Blob(["artifact-bytes"])),
+    } as unknown as Response;
+  }
+
+  it("attaches the bearer for a same-origin download when a token is present", async () => {
+    useAuthStore.setState({ accessToken: "jwt-123" });
+    fetchMock.mockResolvedValue(okResponse());
+
+    await downloadArtifact(`${testOrigin}/api/v1/x/artifact`, "plugin.jar");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer jwt-123");
+    expect(init.headers.Accept).toBe("application/octet-stream");
+  });
+
+  it("omits the bearer for a cross-origin download even with a token present", async () => {
+    useAuthStore.setState({ accessToken: "jwt-123" });
+    fetchMock.mockResolvedValue(okResponse());
+
+    await downloadArtifact("https://cdn.other.com/x.jar", "x.jar");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it("omits the bearer for a same-origin download when no token is present", async () => {
+    fetchMock.mockResolvedValue(okResponse());
+
+    await downloadArtifact(`${testOrigin}/api/v1/x/artifact`, "plugin.jar");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it("triggers a blob-URL download with the requested filename and cleans up", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(okResponse());
+    // The anchor click is already stubbed in beforeEach (shared clickSpy).
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+    const removeSpy = vi.spyOn(document.body, "removeChild");
+
+    await downloadArtifact(`${testOrigin}/api/v1/x/artifact`, "my-plugin.jar");
+
+    const anchor = appendSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.tagName).toBe("A");
+    expect(anchor.getAttribute("href")).toBe("blob:mock-url");
+    expect(anchor.download).toBe("my-plugin.jar");
+    expect(clickSpy).toHaveBeenCalledOnce();
+
+    // Cleanup is deferred behind a 100ms timer.
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(removeSpy).toHaveBeenCalledWith(anchor);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("throws the server-provided message on a non-ok JSON response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ message: "forbidden: yanked release" }),
+    } as unknown as Response);
+
+    await expect(
+      downloadArtifact(`${testOrigin}/api/v1/x/artifact`, "x.jar"),
+    ).rejects.toThrow("forbidden: yanked release");
+  });
+
+  it("throws a status-based message when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error("not json")),
+    } as unknown as Response);
+
+    await expect(
+      downloadArtifact(`${testOrigin}/api/v1/x/artifact`, "x.jar"),
+    ).rejects.toThrow("Download failed (502)");
   });
 });

--- a/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/PlugwerkConstantsTest.kt
+++ b/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/PlugwerkConstantsTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.spi
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the stable REST API contract exposed by [PlugwerkConstants].
+ *
+ * These values are part of the wire contract between host applications and the
+ * Plugwerk server; an accidental change here would silently break every client.
+ * The test exists to make such a change fail loudly and deliberately.
+ */
+class PlugwerkConstantsTest {
+
+    @Test
+    fun `API_VERSION is v1`() {
+        assertEquals("v1", PlugwerkConstants.API_VERSION)
+    }
+
+    @Test
+    fun `API_BASE_PATH is derived from the API version`() {
+        assertEquals("/api/v1", PlugwerkConstants.API_BASE_PATH)
+        assertEquals("/api/${PlugwerkConstants.API_VERSION}", PlugwerkConstants.API_BASE_PATH)
+    }
+
+    @Test
+    fun `DEFAULT_NAMESPACE is default`() {
+        assertEquals("default", PlugwerkConstants.DEFAULT_NAMESPACE)
+    }
+}

--- a/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/model/UninstallResultTest.kt
+++ b/plugwerk-spi/src/test/kotlin/io/plugwerk/spi/model/UninstallResultTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.plugwerk.spi.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class UninstallResultTest {
+
+    private val success = UninstallResult.Success("com.acme.plugin")
+    private val failure = UninstallResult.Failure("com.acme.plugin", "Plugin not installed")
+
+    @Test
+    fun `pluginId accessible on base type without cast`() {
+        val result: UninstallResult = success
+        assertEquals("com.acme.plugin", result.pluginId)
+    }
+
+    @Test
+    fun `pluginId accessible on Failure without cast`() {
+        val result: UninstallResult = failure
+        assertEquals("com.acme.plugin", result.pluginId)
+    }
+
+    @Test
+    fun `isSuccess returns true for Success`() {
+        assertTrue(success.isSuccess())
+        assertFalse(success.isFailure())
+    }
+
+    @Test
+    fun `isFailure returns true for Failure`() {
+        assertTrue(failure.isFailure())
+        assertFalse(failure.isSuccess())
+    }
+
+    @Test
+    fun `onSuccess executes action for Success`() {
+        var captured: String? = null
+        success.onSuccess { captured = it.pluginId }
+        assertEquals("com.acme.plugin", captured)
+    }
+
+    @Test
+    fun `onSuccess skips action for Failure`() {
+        var called = false
+        failure.onSuccess { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun `onFailure executes action for Failure`() {
+        var captured: String? = null
+        failure.onFailure { captured = it.reason }
+        assertEquals("Plugin not installed", captured)
+    }
+
+    @Test
+    fun `onFailure skips action for Success`() {
+        var called = false
+        success.onFailure { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun `onSuccess returns same instance for chaining`() {
+        assertSame(success, success.onSuccess { })
+        assertSame(failure, failure.onSuccess { })
+    }
+
+    @Test
+    fun `onFailure returns same instance for chaining`() {
+        assertSame(success, success.onFailure { })
+        assertSame(failure, failure.onFailure { })
+    }
+
+    @Test
+    fun `onSuccess and onFailure are chainable`() {
+        var successCalled = false
+        var failureCalled = false
+
+        success
+            .onSuccess { successCalled = true }
+            .onFailure { failureCalled = true }
+
+        assertTrue(successCalled)
+        assertFalse(failureCalled)
+    }
+
+    @Test
+    fun `fold maps Success to value`() {
+        val message = success.fold(
+            onSuccess = { "Removed ${it.pluginId}" },
+            onFailure = { "Failed: ${it.reason}" },
+        )
+        assertEquals("Removed com.acme.plugin", message)
+    }
+
+    @Test
+    fun `fold maps Failure to value`() {
+        val message = failure.fold(
+            onSuccess = { "Removed ${it.pluginId}" },
+            onFailure = { "Failed: ${it.reason}" },
+        )
+        assertEquals("Failed: Plugin not installed", message)
+    }
+
+    @Test
+    fun `reasonOrNull returns reason for Failure`() {
+        assertEquals("Plugin not installed", failure.reasonOrNull())
+    }
+
+    @Test
+    fun `reasonOrNull returns null for Success`() {
+        assertNull(success.reasonOrNull())
+    }
+}


### PR DESCRIPTION
## Summary

Expands automated test coverage across the whole stack with **behaviour-focused** tests (not coverage padding), targeting the widest real gaps. All additions are verified locally — library/frontend/backend unit tests plus a Testcontainers-backed smoke test.

**Library modules**
- `plugwerk-spi`: `UninstallResult` behaviour (isSuccess/isFailure, onSuccess/onFailure chaining + identity, fold, reasonOrNull) and a contract test locking the stable REST API constants.
- `plugwerk-descriptor`: direct coverage of the `validateEntryName` Zip-Slip guard — safe names (incl. spaces) pass, `..` path traversal and embedded NUL bytes are rejected.
- `plugwerk-client-plugin`: `DtoMappers` field mapping (downloadUrl deliberately left null, null sha256/requiresSystemVersion preserved) and every branch of the status mapping, plus the SDK exception hierarchy message formatting.

**Frontend** (closed the three widest gaps)
- `userSettingsStore` (~9% → ~full): load/update/reset plus every branch of `extractErrorMessage`.
- `downloadArtifact` (~24% → high): expanded past `decideDownload` to the `fetch` path — bearer attach/omit by origin+token, blob-URL download side effects with deferred cleanup, and both error-translation branches.
- `CopyablePluginId` (~22% → high): render, clipboard copy + icon swap, 2s revert, click-propagation stop, and graceful clipboard-failure handling.

**Backend**
- `HttpTelemetrySender`: fail-open guards (empty/blank/non-HTTPS endpoint → zero network traffic, never throws) via MockWebServer (ADR-0039).
- `FileFormat.fromExtension`: zip/jar mapping, case-insensitivity, default-to-JAR fallback.
- `RefreshTokenCookieFactory`: locks the ADR-0027 cookie invariants (HttpOnly, Secure toggle, SameSite=Strict, Path=/api/v1/auth, Max-Age) for `build()`/`clear()` and the startup misconfiguration warning path.

**Smoke / integration (Testcontainers)**
- `SmokeTest` — **review approval and rejection flow**: manual-review namespace, upload → `draft`, surfaces in `GET /reviews/pending`, approve (→ `published`, leaves the queue), reject a second release (→ `yanked`).
- `SmokeTest` — **plugin update-check flow**: auto-approving namespace publishes 1.0.0 then 2.0.0; a client on 1.0.0 is told 2.0.0 is available, a client on 2.0.0 gets an empty update set.
- `OidcKeycloakLoginIT` — **full OIDC web-login against a real Keycloak** (26.1 via Testcontainers, imports a throwaway realm). Drives authorize → Keycloak HTML login-form submit → callback → code exchange; asserts alice is provisioned as an EXTERNAL user with a refresh cookie, and that a wrong password provisions nobody. Complements the existing mock-oauth2-server flow with a genuine IdP (discovery, PKCE S256, ID-token validation).

All verified against real Postgres (and real Keycloak) via the `integrationTest` task.

13 test files (+ 1 test realm resource).

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build
- [x] Test coverage (no production code changes)

## Checklist

- [x] Tests pass locally (each module verified; smoke test run against real Postgres via `integrationTest`)
- [ ] Documentation updated (not applicable — test-only)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block (not applicable — no migrations)
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: **Claude Code — Claude Opus 4.8**)
- [ ] This PR was co-authored by human + AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MEte2s82Xvz4FYC9ukd6h
