### PR TITLE
fix(telemetry): opt out of telemetry in E2E CI jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,10 @@ jobs:
           PLUGWERK_AUTH_ADMIN_PASSWORD: admin
           PLUGWERK_AUTH_JWT_SECRET: ci-smoke-test-secret-min-32-characters!!
           PLUGWERK_AUTH_ENCRYPTION_KEY: ci-encrypt-16chr
+          # The boot fires the server-start beacon and the flow triggers activation
+          # events; each CI run is a fresh install (new UUID), so leaving telemetry
+          # on would register every run as a new install in analytics. Opt out.
+          PLUGWERK_TELEMETRY: "false"
 
   # Browser-driven UI E2E (issue #241). Builds the server JAR (which embeds the
   # production frontend bundle), runs it against a real PostgreSQL, then drives
@@ -119,6 +123,10 @@ jobs:
           PLUGWERK_AUTH_RATE_LIMIT_MAX_ATTEMPTS: "10000"
           # Default artifact root (/var/plugwerk) is not writable on the runner.
           PLUGWERK_STORAGE_ROOT: ${{ runner.temp }}/plugwerk-artifacts
+          # Opt out of telemetry: boot fires the server-start beacon and the browser
+          # scenarios trigger activation events. Each run is a fresh install (new
+          # UUID), so leaving it on registers every CI run as a new analytics install.
+          PLUGWERK_TELEMETRY: "false"
         run: |
           java -jar ../plugwerk-server-backend/build/libs/*.jar \
             > "$RUNNER_TEMP/plugwerk-server.log" 2>&1 &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       PLUGWERK_AUTH_JWT_SECRET: "${PLUGWERK_AUTH_JWT_SECRET:?Set PLUGWERK_AUTH_JWT_SECRET (min 32 chars)}"
       PLUGWERK_AUTH_ENCRYPTION_KEY: "${PLUGWERK_AUTH_ENCRYPTION_KEY:?Set PLUGWERK_AUTH_ENCRYPTION_KEY (exactly 16 chars)}"
       PLUGWERK_AUTH_ADMIN_PASSWORD: ${PLUGWERK_AUTH_ADMIN_PASSWORD:-}
+      # Opt-out telemetry master switch, passed through from the host env. Defaults
+      # to true (real deployments send the beacon); CI's E2E smoke test sets
+      # PLUGWERK_TELEMETRY=false so ephemeral CI installs never pollute analytics.
+      PLUGWERK_TELEMETRY: ${PLUGWERK_TELEMETRY:-true}
     volumes:
       - plugwerk-artifacts:/var/plugwerk/artifacts
     ports:


### PR DESCRIPTION
## Problem

PostHog was flooded with events originating from CI. Root cause: both jobs in `.github/workflows/e2e.yml` boot the **real application in the production profile**, where the telemetry endpoint defaults to the live proxy (`…plugwerk.workers.dev/v1/events`) since DEV-34 made that the default.

Per run this produced:
- a `server_start` beacon on `ApplicationReadyEvent`, and
- the activation events (namespace create / plugin publish) that the Playwright scenarios drive.

Worse than noise: each E2E run starts from a **fresh database**, so `InstallIdProvider` mints a **new install UUID** every time. PostHog therefore counted **every push to `main` and every PR** as a brand-new install — polluting event volume *and* the install / active-instance metric, plus surfacing `jar` and `docker-compose` installs that were never real deployments.

Unit and integration tests were already safe — `application-test.yml` and `application-integration.yml` both blank the endpoint. The gap was only the two full-boot E2E jobs.

## Fix

Set the `PLUGWERK_TELEMETRY=false` master opt-out (the single source of truth: it gates *before* UUID creation and before any HTTP call) in both E2E jobs:

- **`playwright-e2e`** — one env line on the server-start step; reaches the `java -jar` process directly.
- **`smoke-test`** — `docker-compose.yml` did not pass `PLUGWERK_TELEMETRY` through, so added a `${PLUGWERK_TELEMETRY:-true}` passthrough (default stays `true` for real deployments) and set it `false` in the job env.

## Verification

- `docker compose config` resolves the passthrough to `true` by default and to `false` when the CI env var is set (both confirmed locally).
- `docker compose config -q` passes (compose file valid).
- No production behavior changes: real docker-compose / jar deployments still default to telemetry **on**.

## Follow-up (not in this PR)

Consider backfilling PostHog to filter out the historical CI installs (by `install_type` / the affected `install_id`s) so past metrics read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
