### PR TITLE
feat(telemetry): default the beacon endpoint to the live proxy (DEV-34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,7 +195,11 @@ PLUGWERK_AUTH_ENCRYPTION_KEY=
 # first start + once daily. See the "Telemetry & Privacy" section of README.md.
 # Set to false to fully disable (no install UUID, no schedule, no HTTP).
 # PLUGWERK_TELEMETRY=true
-# HTTPS-only analytics endpoint. Empty (default) = build but never send.
+# HTTPS-only analytics endpoint. Default: the live Plugwerk telemetry proxy
+# (https://plugwerk-telemetry-proxy.plugwerk.workers.dev/v1/events, a Cloudflare
+# Worker enforcing the zero-PII allowlist — see telemetry-proxy/README.md).
+# Set empty to build the payload but never send; PLUGWERK_TELEMETRY=false
+# disables telemetry entirely.
 # PLUGWERK_TELEMETRY_ENDPOINT=
 # Override the auto-detected install type: docker-compose | jar | k8s.
 # PLUGWERK_INSTALL_TYPE=

--- a/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
+++ b/plugwerk-server/plugwerk-server-backend/src/main/kotlin/io/plugwerk/server/PlugwerkProperties.kt
@@ -76,10 +76,14 @@ data class PlugwerkProperties(
      *   Environment variable: `PLUGWERK_TELEMETRY` (Spring relaxed binding maps it to
      *   `plugwerk.telemetry.enabled` via the `application.yml` placeholder).
      *
-     * @property endpoint HTTPS-only analytics endpoint the beacon POSTs to. Empty by
-     *   default until the Plugwerk-owned endpoint is provisioned; an empty or
-     *   non-HTTPS value means the payload is built but never sent (a harmless no-op
-     *   under the fail-open design). **Do not block on this being live.**
+     * @property endpoint HTTPS-only analytics endpoint the beacon POSTs to. The
+     *   shipped default (`application.yml`) is the live Plugwerk telemetry proxy
+     *   `https://plugwerk-telemetry-proxy.plugwerk.workers.dev/v1/events` — a
+     *   Cloudflare Worker enforcing the zero-PII allowlist (see
+     *   `telemetry-proxy/README.md`). An empty or non-HTTPS value means the payload
+     *   is built but never sent (a harmless no-op under the fail-open design); the
+     *   class-level default stays empty as the conservative fallback for contexts
+     *   that bind no configuration.
      *
      *   Environment variable: `PLUGWERK_TELEMETRY_ENDPOINT`
      *

--- a/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/main/resources/application.yml
@@ -163,12 +163,14 @@ plugwerk:
     # UUID is generated, no heartbeat is scheduled, and no HTTP call is made.
     # Env: PLUGWERK_TELEMETRY
     enabled: ${PLUGWERK_TELEMETRY:true}
-    # HTTPS-only, Plugwerk-owned analytics endpoint the beacon POSTs to. Empty by
-    # default until the live endpoint is provisioned; an empty or non-HTTPS value
-    # means the payload is built but never sent (a harmless no-op). Do NOT treat
-    # an unset endpoint as a reason to delay a deployment.
+    # HTTPS-only, Plugwerk-operated analytics endpoint the beacon POSTs to.
+    # Default: the live Plugwerk telemetry proxy (Cloudflare Worker on workers.dev,
+    # see telemetry-proxy/README.md). An empty or non-HTTPS value means the payload
+    # is built but never sent (a harmless no-op under the fail-open design).
     # Env: PLUGWERK_TELEMETRY_ENDPOINT
-    endpoint: ${PLUGWERK_TELEMETRY_ENDPOINT:}
+    # Example: PLUGWERK_TELEMETRY_ENDPOINT= (build but never send; full opt-out
+    # is PLUGWERK_TELEMETRY=false)
+    endpoint: ${PLUGWERK_TELEMETRY_ENDPOINT:https://plugwerk-telemetry-proxy.plugwerk.workers.dev/v1/events}
     # Override the auto-detected install type (docker-compose | jar | k8s). Empty
     # (default) = auto-detect (KUBERNETES_SERVICE_HOST ⇒ k8s; /.dockerenv ⇒
     # docker-compose; else jar). An unrecognized value reports as 'unknown'.

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-integration.yml
@@ -7,6 +7,10 @@ spring:
     enabled: true
 
 plugwerk:
+  # Blank the endpoint so integration runs never send real events to the live
+  # telemetry proxy (the production default). See application-test.yml.
+  telemetry:
+    endpoint: ""
   storage:
     type: fs
     fs:

--- a/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
+++ b/plugwerk-server/plugwerk-server-backend/src/test/resources/application-test.yml
@@ -14,6 +14,12 @@ spring:
     enabled: false
 
 plugwerk:
+  # The production endpoint default points at the LIVE telemetry proxy. Full-boot
+  # test contexts fire the server-start beacon on ApplicationReadyEvent — blank
+  # the endpoint here so test runs never send real events. Telemetry ITs that
+  # need a specific endpoint override this via @TestPropertySource.
+  telemetry:
+    endpoint: ""
   auth:
     oidc:
       # Tests use mock-oauth2-server / Keycloak on 127.0.0.1 — relax SSRF


### PR DESCRIPTION
## Summary

Flips the shipped default of `plugwerk.telemetry.endpoint` from empty ("build but never send") to the **live telemetry proxy**: `https://plugwerk-telemetry-proxy.plugwerk.workers.dev/v1/events`. The proxy (#573 + #601) is deployed, secret-provisioned, and verified live (guard matrix, smoke `204`/`400`, `go-live-check.sh` PASS in workers.dev mode; events confirmed arriving in PostHog EU).

Opt-out semantics are unchanged and remain fully documented: `PLUGWERK_TELEMETRY=false` disables telemetry entirely; setting `PLUGWERK_TELEMETRY_ENDPOINT` to empty (or any non-HTTPS value) keeps the fail-open "build but never send" behavior.

### Test-safety note (please review deliberately)

The server-start beacon fires on `ApplicationReadyEvent`, so every full-boot `@SpringBootTest` context would now deliver a real event (with a throwaway H2 install UUID) to the live proxy. Both test profiles therefore blank the endpoint (`application-test.yml`, `application-integration.yml`); telemetry ITs that need a concrete endpoint keep overriding it via `@TestPropertySource` (higher precedence), so `TelemetryBeaconIT` / `TelemetryDisabledIT` are unaffected.

### Files

- `application.yml` — endpoint default + updated inline docs
- `PlugwerkProperties.kt` — KDoc for the new shipped default (class-level fallback stays empty as the conservative default for unbound contexts)
- `.env.example` — updated guidance
- `application-test.yml` / `application-integration.yml` — blank endpoint for test runs

### Verification

- `spotlessApply` clean; `:plugwerk-server-backend:test --tests "*Telemetry*"` green.
- Live chain verified end-to-end on 2026-07-20 (DEV-54 evidence in the deploy session log; smoke events use the fixed synthetic install id `3f2504e0-4f89-41d3-9a0c-0305e82c3301` — filter that `distinct_id` in PostHog analytics).

## Related Issues

Refs DEV-34 (deploy), DEV-33 (security sign-off gates go-live), DEV-28 (epic). Follow-up to #573 / #601.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (application.yml, KDoc, .env.example)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A (no DB changes)

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Fable 5, via Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
