### PR TITLE
fix(telemetry): fail closed on unset secret + find local wrangler (DEV-34)

### DIFF
--- a/telemetry-proxy/go-live-check.sh
+++ b/telemetry-proxy/go-live-check.sh
@@ -151,8 +151,17 @@ fi
 # --- Condition 2: PostHog project key secret --------------------------------
 echo
 echo "[2/3] PostHog project key secret (phc_ prefix enforced in code)"
+# Prefer a global wrangler, fall back to the project-local install (npm ci puts
+# it in node_modules/.bin next to this script) so the check also runs when
+# wrangler was never installed globally.
+WRANGLER_BIN=""
 if command -v wrangler >/dev/null 2>&1; then
-  if secrets_json="$(cd "$SCRIPT_DIR" && wrangler secret list --format json 2>/dev/null)"; then
+  WRANGLER_BIN="wrangler"
+elif [[ -x "${SCRIPT_DIR}/node_modules/.bin/wrangler" ]]; then
+  WRANGLER_BIN="${SCRIPT_DIR}/node_modules/.bin/wrangler"
+fi
+if [[ -n "$WRANGLER_BIN" ]]; then
+  if secrets_json="$(cd "$SCRIPT_DIR" && "$WRANGLER_BIN" secret list --format json 2>/dev/null)"; then
     if printf '%s' "$secrets_json" | python3 -c \
       'import json,sys; sys.exit(0 if any(s.get("name")=="POSTHOG_PROJECT_KEY" for s in json.load(sys.stdin)) else 1)'; then
       ok "POSTHOG_PROJECT_KEY secret is set on the deployed Worker"
@@ -166,8 +175,9 @@ if command -v wrangler >/dev/null 2>&1; then
     info "      proves a working phc_ key, and the code guard rejects any non-phc_ key."
   fi
 else
-  info "SKIP: wrangler not installed. The phc_ prefix is enforced in code (src/posthog.ts);"
-  info "      a passing smoke 204 below confirms a valid phc_ key is configured."
+  info "SKIP: wrangler not found on PATH or in node_modules/.bin (run 'npm ci' here)."
+  info "      The phc_ prefix is enforced in code (src/posthog.ts); a passing"
+  info "      smoke 204 below confirms a valid phc_ key is configured."
 fi
 
 # --- Condition 3: no Logpush body/header capture ----------------------------

--- a/telemetry-proxy/src/posthog.ts
+++ b/telemetry-proxy/src/posthog.ts
@@ -26,8 +26,12 @@ import type { ValidPayload } from "./validate";
 
 /** Worker environment bindings. `POSTHOG_PROJECT_KEY` is an encrypted secret. */
 export interface PostHogEnv {
-  /** Encrypted Worker secret — set via `wrangler secret put POSTHOG_PROJECT_KEY`. Never logged. */
-  POSTHOG_PROJECT_KEY: string;
+  /**
+   * Encrypted Worker secret — set via `wrangler secret put POSTHOG_PROJECT_KEY`.
+   * Never logged. Typed optional because a freshly deployed Worker has no secret
+   * yet; that state fails closed with 502 instead of an uncaught TypeError (500).
+   */
+  POSTHOG_PROJECT_KEY?: string;
   /** Optional non-secret override of the capture endpoint (defaults to PostHog EU Cloud). */
   POSTHOG_CAPTURE_URL?: string;
 }
@@ -52,10 +56,12 @@ export interface PostHogEnv {
  */
 export async function forwardToPostHog(payload: ValidPayload, env: PostHogEnv): Promise<boolean> {
   // Defense-in-depth go-live gate: only a write-only project key may forward events.
-  // The key VALUE is never logged — only the fact that the prefix check failed.
-  if (!env.POSTHOG_PROJECT_KEY.startsWith(POSTHOG_PROJECT_KEY_PREFIX)) {
+  // An unset secret (fresh deploy) takes the same fail-closed path instead of
+  // throwing. The key VALUE is never logged — only the fact that the check failed.
+  const projectKey = env.POSTHOG_PROJECT_KEY ?? "";
+  if (!projectKey.startsWith(POSTHOG_PROJECT_KEY_PREFIX)) {
     console.error(
-      `POSTHOG_PROJECT_KEY is not a '${POSTHOG_PROJECT_KEY_PREFIX}' project key; refusing to forward (502).`,
+      `POSTHOG_PROJECT_KEY is missing or not a '${POSTHOG_PROJECT_KEY_PREFIX}' project key; refusing to forward (502).`,
     );
     return false;
   }
@@ -63,7 +69,7 @@ export async function forwardToPostHog(payload: ValidPayload, env: PostHogEnv): 
   const captureUrl = env.POSTHOG_CAPTURE_URL ?? DEFAULT_POSTHOG_CAPTURE_URL;
 
   const body = JSON.stringify({
-    api_key: env.POSTHOG_PROJECT_KEY,
+    api_key: projectKey,
     event: payload.event,
     distinct_id: payload.installId,
     properties: {

--- a/telemetry-proxy/test/worker.test.ts
+++ b/telemetry-proxy/test/worker.test.ts
@@ -217,6 +217,21 @@ describe("PostHog project key guard (DEV-54 condition 2)", () => {
     expect(res.status).toBe(204);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("502s (not 500) and never forwards when the secret is UNSET (fresh deploy)", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { POSTHOG_PROJECT_KEY: _omitted, ...envWithoutKey } = ENV;
+    const res = await (
+      worker.fetch as (r: Request, e: typeof envWithoutKey, c: ExecutionContext) => Promise<Response>
+    )(post(VALID_BODY), envWithoutKey, ctx);
+
+    expect(res.status).toBe(502);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
 });
 
 describe("kill switch (PROXY_DISABLED)", () => {


### PR DESCRIPTION
## Summary

Two small hardenings on the telemetry proxy, both found during the 2026-07-20 live deploy session:

1. **Fail closed (502) on unset secret.** A freshly deployed Worker without the `POSTHOG_PROJECT_KEY` secret threw an uncaught `TypeError` → HTTP `500` (observed live before the secret was provisioned). It now takes the same fail-closed `502` path as a misconfigured non-`phc_` key, with a secret-free error log. The env binding is typed optional to match runtime reality; after the prefix guard the key is used via a narrowed local, so type-safety is preserved.
2. **`go-live-check.sh` finds the project-local wrangler.** The secret-existence check only looked for a global `wrangler` on PATH and reported SKIP otherwise. It now falls back to `node_modules/.bin/wrangler` (present after the runbook's `npm ci`), turning the check into a real PASS in the documented flow. Verified against the live Worker: condition [2/3] now reports PASS, overall check PASS.

No behavior change for correctly configured deployments.

### Verification

- `tsc` clean; 58 vitest cases green (new regression test: unset secret → `502`, no forward, secret-free log).
- `bash -n` clean; `go-live-check.sh` run against the live endpoint (PASS).

## Related Issues

Refs DEV-34. Follow-up to #573 / #601 / #602.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable) — N/A (behavior documented in code comments)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A (no DB changes)

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Fable 5, via Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
