### PR TITLE
fix(build): honor -Pversion override instead of silently discarding it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,10 @@ plugins {
     alias(libs.plugins.spotless)
 }
 
-val projectVersion = file("VERSION").readText().trim()
+// An explicit -Pversion (release.yml derives it from the git tag) overrides the
+// VERSION file; without it the unconditional assignment below would silently
+// discard the flag.
+val projectVersion = providers.gradleProperty("version").orNull ?: file("VERSION").readText().trim()
 
 allprojects {
     group = "io.plugwerk"


### PR DESCRIPTION
## Summary

`release.yml` passes `-Pversion=<tag>` to the Maven Central / GitHub Packages publish steps, but the root `build.gradle.kts` unconditionally overwrote `version` with the `VERSION` file content — the flag was silently ignored. It has been harmless so far because the tag checkout's `VERSION` file always matched the tag, but the flag was a lie: an intentional `-Pversion` override would have been discarded without any warning.

This resolves the project version as:

1. explicit `-Pversion` gradle property (e.g. tag-derived in `release.yml`), if present
2. otherwise the `VERSION` file (local builds, CI, `snapshot-publish.yml` — all unchanged)

The resolved version flows into `buildInfo()` → Spring `BuildProperties` → the telemetry beacon's `version` property, so release builds now provably report the tag version.

## Test plan

- [x] `gradlew properties` without the flag → `1.2.0-SNAPSHOT` (VERSION file)
- [x] `gradlew properties -Pversion=9.9.9-TEST` → `9.9.9-TEST` (override wins)
- [x] CI green on this PR (build uses the VERSION-file path, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
