### PR TITLE
refactor(telemetry): switch proxy to the workers.dev variant (DEV-32)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -51,12 +51,13 @@ a one-line opt-out (below).
   (DPA)** is in place with PostHog before any production data is ingested (see the
   DPA-acceptance runbook in
   [`telemetry-proxy/README.md`](telemetry-proxy/README.md#dpa-acceptance-do-this-first)).
-- **Sub-processor (transport):** **Cloudflare**, which operates the
-  `telemetry.plugwerk.io` reverse proxy under its standard DPA. It processes the
+- **Sub-processor (transport):** **Cloudflare**, which operates the telemetry
+  reverse proxy (a Cloudflare Worker on the `workers.dev` platform domain)
+  under its standard DPA. It processes the
   connection (including source IP) transiently to route the request; the IP is not
   forwarded to PostHog.
-- **Transport:** beacons go to a Plugwerk-owned HTTPS reverse proxy
-  (`telemetry.plugwerk.io`) that validates the payload against the four-field
+- **Transport:** beacons go to a Plugwerk-operated HTTPS reverse proxy (a
+  Cloudflare Worker) that validates the payload against the four-field
   allowlist and forwards it to PostHog. Request bodies are never logged.
 
 ## Retention

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Plugwerk sends a small, **opt-out**, privacy-respecting telemetry beacon so the 
 
 **No** hostnames, IP addresses, namespaces, usernames, plugin names, or request data are ever collected. The payload is the four fields above and there is no code path that adds a fifth — see [ADR-0039](docs/adrs/0039-telemetry-beacon.md).
 
-**Where it goes.** Beacons are sent over HTTPS to a Plugwerk-owned reverse proxy (`telemetry.plugwerk.io`) and forwarded to **PostHog EU Cloud**, where they are stored and processed **within the EU**. PostHog acts as a data processor under a **Data Processing Agreement (DPA)** that is signed before any telemetry is ingested (see the [runbook](telemetry-proxy/README.md#dpa-acceptance-do-this-first)), and events are configured person-profile-free (`$process_person_profile: false`). The controller is **devtank42 GmbH**. Full details: [`PRIVACY.md`](PRIVACY.md).
+**Where it goes.** Beacons are sent over HTTPS to a Plugwerk-operated reverse proxy (a Cloudflare Worker on the `workers.dev` platform domain) and forwarded to **PostHog EU Cloud**, where they are stored and processed **within the EU**. PostHog acts as a data processor under a **Data Processing Agreement (DPA)** that is signed before any telemetry is ingested (see the [runbook](telemetry-proxy/README.md#dpa-acceptance-do-this-first)), and events are configured person-profile-free (`$process_person_profile: false`). The controller is **devtank42 GmbH**. Full details: [`PRIVACY.md`](PRIVACY.md).
 
 It is **fail-open**: the beacon runs off the startup and request paths with short timeouts, and any failure (unreachable endpoint, timeout, error response) is silently ignored. Telemetry can never affect startup, health, or readiness.
 

--- a/telemetry-proxy/README.md
+++ b/telemetry-proxy/README.md
@@ -1,11 +1,13 @@
 # Plugwerk Telemetry Reverse Proxy
 
-A ~40-line Cloudflare Worker that backs `POST https://telemetry.plugwerk.io/v1/events`.
+A ~40-line Cloudflare Worker that backs the telemetry ingestion endpoint
+`POST https://plugwerk-telemetry-proxy.<account>.workers.dev/v1/events`
+(**workers.dev variant** — no custom domain, no zone, no nameserver change).
 It validates an opt-out telemetry beacon against a **strict zero-PII allowlist**, then
 forwards accepted events to PostHog EU Cloud. It is the receiving half of the beacon
 shipped in DEV-23; the architecture is recorded in DEV-27 / DEV-28.
 
-> **Scope:** this directory is **build only**. Live deploy, DNS, and the production
+> **Scope:** this directory is **build only**. Live deploy and the production
 > smoke test are handled by the deploy sibling (DEV-34) and depend on infra
 > provisioning (DEV-31). A security review (DEV-33) gates go-live.
 
@@ -48,10 +50,14 @@ both keyed by client IP at **60 requests / 60 s**:
    content-type guards and returns `429` before reading the body or forwarding.
    **Caveat:** the Workers rate-limit binding counts **per Cloudflare colo**, not
    globally — it is best-effort, not an authoritative global cap.
-2. **Cloudflare zone rate-limiting rule** (authoritative, global; provisioned in the
-   DEV-34 deploy runbook below). It blocks at the edge before the Worker spins up.
+2. **Cloudflare zone rate-limiting rule** (authoritative, global) — **custom-domain
+   variant only**, because zone rules require the domain's zone on Cloudflare.
 
-Both are required: layer 1 travels with the code, layer 2 is the global enforcement.
+**workers.dev variant:** there is no zone, so layer 1 plus Cloudflare's always-on
+platform DDoS mitigation are the only limiting layers. This deviation from the
+two-layer design is an explicit DEV-33 sign-off point. In the custom-domain variant
+both layers are required: layer 1 travels with the code, layer 2 is the global
+enforcement.
 
 The `502`/fail-open split is deliberate: the client beacon fails open on its side
 (DEV-23), so a `5xx` here never affects the Plugwerk server — it only makes our own
@@ -93,8 +99,9 @@ npm run dev              # wrangler dev on http://127.0.0.1:8787
 
 ## Deploy runbook (deploy sibling — DEV-34)
 
-Prerequisite: the `plugwerk.io` zone is on Cloudflare and `telemetry.plugwerk.io`
-resolves (see **DNS** below). PostHog project + key provisioned in DEV-31.
+Prerequisite (workers.dev variant): a Cloudflare account with Workers enabled and
+`wrangler login` completed — **no zone, no DNS change, no custom domain needed**.
+PostHog project + key provisioned in DEV-31.
 
 ### DPA acceptance (do this first)
 
@@ -152,30 +159,41 @@ is still never logged — only the fact that the prefix check failed.
 npm run deploy           # wrangler deploy
 ```
 
-`wrangler.toml` binds the route `telemetry.plugwerk.io/v1/*` on `zone_name = "plugwerk.io"`.
+`wrangler.toml` sets `workers_dev = true`, so the Worker is served on the account's
+workers.dev subdomain. `wrangler deploy` prints the final public URL.
 
-### DNS pointing
+### Endpoint URL (workers.dev — no DNS needed)
 
-Add a proxied DNS record for `telemetry` on the `plugwerk.io` zone (orange-cloud
-ON so the Worker route intercepts):
-
-- `telemetry` → `AAAA 100::` (or any placeholder) **proxied**, **or** a `CNAME`
-  to a proxied hostname. The record only needs to exist and be proxied; the Worker
-  route handles `/v1/*`. TLS is automatic via Cloudflare's edge cert for the zone.
+The deploy output prints the public URL, e.g.
+`https://plugwerk-telemetry-proxy.<account>.workers.dev` (the account subdomain is
+shown in the dashboard under **Workers & Pages → account subdomain**). TLS is
+automatic. This URL plus `/v1/events` is the value released Plugwerk builds ship
+as `PLUGWERK_TELEMETRY_ENDPOINT`.
 
 Verify after deploy:
 
 ```bash
-./smoke-test.sh https://telemetry.plugwerk.io   # expect 204 then 400
+./smoke-test.sh https://plugwerk-telemetry-proxy.<account>.workers.dev   # expect 204 then 400
 ```
 
-### Zone rate-limiting rule (REQUIRED — authoritative edge control)
+> **Future option (custom domain):** if the `plugwerk.io` zone is ever moved to
+> Cloudflare, re-enable the commented `routes` block in `wrangler.toml`, add a
+> proxied DNS record for `telemetry` (e.g. `AAAA 100::`, orange-cloud ON), and
+> provision the zone rate-limiting rule below. The workers.dev URL keeps working
+> in parallel, so already-shipped installs continue to deliver.
 
-The in-code Worker binding (`[[ratelimits]]` in `wrangler.toml`) only throttles
-**per Cloudflare colo**, not globally. Go-live therefore also requires an
-authoritative **zone rate-limiting rule** that blocks at the edge before the Worker
-runs. This is the DEV-33 HIGH gate (DEV-47); it must exist before opening the route
-to production traffic.
+### Zone rate-limiting rule (custom-domain variant only)
+
+> **workers.dev variant:** zone rate-limiting rules are zone-scoped and therefore
+> **not available** — skip this section. The in-code binding plus Cloudflare's
+> always-on DDoS mitigation are the limiting layers; have DEV-33 sign off on this
+> deviation explicitly.
+
+In the custom-domain variant, the in-code Worker binding (`[[ratelimits]]` in
+`wrangler.toml`) only throttles **per Cloudflare colo**, not globally. Go-live
+therefore also requires an authoritative **zone rate-limiting rule** that blocks at
+the edge before the Worker runs. This is the DEV-33 HIGH gate (DEV-47); it must
+exist before opening the route to production traffic.
 
 Configure on the `plugwerk.io` zone (Security → WAF → Rate limiting rules), or via
 API on the `http_ratelimit` phase ruleset:
@@ -229,15 +247,20 @@ confirm all three go-live security conditions against the **live** config and
 capture the output as the DEV-54 sign-off evidence:
 
 ```bash
+# workers.dev variant (no zone): omit the CF_* vars — the zone-scoped checks are
+# skipped with an explicit notice; the secret check and live smoke still run:
+./go-live-check.sh https://plugwerk-telemetry-proxy.<account>.workers.dev
+
+# custom-domain variant: set BOTH vars to also verify the zone conditions:
 CF_API_TOKEN=<zone-scoped token> CF_ZONE_ID=<plugwerk.io zone id> \
   ./go-live-check.sh https://telemetry.plugwerk.io
 ```
 
 It asserts: (1) the zone rate-limit rule above is present (block, `ip.src`,
-60/60s, host + `/v1/`); (2) the `POSTHOG_PROJECT_KEY` secret is set (its `phc_`
-prefix is enforced in code, proven by the smoke `204`); (3) no Logpush job on the
-zone captures request bodies or headers. It then runs the live smoke test
-(`204`/`400`). It makes no changes.
+60/60s, host + `/v1/`) — custom-domain variant only; (2) the `POSTHOG_PROJECT_KEY`
+secret is set (its `phc_` prefix is enforced in code, proven by the smoke `204`);
+(3) no Logpush job on the zone captures request bodies or headers — custom-domain
+variant only. It then runs the live smoke test (`204`/`400`). It makes no changes.
 
 ### Emergency stop (kill switch)
 
@@ -284,6 +307,6 @@ allowlist until it is regenerated.
 | `src/ratelimit.ts`    | Per-IP rate-limit binding type + metering helper       |
 | `src/constants.ts`    | Allowlist, enums, limits, endpoints                    |
 | `test/*.test.ts`      | Validator + handler unit tests (incl. rate-limit regression) |
-| `wrangler.toml`       | Worker config + route + rate-limit binding (no secrets) |
+| `wrangler.toml`       | Worker config (workers.dev) + rate-limit binding (no secrets) |
 | `smoke-test.sh`       | curl smoke test (204 valid / 400 extra-field)          |
-| `go-live-check.sh`    | read-only go-live security verifier (DEV-54: zone rule, secret, Logpush) |
+| `go-live-check.sh`    | read-only go-live security verifier (DEV-54: secret + smoke; zone rule/Logpush in custom-domain mode) |

--- a/telemetry-proxy/go-live-check.sh
+++ b/telemetry-proxy/go-live-check.sh
@@ -3,37 +3,51 @@
 # Go-live security verifier for the Plugwerk telemetry endpoint (DEV-54).
 #
 # Read-only. It inspects the LIVE Cloudflare configuration and the deployed Worker
-# and asserts the three security go-live conditions that gate opening
-# telemetry.plugwerk.io/v1/* to production traffic:
+# and asserts the security go-live conditions that gate opening the ingestion
+# endpoint to production traffic:
 #
-#   1. Zone rate-limiting rule applied  (authoritative edge layer; the in-code
-#      [[ratelimits]] binding is only best-effort per-colo).
+#   1. Zone rate-limiting rule applied  (custom-domain variant ONLY — zone rules
+#                                        do not exist for workers.dev; there the
+#                                        in-code [[ratelimits]] binding + platform
+#                                        DDoS mitigation are the limiting layers,
+#                                        a deviation signed off in DEV-33).
 #   2. PostHog secret is set            (the phc_ project-key prefix is enforced
 #                                        in code — src/posthog.ts — and proven by
 #                                        the smoke 204; this script confirms the
 #                                        secret EXISTS, since its value is not
 #                                        readable by design).
-#   3. No Logpush request-body/header capture on the zone.
+#   3. No Logpush request-body/header capture on the zone (custom-domain variant
+#      ONLY, same reason as condition 1).
 #
 # It makes no changes. Run it at deploy time (DEV-34) and paste the output into the
 # DEV-54 thread as the go-live confirmation evidence.
 #
 # Usage:
-#   CF_API_TOKEN=<zone-scoped token> CF_ZONE_ID=<plugwerk.io zone id> \
-#     ./go-live-check.sh [BASE_URL]
+#   # workers.dev variant (no zone) — zone checks are skipped with a notice:
+#   ./go-live-check.sh https://plugwerk-telemetry-proxy.<account>.workers.dev
 #
-#   BASE_URL (optional) defaults to https://telemetry.plugwerk.io and, when set,
-#   triggers the live smoke test (204 valid / 400 extra-field) via smoke-test.sh.
+#   # custom-domain variant — set BOTH CF_* vars to verify the zone conditions:
+#   CF_API_TOKEN=<zone-scoped token> CF_ZONE_ID=<plugwerk.io zone id> \
+#     ./go-live-check.sh https://telemetry.plugwerk.io
+#
+#   BASE_URL (required) is the deployed endpoint; the live smoke test
+#   (204 valid / 400 extra-field) runs against it via smoke-test.sh.
 #
 # Requirements: curl, python3. Optional: wrangler (for the secret-existence check).
 
 set -euo pipefail
 
-HOST="telemetry.plugwerk.io"
 CF_API="https://api.cloudflare.com/client/v4"
 EXPECTED_PERIOD=60
 EXPECTED_REQUESTS=60
-BASE_URL="${1:-https://${HOST}}"
+
+BASE_URL="${1:-}"
+if [[ -z "$BASE_URL" ]]; then
+  echo "Usage: ./go-live-check.sh <base-url>" >&2
+  echo "  e.g.: ./go-live-check.sh https://plugwerk-telemetry-proxy.<account>.workers.dev" >&2
+  exit 2
+fi
+HOST="$(printf '%s' "$BASE_URL" | sed -E 's|^[a-zA-Z]+://||; s|/.*$||')"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -51,8 +65,16 @@ require() {
 require curl
 require python3
 
-: "${CF_API_TOKEN:?Set CF_API_TOKEN to a zone-scoped Cloudflare API token}"
-: "${CF_ZONE_ID:?Set CF_ZONE_ID to the plugwerk.io Cloudflare zone id}"
+# Mode detection: both CF_* vars -> custom-domain mode (zone checks run);
+# neither -> workers.dev mode (zone checks are skipped, visibly); one -> error.
+if [[ -n "${CF_API_TOKEN:-}" && -n "${CF_ZONE_ID:-}" ]]; then
+  ZONE_MODE=1
+elif [[ -z "${CF_API_TOKEN:-}" && -z "${CF_ZONE_ID:-}" ]]; then
+  ZONE_MODE=0
+else
+  echo "ERROR: set BOTH CF_API_TOKEN and CF_ZONE_ID (custom-domain mode) or NEITHER (workers.dev mode)." >&2
+  exit 2
+fi
 
 cf_get() {
   curl -sS --fail-with-body \
@@ -67,7 +89,11 @@ echo "================================================================"
 # --- Condition 1: zone rate-limiting rule -----------------------------------
 echo
 echo "[1/3] Zone rate-limiting rule (http_ratelimit phase)"
-if rl_json="$(cf_get "rulesets/phases/http_ratelimit/entrypoint" 2>/dev/null)"; then
+if [[ "$ZONE_MODE" == "0" ]]; then
+  info "SKIP (workers.dev variant): no zone fronts the Worker, so no zone rate-limiting"
+  info "rule can exist. Limiting layers: in-code [[ratelimits]] binding (60/60s per IP,"
+  info "per colo) + Cloudflare's always-on DDoS mitigation. Deviation signed off in DEV-33."
+elif rl_json="$(cf_get "rulesets/phases/http_ratelimit/entrypoint" 2>/dev/null)"; then
   result="$(
     HOST="$HOST" EXPECTED_PERIOD="$EXPECTED_PERIOD" EXPECTED_REQUESTS="$EXPECTED_REQUESTS" \
     python3 - "$rl_json" <<'PY'
@@ -147,7 +173,10 @@ fi
 # --- Condition 3: no Logpush body/header capture ----------------------------
 echo
 echo "[3/3] Logpush — no request-body / header capture"
-if lp_json="$(cf_get "logpush/jobs" 2>/dev/null)"; then
+if [[ "$ZONE_MODE" == "0" ]]; then
+  info "SKIP (workers.dev variant): Logpush jobs are zone-scoped; no zone exists."
+  info "Do not add an account-level Workers Logpush job that captures request bodies."
+elif lp_json="$(cf_get "logpush/jobs" 2>/dev/null)"; then
   result="$(python3 - "$lp_json" <<'PY'
 import json, sys
 

--- a/telemetry-proxy/package.json
+++ b/telemetry-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Cloudflare Worker reverse proxy for Plugwerk zero-PII telemetry ingestion (telemetry.plugwerk.io/v1/events).",
+  "description": "Cloudflare Worker reverse proxy for Plugwerk zero-PII telemetry ingestion (POST /v1/events on the workers.dev endpoint).",
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "dev": "wrangler dev",

--- a/telemetry-proxy/smoke-test.sh
+++ b/telemetry-proxy/smoke-test.sh
@@ -8,7 +8,7 @@
 #   BASE_URL defaults to http://127.0.0.1:8787 (the `wrangler dev` default).
 #   Examples:
 #     ./smoke-test.sh                                  # local wrangler dev
-#     ./smoke-test.sh https://telemetry.plugwerk.io    # deployed endpoint
+#     ./smoke-test.sh https://plugwerk-telemetry-proxy.<account>.workers.dev   # deployed endpoint
 #
 # Checks:
 #   1. A valid zero-PII payload  -> 204 No Content

--- a/telemetry-proxy/src/index.ts
+++ b/telemetry-proxy/src/index.ts
@@ -136,7 +136,7 @@ const handler: ExportedHandler<Env> = {
     // ingestion attempts are metered. Throttled requests get a 429 and we skip the body
     // read and the outbound PostHog forward entirely — this endpoint is public and
     // unauthenticated, so it must not become an amplifier (OWASP API4:2023). Best-effort
-    // per-colo throttle; the authoritative global cap is the zone rule (see DEV-34).
+    // per-colo throttle; in the custom-domain variant a zone rule adds the global cap (DEV-34).
     if (!(await isWithinRateLimit(request, env))) {
       return emptyResponse(429, { "retry-after": String(RATE_LIMIT_PERIOD_SECONDS) });
     }

--- a/telemetry-proxy/src/ratelimit.ts
+++ b/telemetry-proxy/src/ratelimit.ts
@@ -34,10 +34,11 @@ export interface RateLimitEnv {
    * as the `[[ratelimits]]` binding `RATE_LIMITER`).
    *
    * CAVEAT: this binding counts per Cloudflare colo (data center), NOT globally, so
-   * it is best-effort throttling — not an authoritative global cap. The authoritative
-   * edge control is a Cloudflare zone rate-limiting rule on the route, which blocks
-   * before the Worker even spins up and is global (provisioned in the DEV-34 deploy
-   * runbook). Both layers are required; this one travels with the code.
+   * it is best-effort throttling — not an authoritative global cap. In the
+   * workers.dev variant it is the only app-level limiter (plus Cloudflare's
+   * always-on DDoS mitigation) — a deviation signed off in DEV-33. In the
+   * custom-domain variant a zone rate-limiting rule adds the authoritative global
+   * edge cap (see the README runbook). This layer travels with the code either way.
    */
   RATE_LIMITER: RateLimit;
 }

--- a/telemetry-proxy/wrangler.toml
+++ b/telemetry-proxy/wrangler.toml
@@ -6,11 +6,19 @@ name = "plugwerk-telemetry-proxy"
 main = "src/index.ts"
 compatibility_date = "2025-06-01"
 
-# Public ingestion route. The zone telemetry.plugwerk.io must already exist on
-# the plugwerk.io Cloudflare zone before this route resolves (DEV-31 / DEV-34).
-routes = [
-  { pattern = "telemetry.plugwerk.io/v1/*", zone_name = "plugwerk.io" },
-]
+# Ingestion endpoint — workers.dev variant (no custom domain, no zone, no
+# nameserver change; DEV-31 / DEV-34). The Worker is served on the account's
+# workers.dev subdomain:
+#   https://plugwerk-telemetry-proxy.<account>.workers.dev/v1/events
+workers_dev = true
+
+# FUTURE OPTION (custom-domain variant): if the plugwerk.io zone is ever moved
+# to Cloudflare, re-enable this route AND provision the zone rate-limiting rule
+# from README.md — they go together (DEV-33 / DEV-47). The workers.dev URL keeps
+# working in parallel, so old installs continue to deliver.
+# routes = [
+#   { pattern = "telemetry.plugwerk.io/v1/*", zone_name = "plugwerk.io" },
+# ]
 
 # Observability helps monitor 4xx/5xx delivery rates without logging payloads.
 [observability]
@@ -22,10 +30,11 @@ enabled = true
 # real ingestion attempt and returns 429 before forwarding to PostHog.
 #
 # CAVEAT: this binding counts per Cloudflare colo (data center), NOT globally — it
-# is best-effort throttling, not an authoritative global cap. The authoritative
-# edge control is a Cloudflare ZONE rate-limiting rule on telemetry.plugwerk.io/v1/*
-# (blocks before the Worker even spins up, and is global), provisioned in the
-# DEV-34 deploy runbook. Both layers are required.
+# is best-effort throttling, not an authoritative global cap. In the workers.dev
+# variant it is the only app-level limiter (plus Cloudflare's always-on DDoS
+# mitigation) — an accepted deviation to be signed off in DEV-33. In the
+# custom-domain variant, additionally provision the authoritative zone
+# rate-limiting rule from the README runbook.
 #
 # `period` must be 10 or 60. `namespace_id` is an account-unique integer; reusing
 # it across bindings/Workers shares the same counters (intentional here: one limiter).


### PR DESCRIPTION
## Summary

Follow-up to #573 — the **workers.dev variant** of the telemetry proxy. This commit was pushed to the `feat/dev32-telemetry-proxy` branch ~22 hours after #573 had already been merged, so it never landed on `main` (see AGENTS.md → "Adding commits to an existing PR"). Re-applied here on a fresh branch off `main`, unchanged.

**Why:** the `plugwerk.io` DNS stays at its current registrar-managed nameservers, so the zone-based route (`telemetry.plugwerk.io`) is not available. The Worker is served on the account's `workers.dev` subdomain instead — no custom domain, no zone, no nameserver change. Released builds ship `PLUGWERK_TELEMETRY_ENDPOINT=https://plugwerk-telemetry-proxy.<account>.workers.dev/v1/events`.

### Changes

- `wrangler.toml`: `workers_dev = true`; the zone route stays as a commented future option (re-enable only together with the zone rate-limiting rule).
- `go-live-check.sh`: two modes — without `CF_*` vars the zone-scoped checks (rate rule, Logpush) are skipped with an explicit notice; the secret check and live smoke always run. `BASE_URL` is now a required argument.
- Runbook: DNS section replaced by "Endpoint URL (workers.dev)"; zone rate-limiting marked custom-domain-only.
- Root `README.md` + `PRIVACY.md`: describe the proxy without the fixed hostname (Cloudflare Worker on the `workers.dev` platform domain) — both are public privacy statements and must not promise a hostname that will not exist.

### Review note (DEV-33)

Without a zone there is **no authoritative zone rate-limiting rule** — the in-code per-colo `[[ratelimits]]` binding plus Cloudflare's always-on DDoS mitigation are the only limiting layers. This single-layer deviation from the #573 design is flagged in code, runbook, and here as an explicit DEV-33 sign-off point.

### Verification

- TypeScript typecheck clean; 57 vitest cases green (worker behavior unchanged — docs/config/ops tooling only, plus the `go-live-check.sh` mode logic).
- `bash -n` clean on both shell scripts; usage/mode error paths and the workers.dev SKIP path exercised manually.

## Related Issues

Follow-up to #573. Refs DEV-32, DEV-33, DEV-34.

## Type of Change

- [x] Refactoring / operational change (no runtime behavior change)

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (runbook, root README, PRIVACY.md)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A (no DB changes)

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Fable 5, via Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
