### PR TITLE
fix(api): tolerate explicit null on nullable model fields (#599)

### DIFF
--- a/plugwerk-api/plugwerk-api-model/build.gradle.kts
+++ b/plugwerk-api/plugwerk-api-model/build.gradle.kts
@@ -56,7 +56,24 @@ openApiGenerate {
 // Exclude generated ApiUtil.kt (Spring dependency) — only model classes needed
 tasks.openApiGenerate {
     doLast {
-        delete("${layout.buildDirectory.get()}/generated/src/main/kotlin/io/plugwerk/api/ApiUtil.kt")
+        val genRoot = "${layout.buildDirectory.get()}/generated/src/main/kotlin/io/plugwerk/api"
+        delete("$genRoot/ApiUtil.kt")
+
+        // The kotlin-spring generator annotates every *optional* property with
+        // `@field:JsonSetter(nulls = Nulls.FAIL)`, which rejects an explicit
+        // JSON `null` even though the field is nullable — e.g. a release with no
+        // `changelog` serialised as `changelog: null` makes the client SDK throw
+        // InvalidNullException (issue #599). All 57 occurrences sit on nullable
+        // fields (required fields carry no JsonSetter), so relaxing FAIL -> SKIP
+        // is safe: an explicit null is ignored and the field keeps its `null`
+        // default, while required fields still reject null as before.
+        fileTree("$genRoot/model") { include("**/*.kt") }.forEach { file ->
+            val original = file.readText()
+            val patched = original.replace("nulls = Nulls.FAIL", "nulls = Nulls.SKIP")
+            if (patched != original) {
+                file.writeText(patched)
+            }
+        }
     }
 }
 

--- a/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
+++ b/plugwerk-client-plugin/src/test/kotlin/io/plugwerk/client/catalog/PlugwerkCatalogImplTest.kt
@@ -115,6 +115,43 @@ class PlugwerkCatalogImplTest {
     }
 
     @Test
+    fun `listPlugins tolerates a latestRelease with an explicit changelog null (#599)`() {
+        // A release without notes is serialised by the server as `changelog: null`.
+        // The client must not throw InvalidNullException while deserialising the
+        // catalog listing — this is the exact path reported in issue #599.
+        server.enqueue(
+            MockResponse()
+                .setBody(
+                    """{"content":[
+                        {"id":"00000000-0000-0000-0000-000000000001","pluginId":"my-plugin","name":"My Plugin","status":"active","latestRelease":{"id":"00000000-0000-0000-0000-000000000002","pluginId":"my-plugin","version":"1.0.0","status":"published","changelog":null}}
+                    ],"totalElements":1,"page":0,"size":20,"totalPages":1}""",
+                )
+                .setResponseCode(200),
+        )
+
+        val plugins = catalog.listPlugins()
+
+        assertEquals(1, plugins.size)
+        assertEquals("my-plugin", plugins[0].pluginId)
+    }
+
+    @Test
+    fun `getPluginRelease tolerates explicit nulls for changelog and sha256 (#599)`() {
+        server.enqueue(
+            MockResponse()
+                .setBody(
+                    """{"id":"00000000-0000-0000-0000-000000000002","pluginId":"my-plugin","version":"1.2.0","status":"published","changelog":null,"artifactSha256":null}""",
+                )
+                .setResponseCode(200),
+        )
+
+        val release = catalog.getPluginRelease("my-plugin", "1.2.0")
+
+        assertEquals("1.2.0", release?.version)
+        assertNull(release?.artifactSha256)
+    }
+
+    @Test
     fun `searchPlugins appends query parameters`() {
         server.enqueue(
             MockResponse()


### PR DESCRIPTION
## Summary

Fixes #599 — the client SDK threw `InvalidNullException` when the server serialised `changelog: null` for a release without notes, breaking the `plugwerk/examples` integration tests (`catalog().listPlugins()` / `searchPlugins()`).

### Root cause
The `kotlin-spring` OpenAPI generator annotates **every optional property** with `@field:JsonSetter(nulls = Nulls.FAIL)`. For a genuinely nullable field (`changelog: String? = null`) that is inconsistent: an *absent* field is fine (uses the default), but an *explicit* JSON `null` is rejected. Serialisation still emits `changelog: null`, so the client can't read what the server writes.

### Fix
Relax the generated model in the existing `openApiGenerate` post-processing `doLast` of `plugwerk-api-model`: rewrite `Nulls.FAIL` → `Nulls.SKIP` across the generated model classes.

- All **57** `Nulls.FAIL` occurrences sit on **nullable** fields (verified — required fields carry no `JsonSetter`), so the change is safe: an explicit `null` is now ignored and the field keeps its `null` default, while required fields still reject `null` as before.
- There is a **single** generated model (`io.plugwerk.api.model`), shared by both the server (via `plugwerk-api-endpoint`, which generates APIs only) and the client (`plugwerk-api-model` directly) — so this fixes **both sides at once**.
- Chosen over a custom Mustache template (would need vendoring + syncing on every generator bump) and over a server-side `@JsonInclude(NON_NULL)` (serialisation-only workaround that leaves the model intolerant). The post-processing approach matches the module's existing pattern (it already deletes `ApiUtil.kt` in the same `doLast`).

### Tests
Regression tests in `PlugwerkCatalogImplTest` covering the exact reported path — a catalog listing whose `latestRelease` has `changelog: null`, and a release detail with explicit `changelog`/`artifactSha256` nulls. `./gradlew :plugwerk-client-plugin:test` is green (model regenerated with `Nulls.SKIP`; `0` `Nulls.FAIL` remain).

### Release note
On merge to `main`, `snapshot-publish.yml` republishes `plugwerk-client-plugin:1.1.0-SNAPSHOT` with the tolerant model, unblocking `plugwerk/examples` (PR #59).

## Related Issues

Closes #599.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally (`:plugwerk-client-plugin:test` green, incl. two new #599 regression tests)
- [ ] Documentation updated (not applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block (not applicable — no migrations)
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: **Claude Code — Claude Opus 4.8**)
- [ ] This PR was co-authored by human + AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MEte2s82Xvz4FYC9ukd6h
