### PR TITLE
test(frontend): deflake EmailTemplateEditPage suite by stubbing CodeMirror

### DIFF
--- a/plugwerk-server/plugwerk-server-frontend/src/components/admin/mustache/MustacheCodeEditor.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/components/admin/mustache/MustacheCodeEditor.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025-present devtank42 GmbH
+ *
+ * This file is part of Plugwerk.
+ *
+ * Plugwerk is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Plugwerk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Plugwerk. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { act, screen, waitFor } from "@testing-library/react";
+import { renderWithTheme } from "../../../test/renderWithTheme";
+import {
+  MustacheCodeEditor,
+  type MustacheCodeEditorHandle,
+} from "./MustacheCodeEditor";
+
+// The page suites stub this component out (CodeMirror is expensive under
+// jsdom), so the real editor keeps its direct coverage here: one small suite,
+// few mounts, no user-event round-trips.
+describe("MustacheCodeEditor", () => {
+  const PLACEHOLDERS = ["username", "resetLink"] as const;
+
+  it("renders the doc text inside a labelled group (plain language)", () => {
+    renderWithTheme(
+      <MustacheCodeEditor
+        value="Hello {{username}}, welcome!"
+        onChange={() => {}}
+        placeholders={PLACEHOLDERS}
+        language="plain"
+        ariaLabel="Plaintext body"
+      />,
+    );
+    const group = screen.getByRole("group", { name: "Plaintext body" });
+    expect(group.textContent ?? "").toContain("Hello");
+    expect(group.textContent ?? "").toContain("{{username}}");
+  });
+
+  it("renders the html language variant with line-number gutters", () => {
+    renderWithTheme(
+      <MustacheCodeEditor
+        value="<p>Hi {{username}}</p>"
+        onChange={() => {}}
+        placeholders={PLACEHOLDERS}
+        language="html"
+        ariaLabel="HTML body"
+      />,
+    );
+    const group = screen.getByRole("group", { name: "HTML body" });
+    expect(group.textContent ?? "").toContain("{{username}}");
+    // lineNumbers/foldGutter are enabled for html only — the gutter element
+    // is the observable difference to the plain variant.
+    expect(group.querySelector(".cm-gutters")).not.toBeNull();
+  });
+
+  it("insertAtCursor dispatches a change and fires onChange", async () => {
+    const onChange = vi.fn();
+    const editorRef: { current: MustacheCodeEditorHandle | null } = {
+      current: null,
+    };
+    renderWithTheme(
+      <MustacheCodeEditor
+        value="Hello "
+        onChange={onChange}
+        placeholders={PLACEHOLDERS}
+        language="plain"
+        ariaLabel="Plaintext body"
+        editorRef={editorRef}
+      />,
+    );
+
+    expect(editorRef.current).not.toBeNull();
+    act(() => {
+      editorRef.current?.insertAtCursor("{{username}}");
+    });
+
+    await waitFor(() => {
+      // react-codemirror passes (value, viewUpdate) to onChange.
+      expect(onChange).toHaveBeenCalledWith(
+        expect.stringContaining("{{username}}"),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("disabled turns off contenteditable", () => {
+    renderWithTheme(
+      <MustacheCodeEditor
+        value="read only"
+        onChange={() => {}}
+        placeholders={PLACEHOLDERS}
+        language="plain"
+        ariaLabel="Plaintext body"
+        disabled
+      />,
+    );
+    const group = screen.getByRole("group", { name: "Plaintext body" });
+    const content = group.querySelector(".cm-content");
+    expect(content?.getAttribute("contenteditable")).toBe("false");
+  });
+});

--- a/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.test.tsx
+++ b/plugwerk-server/plugwerk-server-frontend/src/pages/admin/EmailTemplateEditPage.test.tsx
@@ -38,6 +38,57 @@ vi.mock("../../api/config", () => ({
   },
 }));
 
+// Replace the CodeMirror-backed editor with a lightweight stub. Real CodeMirror
+// measures the DOM through Range.getClientRects, which jsdom does not lay out —
+// with two to three editors per page render the retrying measure loop makes this
+// suite time out on contended CI runners. The stub preserves everything the page
+// contract needs: a labelled group exposing the doc text, onChange, and the
+// insertAtCursor/focus handle used by the placeholder chips. The real component
+// keeps its own coverage in MustacheCodeEditor.test.tsx.
+vi.mock("../../components/admin/mustache/MustacheCodeEditor", () => ({
+  MustacheCodeEditor: function MustacheCodeEditorStub({
+    value,
+    onChange,
+    ariaLabel,
+    disabled,
+    onFocus,
+    editorRef,
+  }: {
+    value: string;
+    onChange: (next: string) => void;
+    ariaLabel: string;
+    disabled?: boolean;
+    onFocus?: () => void;
+    editorRef?: {
+      current: {
+        insertAtCursor: (text: string) => void;
+        focus: () => void;
+      } | null;
+    };
+  }) {
+    if (editorRef) {
+      editorRef.current = {
+        insertAtCursor: (text: string) => onChange(value + text),
+        focus: () => {},
+      };
+    }
+    return (
+      <div role="group" aria-label={ariaLabel}>
+        <textarea
+          aria-label={`${ariaLabel} text`}
+          value={value}
+          disabled={disabled}
+          onFocus={onFocus}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        {/* CodeMirror renders the doc as inline DOM text; mirror that so the
+            page tests' textContent assertions keep working. */}
+        <span aria-hidden="true">{value}</span>
+      </div>
+    );
+  },
+}));
+
 const TEMPLATE: MailTemplateResponse = {
   key: "auth.password_reset",
   friendlyName: "Auth · Password Reset",
@@ -771,13 +822,12 @@ describe("EmailTemplateEditPage", () => {
     const user = userEvent.setup();
     renderAt();
 
-    // HTML editor is visible (template has an HTML body). Focus its
-    // contenteditable so lastFocusedRef flips to "bodyHtml", then click a
-    // chip — insertion is dispatched to the HTML editor handle.
+    // HTML editor is visible (template has an HTML body). Focus its editable
+    // surface (the stub's labelled textarea) so lastFocusedRef flips to
+    // "bodyHtml", then click a chip — insertion is dispatched to the HTML
+    // editor handle.
     const htmlGroup = screen.getByRole("group", { name: "HTML body" });
-    const htmlContent = htmlGroup.querySelector(".cm-content");
-    expect(htmlContent).not.toBeNull();
-    fireEvent.focus(htmlContent as Element);
+    fireEvent.focus(within(htmlGroup).getByLabelText("HTML body text"));
 
     await user.click(screen.getAllByText("{{username}}")[0]);
 
@@ -822,9 +872,9 @@ describe("EmailTemplateEditPage", () => {
     // fallback branch), so it mounts but stays empty.
     await user.click(screen.getByLabelText("Plaintext only"));
     const htmlEditor = await screen.findByRole("group", { name: "HTML body" });
-    // Read the editable content element directly — the group wrapper also
-    // contains CodeMirror's line-number gutter, which is not document text.
-    const content = htmlEditor.querySelector(".cm-content");
-    expect((content?.textContent ?? "").trim()).toBe("");
+    // Read the editable surface (the stub's labelled textarea) directly.
+    const content =
+      within(htmlEditor).getByLabelText<HTMLTextAreaElement>("HTML body text");
+    expect(content.value).toBe("");
   });
 });

--- a/plugwerk-server/plugwerk-server-frontend/src/test/setup.ts
+++ b/plugwerk-server/plugwerk-server-frontend/src/test/setup.ts
@@ -33,6 +33,19 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// jsdom performs no layout, so Range measurement APIs used by CodeMirror's
+// measure loop are missing. Provide inert stand-ins so mounting a real editor
+// neither throws ("textRange(...).getClientRects is not a function") nor floods
+// stderr with retries.
+if (typeof Range !== "undefined") {
+  if (typeof Range.prototype.getClientRects !== "function") {
+    Range.prototype.getClientRects = () => [] as unknown as DOMRectList;
+  }
+  if (typeof Range.prototype.getBoundingClientRect !== "function") {
+    Range.prototype.getBoundingClientRect = () => new DOMRect();
+  }
+}
+
 // matchMedia is not implemented in jsdom — mock globally before any store initialises
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Summary

Deflakes the `EmailTemplateEditPage` vitest suite — the flake that failed three unrelated CI runs within 24h (#601, #603, and the `main` run after the #603 merge), each fixed only by a manual rerun.

**Root cause:** the suite mounts two to three **real CodeMirror editors per page render**. CodeMirror's measure loop calls `Range.getClientRects`, which jsdom does not implement — every editor update throws (`textRange(...).getClientRects is not a function`, visible as stderr spam in every failed run), retries, and accumulates. On contended CI runners this churn blows the 15s per-test timeout that DEV-44 had already raised once as a symptom fix.

### Changes

1. **`EmailTemplateEditPage.test.tsx`** — mocks `MustacheCodeEditor` with a lightweight labelled-group stub that preserves the page-facing contract: doc text exposed via `textContent`, `onChange`, and the `insertAtCursor`/`focus` handle used by the placeholder chips. Two assertions that reached into CodeMirror internals (`querySelector(".cm-content")`) now query the stub's accessible textarea instead. These are page-logic tests; the editor itself is not their subject.
2. **`MustacheCodeEditor.test.tsx` (new)** — the real component keeps direct coverage in a small dedicated suite: labelled group + doc text, html-variant gutters, `insertAtCursor` dispatch fires `onChange`, `disabled` turns off `contenteditable`.
3. **`test/setup.ts`** — inert `Range.getClientRects`/`getBoundingClientRect` stand-ins (jsdom performs no layout), so suites that do mount real CodeMirror neither throw nor flood stderr.

### Verification

- Full frontend gate locally: **688 tests in 65 files green**, coverage thresholds met, `eslint` 0 errors (the 12 warnings are the pre-existing DEV-29 set), `prettier` applied, license headers OK, `tsc -b` clean, production build OK.
- Suite runtime (local): page suite alone was 6.8s with heavy stderr spam; page suite + new editor suite together now run in ~5.1s with silent output. The CI win is stability, not just speed — the per-keystroke measure churn is gone.

## Related Issues

Refs DEV-44 (previous timeout raise) and the flake documented across #601/#603 reruns.

## Type of Change

- [x] Test improvement (no production code changed)

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] Every new Liquibase changeSet has an explicit `rollback:` block — N/A (no DB changes)

## AI Agent Disclosure

- [x] This PR was authored by an AI agent (Claude Fable 5, via Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
